### PR TITLE
 RewriteFlagsDriver was removed from MakeTuples2016.lcsim

### DIFF
--- a/steering-files/src/main/resources/org/hps/steering/analysis/MakeTuples2016.lcsim
+++ b/steering-files/src/main/resources/org/hps/steering/analysis/MakeTuples2016.lcsim
@@ -3,7 +3,6 @@
     <execute>
         <driver name="EventMarkerDriver"/>
         <driver name="CleanupDriver"/>
-        <driver name="RewriteFlagsDriver"/>
         <driver name="EventFlagFilter"/>
         <driver name="RawTrackerHitSensorSetup"/>
     
@@ -16,7 +15,6 @@
             <eventInterval>1000</eventInterval>
         </driver>        
         <driver name="CleanupDriver" type="org.lcsim.recon.tracking.digitization.sisim.config.ReadoutCleanupDriver"/>
-        <driver name="RewriteFlagsDriver" type = "org.hps.users.holly.RewriteFlagsDriver" />
         <driver name="EventFlagFilter" type="org.hps.recon.filtering.EventFlagFilter">
             <flagNames>svt_bias_good svt_burstmode_noise_good svt_event_header_good</flagNames>
         </driver>


### PR DESCRIPTION
ntuplemaker was crushing with a new release, while with a tpass1c it didn't crush.
It was trying to call a driver from users directory
org.hps.users.holly.RewriteFlagsDriver
Sebouh mention that users were completely removed from the 3.11 release.

As Sebouh suggested, RewriteFlagsDriver is removed from MakeTuples2016.lcsim,
now it seems to work again