### PR TITLE
Support usage offline conditions database

### DIFF
--- a/conditions/pom.xml
+++ b/conditions/pom.xml
@@ -43,6 +43,12 @@
       <version>5.1.26</version>
       <scope>runtime</scope>
     </dependency>
+    <!-- https://mvnrepository.com/artifact/org.xerial/sqlite-jdbc -->
+    <dependency>
+      <groupId>org.xerial</groupId>
+      <artifactId>sqlite-jdbc</artifactId>
+      <version>3.23.1</version>
+    </dependency>
     <dependency>
       <groupId>org.reflections</groupId>
       <artifactId>reflections</artifactId>

--- a/conditions/pom.xml
+++ b/conditions/pom.xml
@@ -43,7 +43,6 @@
       <version>5.1.26</version>
       <scope>runtime</scope>
     </dependency>
-    <!-- https://mvnrepository.com/artifact/org.xerial/sqlite-jdbc -->
     <dependency>
       <groupId>org.xerial</groupId>
       <artifactId>sqlite-jdbc</artifactId>

--- a/conditions/src/main/java/org/hps/conditions/api/ConditionsRecord.java
+++ b/conditions/src/main/java/org/hps/conditions/api/ConditionsRecord.java
@@ -1,5 +1,6 @@
 package org.hps.conditions.api;
 
+import java.text.SimpleDateFormat;
 import java.util.Comparator;
 import java.util.Date;
 import java.util.HashSet;
@@ -312,6 +313,15 @@ public final class ConditionsRecord extends BaseConditionsObject {
         this.setFieldValue("created_by", System.getProperty("user.name"));
     }
 
+    static SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd hh:mm:ss");
+    private static Date stringToDate(String dateString) {
+        try {
+            return DATE_FORMAT.parse((String) dateString);
+        } catch (java.text.ParseException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     /**
      * Get the date this record was created.
      *
@@ -319,7 +329,12 @@ public final class ConditionsRecord extends BaseConditionsObject {
      */
     @Field(names = {"created"})
     public Date getCreated() {
-        return this.getFieldValue("created");
+        Object created = this.getFieldValue("created");
+        if (created instanceof String) { /* handle sqlite dates which are returned as strings */
+            return stringToDate((String) created);
+        } else {
+            return this.getFieldValue("created");
+        }
     }
 
     /**
@@ -402,7 +417,12 @@ public final class ConditionsRecord extends BaseConditionsObject {
      */
     @Field(names = {"updated"})
     public Date getUpdated() {
-        return this.getFieldValue("updated");
+        Object updated = this.getFieldValue("updated");
+        if (updated instanceof String) { /* handle sqlite dates which are returned as strings */
+            return stringToDate((String) updated);
+        } else {
+            return this.getFieldValue("updated");
+        }
     }
 
     /**

--- a/conditions/src/main/java/org/hps/conditions/database/DatabaseConditionsManager.java
+++ b/conditions/src/main/java/org/hps/conditions/database/DatabaseConditionsManager.java
@@ -68,7 +68,7 @@ public final class DatabaseConditionsManager extends ConditionsManagerImplementa
      */
     private static final int TEST_RUN_MAX_RUN = 1365;
 
-    private static String DEFAULT_URL = "jdbc:mysql://hpsdb.jlab.org/:3306/";
+    private static String DEFAULT_URL = "jdbc:mysql://hpsdb.jlab.org:3306/hps_conditions";
     private static String DEFAULT_USER = "hpsuser";
     private static String DEFAULT_PASSWORD = "darkphoton";
 

--- a/conditions/src/main/java/org/hps/conditions/database/DatabaseConditionsManager.java
+++ b/conditions/src/main/java/org/hps/conditions/database/DatabaseConditionsManager.java
@@ -67,6 +67,12 @@ public final class DatabaseConditionsManager extends ConditionsManagerImplementa
      */
     private static final int TEST_RUN_MAX_RUN = 1365;
 
+    private static String DEFAULT_URL = "jdbc:mysql://hpsdb.jlab.org/:3306/";
+    private static String DEFAULT_USER = "hpsuser";
+    private static String DEFAULT_PASSWORD = "darkphoton";
+    // jdbc:mysql://mysql-node03.slac.stanford.edu:3306/
+    // jdbc:mysql://hpsdb.jlab.org/:3306/
+
     static {
         DriverManager.setLoginTimeout(30);
     }
@@ -580,21 +586,48 @@ public final class DatabaseConditionsManager extends ConditionsManagerImplementa
     public synchronized void openConnection() {
         try {
             if (this.connection == null || this.connection.isClosed()) {
+
                 // Do the connection parameters need to be figured out automatically?
-                if (this.connectionParameters == null) {
+                //if (this.connectionParameters == null) {
                     // Setup the default read-only connection, which will choose a SLAC or JLab database.
-                    this.connectionParameters = ConnectionParameters.fromResource(CONNECTION_RESOURCE);
+                //    this.connectionParameters = ConnectionParameters.fromResource(CONNECTION_RESOURCE);
+                //}
+                String url = System.getProperty("org.hps.conditions.url");
+                if (url == null) {
+                    url = DEFAULT_URL;
+                }
+                String user = System.getProperty("org.hps.conditions.user");
+                if (user == null) {
+                    user = DEFAULT_USER;
+                }
+                String password = System.getProperty("org.hps.conditions.password");
+                if (password == null) {
+                    password = DEFAULT_PASSWORD;
                 }
 
+                Properties p = new Properties();
+                p.setProperty("user", user);
+                p.setProperty("password", password);
+
+                LOG.info("Opening connection ..." + '\n'
+                        + "url: " + url + '\n'
+                        + "user: " + user + '\n'
+                        + "password: " + password + '\n'
+                );
+
+                connection = DriverManager.getConnection(url, connectionProperties);
+
                 // Print connection info to the log.
+                /*
                 LOG.info("Opening connection ... " + '\n' + "connection: "
                         + this.connectionParameters.getConnectionString() + '\n' + "host: "
                         + this.connectionParameters.getHostname() + '\n' + "port: "
                         + this.connectionParameters.getPort() + '\n' + "user: " + this.connectionParameters.getUser()
                         + '\n' + "database: " + this.connectionParameters.getDatabase());
+                */
 
                 // Create the connection using the parameters.
-                this.connection = this.connectionParameters.createConnection();
+                //this.connection = this.connectionParameters.createConnection();
             }
         } catch (SQLException e) {
             throw new RuntimeException(e);

--- a/conditions/src/main/java/org/hps/conditions/database/DatabaseConditionsManager.java
+++ b/conditions/src/main/java/org/hps/conditions/database/DatabaseConditionsManager.java
@@ -15,6 +15,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Properties;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -70,8 +71,6 @@ public final class DatabaseConditionsManager extends ConditionsManagerImplementa
     private static String DEFAULT_URL = "jdbc:mysql://hpsdb.jlab.org/:3306/";
     private static String DEFAULT_USER = "hpsuser";
     private static String DEFAULT_PASSWORD = "darkphoton";
-    // jdbc:mysql://mysql-node03.slac.stanford.edu:3306/
-    // jdbc:mysql://hpsdb.jlab.org/:3306/
 
     static {
         DriverManager.setLoginTimeout(30);
@@ -587,11 +586,6 @@ public final class DatabaseConditionsManager extends ConditionsManagerImplementa
         try {
             if (this.connection == null || this.connection.isClosed()) {
 
-                // Do the connection parameters need to be figured out automatically?
-                //if (this.connectionParameters == null) {
-                    // Setup the default read-only connection, which will choose a SLAC or JLab database.
-                //    this.connectionParameters = ConnectionParameters.fromResource(CONNECTION_RESOURCE);
-                //}
                 String url = System.getProperty("org.hps.conditions.url");
                 if (url == null) {
                     url = DEFAULT_URL;
@@ -605,9 +599,9 @@ public final class DatabaseConditionsManager extends ConditionsManagerImplementa
                     password = DEFAULT_PASSWORD;
                 }
 
-                Properties p = new Properties();
-                p.setProperty("user", user);
-                p.setProperty("password", password);
+                Properties props = new Properties();
+                props.setProperty("user", user);
+                props.setProperty("password", password);
 
                 LOG.info("Opening connection ..." + '\n'
                         + "url: " + url + '\n'
@@ -615,19 +609,7 @@ public final class DatabaseConditionsManager extends ConditionsManagerImplementa
                         + "password: " + password + '\n'
                 );
 
-                connection = DriverManager.getConnection(url, connectionProperties);
-
-                // Print connection info to the log.
-                /*
-                LOG.info("Opening connection ... " + '\n' + "connection: "
-                        + this.connectionParameters.getConnectionString() + '\n' + "host: "
-                        + this.connectionParameters.getHostname() + '\n' + "port: "
-                        + this.connectionParameters.getPort() + '\n' + "user: " + this.connectionParameters.getUser()
-                        + '\n' + "database: " + this.connectionParameters.getDatabase());
-                */
-
-                // Create the connection using the parameters.
-                //this.connection = this.connectionParameters.createConnection();
+                connection = DriverManager.getConnection(url, props);
             }
         } catch (SQLException e) {
             throw new RuntimeException(e);

--- a/conditions/src/test/java/org/hps/conditions/database/OfflineConditionsManagerTest.java
+++ b/conditions/src/test/java/org/hps/conditions/database/OfflineConditionsManagerTest.java
@@ -1,0 +1,31 @@
+package org.hps.conditions.database;
+
+import junit.framework.TestCase;
+
+import org.hps.conditions.ecal.EcalCalibration;
+import org.hps.conditions.ecal.EcalCalibration.EcalCalibrationCollection;
+
+public class OfflineConditionsManagerTest extends TestCase {
+    
+    /**
+     * Perform basic tests of the database conditions manager.
+     * 
+     * @throws Exception if any error is thrown
+     */
+    public void testOfflineDatabaseConditionsManager() throws Exception {
+       
+        System.setProperty("org.hps.conditions.url", "jdbc:sqlite:hps_conditions.db"); 
+        DatabaseConditionsManager manager = new DatabaseConditionsManager();
+        manager.openConnection();
+
+        manager.setDetector("HPS-EngRun2015-Nominal-v2", 5772);
+
+        EcalCalibrationCollection testCollection = manager.getCachedConditions(EcalCalibrationCollection.class, "ecal_calibrations").getCachedData();
+        TestCase.assertTrue("The test collection should not be empty.", testCollection.size() > 0);
+        for (EcalCalibration calib : testCollection) {
+            System.out.println(calib);
+        }
+  
+        manager.closeConnection();
+    }
+}


### PR DESCRIPTION
Makes the following changes to support offline conditions db...

Usage of ConnectionParameters class is replaced in DatabaseConditionsManager by a simpler scheme which directly creates the connection from default information or Java system properties.

Replaces current conditions db system properties with the following simplified scheme:

`org.hps.conditions.url` - full URL of connection string passed to JDBC (defaults to JLab MySQL db)

For example to run with a local SQLite db file:

```
 -Dorg.hps.conditions.url=jdbc:sqlite:/path/to/the/hps_conditions.db
```

`org.hps.conditions.user` - user name in database (default used if not provided or not used when running offline)

`org.hps.conditions.password` - password to the database (default used if not provided or not used when running offline)

These changes will necessitate that some db scripts are updated for them to work properly.

The ConnectionParameters class can be considered deprecated at this point.

I have tested the hps-java readout with both online and offline conditions db modes, and it appears to run fine.

The actual conditions values in the SQLite db file still need to be verified by checking that the recon results using either are exactly the same.

Side effect: The db code for retrying for a connection has been disabled for now as it lives in the no-longer-used ConnectionParameters class (it can be added back later in the db manager if needed).

It is likely possible that this PR should not be merged without further changes but I wanted to put it up before I am basically unavailable for 3 months.