### PR TITLE
added steering file V0CandidateFilter2015Pass7.lcsim

### DIFF
--- a/steering-files/src/main/resources/org/hps/steering/production/V0CandidateFilter2015Pass7.lcsim
+++ b/steering-files/src/main/resources/org/hps/steering/production/V0CandidateFilter2015Pass7.lcsim
@@ -1,0 +1,26 @@
+<lcsim xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" 
+       xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/lcsim/1.0/lcsim.xsd">
+    <control>
+        <printDriverStatistics>true</printDriverStatistics>
+    </control>
+    <execute>
+        <driver name="EventFlagFilter"/>
+        <driver name="StripEvent"/>
+        <driver name="Writer"/>
+    </execute>
+    <drivers>
+        <!-- Driver to reject "bad" events -->
+        <driver name="EventFlagFilter" 
+                type="org.hps.recon.filtering.EventFlagFilter">
+        </driver>
+        <!-- Driver to strip events -->
+        <driver name="StripEvent"
+                type="org.hps.recon.filtering.V0CandidateFilter2015Pass7">
+        </driver>
+        <!-- Driver to write output slcio file -->
+        <driver name="Writer"
+                type="org.lcsim.util.loop.LCIODriver">
+            <outputFilePath>${outputFile}.slcio</outputFilePath>
+        </driver>
+    </drivers>
+</lcsim>


### PR DESCRIPTION
Added the steering file.  I tested it by plotting the pair momenta of v0s, requiring only that there be good svt flags, and that the tracks be on opposite sides of the detector for both the original file and the skimmed file, and the two histograms are identical.  