### PR TITLE
Iss224d : Store additional information in LCIO for fitted vertices

### DIFF
--- a/recon/src/main/java/org/hps/recon/particle/HpsReconParticleDriver.java
+++ b/recon/src/main/java/org/hps/recon/particle/HpsReconParticleDriver.java
@@ -119,7 +119,7 @@ public class HpsReconParticleDriver extends ReconParticleDriver {
     }
 
     private boolean _patchVertexTrackParameters = true;
-    private boolean _storeCovTrkMomList = true;
+    private boolean _storeCovTrkMomList = false;
 
     /**
      * Processes the track and cluster collections in the event into

--- a/recon/src/main/java/org/hps/recon/particle/HpsReconParticleDriver.java
+++ b/recon/src/main/java/org/hps/recon/particle/HpsReconParticleDriver.java
@@ -1,5 +1,6 @@
 package org.hps.recon.particle;
 
+import hep.physics.matrix.SymmetricMatrix;
 import hep.physics.vec.BasicHep3Vector;
 import hep.physics.vec.BasicHepLorentzVector;
 import hep.physics.vec.Hep3Vector;
@@ -15,12 +16,13 @@ import org.lcsim.event.ReconstructedParticle;
 import org.lcsim.event.Track;
 import org.lcsim.event.Vertex;
 import org.lcsim.event.base.BaseReconstructedParticle;
-import org.hps.recon.tracking.CoordinateTransformations;
 import org.hps.recon.tracking.TrackType;
 import org.hps.recon.tracking.TrackUtils;
 import org.hps.recon.vertexing.BilliorTrack;
 import org.hps.recon.vertexing.BilliorVertex;
 import org.hps.recon.vertexing.BilliorVertexer;
+import org.lcsim.event.TrackState;
+import org.lcsim.event.base.BaseTrackState;
 import org.lcsim.fit.helicaltrack.HelicalTrackFit;
 import org.lcsim.fit.helicaltrack.HelixUtils;
 
@@ -115,14 +117,9 @@ public class HpsReconParticleDriver extends ReconParticleDriver {
          */
         TARGET_CONSTRAINED
     }
-    
-    private boolean storeCovVtxMomList = false;
 
     private boolean _patchVertexTrackParameters = true;
-    
-    public void setStoreCovVtxMomList(boolean input) {
-        storeCovVtxMomList = input;
-    }
+    private boolean _storeCovTrkMomList = true;
 
     /**
      * Processes the track and cluster collections in the event into
@@ -150,6 +147,10 @@ public class HpsReconParticleDriver extends ReconParticleDriver {
         event.put(beamConMollerVerticesColName, beamConMollerVertices, Vertex.class, 0);
         event.put(targetConMollerVerticesColName, targetConMollerVertices, Vertex.class, 0);
     }
+    
+    protected void setStoreVertexCovars(boolean input) {
+        _storeCovTrkMomList = input;
+    }
 
     /**
      * Creates reconstructed V0 candidate particles and vertices for electron
@@ -164,13 +165,12 @@ public class HpsReconParticleDriver extends ReconParticleDriver {
 
         // Iterate over the positrons and electrons to perform vertexing
         // on the pairs.
-        for (ReconstructedParticle positron : positrons) {
+        for (ReconstructedParticle positron : positrons)
             for (ReconstructedParticle electron : electrons) {
 
                 // Don't vertex a GBL track with a SeedTrack.
-                if (TrackType.isGBL(positron.getType()) != TrackType.isGBL(electron.getType())) {
+                if (TrackType.isGBL(positron.getType()) != TrackType.isGBL(electron.getType()))
                     continue;
-                }
                 // Only vertex two particles if at least one strategy found both tracks. Take out this check once we reduce the number of tracks.
                 // This is dumb so I took it out. - Matt Solt
                 /*if ((positron.getType() & electron.getType() & 0x1f) == 0) {
@@ -180,36 +180,30 @@ public class HpsReconParticleDriver extends ReconParticleDriver {
                 // Make V0 candidates
                 this.makeV0Candidates(electron, positron);
             }
-        }
 
         List<ReconstructedParticle> topElectrons = new ArrayList<ReconstructedParticle>();
         List<ReconstructedParticle> botElectrons = new ArrayList<ReconstructedParticle>();
-        for (ReconstructedParticle electron : electrons) {
-            if (electron.getTracks().get(0).getTrackStates().get(0).getTanLambda() > 0) {
+        for (ReconstructedParticle electron : electrons)
+            if (electron.getTracks().get(0).getTrackStates().get(0).getTanLambda() > 0)
                 topElectrons.add(electron);
-            } else {
+            else
                 botElectrons.add(electron);
-            }
-        }
 
         // Iterate over the collection of electrons and create e-e- pairs 
-        for (ReconstructedParticle topElectron : topElectrons) {
+        for (ReconstructedParticle topElectron : topElectrons)
 
             for (ReconstructedParticle botElectron : botElectrons) {
                 // Don't vertex a GBL track with a SeedTrack.
-                if (TrackType.isGBL(topElectron.getType()) != TrackType.isGBL(botElectron.getType())) {
+                if (TrackType.isGBL(topElectron.getType()) != TrackType.isGBL(botElectron.getType()))
                     continue;
-                }
 
                 // Only vertex two particles if at least one strategy found both tracks. Take out this check once we reduce the number of tracks.
-                if ((topElectron.getType() & botElectron.getType() & 0x1f) == 0) {
+                if ((topElectron.getType() & botElectron.getType() & 0x1f) == 0)
                     continue;
-                }
 
                 // Make Moller candidates
                 this.makeMollerCandidates(topElectron, botElectron);
             }
-        }
     }
 
     /**
@@ -220,24 +214,18 @@ public class HpsReconParticleDriver extends ReconParticleDriver {
     protected void startOfData() {
         // If the LCIO collection names have not been defined, assign
         // them to the default names.
-        if (unconstrainedV0CandidatesColName == null) {
+        if (unconstrainedV0CandidatesColName == null)
             unconstrainedV0CandidatesColName = "UnconstrainedV0Candidates";
-        }
-        if (beamConV0CandidatesColName == null) {
+        if (beamConV0CandidatesColName == null)
             beamConV0CandidatesColName = "BeamspotConstrainedV0Candidates";
-        }
-        if (targetConV0CandidatesColName == null) {
+        if (targetConV0CandidatesColName == null)
             targetConV0CandidatesColName = "TargetConstrainedV0Candidates";
-        }
-        if (unconstrainedV0VerticesColName == null) {
+        if (unconstrainedV0VerticesColName == null)
             unconstrainedV0VerticesColName = "UnconstrainedV0Vertices";
-        }
-        if (beamConV0VerticesColName == null) {
+        if (beamConV0VerticesColName == null)
             beamConV0VerticesColName = "BeamspotConstrainedV0Vertices";
-        }
-        if (targetConV0VerticesColName == null) {
+        if (targetConV0VerticesColName == null)
             targetConV0VerticesColName = "TargetConstrainedV0Vertices";
-        }
     }
 
     /**
@@ -249,14 +237,21 @@ public class HpsReconParticleDriver extends ReconParticleDriver {
      * @param positron - The positron track.
      * @return Returns the reconstructed vertex as a <code>BilliorVertex
      * </code> object.
+     * mg--8/14/17--add the displaced vertex refit for the UNCONSTRAINED and
+     * BS_CONSTRAINED fits
      */
-    private BilliorVertex fitVertex(Constraint constraint, BilliorTrack electron, BilliorTrack positron) {
+    private BilliorVertex fitVertex(Constraint constraint, ReconstructedParticle electron, ReconstructedParticle positron) {
+
+        // Covert the tracks to BilliorTracks.
+        BilliorTrack electronBTrack = toBilliorTrack(electron.getTracks().get(0));
+        BilliorTrack positronBTrack = toBilliorTrack(positron.getTracks().get(0));
+
         // Create a vertex fitter from the magnetic field.
         BilliorVertexer vtxFitter = new BilliorVertexer(bField);
         // TODO: The beam size should come from the conditions database.
         vtxFitter.setBeamSize(beamSize);
         vtxFitter.setBeamPosition(beamPosition);
-
+        vtxFitter.setStoreCovTrkMomList(_storeCovTrkMomList);
         vtxFitter.setDebug(debug);
 
         // Perform the vertexing based on the specified constraint.
@@ -275,15 +270,34 @@ public class HpsReconParticleDriver extends ReconParticleDriver {
         // Add the electron and positron tracks to a track list for
         // the vertex fitter.
         List<BilliorTrack> billiorTracks = new ArrayList<BilliorTrack>();
-        billiorTracks.add(electron);
-        billiorTracks.add(positron);
+        billiorTracks.add(electronBTrack);
+        billiorTracks.add(positronBTrack);
 
-        vtxFitter.setStoreCovTrkMomList(storeCovVtxMomList);
-
-        // Find and return a vertex based on the tracks.
+        // Find a vertex based on the tracks.
         BilliorVertex vtx = vtxFitter.fitVertex(billiorTracks);
 
-        return vtx;
+        // mg 8/14/17 
+        // if this is an unconstrained or BS constrained vertex, propogate the 
+        // tracks to the vertex found in previous fit and do fit again
+        //  ...  this is required because the vertex fit assumes trajectories 
+        // change linearly about the reference point (which we initially guess to be 
+        // (0,0,0) while for long-lived decays there is significant curvature
+        if (constraint == Constraint.BS_CONSTRAINED || constraint == Constraint.UNCONSTRAINED) {
+            List<ReconstructedParticle> recoList = new ArrayList<ReconstructedParticle>();
+            recoList.add(electron);
+            recoList.add(positron);
+            List<BilliorTrack> shiftedTracks = shiftTracksToVertex(recoList, vtx.getPosition());
+            if (constraint == Constraint.BS_CONSTRAINED) {
+                Hep3Vector beamRelToNewRef = new BasicHep3Vector(-vtx.getPosition().z() + beamPosition[0], -vtx.getPosition().x() + beamPosition[1], 0);
+                vtxFitter.setBeamPosition(beamRelToNewRef.v());
+            }
+
+            BilliorVertex vtxNew = vtxFitter.fitVertex(shiftedTracks);
+            Hep3Vector vtxPosNew = VecOp.add(vtx.getPosition(), vtxNew.getPosition());//the refit vertex is measured wrt the original vertex position
+            vtxNew.setPosition(vtxPosNew);//just change the position...the errors and momenta are correct in re-fit
+            return vtxNew;
+        } else
+            return vtx;
     }
 
     /**
@@ -291,15 +305,11 @@ public class HpsReconParticleDriver extends ReconParticleDriver {
      */
     private void makeV0Candidates(ReconstructedParticle electron, ReconstructedParticle positron) {
 
-        // Covert the tracks to BilliorTracks.
-        BilliorTrack electronBTrack = toBilliorTrack(electron.getTracks().get(0));
-        BilliorTrack positronBTrack = toBilliorTrack(positron.getTracks().get(0));
-
         // Create candidate particles for each constraint.
         for (Constraint constraint : Constraint.values()) {
 
             // Generate a candidate vertex and particle.
-            BilliorVertex vtxFit = fitVertex(constraint, electronBTrack, positronBTrack);
+            BilliorVertex vtxFit = fitVertex(constraint, electron, positron);
             ReconstructedParticle candidate = this.makeReconstructedParticle(electron, positron, vtxFit);
 
             // Add the candidate vertex and particle to the
@@ -308,9 +318,8 @@ public class HpsReconParticleDriver extends ReconParticleDriver {
 
                 case UNCONSTRAINED:
                     // patch the track parameters at the found vertex
-                    if (_patchVertexTrackParameters) {
+                    if (_patchVertexTrackParameters)
                         patchVertex(vtxFit);
-                    }
                     unconstrainedV0Vertices.add(vtxFit);
                     unconstrainedV0Candidates.add(candidate);
                     break;
@@ -334,15 +343,11 @@ public class HpsReconParticleDriver extends ReconParticleDriver {
      */
     private void makeMollerCandidates(ReconstructedParticle topElectron, ReconstructedParticle botElectron) {
 
-        // Covert the tracks to BilliorTracks.
-        BilliorTrack firstElectronBTrack = toBilliorTrack(topElectron.getTracks().get(0));
-        BilliorTrack secondElectronBTrack = toBilliorTrack(botElectron.getTracks().get(0));
-
         // Create candidate particles for each constraint.
         for (Constraint constraint : Constraint.values()) {
 
             // Generate a candidate vertex and particle.
-            BilliorVertex vtxFit = fitVertex(constraint, firstElectronBTrack, secondElectronBTrack);
+            BilliorVertex vtxFit = fitVertex(constraint, topElectron, botElectron);
             ReconstructedParticle candidate = makeReconstructedParticle(topElectron, botElectron, vtxFit);
 
             // Add the candidate vertex and particle to the
@@ -351,9 +356,8 @@ public class HpsReconParticleDriver extends ReconParticleDriver {
 
                 case UNCONSTRAINED:
                     // patch the track parameters at the found vertex
-                    if (_patchVertexTrackParameters) {
+                    if (_patchVertexTrackParameters)
                         patchVertex(vtxFit);
-                    }
                     unconstrainedMollerVertices.add(vtxFit);
                     unconstrainedMollerCandidates.add(candidate);
                     break;
@@ -405,7 +409,8 @@ public class HpsReconParticleDriver extends ReconParticleDriver {
         fittedMomentum = VecOp.add(fittedMomentum, new BasicHep3Vector(vtxFit.getParameters().get("p2X"),
                 vtxFit.getParameters().get("p2Y"),
                 vtxFit.getParameters().get("p2Z")));
-        fittedMomentum = CoordinateTransformations.transformVectorToDetector(fittedMomentum);
+        //mg 10/24/2017...billiorvertex now returns momentum in JLAB frame
+        //         fittedMomentum = CoordinateTransformations.transformVectorToDetector(fittedMomentum);
 
         // If both the electron and positron have an associated Ecal cluster,
         // calculate the total energy and assign it to the V0 particle
@@ -447,6 +452,19 @@ public class HpsReconParticleDriver extends ReconParticleDriver {
     private BilliorTrack toBilliorTrack(Track track) {
         // Generate and return the billior track.
         return new BilliorTrack(track);
+    }
+
+    /**
+     * Converts a <code>TrackState</code> object to a <code>BilliorTrack
+     * </code> object.
+     *
+     * @param track - The original track state
+     * @return Returns the original track as a <code>BilliorTrack
+     * </code> object.
+     */
+    private BilliorTrack toBilliorTrack(TrackState trackstate) {
+        // Generate and return the billior track.
+        return new BilliorTrack(trackstate, 0, 0); // track state doesn't store chi^2 info (stored in the Track object)
     }
 
     public void setPatchVertexTrackParameters(boolean b) {
@@ -493,10 +511,25 @@ public class HpsReconParticleDriver extends ReconParticleDriver {
         double psum = Math.sqrt(pxsum * pxsum + pysum * pysum + pzsum * pzsum);
         double evtmass = esum * esum - psum * psum;
 
-        if (evtmass > 0) {
+        if (evtmass > 0)
             return Math.sqrt(evtmass);
-        } else {
+        else
             return -99;
+    }
+
+    private List<BilliorTrack> shiftTracksToVertex(List<ReconstructedParticle> particles, Hep3Vector vtxPos) {
+        ///     Ok...shift the reference point....        
+        double[] newRef = {vtxPos.z(), vtxPos.x(), 0.0};//the  TrackUtils.getParametersAtNewRefPoint method only shifts in xy tracking frame
+        List<BilliorTrack> newTrks = new ArrayList<BilliorTrack>();
+        for (ReconstructedParticle part : particles) {
+            BaseTrackState oldTS = (BaseTrackState) part.getTracks().get(0).getTrackStates().get(0);
+            double[] newParams = TrackUtils.getParametersAtNewRefPoint(newRef, oldTS);
+            SymmetricMatrix newCov = TrackUtils.getCovarianceAtNewRefPoint(newRef, oldTS.getReferencePoint(), oldTS.getParameters(), new SymmetricMatrix(5, oldTS.getCovMatrix(), true));
+            //mg...I don't like this re-casting, but toBilliorTrack only takes Track as input
+            BaseTrackState newTS = new BaseTrackState(newParams, newRef, newCov.asPackedArray(true), TrackState.AtIP, bField);
+            BilliorTrack electronBTrackShift = this.toBilliorTrack(newTS);
+            newTrks.add(electronBTrackShift);
         }
+        return newTrks;
     }
 }

--- a/recon/src/main/java/org/hps/recon/particle/HpsReconParticleDriver.java
+++ b/recon/src/main/java/org/hps/recon/particle/HpsReconParticleDriver.java
@@ -15,6 +15,7 @@ import org.lcsim.event.ReconstructedParticle;
 import org.lcsim.event.Track;
 import org.lcsim.event.Vertex;
 import org.lcsim.event.base.BaseReconstructedParticle;
+import org.hps.recon.tracking.CoordinateTransformations;
 import org.hps.recon.tracking.TrackType;
 import org.hps.recon.tracking.TrackUtils;
 import org.hps.recon.vertexing.BilliorTrack;

--- a/recon/src/main/java/org/hps/recon/particle/HpsReconParticleDriver.java
+++ b/recon/src/main/java/org/hps/recon/particle/HpsReconParticleDriver.java
@@ -116,7 +116,7 @@ public class HpsReconParticleDriver extends ReconParticleDriver {
         TARGET_CONSTRAINED
     }
     
-    private boolean storeCovVtxMomList = true;
+    private boolean storeCovVtxMomList = false;
 
     private boolean _patchVertexTrackParameters = true;
     

--- a/recon/src/main/java/org/hps/recon/vertexing/BilliorVertexer.java
+++ b/recon/src/main/java/org/hps/recon/vertexing/BilliorVertexer.java
@@ -23,6 +23,7 @@ public class BilliorVertexer {
     // the value of the magnetic field in the vicinity of the vertex
     // default is a constant field along the z axis
 
+    private boolean storeCovTrkMomList = false;
     private boolean _debug = false;
     private final double _bField;
     private boolean _beamspotConstraint;
@@ -61,6 +62,10 @@ public class BilliorVertexer {
             _constraintType = "TargetConstrained";
     }
 
+    public void setStoreCovTrkMomList(boolean value) {
+        storeCovTrkMomList = value;
+    }
+    
     public void setDebug(boolean debug) {
         _debug = debug;
     }
@@ -87,6 +92,7 @@ public class BilliorVertexer {
         pcov.add(CoordinateTransformations.transformCovarianceToDetector(new SymmetricMatrix(this.getFittedMomentumCovariance(0))));
         pcov.add(CoordinateTransformations.transformCovarianceToDetector(new SymmetricMatrix(this.getFittedMomentumCovariance(1))));
         vertex.setTrackMomentumCovariances(pcov);
+        vertex.setStoreCovTrkMomList(storeCovTrkMomList);
         return vertex;
     }
 


### PR DESCRIPTION
branch iss224d : 
- option to store in LCIO Vertex the covariance matrices for re-fitted tracks
- store in LCIO Vertex the error on invariant mass
- constructor to rebuild BilliorVertex object from LCIO Vertex information

Passes integration tests