### PR TITLE
fixed mistake in 6.6 GeV detector

### DIFF
--- a/detector-data/detectors/HPS-PhysicsRun2016-Nominal-v5-0-6pt6-fieldmap/HPS-PhysicsRun2016-Nominal-v5-0-6pt6-fieldmap.lcdd
+++ b/detector-data/detectors/HPS-PhysicsRun2016-Nominal-v5-0-6pt6-fieldmap/HPS-PhysicsRun2016-Nominal-v5-0-6pt6-fieldmap.lcdd
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <lcdd xmlns:lcdd="http://www.lcsim.org/schemas/lcdd/1.0" xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/lcdd/1.0/lcdd.xsd">
   <header>
-    <detector name="HPS-PhysicsRun2016-Nominal-v5-0-4pt4-fieldmap" />
-    <generator name="lcsim" version="1.0" file="/nfs/slac/g/hps2/mrsolt/hps/hps-java/detector-data/detectors/HPS-PhysicsRun2016-Nominal-v5-0-6pt6-fieldmap/compact.xml" checksum="1811999516" />
+    <detector name="HPS-PhysicsRun2016-Nominal-v5-0-6pt6-fieldmap" />
+    <generator name="lcsim" version="1.0" file="/nfs/slac/g/hps2/mrsolt/hps/hps-java/detector-data/detectors/HPS-PhysicsRun2016-Nominal-v5-0-6pt6-fieldmap/compact.xml" checksum="3862883916" />
     <author name="NONE" />
     <comment>HPS detector for 2016 Physics Run at 6.6 GeV. Based on HPS-PhysicsRun2015-Nominal-v5-0-fieldmap. Millepede constants are cleaned up (tweak parameters are set to 0) but their actual values are unchanged. LCDD is generated using the corrected SVT dead material (no carbon fiber in the beam plane). Fieldmap for 6.6 GeV is included.</comment>
   </header>

--- a/detector-data/detectors/HPS-PhysicsRun2016-Nominal-v5-0-6pt6-fieldmap/compact.xml
+++ b/detector-data/detectors/HPS-PhysicsRun2016-Nominal-v5-0-6pt6-fieldmap/compact.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <lccdd xmlns:compact="http://www.lcsim.org/schemas/compact/1.0" xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/compact/1.0/compact.xsd">
     
-    <info name="HPS-PhysicsRun2016-Nominal-v5-0-4pt4-fieldmap">
+    <info name="HPS-PhysicsRun2016-Nominal-v5-0-6pt6-fieldmap">
         <comment>HPS detector for 2016 Physics Run at 6.6 GeV.
             Based on HPS-PhysicsRun2015-Nominal-v5-0-fieldmap.
             Millepede constants are cleaned up (tweak parameters are set to 0) but their actual values are unchanged.

--- a/detector-data/detectors/HPS-Proposal2017-Nominal-v2-6pt6-fieldmap/HPS-Proposal2017-Nominal-v2-6pt6-fieldmap.lcdd
+++ b/detector-data/detectors/HPS-Proposal2017-Nominal-v2-6pt6-fieldmap/HPS-Proposal2017-Nominal-v2-6pt6-fieldmap.lcdd
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <lcdd xmlns:lcdd="http://www.lcsim.org/schemas/lcdd/1.0" xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/lcdd/1.0/lcdd.xsd">
   <header>
-    <detector name="HPS-Proposal2017-Nominal-v2-4pt4-fieldmap" />
-    <generator name="lcsim" version="1.0" file="/nfs/slac/g/hps2/mrsolt/hps/hps-java/detector-data/detectors/HPS-Proposal2017-Nominal-v2-6pt6-fieldmap/compact.xml" checksum="1075183250" />
+    <detector name="HPS-Proposal2017-Nominal-v2-6pt6-fieldmap" />
+    <generator name="lcsim" version="1.0" file="/nfs/slac/g/hps2/mrsolt/hps/hps-java/detector-data/detectors/HPS-Proposal2017-Nominal-v2-6pt6-fieldmap/compact.xml" checksum="308138138" />
     <author name="NONE" />
     <comment>HPS detector for 2017 proposal with fieldmap, tracker at nominal opening angle, no SVT survey, this detector uses the corrected fieldmap scaled to -1.50T for 6.6 GeV.</comment>
   </header>

--- a/detector-data/detectors/HPS-Proposal2017-Nominal-v2-6pt6-fieldmap/compact.xml
+++ b/detector-data/detectors/HPS-Proposal2017-Nominal-v2-6pt6-fieldmap/compact.xml
@@ -2,7 +2,7 @@
        xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
        xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/compact/1.0/compact.xsd">
     
-    <info name="HPS-Proposal2017-Nominal-v2-4pt4-fieldmap">
+    <info name="HPS-Proposal2017-Nominal-v2-6pt6-fieldmap">
         <comment>HPS detector for 2017 proposal with fieldmap,
                  tracker at nominal opening angle, no SVT survey,  
                  this detector uses the corrected fieldmap scaled to -1.50T for 6.6 GeV.


### PR DESCRIPTION
Correct mistakes in compact files for the L0/nominal 6.6 GeV detectors. Updated corresponding lcdd files.