### PR TITLE
add space between log level and name

### DIFF
--- a/logging/src/main/resources/org/hps/logging/config/logging.properties
+++ b/logging/src/main/resources/org/hps/logging/config/logging.properties
@@ -16,7 +16,7 @@ handlers = java.util.logging.ConsoleHandler
 
 # New simplified format
 # [LEVEL][LOGGER] MESSAGE
-java.util.logging.SimpleFormatter.format = [%4$s][%3$s] %5$s%6$s%n
+java.util.logging.SimpleFormatter.format = [%4$s] [%3$s] %5$s%6$s%n
 
 # configure the console handler
 java.util.logging.ConsoleHandler.level = ALL

--- a/logging/src/main/resources/org/hps/logging/config/test_logging.properties
+++ b/logging/src/main/resources/org/hps/logging/config/test_logging.properties
@@ -16,7 +16,7 @@ handlers = java.util.logging.ConsoleHandler
 
 # New simplified format
 # [LEVEL][LOGGER] MESSAGE
-java.util.logging.SimpleFormatter.format = [%4$s][%3$s] %5$s%6$s%n
+java.util.logging.SimpleFormatter.format = [%4$s] [%3$s] %5$s%6$s%n
 
 # configure the console handler
 java.util.logging.ConsoleHandler.level = ALL


### PR DESCRIPTION
Add space between level and logger name in output for awk and friends.