### PR TITLE
Iss266: Fix TrackState at ECal

### DIFF
--- a/tracking/src/main/java/org/hps/recon/tracking/TrackDataDriver.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/TrackDataDriver.java
@@ -40,6 +40,7 @@ public final class TrackDataDriver extends Driver {
     double bField = 0;
 
     /** Collection Names */
+    private String TRK_COLLECTION_NAME = "GBLTracks";
 
     /** Collection name of TrackResidualData objects */
     private static final String TRK_RESIDUALS_COL_NAME = "TrackResiduals";
@@ -59,28 +60,16 @@ public final class TrackDataDriver extends Driver {
     /** Position of the Ecal face */
     private double ecalPosition = 0; // mm
 
-    /** Z position to start extrapolation from */
-    double extStartPos = 700; // mm
+    double epsilon = 0.005; // mm
 
-    double stepSize = 5.0; // mm
-
-    /** The default number of layers */
-    int layerNum = 6;
     List<HpsSiSensor> sensors = null;
 
     /** Default constructor */
     public TrackDataDriver() {
     }
 
-    /**
-     * Set the position along Z where the extrapolation of a track should
-     * begin.
-     * 
-     * @param extStartPoint Position along Z where the extrapolation should 
-     *                      begin
-     */
-    void setExtrapolationStartPosition(double extStartPos) {
-        this.extStartPos = extStartPos;
+    public void setTrackCollectionName(String input) {
+        TRK_COLLECTION_NAME = input;
     }
 
     /**
@@ -89,17 +78,12 @@ public final class TrackDataDriver extends Driver {
      * 
      * @param stepSize The extrapolation length between iterations in mm. 
      */
-    void setStepSize(double stepSize) {
-        this.stepSize = stepSize;
+    public void setEpsilon(double input) {
+        epsilon = input;
     }
 
-    /**
-     * Set number of tracking layers. Default is 6 layers.
-     * 
-     */
-
-    public void setLayerNum(int layerNum) {
-        this.layerNum = layerNum;
+    public void setECalPosition(double input) {
+        ecalPosition = input;
     }
 
     /**
@@ -118,7 +102,8 @@ public final class TrackDataDriver extends Driver {
         sensors = detector.getSubdetector("Tracker").getDetectorElement().findDescendants(HpsSiSensor.class);
 
         // Get the position of the Ecal from the compact description
-        ecalPosition = detector.getConstants().get(ECAL_POSITION_CONSTANT_NAME).getValue();
+        if (ecalPosition == 0)
+            ecalPosition = detector.getConstants().get(ECAL_POSITION_CONSTANT_NAME).getValue();
     }
 
     /**
@@ -137,7 +122,13 @@ public final class TrackDataDriver extends Driver {
         // Get all collections of the type Track from the event. This is
         // required since the event contains a track collection for each of the
         // different tracking strategies.
-        List<List<Track>> trackCollections = event.get(Track.class);
+        List<List<Track>> trackCollections = null;
+        if (TRK_COLLECTION_NAME == null) {
+            trackCollections = event.get(Track.class);
+        } else {
+            trackCollections = new ArrayList<List<Track>>();
+            trackCollections.add(event.get(Track.class, TRK_COLLECTION_NAME));
+        }
 
         // Get the collection of LCRelations relating RotatedHelicalTrackHits to
         // HelicalTrackHits
@@ -172,7 +163,6 @@ public final class TrackDataDriver extends Driver {
 
         boolean isFirstHit;
 
-        HpsSiSensor sensor = null;
         Hep3Vector stereoHitPosition;
         Hep3Vector trackPosition;
         HelicalTrackHit helicalTrackHit;
@@ -180,7 +170,6 @@ public final class TrackDataDriver extends Driver {
         List<Double> t0Residuals = new ArrayList<Double>();
         List<Double> trackResidualsX = new ArrayList<Double>();
         List<Float> trackResidualsY = new ArrayList<Float>();
-        List<Integer> sensorLayers = new ArrayList<Integer>();
         List<Integer> stereoLayers = new ArrayList<Integer>();
 
         // Loop over each of the track collections retrieved from the event
@@ -191,11 +180,11 @@ public final class TrackDataDriver extends Driver {
                 totalT0 = 0;
                 totalHits = 0;
                 t0Residuals.clear();
-                sensorLayers.clear();
                 trackResidualsX.clear();
                 trackResidualsY.clear();
                 stereoLayers.clear();
                 isFirstHit = true;
+                HpsSiSensor LastSensor = null;
 
                 // Change the position of a HelicalTrackHit to be the corrected
                 // one.
@@ -206,6 +195,7 @@ public final class TrackDataDriver extends Driver {
                 //
                 // Loop over all stereo hits comprising a track
                 for (TrackerHit rotatedStereoHit : track.getTrackerHits()) {
+                    HpsSiSensor sensor = null;
                     // Loop over the clusters comprising the stereo hit
                     for (HelicalTrackStrip cluster : ((HelicalTrackCross) rotatedStereoHit).getStrips()) {
 
@@ -250,6 +240,12 @@ public final class TrackDataDriver extends Driver {
                     stereoHitPosition = CoordinateTransformations.transformVectorToDetector(stereoHitPosition);
                     helicalTrackHit.setPosition(stereoHitPosition.v());
 
+                    if (LastSensor == null)
+                        LastSensor = sensor;
+                    else {
+                        if (sensor.getLayerNumber() > LastSensor.getLayerNumber())
+                            LastSensor = sensor;
+                    }
                 }
 
                 //
@@ -260,16 +256,15 @@ public final class TrackDataDriver extends Driver {
 
                 // Extrapolate the track to the face of the Ecal and get the TrackState
                 if (TrackType.isGBL(track.getType())) {
-                    TrackState stateIP = TrackUtils.getTrackStateAtLocation(track, TrackState.AtIP);
-                    if (stateIP == null)
-                        throw new RuntimeException("IP track state for GBL track was not found");
-                    TrackState stateEcalIP = TrackUtils.extrapolateTrackUsingFieldMap(stateIP, extStartPos, ecalPosition, stepSize, bFieldMap);
-                    track.getTrackStates().add(stateEcalIP);
+                    TrackState stateAtLast = TrackUtils.getTrackStateAtLocation(track, TrackState.AtLastHit);
+                    if (stateAtLast != null && LastSensor != null) {
+                        Hep3Vector atLastSensor = TrackStateUtils.getLocationAtSensor(stateAtLast, LastSensor, bField);
+                        if (atLastSensor != null) {
+                            TrackState stateEcal = TrackUtils.extrapolateToEndplane(stateAtLast, atLastSensor.z(), ecalPosition, epsilon, bFieldMap);
+                            track.getTrackStates().add(stateEcal);
+                        }
+                    }
 
-                } else {
-                    LOGGER.fine("Extrapolate seed track to ECal from vertex");
-                    TrackState state = TrackUtils.extrapolateTrackUsingFieldMap(track, extStartPos, ecalPosition, stepSize, bFieldMap);
-                    track.getTrackStates().add(state);
                 }
 
                 LOGGER.fine(Integer.toString(track.getTrackStates().size()) + " track states for this track at this point:");
@@ -285,7 +280,7 @@ public final class TrackDataDriver extends Driver {
 
                 // Calculate the track isolation constants for each of the 
                 // layers
-                Double[] isolations = TrackUtils.getIsolations(track, hitToStrips, hitToRotated, layerNum);
+                Double[] isolations = TrackUtils.getIsolations(track, hitToStrips, hitToRotated, 6);
                 double qualityArray[] = new double[isolations.length];
                 for (int i = 0; i < isolations.length; i++) {
                     qualityArray[i] = isolations[i] == null ? -99999999.0 : isolations[i];

--- a/tracking/src/main/java/org/hps/recon/tracking/TrackStateUtils.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/TrackStateUtils.java
@@ -172,7 +172,7 @@ public class TrackStateUtils {
             if (!foundFirst)
                 first++;
             last++;
-            if (state.getLocation() == TrackState.AtFirstHit) {
+            if ((state.getLocation() == TrackState.AtFirstHit) || (state.getLocation() == -1)) {
                 foundFirst = true;
             }
             if (state.getLocation() == TrackState.AtLastHit) {

--- a/tracking/src/main/java/org/hps/recon/tracking/TrackUtils.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/TrackUtils.java
@@ -1529,39 +1529,31 @@ public class TrackUtils {
      * system.
      */
     public static TrackState extrapolateTrackUsingFieldMap(TrackState track, double startPositionX, double endPositionX, double stepSize, FieldMap fieldMap) {
-
         // Start by extrapolating the track to the approximate point where the
         // fringe field begins.
         Hep3Vector currentPosition = TrackUtils.extrapolateHelixToXPlane(track, startPositionX);
-        // System.out.println("Track position at start of fringe: " +
-        // currentPosition.toString());
+        return extrapolateToEndplane(TrackUtils.getHTF(track), Math.signum(track.getOmega()), currentPosition.x(), endPositionX, 0.005, stepSize, fieldMap);
+    }
 
-        // Get the HelicalTrackFit object associated with the track. This will
-        // be used to calculate the path length to the start of the fringe and
-        // to find the initial momentum of the track.
-        HelicalTrackFit helicalTrackFit = TrackUtils.getHTF(track);
+    public static TrackState extrapolateToEndplane(TrackState ts, double startPosition, double endPosition, double epsilon, FieldMap fieldMap) {
+        HelicalTrackFit helicalTrackFit = TrackUtils.getHTF(ts);
+        return extrapolateToEndplane(helicalTrackFit, Math.signum(ts.getOmega()), startPosition, endPosition, epsilon, 0, fieldMap);
+    }
 
-        // Calculate the path length to the start of the fringe field.
-        double pathToStart = HelixUtils.PathToXPlane(helicalTrackFit, startPositionX, 0., 0).get(0);
+    public static TrackState extrapolateToEndplane(HelicalTrackFit helicalTrackFit, double q, double startPosition, double endPosition, double epsilon, double stepSize, FieldMap fieldMap) {
+        // start position: x along beam line (tracking frame!)
+        Hep3Vector currentPosition = new BasicHep3Vector(startPosition, 0, 0);
+        // Calculate the path length to the start position
+        double pathToStart = HelixUtils.PathToXPlane(helicalTrackFit, startPosition, 0., 0).get(0);
 
-        // Get the momentum of the track and calculate the magnitude. The
-        // momentum can be calculate using the track curvature and magnetic
-        // field strength in the middle of the analyzing magnet.
-        // FIXME: The position of the middle of the analyzing magnet should
-        // be retrieved from the compact description.
-        double bFieldY = fieldMap.getField(new BasicHep3Vector(0, 0, 500.0)).y();
+        // Get the momentum of the track
+        double bFieldY = fieldMap.getField(currentPosition).y();
         double p = Math.abs(helicalTrackFit.p(bFieldY));
-
-        // Get a unit vector giving the track direction at the start of the of
-        // the fringe field
+        // Get a unit vector giving the track direction at the start
         Hep3Vector helixDirection = HelixUtils.Direction(helicalTrackFit, pathToStart);
-        // Calculate the momentum vector at the start of the fringe field
+        // Calculate the momentum vector at the start
         Hep3Vector currentMomentum = VecOp.mult(p, helixDirection);
-        // System.out.println("Track momentum vector: " +
-        // currentMomentum.toString());
 
-        // Get the charge of the track.
-        double q = Math.signum(track.getOmega());
         // HACK: LCSim doesn't deal well with negative fields so they are
         // turned to positive for tracking purposes. As a result,
         // the charge calculated using the B-field, will be wrong
@@ -1569,50 +1561,48 @@ public class TrackUtils {
         if (bFieldY < 0)
             q = q * (-1);
 
-        // Swim the track through the B-field until the end point is reached.
-        // The position of the track will be incremented according to the step
-        // size up to ~90% of the final position. At this point, a finer
-        // track size will be used.
-        boolean stepSizeChange = false;
+        // Swim the track through the B-field until the end point is reached
+        Hep3Vector currentPositionDet = null;
 
-        while (currentPosition.x() < endPositionX) {
+        double distance = endPosition - currentPosition.x();
+        if (stepSize == 0)
+            stepSize = distance / 100.0;
+        double sign = Math.signum(distance);
+        distance = Math.abs(distance);
 
+        while (distance > epsilon) {
             // The field map coordinates are in the detector frame so the
             // extrapolated track position needs to be transformed from the
             // track frame to detector.
-            Hep3Vector currentPositionDet = CoordinateTransformations.transformVectorToDetector(currentPosition);
+            currentPositionDet = CoordinateTransformations.transformVectorToDetector(currentPosition);
 
             // Get the field at the current position along the track.
             bFieldY = fieldMap.getField(currentPositionDet).y();
-            // System.out.println("Field along y (z in detector): " + bField);
 
-            // Get a tracjectory (Helix or Line objects) created with the
+            // Get a trajectory (Helix or Line objects) created with the
             // track parameters at the current position.
-            Trajectory trajectory = getTrajectory(currentMomentum, new org.lcsim.spacegeom.SpacePoint(currentPosition), q, bFieldY);
+            Trajectory trajectory = TrackUtils.getTrajectory(currentMomentum, new org.lcsim.spacegeom.SpacePoint(currentPosition), q, bFieldY);
 
             // Using the new trajectory, extrapolated the track by a step and
             // update the extrapolated position.
-            currentPosition = trajectory.getPointAtDistance(stepSize);
-            // System.out.println("Current position: " + ((Hep3Vector)
-            // currentPosition).toString());
+            Hep3Vector currentPositionTry = trajectory.getPointAtDistance(stepSize);
 
+            if ((Math.abs(endPosition - currentPositionTry.x()) > epsilon) && (Math.signum(endPosition - currentPositionTry.x()) != sign)) {
+                // went too far, try again with smaller step-size
+                if (Math.abs(stepSize) > 0.001) {
+                    stepSize /= 2.0;
+                    continue;
+                } else {
+                    break;
+                }
+            }
+            currentPosition = currentPositionTry;
+
+            distance = Math.abs(endPosition - currentPosition.x());
             // Calculate the momentum vector at the new position. This will
             // be used when creating the trajectory that will be used to
             // extrapolate the track in the next iteration.
             currentMomentum = VecOp.mult(currentMomentum.magnitude(), trajectory.getUnitTangentAtLength(stepSize));
-
-            // If the position of the track along X (or z in the detector frame)
-            // is at 90% of the total distance, reduce the step size.
-            if (currentPosition.x() / endPositionX > .80 && !stepSizeChange) {
-                stepSize /= 10;
-                // System.out.println("Changing step size: " + stepSize);
-                stepSizeChange = true;
-            }
-
-            if (currentMomentum.x() < 0) {
-                throw new RuntimeException("extrapolateTrackUsingFieldMap track going backwards - abort search\n");
-            }
-
         }
 
         // Calculate the track parameters at the Extrapolation point
@@ -1630,7 +1620,8 @@ public class TrackUtils {
         trackParameters[ParameterName.tanLambda.ordinal()] = tanLambda;
 
         // Create a track state at the extrapolation point
-        TrackState trackState = new BaseTrackState(trackParameters, currentPosition.v(), track.getCovMatrix(), TrackState.AtCalorimeter, bFieldY);
+        TrackState trackState = new BaseTrackState(trackParameters, bFieldY);
+        ((BaseTrackState) trackState).setReferencePoint(currentPosition.v());
 
         return trackState;
     }

--- a/tracking/src/main/java/org/hps/recon/tracking/TrackUtils.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/TrackUtils.java
@@ -1547,7 +1547,7 @@ public class TrackUtils {
         double pathToStart = HelixUtils.PathToXPlane(helicalTrackFit, startPosition, 0., 0).get(0);
 
         // Get the momentum of the track
-        double bFieldY = fieldMap.getField(currentPosition).y();
+        double bFieldY = fieldMap.getField(new BasicHep3Vector(0, 0, startPosition)).y();
         double p = Math.abs(helicalTrackFit.p(bFieldY));
         // Get a unit vector giving the track direction at the start
         Hep3Vector helixDirection = HelixUtils.Direction(helicalTrackFit, pathToStart);


### PR DESCRIPTION
Now uses TrackState at final sensor (if available), and starts the extrapolation to the ECal from the helix intercept at final sensor.