### PR TITLE
Iss361

### DIFF
--- a/steering-files/src/main/resources/org/hps/steering/recon/PhysicsRun2016FullRecon.lcsim
+++ b/steering-files/src/main/resources/org/hps/steering/recon/PhysicsRun2016FullRecon.lcsim
@@ -146,11 +146,14 @@
             <beamPositionY> -0.138 </beamPositionY>
             <beamSigmaY> 0.030 </beamSigmaY>
             <beamPositionZ> -3.9 </beamPositionZ>
-	    <maxElectronP> 2.2 </maxElectronP>
+	    <maxElectronP> 2.6 </maxElectronP>
+	    <maxVertexP> 2.8 </maxVertexP>
+	    <minVertexChisqProb> 3.e-12 </minVertexChisqProb>
+	    <maxVertexClusterDt> 2.5 </maxVertexClusterDt>
         </driver>  
         <driver name="GBLRefitterDriver" type="org.hps.recon.tracking.gbl.GBLRefitterDriver" >
-	  <maxTrackChisq5hits> 0.00000001 </maxTrackChisq5hits>
-	  <maxTrackChisq6hits> 0.00000001 </maxTrackChisq6hits>
+	  <maxTrackChisq5hits> 60. </maxTrackChisq5hits>
+	  <maxTrackChisq6hits> 72. </maxTrackChisq6hits>
 	</driver>
         <driver name="LCIOWriter" type="org.lcsim.util.loop.LCIODriver">
             <outputFilePath>${outputFile}.slcio</outputFilePath>

--- a/steering-files/src/main/resources/org/hps/steering/recon/PhysicsRun2016FullRecon.lcsim
+++ b/steering-files/src/main/resources/org/hps/steering/recon/PhysicsRun2016FullRecon.lcsim
@@ -146,7 +146,7 @@
             <beamPositionY> -0.138 </beamPositionY>
             <beamSigmaY> 0.030 </beamSigmaY>
             <beamPositionZ> -3.9 </beamPositionZ>
-	    <maxElectronP> 2.6 </maxElectronP>
+	    <maxElectronP> 2.15 </maxElectronP>
 	    <maxVertexP> 2.8 </maxVertexP>
 	    <minVertexChisqProb> 1.7e-16 </minVertexChisqProb>
 	    <maxVertexClusterDt> 2.5 </maxVertexClusterDt>

--- a/steering-files/src/main/resources/org/hps/steering/recon/PhysicsRun2016FullRecon.lcsim
+++ b/steering-files/src/main/resources/org/hps/steering/recon/PhysicsRun2016FullRecon.lcsim
@@ -148,7 +148,7 @@
             <beamPositionZ> -3.9 </beamPositionZ>
 	    <maxElectronP> 2.6 </maxElectronP>
 	    <maxVertexP> 2.8 </maxVertexP>
-	    <minVertexChisqProb> 3.e-12 </minVertexChisqProb>
+	    <minVertexChisqProb> 1.7e-16 </minVertexChisqProb>
 	    <maxVertexClusterDt> 2.5 </maxVertexClusterDt>
         </driver>  
         <driver name="GBLRefitterDriver" type="org.hps.recon.tracking.gbl.GBLRefitterDriver" >

--- a/steering-files/src/main/resources/org/hps/steering/recon/PhysicsRun2016FullRecon.lcsim
+++ b/steering-files/src/main/resources/org/hps/steering/recon/PhysicsRun2016FullRecon.lcsim
@@ -139,15 +139,19 @@
         <driver name="MergeTrackCollections" type="org.hps.recon.tracking.MergeTrackCollections" />
         <driver name="TrackDataDriver" type="org.hps.recon.tracking.TrackDataDriver" />
         <driver name="ReconParticleDriver" type="org.hps.recon.particle.HpsReconParticleDriver" > 
-            <ecalClusterCollectionName>EcalClustersCorr</ecalClusterCollectionName>        
+            <ecalClusterCollectionName>EcalClustersCorr</ecalClusterCollectionName>
             <trackCollectionNames>GBLTracks</trackCollectionNames>
             <beamPositionX> -0.246 </beamPositionX>
             <beamSigmaX> 0.125 </beamSigmaX>
             <beamPositionY> -0.138 </beamPositionY>
             <beamSigmaY> 0.030 </beamSigmaY>
             <beamPositionZ> -3.9 </beamPositionZ>
+	    <maxElectronP> 2.2 </maxElectronP>
         </driver>  
-        <driver name="GBLRefitterDriver" type="org.hps.recon.tracking.gbl.GBLRefitterDriver"/>
+        <driver name="GBLRefitterDriver" type="org.hps.recon.tracking.gbl.GBLRefitterDriver" >
+	  <maxTrackChisq5hits> 0.00000001 </maxTrackChisq5hits>
+	  <maxTrackChisq6hits> 0.00000001 </maxTrackChisq6hits>
+	</driver>
         <driver name="LCIOWriter" type="org.lcsim.util.loop.LCIODriver">
             <outputFilePath>${outputFile}.slcio</outputFilePath>
         </driver>

--- a/tracking/src/main/java/org/hps/recon/tracking/gbl/GBLRefitterDriver.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/gbl/GBLRefitterDriver.java
@@ -63,6 +63,18 @@ public class GBLRefitterDriver extends Driver {
         cuts.setMaxTrackChisq(nhits, input);
     }
 
+    public void setMaxTrackChisq5hits(double input){
+        if (cuts == null)
+            cuts = new StandardCuts();
+        cuts.setMaxTrackChisq(5, input);
+    }
+
+    public void setMaxTrackChisq6hits(double input){
+        if (cuts == null)
+            cuts = new StandardCuts();
+        cuts.setMaxTrackChisq(6, input);
+    }
+
     public void setMaxTrackChisq(double input) {
         if (cuts == null)
             cuts = new StandardCuts();


### PR DESCRIPTION
Some of MOUSE cuts were set in the steering files, which basically loosen MOUSE cuts.

In order to set chu2/NDF cut, the driver GBLRefitterDriver.java has modified, i.e.
two separate methods are added for 5 and 6 hit tracks.