### PR TITLE
Simple Skim Drivers and steering files for Moller and V0

### DIFF
--- a/recon/src/main/java/org/hps/recon/filtering/MollerSkimDriver.java
+++ b/recon/src/main/java/org/hps/recon/filtering/MollerSkimDriver.java
@@ -1,0 +1,32 @@
+package org.hps.recon.filtering;
+
+import java.util.List;
+import org.lcsim.event.EventHeader;
+import org.lcsim.event.ReconstructedParticle;
+
+/**
+ *
+ * @author Norman Graf
+ */
+public class MollerSkimDriver extends EventReconFilter {
+
+    private String mollerCollectionName = "UnconstrainedMollerCandidates";
+
+    /**
+     * sets the Moller candidate collection to use.
+     *
+     * @param val
+     */
+    public void setMollerCollectionName(String val) {
+        this.mollerCollectionName = val;
+    }
+
+    public void process(EventHeader event) {
+        incrementEventProcessed();
+        List<ReconstructedParticle> mollers = event.get(ReconstructedParticle.class, mollerCollectionName);
+        if (mollers.size() == 0) {
+            skipEvent();
+        }
+        incrementEventPassed();
+    }
+}

--- a/recon/src/main/java/org/hps/recon/filtering/V0SkimDriver.java
+++ b/recon/src/main/java/org/hps/recon/filtering/V0SkimDriver.java
@@ -1,0 +1,32 @@
+package org.hps.recon.filtering;
+
+import java.util.List;
+import org.lcsim.event.EventHeader;
+import org.lcsim.event.ReconstructedParticle;
+
+/**
+ *
+ * @author Norman Graf
+ */
+public class V0SkimDriver extends EventReconFilter {
+
+    private String v0CollectionName = "UnconstrainedV0Candidates";
+
+    /**
+     * sets the V0 candidate collection to use.
+     *
+     * @param val
+     */
+    public void setV0CollectionName(String val) {
+        this.v0CollectionName = val;
+    }
+
+    public void process(EventHeader event) {
+        incrementEventProcessed();
+        List<ReconstructedParticle> vertices = event.get(ReconstructedParticle.class, v0CollectionName);
+        if (vertices.size() == 0) {
+            skipEvent();
+        }
+        incrementEventPassed();
+    }
+}

--- a/steering-files/src/main/resources/org/hps/steering/production/MollerSkim.lcsim
+++ b/steering-files/src/main/resources/org/hps/steering/production/MollerSkim.lcsim
@@ -1,0 +1,21 @@
+<lcsim xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" 
+       xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/lcsim/1.0/lcsim.xsd">
+    <control>
+        <printDriverStatistics>true</printDriverStatistics>
+    </control>
+    <execute>
+        <driver name="MollerSkim"/>
+        <driver name="Writer"/>
+    </execute>
+    <drivers>
+        <!-- Select Events with non-empty Moller candidate collection -->
+        <driver name="MollerSkim" 
+                type="org.hps.recon.filtering.MollerSkimDriver"
+        </driver>
+        <!-- Driver to write output slcio file -->
+        <driver name="Writer" 
+                type="org.lcsim.util.loop.LCIODriver">
+            <outputFilePath>${outputFile}.slcio</outputFilePath>
+        </driver>
+    </drivers>
+</lcsim>

--- a/steering-files/src/main/resources/org/hps/steering/production/V0Skim.lcsim
+++ b/steering-files/src/main/resources/org/hps/steering/production/V0Skim.lcsim
@@ -1,0 +1,21 @@
+<lcsim xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" 
+       xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/lcsim/1.0/lcsim.xsd">
+    <control>
+        <printDriverStatistics>true</printDriverStatistics>
+    </control>
+    <execute>
+        <driver name="V0Skim"/>
+        <driver name="Writer"/>
+    </execute>
+    <drivers>
+        <!-- Select Events with non-empty V0 candidate collection -->
+        <driver name="V0Skim"
+                type="org.hps.recon.filtering.V0SkimDriver">
+        </driver>
+        <!-- Driver to write output slcio file -->
+        <driver name="Writer"
+                type="org.lcsim.util.loop.LCIODriver">
+            <outputFilePath>${outputFile}.slcio</outputFilePath>
+        </driver>
+    </drivers>
+</lcsim>


### PR DESCRIPTION
With new object standardization, skim events based solely on whether the V0 and Moller collections are non-empty.