### PR TITLE
Iss118: Performance optimizations for raw tracker hit pulse fitting

### DIFF
--- a/tracking/src/main/java/org/hps/recon/tracking/PulseShape.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/PulseShape.java
@@ -71,6 +71,8 @@ public abstract class PulseShape {
             peak_t = 3.0 * Math.pow(tp * Math.pow(tp2, 3), 0.25); //approximate solution to exp(x)=1+x+x^2*tp/(2*tp2), where x=(1/tp2-1/tp)*t
             peak_amp = getAmplitudeIntegralNorm(peak_t);
             
+            //System.out.println(tp + "  " + tp2);
+            
             A = (Math.pow(tp, 2) / Math.pow(tp - tp2, 3));
             B = (tp - tp2) / (tp * tp2);
         }
@@ -128,12 +130,11 @@ public abstract class PulseShape {
                 time += dt;
             }
             
-            double a = Math.exp(-time/tp);
-            double a2 = Math.exp(-time/tp2);
+            double a = A*Math.exp(-time/tp)/peak_amp;
+            double a2 = A*Math.exp(-time/tp2)/peak_amp;
 
             for(; i< amplitudes.length; i++){
-                amplitudes[i] = A * (a
-                        - a2 * (1 + time * B + 0.5 * time * time * B*B))/peak_amp;
+                amplitudes[i] = a - a2 * (1 + time * B + 0.5 * time * time * B*B);
                 a*=b;
                 a2*=b2;
                 time += dt;

--- a/tracking/src/main/java/org/hps/recon/tracking/PulseShape.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/PulseShape.java
@@ -69,12 +69,11 @@ public abstract class PulseShape {
             tp = sensor.getShapeFitParameters(channel)[HpsSiSensor.TP_INDEX];
             tp2 = sensor.getShapeFitParameters(channel)[HpsSiSensor.TP_INDEX + 1];
             peak_t = 3.0 * Math.pow(tp * Math.pow(tp2, 3), 0.25); //approximate solution to exp(x)=1+x+x^2*tp/(2*tp2), where x=(1/tp2-1/tp)*t
-            peak_amp = getAmplitudeIntegralNorm(peak_t);
-            
-            //System.out.println(tp + "  " + tp2);
             
             A = (Math.pow(tp, 2) / Math.pow(tp - tp2, 3));
             B = (tp - tp2) / (tp * tp2);
+            peak_amp = getAmplitudeIntegralNorm(peak_t);
+            
         }
 
         @Override

--- a/tracking/src/main/java/org/hps/recon/tracking/PulseShape.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/PulseShape.java
@@ -48,12 +48,18 @@ public abstract class PulseShape {
         private double tp2;
         private double peak_t, peak_amp;
 
+        //combinations of tp and tp2:
+        private double A, B;
+        
         @Override
         public void setParameters(int channel, HpsSiSensor sensor) {
             tp = sensor.getShapeFitParameters(channel)[HpsSiSensor.TP_INDEX];
             tp2 = sensor.getShapeFitParameters(channel)[HpsSiSensor.TP_INDEX + 1];
             peak_t = 3.0 * Math.pow(tp * Math.pow(tp2, 3), 0.25); //approximate solution to exp(x)=1+x+x^2*tp/(2*tp2), where x=(1/tp2-1/tp)*t
             peak_amp = getAmplitudeIntegralNorm(peak_t);
+            
+            A = (Math.pow(tp, 2) / Math.pow(tp - tp2, 3));
+            B = (tp - tp2) / (tp * tp2);
         }
 
         @Override
@@ -62,9 +68,14 @@ public abstract class PulseShape {
                 return 0;
             }
             //===> return (time / channelConstants.getTp()) * Math.exp(1 - time / channelConstants.getTp());
-            return (Math.pow(tp, 2) / Math.pow(tp - tp2, 3))
-                    * (Math.exp(-time / tp)
-                    - Math.exp(-time / tp2) * (1 + time * (tp - tp2) / (tp * tp2) + 0.5 * Math.pow(time * (tp - tp2) / (tp * tp2), 2)));
+            //return (Math.pow(tp, 2) / Math.pow(tp - tp2, 3))
+            //        * (Math.exp(-time / tp)
+            //        - Math.exp(-time / tp2) * (1 + time * (tp - tp2) / (tp * tp2) + 0.5 * Math.pow(time * (tp - tp2) / (tp * tp2), 2)));
+            
+            return A * (Math.exp(-time / tp)
+                            - Math.exp(-time / tp2) * (1 + time * B + 0.5 * time * time * B*B));
+                    
+            
 //            return (time / tp) * Math.exp(1 - time / tp);
         }
 

--- a/tracking/src/main/java/org/hps/recon/tracking/PulseShape.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/PulseShape.java
@@ -14,6 +14,19 @@ public abstract class PulseShape {
     public abstract double getAmplitudePeakNorm(double time);
 
     public abstract double getAmplitudeIntegralNorm(double time);
+    
+    /**
+     * convenience method for getting amplitudes at multiple evenly spaced 
+     * time intervals
+     * @param t0
+     * @param dt
+     * @param amplitudes
+     */
+    public void getAmplitudesPeakNorm(double t0, double dt, double[] amplitudes){
+        for(int i = amplitudes.length-1; i>=0; i--){
+            amplitudes[i] = getAmplitudePeakNorm(t0+dt*i);
+        }
+    }
 
 //    public abstract double getAmplitude(double time, int channel, HpsSiSensor sensor);
     public static class CRRC extends PulseShape {
@@ -96,6 +109,38 @@ public abstract class PulseShape {
             
             return A * (Math.exp(-time / tp)
                     - Math.exp(-time / tp2) * (1 + time * B + 0.5 * time * time * B*B))/peak_amp;
+        }
+        
+        @Override
+        public void getAmplitudesPeakNorm(double t0, double dt, double[] amplitudes) {
+            
+            
+            double b = Math.exp(-dt/tp);
+            double b2 = Math.exp(-dt/tp2);
+            
+            double time = t0;
+            int i;
+            for(i = 0; i< amplitudes.length; i++){
+                if(time < 0) 
+                    amplitudes[i]= 0;
+                else
+                    break;
+                time += dt;
+            }
+            
+            double a = Math.exp(-time/tp);
+            double a2 = Math.exp(-time/tp2);
+
+            for(; i< amplitudes.length; i++){
+                amplitudes[i] = A * (a
+                        - a2 * (1 + time * B + 0.5 * time * time * B*B))/peak_amp;
+                a*=b;
+                a2*=b2;
+                time += dt;
+                //if(Math.abs(amplitudes[i]-getAmplitudePeakNorm(t0+i*dt))>1e-10)
+                  //      System.out.println(amplitudes[i]+ " " + getAmplitudePeakNorm(t0+i*dt)  + " " + (amplitudes[i]-getAmplitudePeakNorm(t0+i*dt)));
+            }
+            
         }
     }
 }

--- a/tracking/src/main/java/org/hps/recon/tracking/PulseShape.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/PulseShape.java
@@ -81,7 +81,21 @@ public abstract class PulseShape {
 
         @Override
         public double getAmplitudePeakNorm(double time) {
-            return getAmplitudeIntegralNorm(time) / peak_amp;
+            //return getAmplitudeIntegralNorm(time) / peak_amp;
+            
+            //avoid extra function-calls to increase speed.
+            // I am only doing this optimization because the profiler told me that
+            // this is where almost a third of our processing time is found. --SJP.
+            
+            
+            //returned value is equal to getAmplitudeIntegralNorm(time) / peak_amp;
+            
+            if (time < 0) {
+                return 0;
+            }
+            
+            return A * (Math.exp(-time / tp)
+                    - Math.exp(-time / tp2) * (1 + time * B + 0.5 * time * time * B*B))/peak_amp;
         }
     }
 }

--- a/tracking/src/main/java/org/hps/recon/tracking/ShaperLinearFitAlgorithm.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/ShaperLinearFitAlgorithm.java
@@ -368,29 +368,29 @@ public class ShaperLinearFitAlgorithm implements ShaperFitAlgorithm, FCNBase {
 
         for (int j = 0; j < nUsedSamples; j++) {
             double sigma_j = sigma[firstUsedSample + j];
-            double sample_time = HPSSVTConstants.SAMPLING_INTERVAL * (firstUsedSample + j);
+            /*double sample_time = HPSSVTConstants.SAMPLING_INTERVAL * (firstUsedSample + j);
             for (int i = 0; i < nFittedPulses; i++) {
                 //===> sc_mat.setEntry(i, j, getAmplitude(HPSSVTConstants.SAMPLING_INTERVAL * (firstUsedSample + j) - times[i], channelConstants) / sigma[firstUsedSample + j]);
                 sc_mat.setEntry(i, j, shape.getAmplitudePeakNorm(sample_time - times[i]) / sigma_j);
-            }
+            }*/
             if (fitPedestal) {
                 sc_mat.setEntry(nFittedPulses, j, 1.0 / sigma_j);
             }
             y_vec.setEntry(j, y[firstUsedSample + j] / sigma_j);
             var_vec.setEntry(j, sigma_j * sigma_j);
         }
-
-        double[] amplitudes = new double[nUsedSamples];
+        // amplitudez is spelled with a zed for a reazon.  Changing the spelling to use an "s" will break the code.  believe me I tried.      
+        double[] amplitudez = new double[nUsedSamples];
         for(int i = 0; i< nFittedPulses; i++){
             double t0 = HPSSVTConstants.SAMPLING_INTERVAL * firstUsedSample - times[i];
-            shape.getAmplitudesPeakNorm(t0, HPSSVTConstants.SAMPLING_INTERVAL, amplitudes);
+            shape.getAmplitudesPeakNorm(t0, HPSSVTConstants.SAMPLING_INTERVAL, amplitudez);
            
             for(int j = 0; j<nUsedSamples; j++){
                 
-                double err = amplitudes[j]/sigma[firstUsedSample+j]-sc_mat.getEntry(i, j);
-                if(Math.abs(err) > 1e-10)
-                    System.out.println(amplitudes[j]/sigma[firstUsedSample + j] + " " + err);
-                //sc_mat.setEntry(i, j, amplitudes[j] / sigma[firstUsedSample + j]);
+                //double err = amplitudes[j]/sigma[firstUsedSample+j]-sc_mat.getEntry(i, j);
+                //if(Math.abs(err) > 1e-10)
+                    //System.out.println(amplitudes[j]/sigma[firstUsedSample + j] + " " + err);
+                sc_mat.setEntry(i, j, amplitudez[j] / sigma[firstUsedSample + j]);
             }
         }
         RealVector a_vec = sc_mat.operate(y_vec);

--- a/tracking/src/main/java/org/hps/recon/tracking/ShaperLinearFitAlgorithm.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/ShaperLinearFitAlgorithm.java
@@ -379,6 +379,20 @@ public class ShaperLinearFitAlgorithm implements ShaperFitAlgorithm, FCNBase {
             y_vec.setEntry(j, y[firstUsedSample + j] / sigma_j);
             var_vec.setEntry(j, sigma_j * sigma_j);
         }
+
+        double[] amplitudes = new double[nUsedSamples];
+        for(int i = 0; i< nFittedPulses; i++){
+            double t0 = HPSSVTConstants.SAMPLING_INTERVAL * firstUsedSample - times[i];
+            shape.getAmplitudesPeakNorm(t0, HPSSVTConstants.SAMPLING_INTERVAL, amplitudes);
+           
+            for(int j = 0; j<nUsedSamples; j++){
+                
+                double err = amplitudes[j]/sigma[firstUsedSample+j]-sc_mat.getEntry(i, j);
+                if(Math.abs(err) > 1e-10)
+                    System.out.println(amplitudes[j]/sigma[firstUsedSample + j] + " " + err);
+                //sc_mat.setEntry(i, j, amplitudes[j] / sigma[firstUsedSample + j]);
+            }
+        }
         RealVector a_vec = sc_mat.operate(y_vec);
         RealMatrix coeff_mat = sc_mat.multiply(sc_mat.transpose());
         DecompositionSolver a_solver;

--- a/tracking/src/main/java/org/hps/recon/tracking/ShaperLinearFitAlgorithm.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/ShaperLinearFitAlgorithm.java
@@ -367,15 +367,17 @@ public class ShaperLinearFitAlgorithm implements ShaperFitAlgorithm, FCNBase {
         RealVector var_vec = new ArrayRealVector(nUsedSamples);
 
         for (int j = 0; j < nUsedSamples; j++) {
+            double sigma_j = sigma[firstUsedSample + j];
+            double sample_time = HPSSVTConstants.SAMPLING_INTERVAL * (firstUsedSample + j);
             for (int i = 0; i < nFittedPulses; i++) {
                 //===> sc_mat.setEntry(i, j, getAmplitude(HPSSVTConstants.SAMPLING_INTERVAL * (firstUsedSample + j) - times[i], channelConstants) / sigma[firstUsedSample + j]);
-                sc_mat.setEntry(i, j, shape.getAmplitudePeakNorm(HPSSVTConstants.SAMPLING_INTERVAL * (firstUsedSample + j) - times[i]) / sigma[firstUsedSample + j]);
+                sc_mat.setEntry(i, j, shape.getAmplitudePeakNorm(sample_time - times[i]) / sigma_j);
             }
             if (fitPedestal) {
-                sc_mat.setEntry(nFittedPulses, j, 1.0 / sigma[firstUsedSample + j]);
+                sc_mat.setEntry(nFittedPulses, j, 1.0 / sigma_j);
             }
-            y_vec.setEntry(j, y[firstUsedSample + j] / sigma[firstUsedSample + j]);
-            var_vec.setEntry(j, sigma[firstUsedSample + j] * sigma[firstUsedSample + j]);
+            y_vec.setEntry(j, y[firstUsedSample + j] / sigma_j);
+            var_vec.setEntry(j, sigma_j * sigma_j);
         }
         RealVector a_vec = sc_mat.operate(y_vec);
         RealMatrix coeff_mat = sc_mat.multiply(sc_mat.transpose());


### PR DESCRIPTION
The "a" stands for a more "aggressive approach" to improving pulse fitting than the original iss118 branch has.  Basically, calculates the estimated amplitudes for all the samples in a single function, in such a way that it reduces the number of calls to Math.exp().  This is in addition to the improvements that are in branch 118.