### PR TITLE
Iss134b: upgraded tracking unit tests

### DIFF
--- a/tracking/src/test/java/org/hps/recon/tracking/ComparisonTest.java
+++ b/tracking/src/test/java/org/hps/recon/tracking/ComparisonTest.java
@@ -36,6 +36,7 @@ public class ComparisonTest extends ReconTestSkeleton {
         testTrackingDriver = new TrackingReconstructionPlots();
         ((TrackingReconstructionPlots) testTrackingDriver).setOutputPlots(aidaOutputFile.getPath());
         ((TrackingReconstructionPlots) testTrackingDriver).aida = aida;
+        ((TrackingReconstructionPlots) testTrackingDriver).setDoResidualPlots(true);
         super.testRecon();
 
         IHistogram1D ntracks = aida.histogram1D("Tracks per Event");

--- a/tracking/src/test/java/org/hps/recon/tracking/ReconTestSkeleton.java
+++ b/tracking/src/test/java/org/hps/recon/tracking/ReconTestSkeleton.java
@@ -27,7 +27,7 @@ public class ReconTestSkeleton extends TestCase {
         System.getProperties().setProperty("hep.aida.IAnalysisFactory", "hep.aida.ref.BatchAnalysisFactory");
     }
     protected String testInputFileName = "ap_prompt_raw.slcio";
-    protected String testOutputFileName = "RecoTest_" + testInputFileName;
+    protected String testOutputFileName;
     protected String testURLBase = "http://www.lcsim.org/test/hps-java";
     protected long nEvents = -1;
     protected URL testURL;
@@ -45,6 +45,7 @@ public class ReconTestSkeleton extends TestCase {
             inputFile = cache.getCachedFile(testURL);
         }
 
+        testOutputFileName = "RecoTest_" + testInputFileName;
         File outputFile = new TestOutputFile(testOutputFileName);
         outputFile.getParentFile().mkdirs();
         boolean loop1Success = true;

--- a/tracking/src/test/java/org/hps/recon/tracking/ReconTestSkeleton.java
+++ b/tracking/src/test/java/org/hps/recon/tracking/ReconTestSkeleton.java
@@ -110,12 +110,6 @@ public class ReconTestSkeleton extends TestCase {
             hthd.setMaxDt(16.0);
             add(hthd);
 
-            org.hps.recon.tracking.TrackerReconDriver trd = new org.hps.recon.tracking.TrackerReconDriver();
-            trd.setStrategyResource("HPS_s123_c5_e46.xml");
-            trd.setRmsTimeCut(8.0);
-            trd.setTrackCollectionName("s123_c5_e46");
-            add(trd);
-
             org.hps.recon.tracking.TrackerReconDriver trd2 = new org.hps.recon.tracking.TrackerReconDriver();
             trd2.setStrategyResource("HPS_s123_c4_e56.xml");
             trd2.setRmsTimeCut(8.0);
@@ -136,7 +130,7 @@ public class ReconTestSkeleton extends TestCase {
 
             org.hps.recon.tracking.MergeTrackCollections mtc = new org.hps.recon.tracking.MergeTrackCollections();
             mtc.setInputTrackCollectionName("");
-            mtc.setRemoveCollections(false);
+            mtc.setRemoveCollections(true);
             add(mtc);
 
             add(new org.hps.recon.tracking.gbl.GBLRefitterDriver());

--- a/tracking/src/test/java/org/hps/recon/tracking/TruthResidualTest.java
+++ b/tracking/src/test/java/org/hps/recon/tracking/TruthResidualTest.java
@@ -25,8 +25,8 @@ import org.lcsim.util.aida.AIDA;
 public class TruthResidualTest extends ReconTestSkeleton {
     static final String inputFileName = "ap_prompt_raw.slcio";
     private AIDA aida;
-    private static final double maxResMean = 1.0; //in mm 
-    private static final double maxResRMS = 1.0; //in mm 
+    private static final double maxResMean = 0.05; //in mm 
+    private static final double maxResRMS = 0.05; //in mm 
 
     public void testRecon() throws Exception {
 


### PR DESCRIPTION
I have just upgraded the tests, in branch iss134b. There are now proper track residuals (I hadn't been able to get these working before).
Updated versions of reference plots (http://www.lcsim.org/test/hps-java/referencePlots/ap_prompt-ref.aida , http://www.lcsim.org/test/hps-java/referencePlots/hps_005772-ref.aida) go with these.