### PR TITLE
steering file for 2015 with ecal time offsets separated

### DIFF
--- a/steering-files/src/main/resources/org/hps/steering/recon/EngineeringRun2015FullRecon.lcsim
+++ b/steering-files/src/main/resources/org/hps/steering/recon/EngineeringRun2015FullRecon.lcsim
@@ -13,6 +13,7 @@
         <!-- Ecal reconstruction drivers -->        
         <driver name="EcalRunningPedestal"/>
         <driver name="EcalRawConverter" />
+        <driver name="EcalTimeCorrection"/>
         <driver name="ReconClusterer" />
         <driver name="CopyCluster" />
         <!-- SVT reconstruction drivers -->
@@ -67,8 +68,8 @@
             <logLevel>CONFIG</logLevel>
         </driver>
         <driver name="EcalRawConverter" type="org.hps.recon.ecal.EcalRawConverterDriver">
-            <ecalCollectionName>EcalCalHits</ecalCollectionName>
-        </driver>             
+        </driver>
+         <driver name="EcalTimeCorrection" type="org.hps.recon.ecal.EcalTimeCorrectionDriver"/>
         <driver name="ReconClusterer" type="org.hps.recon.ecal.cluster.ReconClusterDriver">
             <logLevel>WARNING</logLevel>
             <outputClusterCollectionName>EcalClusters</outputClusterCollectionName>


### PR DESCRIPTION
This uses the new driver that separates where time correction is applied. This used to be done in the original code but was separated so that the conditions database could be used and the offsets could be corrected for 2015 or 2016.