### PR TITLE
Add TI time offset to conditions system

### DIFF
--- a/conditions/src/main/java/org/hps/conditions/database/DatabaseConditionsManager.java
+++ b/conditions/src/main/java/org/hps/conditions/database/DatabaseConditionsManager.java
@@ -947,7 +947,7 @@ public final class DatabaseConditionsManager extends ConditionsManagerImplementa
      * @return the <code>ResultSet</code> from the query
      * @throws RuntimeException if there is a query error
      */
-    ResultSet selectQuery(final String query) {
+    public ResultSet selectQuery(final String query) {
         LOGGER.fine("executing SQL select query ..." + '\n' + query);
         ResultSet result = null;
         Statement statement = null;

--- a/conditions/src/main/java/org/hps/conditions/database/DatabaseUtilities.java
+++ b/conditions/src/main/java/org/hps/conditions/database/DatabaseUtilities.java
@@ -16,7 +16,7 @@ public final class DatabaseUtilities {
      *
      * @param resultSet the database <code>ResultSet</code>
      */
-    static void cleanup(final ResultSet resultSet) {
+    public static void cleanup(final ResultSet resultSet) {
         Statement statement = null;
         try {
             statement = resultSet.getStatement();

--- a/conditions/src/main/java/org/hps/conditions/trigger/TiTimeOffset.java
+++ b/conditions/src/main/java/org/hps/conditions/trigger/TiTimeOffset.java
@@ -1,0 +1,25 @@
+package org.hps.conditions.trigger;
+
+import org.hps.conditions.api.BaseConditionsObject;
+import org.hps.conditions.api.BaseConditionsObjectCollection;
+import org.hps.conditions.database.Converter;
+import org.hps.conditions.database.Table;
+
+@Table(names = {"ti_time_offsets"})
+@Converter(converter = TiTimeOffsetConverter.class)
+public class TiTimeOffset extends BaseConditionsObject {
+    
+    // FIXME: This is not actually used but it is here to make the conditions manager happy.
+    public static class TiTimeOffsetCollection extends BaseConditionsObjectCollection<TiTimeOffset> {
+    }
+    
+    private Long value = null;
+    
+    TiTimeOffset(Long value) {
+        this.value = value;
+    }
+    
+    public Long getValue() {
+        return value;
+    }
+}

--- a/conditions/src/main/java/org/hps/conditions/trigger/TiTimeOffset.java
+++ b/conditions/src/main/java/org/hps/conditions/trigger/TiTimeOffset.java
@@ -5,6 +5,14 @@ import org.hps.conditions.api.BaseConditionsObjectCollection;
 import org.hps.conditions.database.Converter;
 import org.hps.conditions.database.Table;
 
+/**
+ * <p>
+ * Represents the per-run trigger time offset in nanoseconds.
+ * </p>
+ * <p>
+ * A single instance of this class is returned for an entire run.
+ * </p>
+ */
 @Table(names = {"ti_time_offsets"})
 @Converter(converter = TiTimeOffsetConverter.class)
 public class TiTimeOffset extends BaseConditionsObject {

--- a/conditions/src/main/java/org/hps/conditions/trigger/TiTimeOffsetConverter.java
+++ b/conditions/src/main/java/org/hps/conditions/trigger/TiTimeOffsetConverter.java
@@ -1,0 +1,49 @@
+package org.hps.conditions.trigger;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import org.hps.conditions.database.AbstractConditionsObjectConverter;
+import org.hps.conditions.database.DatabaseConditionsManager;
+import org.hps.conditions.database.DatabaseUtilities;
+import org.lcsim.conditions.ConditionsManager;
+
+public class TiTimeOffsetConverter extends AbstractConditionsObjectConverter<TiTimeOffset> {
+
+    public TiTimeOffset getData(final ConditionsManager manager, final String name) {
+
+        final DatabaseConditionsManager databaseConditionsManager = DatabaseConditionsManager.getInstance();
+
+        // Setup connection if necessary.
+        boolean reopenedConnection = false;
+        if (!databaseConditionsManager.isConnected()) {
+            databaseConditionsManager.openConnection();
+            reopenedConnection = true;
+        }
+
+        final String query = "SELECT ti_time_offset from ti_time_offsets WHERE run = " + manager.getRun();
+        final ResultSet resultSet = databaseConditionsManager.selectQuery(query);
+        TiTimeOffset t = null;
+        try {
+            if (resultSet.next()) {
+                t = new TiTimeOffset(resultSet.getLong(1));
+            } else {
+                throw new RuntimeException("No TiTimeOffset condition exists for run " + manager.getRun());
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+
+        DatabaseUtilities.cleanup(resultSet);
+
+        if (reopenedConnection) {
+            databaseConditionsManager.closeConnection();
+        }
+
+        return t;
+    }
+    
+    public Class<TiTimeOffset> getType() {
+        return TiTimeOffset.class;
+    }
+}

--- a/conditions/src/test/java/org/hps/conditions/trigger/TiTimeOffsetTest.java
+++ b/conditions/src/test/java/org/hps/conditions/trigger/TiTimeOffsetTest.java
@@ -1,0 +1,29 @@
+package org.hps.conditions.trigger;
+
+import junit.framework.TestCase;
+
+import org.hps.conditions.database.DatabaseConditionsManager;
+import org.lcsim.conditions.ConditionsManager.ConditionsNotFoundException;
+
+public final class TiTimeOffsetTest extends TestCase {
+
+    private static final int RUN_NUMBER = 5772;
+
+    private static DatabaseConditionsManager conditionsManager;
+
+    public void setUp() {
+        conditionsManager = DatabaseConditionsManager.getInstance();
+        try {
+            conditionsManager.setDetector("HPS-PhysicsRun2016-Nominal-v4-4", RUN_NUMBER);
+        } catch (final ConditionsNotFoundException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public void testTiTimeOffset() {
+        System.out.println("Loading TI time offset for run " + conditionsManager.getRun());
+        final TiTimeOffset t = 
+                conditionsManager.getCachedConditions(TiTimeOffset.class, "ti_time_offsets").getCachedData();
+        System.out.println("run " + RUN_NUMBER + "; ti_time_offset = " + t.getValue());
+    }
+}

--- a/evio/pom.xml
+++ b/evio/pom.xml
@@ -21,10 +21,6 @@
     </dependency>
     <dependency>
       <groupId>org.hps</groupId>
-      <artifactId>hps-run-database</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.hps</groupId>
       <artifactId>hps-tracking</artifactId>
     </dependency>
     <dependency>

--- a/run-database/src/main/java/org/hps/rundb/RunManager.java
+++ b/run-database/src/main/java/org/hps/rundb/RunManager.java
@@ -1,6 +1,5 @@
 package org.hps.rundb;
 
-import java.io.File;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.List;
@@ -22,11 +21,6 @@ import org.lcsim.conditions.ConditionsListener;
  * @author jeremym
  */
 public final class RunManager implements ConditionsListener {
-
-    /**
-     * Name of system property that can be used to specify custom database connection parameters.
-     */
-    private static final String CONNECTION_PROPERTY_FILE = "org.hps.conditions.connection.file";
     
     /**
      * The default connection parameters for read-only access to the run database.
@@ -95,20 +89,7 @@ public final class RunManager implements ConditionsListener {
     /**
      * Class constructor using default connection parameters.
      */
-    public RunManager() {
-        
-        /**
-         * Read database URL from system prop setting.
-         * The database, password and user from that file are overridden.
-         */
-        if (System.getProperties().get(CONNECTION_PROPERTY_FILE) != null) {
-            final String propFile = (String) System.getProperties().get(CONNECTION_PROPERTY_FILE);
-            this.connectionParameters = ConnectionParameters.fromProperties(new File(propFile));
-            this.connectionParameters.setDatabase("hps_run_db_v2");
-            this.connectionParameters.setPassword("darkphoton");
-            this.connectionParameters.setUser("hpsuser");
-            
-        }        
+    public RunManager() {        
         this.connection = this.connectionParameters.createConnection();
         factory = new DaoProvider(this.connection);
         LOGGER.log(Level.INFO, this.connectionParameters.toString());


### PR DESCRIPTION
- Added `ti_time_offsets` table to conditions database

- Added TiTimeOffset conditions class and converter

- Created a simple test to read the TI time offset for a run

- Removed dependence of evio module on run database

- Read TI time offset from conditions system instead of run db in `LCSimEngRunEventBuilder`

- Removed now unnecessary setting of run db connection parameters from properties file (instead there is an existing constructor which can be used which takes a `Connection` object)

This was done primarily to remove the dependence of the EVIO to LCIO conversion on the run database and make this information easily accessible to reconstruction Driver classes.