### PR TITLE
implemented timing correction again due to svn not transferring over …

### DIFF
--- a/ecal-recon/src/main/java/org/hps/recon/ecal/cluster/HitTMCSmearDriver.java
+++ b/ecal-recon/src/main/java/org/hps/recon/ecal/cluster/HitTMCSmearDriver.java
@@ -30,9 +30,11 @@ public class HitTMCSmearDriver extends Driver {
     
    
     // Time resolution as derived for 2016 data
+    //Factor 1.98 derived after running over MC. Probably due to
+    //lack of trigger jitter in simulation.
     private static double calcSmear(double energy, double time){
         Random r = new Random();
-        double sigT = r.nextGaussian()*Math.sqrt(Math.pow(0.188/energy, 2) + Math.pow(0.152, 2));
+        double sigT = r.nextGaussian()*Math.sqrt(Math.pow(0.188/energy, 2) + Math.pow(0.152, 2))/1.98;
         return time + sigT;
     }
             


### PR DESCRIPTION
This was already done previously, but for some reason svn did not migrate over to git. I retested the changes on wab-beam-tri mc and see the desired smearing effect and results in MC that appears to mimic data. 