### PR TITLE
Iss130

### DIFF
--- a/recon/src/main/java/org/hps/recon/particle/HpsReconParticleDriver.java
+++ b/recon/src/main/java/org/hps/recon/particle/HpsReconParticleDriver.java
@@ -117,7 +117,7 @@ public class HpsReconParticleDriver extends ReconParticleDriver {
     }
     
     
-    private boolean _patchVertexTrackParameters;
+    private boolean _patchVertexTrackParameters = true;
 
     /**
      * Processes the track and cluster collections in the event into

--- a/steering-files/src/main/resources/org/hps/steering/recon/PhysicsRun2016FullRecon.lcsim
+++ b/steering-files/src/main/resources/org/hps/steering/recon/PhysicsRun2016FullRecon.lcsim
@@ -1,12 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <lcsim xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/lcsim/1.0/lcsim.xsd">
     <!-- 
-      @brief Steering file that will be used for pass 2 reconstruction of 
-             the 2015 Engineering Run data. 
-      @author <a href="mailto:meeg@slac.stanford.edu">Sho Uemura</a>
+      @brief Steering file that will be used for pass 1 reconstruction of 
+             the 2016 Engineering Run data. 
       @author <a href="mailto:omoreno1@ucsc.edu">Omar Moreno</a>
+      @author <a href="mailto:Norman.Graf@slac.stanford.edu">Norman Graf</a>
     -->
     <execute>
+        
+        <!-- Skip events with known bad conditions -->
+        <driver name="EventFlagFilter"/>
         <!--RF driver-->
         <driver name="RfFitter"/>
  
@@ -64,6 +67,11 @@
         <driver name="EventMarkerDriver" type="org.lcsim.job.EventMarkerDriver">
             <eventInterval>1000</eventInterval>
         </driver> 
+        
+         <!-- Driver to reject "bad" events -->
+         <driver name="EventFlagFilter" type="org.hps.recon.filtering.EventFlagFilter"> 
+             <flagNames>svt_bias_good svt_position_good svt_burstmode_noise_good svt_event_header_good</flagNames> 
+         </driver> 
         
         <driver name="RfFitter" type="org.hps.evio.RfFitterDriver"/>       
 
@@ -136,7 +144,7 @@
         <driver name="TrackDataDriver" type="org.hps.recon.tracking.TrackDataDriver" />
         <driver name="ReconParticleDriver" type="org.hps.recon.particle.HpsReconParticleDriver" > 
             <ecalClusterCollectionName>EcalClustersCorr</ecalClusterCollectionName>        
-            <trackCollectionNames>MatchedTracks GBLTracks</trackCollectionNames>
+            <trackCollectionNames>GBLTracks</trackCollectionNames>
         </driver>  
         <driver name="GBLRefitterDriver" type="org.hps.recon.tracking.gbl.GBLRefitterDriver"/>
         <driver name="LCIOWriter" type="org.lcsim.util.loop.LCIODriver">


### PR DESCRIPTION
Made patching of the track parameters at the fitted vertex the default behavior.

Added the EventFlagFilter Driver to the steering file.
Removed the svt_latency_good check.

Removed MatchedTracks from the list of Track collections used to create ReconstructedParticles in HpsReconParticleDriver.