### PR TITLE
add unit tests for tupleMaker

### DIFF
--- a/analysis/src/test/java/org/hps/analysis/FEETupleDriverTest.java
+++ b/analysis/src/test/java/org/hps/analysis/FEETupleDriverTest.java
@@ -6,8 +6,8 @@ public class FEETupleDriverTest extends TupleDriverTest {
     @Override
     public void testIt() throws Exception {
          testURLBase = "http://www.lcsim.org/test/hps-java/";
-         txtRefFileName = "out_fee_Ref.txt";
-         lcioInputFileName = "tmp.slcio";
+         txtRefFileName = "ntuple_005772_fee_Ref.txt";
+         lcioInputFileName = "hps_005772.0_recon_Rv4657-0-10000.slcio";
          txtOutputFileName = "target/test-output/out_fee.txt";
 
          testTupleDriver = new org.hps.analysis.tuple.FEETupleDriver();

--- a/analysis/src/test/java/org/hps/analysis/FEETupleDriverTest.java
+++ b/analysis/src/test/java/org/hps/analysis/FEETupleDriverTest.java
@@ -1,0 +1,22 @@
+package org.hps.analysis;
+
+
+public class FEETupleDriverTest extends TupleDriverTest {
+
+    @Override
+    public void testIt() throws Exception {
+         testURLBase = "http://www.lcsim.org/test/hps-java/";
+         txtRefFileName = "out_fee_Ref.txt";
+         lcioInputFileName = "tmp.slcio";
+         txtOutputFileName = "target/test-output/out_fee.txt";
+
+         testTupleDriver = new org.hps.analysis.tuple.FEETupleDriver();
+         ((org.hps.analysis.tuple.FEETupleDriver)testTupleDriver).setTupleFile(txtOutputFileName);
+         ((org.hps.analysis.tuple.FEETupleDriver)testTupleDriver).setTriggerType("all");
+         ((org.hps.analysis.tuple.FEETupleDriver)testTupleDriver).setIsGBL(true);
+         ((org.hps.analysis.tuple.FEETupleDriver)testTupleDriver).setCutTuple(true);
+         ((org.hps.analysis.tuple.FEETupleDriver)testTupleDriver).setBeamPosZ(-5.0);
+         
+         super.testIt();
+    }
+}

--- a/analysis/src/test/java/org/hps/analysis/MollerTupleDriverTest.java
+++ b/analysis/src/test/java/org/hps/analysis/MollerTupleDriverTest.java
@@ -1,0 +1,20 @@
+package org.hps.analysis;
+
+public class MollerTupleDriverTest extends TupleDriverTest {
+    @Override
+    public void testIt() throws Exception {
+         testURLBase = "http://www.lcsim.org/test/hps-java/";
+         txtRefFileName = "out_moller_Ref.txt";
+         lcioInputFileName = "tmp.slcio";
+         txtOutputFileName = "target/test-output/out_moller.txt";
+
+         testTupleDriver = new org.hps.analysis.tuple.MollerTupleDriver();
+         ((org.hps.analysis.tuple.MollerTupleDriver)testTupleDriver).setTupleFile(txtOutputFileName);
+         ((org.hps.analysis.tuple.MollerTupleDriver)testTupleDriver).setTriggerType("all");
+         ((org.hps.analysis.tuple.MollerTupleDriver)testTupleDriver).setIsGBL(true);
+         ((org.hps.analysis.tuple.MollerTupleDriver)testTupleDriver).setCutTuple(true);
+         ((org.hps.analysis.tuple.MollerTupleDriver)testTupleDriver).setBeamPosZ(-5.0);
+         
+         super.testIt();
+    }
+}

--- a/analysis/src/test/java/org/hps/analysis/MollerTupleDriverTest.java
+++ b/analysis/src/test/java/org/hps/analysis/MollerTupleDriverTest.java
@@ -4,8 +4,8 @@ public class MollerTupleDriverTest extends TupleDriverTest {
     @Override
     public void testIt() throws Exception {
          testURLBase = "http://www.lcsim.org/test/hps-java/";
-         txtRefFileName = "out_moller_Ref.txt";
-         lcioInputFileName = "tmp.slcio";
+         txtRefFileName = "ntuple_005772_moller_Ref.txt";
+         lcioInputFileName = "hps_005772.0_recon_Rv4657-0-10000.slcio";
          txtOutputFileName = "target/test-output/out_moller.txt";
 
          testTupleDriver = new org.hps.analysis.tuple.MollerTupleDriver();

--- a/analysis/src/test/java/org/hps/analysis/TridentTupleDriverTest.java
+++ b/analysis/src/test/java/org/hps/analysis/TridentTupleDriverTest.java
@@ -4,8 +4,8 @@ public class TridentTupleDriverTest extends TupleDriverTest {
     @Override
     public void testIt() throws Exception {
          testURLBase = "http://www.lcsim.org/test/hps-java/";
-         txtRefFileName = "out_tri_Ref.txt";
-         lcioInputFileName = "tmp.slcio";
+         txtRefFileName = "ntuple_005772_tri_Ref.txt";
+         lcioInputFileName = "hps_005772.0_recon_Rv4657-0-10000.slcio";
          txtOutputFileName = "target/test-output/out_tri.txt";
 
          testTupleDriver = new org.hps.analysis.tuple.TridentTupleDriver();

--- a/analysis/src/test/java/org/hps/analysis/TridentTupleDriverTest.java
+++ b/analysis/src/test/java/org/hps/analysis/TridentTupleDriverTest.java
@@ -1,0 +1,20 @@
+package org.hps.analysis;
+
+public class TridentTupleDriverTest extends TupleDriverTest {
+    @Override
+    public void testIt() throws Exception {
+         testURLBase = "http://www.lcsim.org/test/hps-java/";
+         txtRefFileName = "out_tri_Ref.txt";
+         lcioInputFileName = "tmp.slcio";
+         txtOutputFileName = "target/test-output/out_tri.txt";
+
+         testTupleDriver = new org.hps.analysis.tuple.TridentTupleDriver();
+         ((org.hps.analysis.tuple.TridentTupleDriver)testTupleDriver).setTupleFile(txtOutputFileName);
+         ((org.hps.analysis.tuple.TridentTupleDriver)testTupleDriver).setTriggerType("all");
+         ((org.hps.analysis.tuple.TridentTupleDriver)testTupleDriver).setIsGBL(true);
+         ((org.hps.analysis.tuple.TridentTupleDriver)testTupleDriver).setCutTuple(true);
+         ((org.hps.analysis.tuple.TridentTupleDriver)testTupleDriver).setBeamPosZ(-5.0);
+         
+         super.testIt();
+    }
+}

--- a/analysis/src/test/java/org/hps/analysis/TupleDriverTest.java
+++ b/analysis/src/test/java/org/hps/analysis/TupleDriverTest.java
@@ -21,9 +21,9 @@ import junit.framework.TestCase;
 public class TupleDriverTest extends TestCase {
     protected String testURLBase = null;
             //"http://www.lcsim.org/test/hps-java/";
-    protected String txtRefFileName = "out_fee_Ref.txt";
-    protected String lcioInputFileName = "tmp.slcio";
-    protected String txtOutputFileName = "out_fee.txt";
+    protected String txtRefFileName = "ntuple_005772_fee_Ref.txt";
+    protected String lcioInputFileName = "hps_005772.0_recon_Rv4657-0-10000.slcio";
+    protected String txtOutputFileName = "target/test-output/out_fee.txt";
     protected Driver testTupleDriver = null;
 
     public void testIt() throws Exception {
@@ -58,7 +58,7 @@ public class TupleDriverTest extends TestCase {
 //        ((org.hps.analysis.tuple.FEETupleDriver)testTupleDriver).setBeamPosZ(-5.0);
         loop.add(testTupleDriver);
         
-        loop.loop(1);
+        loop.loop(100);
         loop.dispose();
         
         CompareTextFiles();

--- a/analysis/src/test/java/org/hps/analysis/TupleDriverTest.java
+++ b/analysis/src/test/java/org/hps/analysis/TupleDriverTest.java
@@ -1,0 +1,134 @@
+package org.hps.analysis;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Scanner;
+import java.util.Set;
+
+import org.hps.conditions.database.DatabaseConditionsManager;
+import org.hps.detector.svt.SvtDetectorSetup;
+import org.lcsim.util.Driver;
+import org.lcsim.util.cache.FileCache;
+import org.lcsim.util.loop.LCSimLoop;
+
+import junit.framework.TestCase;
+
+public class TupleDriverTest extends TestCase {
+    protected String testURLBase = null;
+            //"http://www.lcsim.org/test/hps-java/";
+    protected String txtRefFileName = "out_fee_Ref.txt";
+    protected String lcioInputFileName = "tmp.slcio";
+    protected String txtOutputFileName = "out_fee.txt";
+    protected Driver testTupleDriver = null;
+
+    public void testIt() throws Exception {
+
+        File lcioInputFile = null;
+        if (testURLBase == null) {
+            lcioInputFile = new File(lcioInputFileName);
+        } else {
+            URL lcioURL = new URL(testURLBase + "/" + lcioInputFileName);
+            FileCache cache = new FileCache();
+            lcioInputFile = cache.getCachedFile(lcioURL);
+        }
+        
+        LCSimLoop loop = new LCSimLoop();
+        loop.setLCIORecordSource(lcioInputFile);
+        
+        final DatabaseConditionsManager manager = new DatabaseConditionsManager();
+        manager.addConditionsListener(new SvtDetectorSetup());
+        
+        loop.add(new org.lcsim.recon.tracking.digitization.sisim.config.ReadoutCleanupDriver());
+        
+        org.lcsim.recon.tracking.digitization.sisim.config.RawTrackerHitSensorSetup rthss = new org.lcsim.recon.tracking.digitization.sisim.config.RawTrackerHitSensorSetup();
+        String[] readoutColl = { "SVTRawTrackerHits" };
+        rthss.setReadoutCollections(readoutColl);
+        loop.add(rthss);
+        
+//        testTupleDriver = new org.hps.analysis.tuple.FEETupleDriver();
+//        ((org.hps.analysis.tuple.FEETupleDriver)testTupleDriver).setTupleFile(txtOutputFileName);
+//        ((org.hps.analysis.tuple.FEETupleDriver)testTupleDriver).setTriggerType("all");
+//        ((org.hps.analysis.tuple.FEETupleDriver)testTupleDriver).setIsGBL(true);
+//        ((org.hps.analysis.tuple.FEETupleDriver)testTupleDriver).setCutTuple(true);
+//        ((org.hps.analysis.tuple.FEETupleDriver)testTupleDriver).setBeamPosZ(-5.0);
+        loop.add(testTupleDriver);
+        
+        loop.loop(1);
+        loop.dispose();
+        
+        CompareTextFiles();
+    }
+    
+    private void CompareTextFiles() throws Exception {
+        File txtRefFile = null;
+        if (testURLBase == null) {
+            txtRefFile = new File(txtRefFileName);
+        } else {
+            URL txtURL = new URL(testURLBase + "/" + txtRefFileName);
+            FileCache cache = new FileCache();
+            txtRefFile = cache.getCachedFile(txtURL);
+        }
+        File txtNewFile = new File(txtOutputFileName); 
+        
+        Map<String, List<String>> refMap = textToMap(txtRefFile); 
+        Map<String, List<String>> newMap = textToMap(txtNewFile); 
+        
+        Set<String> refMapKeys = refMap.keySet();
+        for (String branchName : refMapKeys) {
+            assertTrue("new text file is missing branch " + branchName, newMap.containsKey(branchName));
+            List<String> branchValsRef = refMap.get(branchName);
+            List<String> branchValsNew = newMap.get(branchName);
+            assertTrue("wrong number of entries in branch " + branchName, branchValsRef.size() == branchValsNew.size());
+            for (int i=0; i<branchValsRef.size(); i++) {
+                assertTrue("there is a wrong entry value in branch " + branchName, branchValsRef.get(i).equals(branchValsNew.get(i)));
+            }
+        }
+        Set<String> newMapKeys = newMap.keySet();
+        for (String branchName : newMapKeys) {
+            if (!refMapKeys.contains(branchName))
+                System.out.println("Note: you have added branch " + branchName);
+        }
+        
+        assertTrue("new text file is missing branches", newMap.size() >= refMap.size());
+    }
+    
+    private Map<String, List<String>> textToMap(File input) {
+        Map<String, List<String>> treeMap = new HashMap<String, List<String>>();
+        String[] mapStrings = null;
+        Scanner scFile = null;
+        String mapString = null;
+        
+        try {
+            scFile = new Scanner(input);
+            mapString = scFile.nextLine(); 
+            mapStrings = mapString.split(":");
+            int numEntries = mapStrings.length;
+            int counter=0;
+            while (scFile.hasNextDouble()) {
+                String addMe = String.format("%f", scFile.nextDouble());
+                if (counter < numEntries) {
+                    List<String> toAdd = new ArrayList<String>();
+                    toAdd.add(addMe);
+                    treeMap.put(mapStrings[counter], toAdd);
+                }
+                else {
+                    treeMap.get(mapStrings[counter % numEntries]).add(addMe);
+                }
+                counter++;
+            }
+
+        }
+        catch(FileNotFoundException ex) {
+            System.out.println("Unable to open txt file");                
+        }
+        
+        scFile.close();
+        
+        return treeMap;
+    }
+}

--- a/analysis/src/test/java/org/hps/analysis/TupleDriverTest.java
+++ b/analysis/src/test/java/org/hps/analysis/TupleDriverTest.java
@@ -45,17 +45,19 @@ public class TupleDriverTest extends TestCase {
         
         loop.add(new org.lcsim.recon.tracking.digitization.sisim.config.ReadoutCleanupDriver());
         
+        loop.add(new org.hps.recon.filtering.EventFlagFilter());
+        
         org.lcsim.recon.tracking.digitization.sisim.config.RawTrackerHitSensorSetup rthss = new org.lcsim.recon.tracking.digitization.sisim.config.RawTrackerHitSensorSetup();
         String[] readoutColl = { "SVTRawTrackerHits" };
         rthss.setReadoutCollections(readoutColl);
         loop.add(rthss);
         
-//        testTupleDriver = new org.hps.analysis.tuple.FEETupleDriver();
-//        ((org.hps.analysis.tuple.FEETupleDriver)testTupleDriver).setTupleFile(txtOutputFileName);
-//        ((org.hps.analysis.tuple.FEETupleDriver)testTupleDriver).setTriggerType("all");
-//        ((org.hps.analysis.tuple.FEETupleDriver)testTupleDriver).setIsGBL(true);
-//        ((org.hps.analysis.tuple.FEETupleDriver)testTupleDriver).setCutTuple(true);
-//        ((org.hps.analysis.tuple.FEETupleDriver)testTupleDriver).setBeamPosZ(-5.0);
+        testTupleDriver = new org.hps.analysis.tuple.FEETupleDriver();
+        ((org.hps.analysis.tuple.FEETupleDriver)testTupleDriver).setTupleFile(txtOutputFileName);
+        ((org.hps.analysis.tuple.FEETupleDriver)testTupleDriver).setTriggerType("all");
+        ((org.hps.analysis.tuple.FEETupleDriver)testTupleDriver).setIsGBL(true);
+        ((org.hps.analysis.tuple.FEETupleDriver)testTupleDriver).setCutTuple(true);
+        ((org.hps.analysis.tuple.FEETupleDriver)testTupleDriver).setBeamPosZ(-5.0);
         loop.add(testTupleDriver);
         
         loop.loop(100);

--- a/analysis/src/test/java/org/hps/analysis/TupleDriverTest.java
+++ b/analysis/src/test/java/org/hps/analysis/TupleDriverTest.java
@@ -18,7 +18,7 @@ import org.lcsim.util.loop.LCSimLoop;
 
 import junit.framework.TestCase;
 
-public class TupleDriverTest extends TestCase {
+abstract public class TupleDriverTest extends TestCase {
     protected String testURLBase = null;
             //"http://www.lcsim.org/test/hps-java/";
     protected String txtRefFileName = "ntuple_005772_fee_Ref.txt";
@@ -51,13 +51,7 @@ public class TupleDriverTest extends TestCase {
         String[] readoutColl = { "SVTRawTrackerHits" };
         rthss.setReadoutCollections(readoutColl);
         loop.add(rthss);
-        
-        testTupleDriver = new org.hps.analysis.tuple.FEETupleDriver();
-        ((org.hps.analysis.tuple.FEETupleDriver)testTupleDriver).setTupleFile(txtOutputFileName);
-        ((org.hps.analysis.tuple.FEETupleDriver)testTupleDriver).setTriggerType("all");
-        ((org.hps.analysis.tuple.FEETupleDriver)testTupleDriver).setIsGBL(true);
-        ((org.hps.analysis.tuple.FEETupleDriver)testTupleDriver).setCutTuple(true);
-        ((org.hps.analysis.tuple.FEETupleDriver)testTupleDriver).setBeamPosZ(-5.0);
+
         loop.add(testTupleDriver);
         
         loop.loop(100);


### PR DESCRIPTION
Three reference txt files have been uploaded to http://www.lcsim.org/test/hps-java/ .
There are 3 unit tests here: FEE, Moller, and Trident.
Do we want to run all of these by default?  They're very quick.