### PR TITLE
Iss126: cuts for track seeding

### DIFF
--- a/tracking/src/main/java/org/hps/recon/tracking/FastCheck.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/FastCheck.java
@@ -15,8 +15,6 @@ import org.lcsim.recon.tracking.seedtracker.SeedCandidate;
 import org.lcsim.recon.tracking.seedtracker.SeedStrategy;
 import org.lcsim.recon.tracking.seedtracker.diagnostic.ISeedTrackerDiagnostics;
 
-//import org.lcsim.util.aida.AIDA;
-
 /**
  * HPS version of LCSim class
  * @author Richard Partridge
@@ -30,12 +28,10 @@ public class FastCheck extends org.lcsim.recon.tracking.seedtracker.FastCheck {
     private double _max_p;
     private double _min_dztot;
 
-    //private AIDA aida = AIDA.defaultInstance();
-
     public FastCheck(SeedStrategy strategy, double bfield, ISeedTrackerDiagnostics diag) {
         super(strategy, bfield, diag);
         _bfield = bfield;
-        setNSigErr(6);
+        setNSigErr(-1);
         setMax_p(1.1);
         setMin_dztot(0.05);
     }
@@ -254,6 +250,10 @@ public class FastCheck extends org.lcsim.recon.tracking.seedtracker.FastCheck {
         if (rcurv < super.getRMin())
             return false;
 
+        // stop checking here unless nsig is set to positive value
+        if (_nsigErr <= 0)
+            return true;
+
         //  Find the point of closest approach
         double x0 = xc * (1. - rcurv / rc);
         double y0 = yc * (1. - rcurv / rc);
@@ -363,22 +363,12 @@ public class FastCheck extends org.lcsim.recon.tracking.seedtracker.FastCheck {
             dztot = _min_dztot;
 
         double dzpred = Math.abs(zpred - z[1]);
-        //aida.histogram2D("DztotVsZpred_all").fill(dzpred, dztot);
-        //aida.histogram2D("MserrVsP").fill(pEstimate, mserr);
-        //if (dztot < 0.5 && dzpred < 0.5) {
-        //  aida.histogram2D("DztotVsP_low").fill(pEstimate, dztot);
-        // aida.histogram2D("ZpredVsP_low").fill(pEstimate, dzpred);
-        // aida.histogram2D("MserrVsP_low").fill(pEstimate, mserr);
-        //}
 
         // comparison of middle z to prediction including error
-        if (dzpred > dztot) {
-            // aida.histogram2D("DztotVsZpred_failed").fill(dzpred, dztot);
+        if (dzpred > dztot)
             return false;
-        }
 
         //  Passed all checks - success!
-        //aida.histogram2D("DztotVsZpred_passed").fill(dzpred, dztot);
         return true;
     }
 

--- a/tracking/src/main/java/org/hps/recon/tracking/FastCheck.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/FastCheck.java
@@ -235,6 +235,18 @@ public class FastCheck extends org.lcsim.recon.tracking.seedtracker.FastCheck {
         if (rcurv < super.getRMin())
             return false;
 
+        // find corrected hit positions
+        CorrectHitPosition(hit1, seed);
+        CorrectHitPosition(hit2, seed);
+        CorrectHitPosition(hit3, seed);
+        double zCorr[] = new double[3];
+        zCorr[0] = hit1.getCorrectedPosition().z();
+        zCorr[1] = hit2.getCorrectedPosition().z();
+        zCorr[2] = hit3.getCorrectedPosition().z();
+        ((HelicalTrackCross) hit1).resetTrackDirection();
+        ((HelicalTrackCross) hit2).resetTrackDirection();
+        ((HelicalTrackCross) hit3).resetTrackDirection();
+
         //  Find the point of closest approach
         double x0 = xc * (1. - rcurv / rc);
         double y0 = yc * (1. - rcurv / rc);
@@ -272,18 +284,6 @@ public class FastCheck extends org.lcsim.recon.tracking.seedtracker.FastCheck {
             if (s[i] < 0.)
                 s[i] += twopi * rcurv;
         }
-
-        // find corrected hit positions
-        CorrectHitPosition(hit1, seed);
-        CorrectHitPosition(hit2, seed);
-        CorrectHitPosition(hit3, seed);
-        double zCorr[] = new double[3];
-        zCorr[0] = hit1.getCorrectedPosition().z();
-        zCorr[1] = hit2.getCorrectedPosition().z();
-        zCorr[2] = hit3.getCorrectedPosition().z();
-        ((HelicalTrackCross) hit1).resetTrackDirection();
-        ((HelicalTrackCross) hit2).resetTrackDirection();
-        ((HelicalTrackCross) hit3).resetTrackDirection();
 
         //  Order the arc lengths and z info by increasing arc length
         for (int i = 0; i < 2; i++) {


### PR DESCRIPTION
By default, produces same tracking output as master (just skips some checks at track seeding stage that were almost never actually cutting out any seeds).  But has a new member of FastCheck, nsigErr, that can be set in order to apply extra cuts at this stage if desired. 
Integration tests: by default, creates 2657 instead of 2656 tracks in EngRun2015FeeReconTest (one extra track due to skipping checks at track seeding stage).  All other tests pass.