### PR TITLE
Iss82: SVT alignment constants must be explicitly enabled when building detector

### DIFF
--- a/detector-model/src/main/java/org/lcsim/geometry/compact/converter/HPSTrackerBuilder.java
+++ b/detector-model/src/main/java/org/lcsim/geometry/compact/converter/HPSTrackerBuilder.java
@@ -10,10 +10,8 @@ import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.hps.conditions.database.DatabaseConditionsManager;
 import org.jdom.DataConversionException;
 import org.jdom.Element;
-import org.lcsim.conditions.ConditionsManager;
 import org.lcsim.detector.Transform3D;
 import org.lcsim.geometry.compact.converter.HPSTestRunTracker2014GeometryDefinition.BaseModule;
 


### PR DESCRIPTION
The system property `org.hps.conditions.enableSvtAlignmentConstants` must be set to enable reading of SVT alignment constants from the database.  Otherwise, the constants from the compact.xml file are used.

This replaces the `disableSvtAlignmentConstants` property which no longer has any effect.