### PR TITLE
modified org.hps.evio.SvtEventFlagger

### DIFF
--- a/evio/src/main/java/org/hps/evio/SvtEventFlagger.java
+++ b/evio/src/main/java/org/hps/evio/SvtEventFlagger.java
@@ -44,6 +44,17 @@ public class SvtEventFlagger {
     private double nominalAngleTop = 0;
     private double nominalAngleBottom = 0;
 
+    private double maxGoodOffsetTime = 35;
+    private double minGoodOffsetTime = 0;
+    
+    public void setMaxGoodOffsetTime(double val){
+        this.maxGoodOffsetTime = val;
+    }
+    
+    public void setMinGoodOffsetTime(double val){
+        this.minGoodOffsetTime = val;
+    }
+    
     public void writeFlags(EventHeader event) {
         Date eventDate = getEventTimeStamp(event);
         if (eventDate != null) {
@@ -69,7 +80,7 @@ public class SvtEventFlagger {
 
         latencyGood = false;
         if (svtTimingConstants != null) {
-            if (svtTimingConstants.getOffsetTime() <= 35) {
+            if (svtTimingConstants.getOffsetTime() <= maxGoodOffsetTime && svtTimingConstants.getOffsetTime() >= minGoodOffsetTime) {
                 latencyGood = true;
             } else {
                 if (((event.getTimeStamp() - 4 * svtTimingConstants.getOffsetPhase()) % 24) < 16) {

--- a/evio/src/main/java/org/hps/evio/SvtEventFlagger.java
+++ b/evio/src/main/java/org/hps/evio/SvtEventFlagger.java
@@ -69,7 +69,7 @@ public class SvtEventFlagger {
 
         latencyGood = false;
         if (svtTimingConstants != null) {
-            if (svtTimingConstants.getOffsetTime() <= 27) {
+            if (svtTimingConstants.getOffsetTime() <= 35) {
                 latencyGood = true;
             } else {
                 if (((event.getTimeStamp() - 4 * svtTimingConstants.getOffsetPhase()) % 24) < 16) {

--- a/evio/src/main/java/org/hps/evio/SvtEventFlagger.java
+++ b/evio/src/main/java/org/hps/evio/SvtEventFlagger.java
@@ -47,6 +47,14 @@ public class SvtEventFlagger {
     private double maxGoodOffsetTime = 35;
     private double minGoodOffsetTime = 0;
     
+    public void setNominalAngleTop(double val){
+        nominalAngleTop = val;
+    }
+    
+    public void setNominalAngleBottom(double val){
+        nominalAngleBottom = val;
+    }
+    
     public void setMaxGoodOffsetTime(double val){
         this.maxGoodOffsetTime = val;
     }


### PR DESCRIPTION
Changed criteria for latency good flag:  was offset_time <= 27. changed
to offset_time <= 35.  This allows all 2016 events reconstructed
hereafter to have the good latency flag set.   (before, the good latency flag was only set for 2/3 of the events)