### PR TITLE
Issue245

### DIFF
--- a/tracking/src/main/java/org/hps/recon/tracking/TrackUtils.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/TrackUtils.java
@@ -188,8 +188,10 @@ public class TrackUtils {
         // take care of phi0 range if needed (this matters for dphi below I
         // think)
         // L3 defines it in the range [-pi,pi]
-        if (phi0 > Math.PI)
-            phi0 -= Math.PI * 2;
+        while (phi0 > Math.PI/2)
+            phi0 -= Math.PI;
+        while (phi0 < -Math.PI/2)
+            phi0 += Math.PI;
 
         double dx = newRefPoint[0] - __refPoint[0];
         double dy = newRefPoint[1] - __refPoint[1];

--- a/tracking/src/main/java/org/hps/recon/tracking/TrackUtils.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/TrackUtils.java
@@ -244,8 +244,10 @@ public class TrackUtils {
         double z0 = par[HelicalTrackFit.z0Index];
         double tanLambda = par[HelicalTrackFit.slopeIndex];
 
-        if (phi0 > Math.PI)
+        while (phi0 > Math.PI)
             phi0 -= Math.PI * 2;
+        while (phi0 < -Math.PI/2)
+            phi0 += Math.PI;
 
         BasicMatrix jac = new BasicMatrix(5, 5);
         //


### PR DESCRIPTION
The code was only checking if phi0 was  > pi/2, not if is was <-pi/2.  This mistake has been in there quite a while, but it probably popped up now because we are using it to extrapolate tracks a long ways from the origin.  Fixed in two places.  