### PR TITLE
Fix dumb conditions init bug.

### DIFF
--- a/monitoring-app/src/main/java/org/hps/monitoring/application/util/ResourceUtil.java
+++ b/monitoring-app/src/main/java/org/hps/monitoring/application/util/ResourceUtil.java
@@ -36,7 +36,15 @@ public final class ResourceUtil {
      * @return the list of available conditions tags
      */
     public static String[] getConditionsTags() {
-        return DatabaseConditionsManager.getInstance().getAvailableTags().toArray(new String[] {});
+        // FIXME: New database manager should probably not be instantiated here.
+        DatabaseConditionsManager mgr = new DatabaseConditionsManager();
+        String[] tags = mgr.getAvailableTags().toArray(new String[]{});
+        try {
+            mgr.getConnection().close();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return tags;
     }
 
     /**


### PR DESCRIPTION
Fix conditions initialization bug when starting monitoring app.

Checked after this fix that the following configuration executes successfully on EVIO data from run 5772:

```
#Tue Mar 13 15:47:26 PDT 2018
SteeringType=RESOURCE
DisconnectOnEndRun=true
AIDAServerName=hps-monitoring-app
WaitTime=1000000000
StationName=MY_STATION
StationPosition=1
LogLevel=ALL
EventBuilderClassName=org.hps.evio.LCSimEngRunEventBuilder
MaxEvents=-1
WaitMode=TIMED
ChunkSize=1
ConditionsTag=engrun2015_pass7
DisconnectOnError=true
DetectorName=HPS-EngRun2015-Nominal-v5-fieldmap
SteeringResource=/org/hps/steering/monitoring/SVTMonitoring.lcsim
EtName=ETBuffer
Verbose=false
Port=11111
LogToFile=false
DataSourceType=ET_SERVER
Host=localhost
QueueSize=0
LogLevelFilter=ALL
Prescale=1
ProcessingStage=LCIO
Blocking=false
```