### PR TITLE
fix ecal cluster energy correction for old, single beamgap geometry parameter

### DIFF
--- a/ecal-recon/src/main/java/org/hps/recon/ecal/cluster/ClusterEnergyCorrection.java
+++ b/ecal-recon/src/main/java/org/hps/recon/ecal/cluster/ClusterEnergyCorrection.java
@@ -147,7 +147,7 @@ public final class ClusterEnergyCorrection {
             BEAMGAPBOT = -ecal.getNode().getChild("layout").getAttribute("beamgapBottom").getDoubleValue();
         } catch (Exception e) {
             try {
-                BEAMGAPBOT = ecal.getNode().getChild("layout").getAttribute("beamgap").getDoubleValue();
+                BEAMGAPBOT = -ecal.getNode().getChild("layout").getAttribute("beamgap").getDoubleValue();
             } catch (Exception ee) {
                 ee.printStackTrace();
             }


### PR DESCRIPTION
Resolves #394 

Only affects geometries that use the old, single `beamgap` parameter and not the ones that use the separate `beamgapTop` and `beamgapBottom`.  
