### PR TITLE
Iss65b: Track Ambiguity-Resolver

### DIFF
--- a/tracking/src/main/java/org/hps/recon/tracking/TrackerReconDriver.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/TrackerReconDriver.java
@@ -34,45 +34,45 @@ public final class TrackerReconDriver extends Driver {
     private static final Logger LOGGER = Logger.getLogger(TrackerReconDriver.class.getPackage().getName());
 
     private String subdetectorName = "Tracker";
-
+    
     // Debug flag.
     private boolean debug = false;
-
+    
     // Tracks found across all events.
     int ntracks = 0;
-
+    
     // Number of events processed.
     int nevents = 0;
-
+    
     // Cache detector object.
     Detector detector = null;
-
+    
     // Default B-field value.
     private double bfield = 0.5;
-
+    
     // Tracking strategies resource path.
     private String strategyResource = "HPS-Test-4pt1.xml";
-
+    
     // Output track collection.
     private String trackCollectionName = "MatchedTracks";
-
+    
     // HelicalTrackHit input collection.
     private String stInputCollectionName = "RotatedHelicalTrackHits";
-
+    
     // Include MS (done by removing XPlanes from the material manager results)
     private boolean includeMS = true;
-
+    
     // number of repetitive fits on confirmed/extended tracks
     private int _iterativeConfirmed = 3;
-
+    
     // use HPS implementation of material manager
     private boolean _useHPSMaterialManager = true;
-
+    
     // enable the use of sectoring using sector binning in SeedTracker
     private boolean _applySectorBinning = true;
-
+    
     private double rmsTimeCut = -1;
-
+    
     private boolean rejectUncorrectedHits = true;
 
     public TrackerReconDriver() {
@@ -81,7 +81,7 @@ public final class TrackerReconDriver extends Driver {
     public void setDebug(boolean debug) {
         this.debug = debug;
     }
-
+    
     public void setSubdetectorName(String subdetectorName) {
         this.subdetectorName = subdetectorName;
     }
@@ -194,7 +194,7 @@ public final class TrackerReconDriver extends Driver {
             HitTimeTrackCheck timeCheck = new HitTimeTrackCheck(rmsTimeCut);
             timeCheck.setDebug(debug);
             stFinal.setTrackCheck(timeCheck);
-        }
+        }    
     }
 
     /**
@@ -230,7 +230,8 @@ public final class TrackerReconDriver extends Driver {
 
         if (rejectUncorrectedHits) {
             Iterator<Track> iter = tracks.iterator();
-            trackLoop: while (iter.hasNext()) {
+            trackLoop: 
+            while (iter.hasNext()) {
                 Track track = iter.next();
                 for (TrackerHit hit : track.getTrackerHits()) {
                     HelicalTrackHit hth = (HelicalTrackHit) hit;

--- a/tracking/src/main/java/org/hps/recon/tracking/TrackerReconDriver.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/TrackerReconDriver.java
@@ -4,16 +4,11 @@ import hep.physics.vec.BasicHep3Vector;
 import hep.physics.vec.Hep3Vector;
 import hep.physics.vec.VecOp;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 import java.util.logging.Logger;
 
 import org.lcsim.event.EventHeader;
-import org.lcsim.event.RelationalTable;
 import org.lcsim.event.Track;
 import org.lcsim.event.TrackerHit;
 import org.lcsim.event.base.BaseTrack;
@@ -30,6 +25,8 @@ import org.lcsim.util.Driver;
  * with the {@link TrackerDigiDriver} digitization Driver.
  *
  * @author Matt Graham
+ * @author Miriam Diamond <mdiamond@slac.stanford.edu>
+ * 
  */
 // FIXME: Printing to System.out should be converted to use logger.
 public final class TrackerReconDriver extends Driver {
@@ -37,48 +34,46 @@ public final class TrackerReconDriver extends Driver {
     private static final Logger LOGGER = Logger.getLogger(TrackerReconDriver.class.getPackage().getName());
 
     private String subdetectorName = "Tracker";
-    
+
     // Debug flag.
     private boolean debug = false;
-    
+
     // Tracks found across all events.
     int ntracks = 0;
-    
+
     // Number of events processed.
     int nevents = 0;
-    
+
     // Cache detector object.
     Detector detector = null;
-    
+
     // Default B-field value.
     private double bfield = 0.5;
-    
+
     // Tracking strategies resource path.
     private String strategyResource = "HPS-Test-4pt1.xml";
-    
+
     // Output track collection.
     private String trackCollectionName = "MatchedTracks";
-    
+
     // HelicalTrackHit input collection.
     private String stInputCollectionName = "RotatedHelicalTrackHits";
-    
+
     // Include MS (done by removing XPlanes from the material manager results)
     private boolean includeMS = true;
-    
+
     // number of repetitive fits on confirmed/extended tracks
     private int _iterativeConfirmed = 3;
-    
+
     // use HPS implementation of material manager
     private boolean _useHPSMaterialManager = true;
-    
+
     // enable the use of sectoring using sector binning in SeedTracker
     private boolean _applySectorBinning = true;
-    
+
     private double rmsTimeCut = -1;
-    
+
     private boolean rejectUncorrectedHits = true;
-    
-    private boolean rejectSharedHits = false;
 
     public TrackerReconDriver() {
     }
@@ -86,7 +81,7 @@ public final class TrackerReconDriver extends Driver {
     public void setDebug(boolean debug) {
         this.debug = debug;
     }
-    
+
     public void setSubdetectorName(String subdetectorName) {
         this.subdetectorName = subdetectorName;
     }
@@ -149,10 +144,6 @@ public final class TrackerReconDriver extends Driver {
         this.rejectUncorrectedHits = rejectUncorrectedHits;
     }
 
-    public void setRejectSharedHits(boolean rejectSharedHits) {
-        this.rejectSharedHits = rejectSharedHits;
-    }
-
     /**
      * This is used to setup the Drivers after XML config.
      */
@@ -203,7 +194,7 @@ public final class TrackerReconDriver extends Driver {
             HitTimeTrackCheck timeCheck = new HitTimeTrackCheck(rmsTimeCut);
             timeCheck.setDebug(debug);
             stFinal.setTrackCheck(timeCheck);
-        }        
+        }
     }
 
     /**
@@ -239,8 +230,7 @@ public final class TrackerReconDriver extends Driver {
 
         if (rejectUncorrectedHits) {
             Iterator<Track> iter = tracks.iterator();
-            trackLoop:
-            while (iter.hasNext()) {
+            trackLoop: while (iter.hasNext()) {
                 Track track = iter.next();
                 for (TrackerHit hit : track.getTrackerHits()) {
                     HelicalTrackHit hth = (HelicalTrackHit) hit;
@@ -250,46 +240,6 @@ public final class TrackerReconDriver extends Driver {
                         this.getLogger().warning(String.format("Discarding track with bad HelicalTrackHit (correction distance %f, chisq penalty %f)", correction, chisq));
                         iter.remove();
                         continue trackLoop;
-                    }
-                }
-            }
-        }
-
-        if (rejectSharedHits) {
-            RelationalTable hitToStrips = TrackUtils.getHitToStripsTable(event);
-            RelationalTable hitToRotated = TrackUtils.getHitToRotatedTable(event);
-
-            Map<TrackerHit, List<Track>> stripsToTracks = new HashMap<TrackerHit, List<Track>>();
-            for (Track track : tracks) {
-                for (TrackerHit hit : track.getTrackerHits()) {
-                    Collection<TrackerHit> htsList = hitToStrips.allFrom(hitToRotated.from(hit));
-                    for (TrackerHit strip : htsList) {
-                        List<Track> sharedTracks = stripsToTracks.get(strip);
-                        if (sharedTracks == null) {
-                            sharedTracks = new ArrayList<Track>();
-                            stripsToTracks.put(strip, sharedTracks);
-                        }
-                        sharedTracks.add(track);
-                    }
-                }
-            }
-            Iterator<Track> iter = tracks.iterator();
-            trackLoop:
-            while (iter.hasNext()) {
-                Track track = iter.next();
-                for (TrackerHit hit : track.getTrackerHits()) {
-                    Collection<TrackerHit> htsList = hitToStrips.allFrom(hitToRotated.from(hit));
-                    for (TrackerHit strip : htsList) {
-                        List<Track> sharedTracks = stripsToTracks.get(strip);
-                        if (sharedTracks.size() > 1) {
-                            for (Track otherTrack : sharedTracks) {
-                                if (otherTrack.getChi2() < track.getChi2()) {
-                                    this.getLogger().warning(String.format("removing track with shared hits: chisq %f, d0 %f (other track has chisq %f)", track.getChi2(), track.getTrackStates().get(0).getD0(), otherTrack.getChi2()));
-                                    iter.remove();
-                                    continue trackLoop;
-                                }
-                            }
-                        }
                     }
                 }
             }

--- a/tracking/src/main/java/org/hps/recon/tracking/TrackerReconDriver.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/TrackerReconDriver.java
@@ -194,7 +194,7 @@ public final class TrackerReconDriver extends Driver {
             HitTimeTrackCheck timeCheck = new HitTimeTrackCheck(rmsTimeCut);
             timeCheck.setDebug(debug);
             stFinal.setTrackCheck(timeCheck);
-        }    
+        }        
     }
 
     /**
@@ -230,7 +230,7 @@ public final class TrackerReconDriver extends Driver {
 
         if (rejectUncorrectedHits) {
             Iterator<Track> iter = tracks.iterator();
-            trackLoop: 
+            trackLoop:
             while (iter.hasNext()) {
                 Track track = iter.next();
                 for (TrackerHit hit : track.getTrackerHits()) {

--- a/tracking/src/main/java/org/hps/recon/tracking/gbl/GBLRefitterDriver.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/gbl/GBLRefitterDriver.java
@@ -2,10 +2,8 @@ package org.hps.recon.tracking.gbl;
 
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import org.apache.commons.math3.util.Pair;
 import org.hps.recon.tracking.MaterialSupervisor;
 import org.hps.recon.tracking.MultipleScattering;
@@ -21,7 +19,6 @@ import org.lcsim.event.LCRelation;
 import org.lcsim.event.RawTrackerHit;
 import org.lcsim.event.RelationalTable;
 import org.lcsim.event.Track;
-import org.lcsim.event.TrackerHit;
 import org.lcsim.event.base.BaseLCRelation;
 import org.lcsim.geometry.Detector;
 import org.lcsim.lcio.LCIOConstants;
@@ -39,7 +36,6 @@ public class GBLRefitterDriver extends Driver {
 
     private double bfield;
     private final MultipleScattering _scattering = new MultipleScattering(new MaterialSupervisor());
-    private boolean mergeTracks = false;
 
     public void setInputCollectionName(String inputCollectionName) {
         this.inputCollectionName = inputCollectionName;
@@ -47,16 +43,6 @@ public class GBLRefitterDriver extends Driver {
 
     public void setOutputCollectionName(String outputCollectionName) {
         this.outputCollectionName = outputCollectionName;
-    }
-
-    /**
-     * Merge tracks with overlapping hit content. Right now nothing actually
-     * happens to the merged tracks; this is just for testing.
-     *
-     * @param mergeTracks default to false
-     */
-    public void setMergeTracks(boolean mergeTracks) {
-        this.mergeTracks = mergeTracks;
     }
 
     @Override
@@ -85,7 +71,6 @@ public class GBLRefitterDriver extends Driver {
         Map<Track, Track> inputToRefitted = new HashMap<Track, Track>();
         for (Track track : tracks) {
             Pair<Track, GBLKinkData> newTrack = MakeGblTracks.refitTrack(TrackUtils.getHTF(track), TrackUtils.getStripHits(track, hitToStrips, hitToRotated), track.getTrackerHits(), 5, track.getType(), _scattering, bfield);
-//            newTrack.getFirst().
             refittedTracks.add(newTrack.getFirst());
             trackRelations.add(new BaseLCRelation(track, newTrack.getFirst()));
             inputToRefitted.put(track, newTrack.getFirst());
@@ -94,60 +79,6 @@ public class GBLRefitterDriver extends Driver {
             kinkDataRelations.add(new BaseLCRelation(newTrack.getSecond(), newTrack.getFirst()));
         }
 
-        if (mergeTracks) {
-            List<Track> mergedTracks = new ArrayList<Track>();
-
-            for (Track track : refittedTracks) {
-                List<TrackerHit> trackHth = track.getTrackerHits();
-                otherTrackLoop:
-                for (Track otherTrack : refittedTracks) {
-                    if (track == otherTrack) {
-                        continue;
-                    }
-
-                    Set<TrackerHit> allHth = new HashSet<TrackerHit>(otherTrack.getTrackerHits());
-                    allHth.addAll(trackHth);
-//                if (allHth.size() == trackHth.size()) {
-//                    continue;
-//                }
-
-                    boolean[] hasHit = new boolean[6];
-
-                    for (TrackerHit hit : allHth) {
-                        int layer = (TrackUtils.getLayer(hit) - 1) / 2;
-                        if (hasHit[layer]) {
-                            continue otherTrackLoop;
-                        }
-                        hasHit[layer] = true;
-                    }
-                    for (Track mergedTrack : mergedTracks) {
-                        if (mergedTrack.getTrackerHits().containsAll(allHth)) {
-                            continue otherTrackLoop;
-                        }
-                    }
-
-                    Pair<Track, GBLKinkData> mergedTrack = MakeGblTracks.refitTrack(TrackUtils.getHTF(track), TrackUtils.getStripHits(track, hitToStrips, hitToRotated), allHth, 5, track.getType(), _scattering, bfield);
-                    mergedTracks.add(mergedTrack.getFirst());
-//                    System.out.format("%f %f %f\n", fit.get_chi2(), inputToRefitted.get(track).getChi2(), inputToRefitted.get(otherTrack).getChi2());
-//                mergedTrackToTrackList.put(mergedTrack, new ArrayList<Track>());
-                }
-            }
-
-            for (Track mergedTrack : mergedTracks) {
-                List<Track> subTracks = new ArrayList<Track>();
-                Set<TrackerHit> trackHth = new HashSet<TrackerHit>(mergedTrack.getTrackerHits());
-                for (Track track : refittedTracks) {
-                    if (trackHth.containsAll(track.getTrackerHits())) {
-                        subTracks.add(track);
-                    }
-                }
-                System.out.format("%f:\t", mergedTrack.getChi2());
-                for (Track subTrack : subTracks) {
-                    System.out.format("%f (%d)\t", subTrack.getChi2(), subTrack.getTrackerHits().size());
-                }
-                System.out.println();
-            }
-        }
         // Put the tracks back into the event and exit
         int flag = 1 << LCIOConstants.TRBIT_HITS;
         event.put(outputCollectionName, refittedTracks, Track.class, flag);
@@ -156,8 +87,7 @@ public class GBLRefitterDriver extends Driver {
         event.put(GBLKinkData.DATA_RELATION_COLLECTION, kinkDataRelations, LCRelation.class, 0);
     }
 
-    private void setupSensors(EventHeader event)
-    {
+    private void setupSensors(EventHeader event) {
         List<RawTrackerHit> rawTrackerHits = null;
         if (event.hasCollection(RawTrackerHit.class, "SVTRawTrackerHits")) {
             rawTrackerHits = event.get(RawTrackerHit.class, "SVTRawTrackerHits");

--- a/tracking/src/main/java/org/hps/recon/tracking/gbl/GBLRefitterDriver.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/gbl/GBLRefitterDriver.java
@@ -71,10 +71,7 @@ public class GBLRefitterDriver extends Driver {
         Map<Track, Track> inputToRefitted = new HashMap<Track, Track>();
         for (Track track : tracks) {
             Pair<Track, GBLKinkData> newTrack = MakeGblTracks.refitTrack(TrackUtils.getHTF(track), TrackUtils.getStripHits(track, hitToStrips, hitToRotated), track.getTrackerHits(), 5, track.getType(), _scattering, bfield);
-<<<<<<< HEAD
             //            newTrack.getFirst().
-=======
->>>>>>> issue65b
             refittedTracks.add(newTrack.getFirst());
             trackRelations.add(new BaseLCRelation(track, newTrack.getFirst()));
             inputToRefitted.put(track, newTrack.getFirst());


### PR DESCRIPTION
I've found a few more drivers that include ad-hoc methods to do some basic ambiguity-solving work (e.g. removing duplicate/shared tracks).   branch iss65b removes these old methods, such that all ambiguity-solving is done only in MergeTrackCollections driver using the proper solver.