### PR TITLE
modified Driver to allow running over persisted lcio files. Added test.

### DIFF
--- a/tracking/src/main/java/org/hps/recon/tracking/gbl/GBLRefitterDriver.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/gbl/GBLRefitterDriver.java
@@ -10,8 +10,15 @@ import org.apache.commons.math3.util.Pair;
 import org.hps.recon.tracking.MaterialSupervisor;
 import org.hps.recon.tracking.MultipleScattering;
 import org.hps.recon.tracking.TrackUtils;
+import org.lcsim.detector.DetectorElementStore;
+import org.lcsim.detector.IDetectorElement;
+import org.lcsim.detector.identifier.IExpandedIdentifier;
+import org.lcsim.detector.identifier.IIdentifier;
+import org.lcsim.detector.identifier.IIdentifierDictionary;
+import org.lcsim.detector.tracker.silicon.SiSensor;
 import org.lcsim.event.EventHeader;
 import org.lcsim.event.LCRelation;
+import org.lcsim.event.RawTrackerHit;
 import org.lcsim.event.RelationalTable;
 import org.lcsim.event.Track;
 import org.lcsim.event.TrackerHit;
@@ -64,6 +71,7 @@ public class GBLRefitterDriver extends Driver {
         if (!event.hasCollection(Track.class, inputCollectionName)) {
             return;
         }
+        setupSensors(event);
         List<Track> tracks = event.get(Track.class, inputCollectionName);
         RelationalTable hitToStrips = TrackUtils.getHitToStripsTable(event);
         RelationalTable hitToRotated = TrackUtils.getHitToRotatedTable(event);
@@ -146,5 +154,47 @@ public class GBLRefitterDriver extends Driver {
         event.put(trackRelationCollectionName, trackRelations, LCRelation.class, 0);
         event.put(GBLKinkData.DATA_COLLECTION, kinkDataCollection, GBLKinkData.class, 0);
         event.put(GBLKinkData.DATA_RELATION_COLLECTION, kinkDataRelations, LCRelation.class, 0);
+    }
+
+    private void setupSensors(EventHeader event)
+    {
+        List<RawTrackerHit> rawTrackerHits = null;
+        if (event.hasCollection(RawTrackerHit.class, "SVTRawTrackerHits")) {
+            rawTrackerHits = event.get(RawTrackerHit.class, "SVTRawTrackerHits");
+        }
+        if (event.hasCollection(RawTrackerHit.class, "RawTrackerHitMaker_RawTrackerHits")) {
+            rawTrackerHits = event.get(RawTrackerHit.class, "RawTrackerHitMaker_RawTrackerHits");
+        }
+        EventHeader.LCMetaData meta = event.getMetaData(rawTrackerHits);
+        // Get the ID dictionary and field information.
+        IIdentifierDictionary dict = meta.getIDDecoder().getSubdetector().getDetectorElement().getIdentifierHelper().getIdentifierDictionary();
+        int fieldIdx = dict.getFieldIndex("side");
+        int sideIdx = dict.getFieldIndex("strip");
+        for (RawTrackerHit hit : rawTrackerHits) {
+            // The "side" and "strip" fields needs to be stripped from the ID for sensor lookup.
+            IExpandedIdentifier expId = dict.unpack(hit.getIdentifier());
+            expId.setValue(fieldIdx, 0);
+            expId.setValue(sideIdx, 0);
+            IIdentifier strippedId = dict.pack(expId);
+            // Find the sensor DetectorElement.
+            List<IDetectorElement> des = DetectorElementStore.getInstance().find(strippedId);
+            if (des == null || des.size() == 0) {
+                throw new RuntimeException("Failed to find any DetectorElements with stripped ID <0x" + Long.toHexString(strippedId.getValue()) + ">.");
+            } else if (des.size() == 1) {
+                hit.setDetectorElement((SiSensor) des.get(0));
+            } else {
+                // Use first sensor found, which should work unless there are sensors with duplicate IDs.
+                for (IDetectorElement de : des) {
+                    if (de instanceof SiSensor) {
+                        hit.setDetectorElement((SiSensor) de);
+                        break;
+                    }
+                }
+            }
+            // No sensor was found.
+            if (hit.getDetectorElement() == null) {
+                throw new RuntimeException("No sensor was found for hit with stripped ID <0x" + Long.toHexString(strippedId.getValue()) + ">.");
+            }
+        }
     }
 }

--- a/tracking/src/test/java/org/hps/recon/tracking/gbl/GBLRefitterDriverTest.java
+++ b/tracking/src/test/java/org/hps/recon/tracking/gbl/GBLRefitterDriverTest.java
@@ -1,0 +1,39 @@
+package org.hps.recon.tracking.gbl;
+
+import java.io.File;
+import java.net.URL;
+import junit.framework.TestCase;
+import org.lcsim.util.cache.FileCache;
+import org.lcsim.util.loop.LCSimLoop;
+import org.lcsim.util.test.TestUtil;
+
+/**
+ *
+ * @author Norman A. Graf
+ *
+ */
+public class GBLRefitterDriverTest extends TestCase
+{
+    static final String testURLBase = "http://www.lcsim.org/test/hps-java/";
+    static final String testFileName = "hpsrun2016_run7636_onetrackonecluster_1000events.slcio";
+    private final int nEvents = 10;
+
+    public void testIt() throws Exception
+    {
+        File outputDir = new TestUtil.TestOutputFile(this.getClass().getSimpleName());
+        outputDir.mkdir();
+
+        URL testURL = new URL(testURLBase + "/" + testFileName);
+        FileCache cache = new FileCache();
+        File lcioInputFile = cache.getCachedFile(testURL);
+        LCSimLoop loop = new LCSimLoop();
+        loop.setLCIORecordSource(lcioInputFile);
+
+        GBLRefitterDriver fitter = new GBLRefitterDriver();
+
+        loop.add(fitter);
+        loop.loop(nEvents);
+        loop.dispose();
+    }
+    
+}


### PR DESCRIPTION
Setup SVT sensors so GBL fit can be performed on events read in from persistent lcio files.
Added a unit test for GBLRefitterDriver. Currently does nothing more than run over a few events.