### PR TITLE
Fix missing ID information in inactive Si readout

### DIFF
--- a/detector-data/detectors/HPS-EngRun2015-Nominal-v7-0-fieldmap/HPS-EngRun2015-Nominal-v7-0-fieldmap.lcdd
+++ b/detector-data/detectors/HPS-EngRun2015-Nominal-v7-0-fieldmap/HPS-EngRun2015-Nominal-v7-0-fieldmap.lcdd
@@ -2,7 +2,7 @@
 <lcdd xmlns:lcdd="http://www.lcsim.org/schemas/lcdd/1.0" xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/lcdd/1.0/lcdd.xsd">
   <header>
     <detector name="HPS-EngRun2015-Nominal-v7-0-fieldmap" />
-    <generator name="lcsim" version="1.0" file="/nfs/slac/g/hps/jeremym/dev/hps-java/detector-data/detectors/HPS-EngRun2015-Nominal-v7-0-fieldmap/compact.xml" checksum="1814056602" />
+    <generator name="lcsim" version="1.0" file="/nfs/slac/g/hps/jeremym/dev/hps-java/detector-data/detectors/HPS-EngRun2015-Nominal-v7-0-fieldmap/compact.xml" checksum="265067860" />
     <author name="NONE" />
     <comment>Copy of v6-fieldmap detector with inactive Si turned on.</comment>
   </header>
@@ -54,7 +54,9 @@
     <tracker name="Tracker" ecut="0.0" eunit="MeV" verbose="0" hits_collection="TrackerHits">
       <idspecref ref="TrackerHits" />
     </tracker>
-    <tracker name="TrackerHits_Inactive_det" ecut="0.0" eunit="MeV" verbose="0" hits_collection="TrackerHits_Inactive" />
+    <tracker name="TrackerHits_Inactive_det" ecut="0.0" eunit="MeV" verbose="0" hits_collection="TrackerHits_Inactive">
+      <idspecref ref="TrackerHits_Inactive" />
+    </tracker>
     <tracker name="ECalScoring" ecut="0.0" eunit="MeV" verbose="0" hits_collection="TrackerHitsECal">
       <idspecref ref="TrackerHitsECal" />
       <hit_processor type="ScoringTrackerHitProcessor" />
@@ -88,7 +90,7 @@
       <color R="0.75" G="0.73" B="0.75" alpha="1.0" />
     </vis>
     <vis name="ECALVis" line_style="unbroken" drawing_style="wireframe" show_daughters="true" visible="true">
-      <color R="0.8" G="0.5" B="0.1" alpha="0.0" />
+      <color R="0.8" G="0.5" B="0.1" alpha="1.0" />
     </vis>
     <vis name="BasePlateVis" line_style="dashed" drawing_style="solid" show_daughters="true" visible="true">
       <color R="0.35" G="0.35" B="0.35" alpha="1.0" />
@@ -1484,7 +1486,7 @@
         <fraction n="1.0" ref="Vacuum" />
       </material>
       <material name="LeadTungstate">
-        <D value="8.28" unit="g/cm3" />
+        <D value="8.28" unit="g/cm3" type="density" />
         <composite n="1" ref="Pb" />
         <composite n="1" ref="W" />
         <composite n="4" ref="O" />

--- a/detector-model/src/main/java/org/lcsim/geometry/compact/converter/lcdd/HPSTracker2014Base.java
+++ b/detector-model/src/main/java/org/lcsim/geometry/compact/converter/lcdd/HPSTracker2014Base.java
@@ -92,6 +92,9 @@ public abstract class HPSTracker2014Base extends LCDDSubdetector {
         if (this.inactiveSiReadoutName != null) {            
             Tracker tracker = new Tracker(this.inactiveSiReadoutName + "_det");
             tracker.setHitsCollection(this.inactiveSiReadoutName);
+            Element element = new Element("idspecref");
+            element.setAttribute("ref", this.inactiveSiReadoutName);
+            tracker.addContent(element);
             lcdd.addSensitiveDetector(tracker);
             this.inactiveSiTracker = tracker;
         }


### PR DESCRIPTION
Made small patch to the detector converter code to add an ID spec based on the readout name.

Includes regenerated LCDD file for v7 detector.

Verified that regenerating the data using the new detector writes valid ID information; I can see non-zero system, layer and module values in the LCSim Event browser in JAS3 now.