### PR TITLE
Always write out all vertex constrained particles.

### DIFF
--- a/recon/src/main/java/org/hps/recon/particle/HpsReconParticleDriver.java
+++ b/recon/src/main/java/org/hps/recon/particle/HpsReconParticleDriver.java
@@ -639,18 +639,16 @@ public class HpsReconParticleDriver extends ReconParticleDriver {
 
         // Create candidate particles for the other two constraints.
         for (Constraint constraint : Constraint.values()) {
-
+            if(constraint == Constraint.UNCONSTRAINED) continue;           // Skip the UNCONSTRAINED case, done already
+            
             // Generate a candidate vertex and particle.
             vtxFit = fitVertex(constraint, electron, positron);
 
             candidate = makeReconstructedParticle(electron, positron, vtxFit);
 
-            // Add the candidate vertex and particle to the
+            // Add the other candidate vertex and particle to the
             // appropriate LCIO collection.
             switch (constraint) {
-
-                case UNCONSTRAINED:
-                    break;              // Done this one already.
 
                 case BS_CONSTRAINED:
                     if (eleIsTop != posIsTop) {

--- a/recon/src/main/java/org/hps/recon/particle/HpsReconParticleDriver.java
+++ b/recon/src/main/java/org/hps/recon/particle/HpsReconParticleDriver.java
@@ -611,7 +611,8 @@ public class HpsReconParticleDriver extends ReconParticleDriver {
             return;
         }
 
-
+        // Handle UNCONSTRAINED case, to make decisions whether we store the vertexes.
+        // This is done here so that we either store all types, or none, but never a mix.
         BilliorVertex vtxFit = fitVertex(Constraint.UNCONSTRAINED, electron, positron);
 
         ReconstructedParticle candidate = makeReconstructedParticle(electron, positron, vtxFit);
@@ -624,7 +625,19 @@ public class HpsReconParticleDriver extends ReconParticleDriver {
             return;
         }
         
-        // Create candidate particles for each constraint.
+        // patch the track parameters at the found vertex
+        if (_patchVertexTrackParameters) {
+            patchVertex(vtxFit);
+        }
+        if (eleIsTop != posIsTop) {
+            unconstrainedV0Vertices.add(vtxFit);
+            unconstrainedV0Candidates.add(candidate);
+        } else {
+            unconstrainedVcVertices.add(vtxFit);
+            unconstrainedVcCandidates.add(candidate);
+        }
+
+        // Create candidate particles for the other two constraints.
         for (Constraint constraint : Constraint.values()) {
 
             // Generate a candidate vertex and particle.
@@ -637,18 +650,7 @@ public class HpsReconParticleDriver extends ReconParticleDriver {
             switch (constraint) {
 
                 case UNCONSTRAINED:
-                    // patch the track parameters at the found vertex
-                    if (_patchVertexTrackParameters) {
-                        patchVertex(vtxFit);
-                    }
-                    if (eleIsTop != posIsTop) {
-                        unconstrainedV0Vertices.add(vtxFit);
-                        unconstrainedV0Candidates.add(candidate);
-                    } else {
-                        unconstrainedVcVertices.add(vtxFit);
-                        unconstrainedVcCandidates.add(candidate);
-                    }
-                    break;
+                    break;              // Done this one already.
 
                 case BS_CONSTRAINED:
                     if (eleIsTop != posIsTop) {

--- a/recon/src/main/java/org/hps/recon/particle/HpsReconParticleDriver.java
+++ b/recon/src/main/java/org/hps/recon/particle/HpsReconParticleDriver.java
@@ -611,21 +611,26 @@ public class HpsReconParticleDriver extends ReconParticleDriver {
             return;
         }
 
+
+        BilliorVertex vtxFit = fitVertex(Constraint.UNCONSTRAINED, electron, positron);
+
+        ReconstructedParticle candidate = makeReconstructedParticle(electron, positron, vtxFit);
+
+        if (candidate.getMomentum().magnitude() > cuts.getMaxVertexP()) {
+            return;
+        }
+
+        if (candidate.getStartVertex().getProbability() < cuts.getMinVertexChisqProb()) {
+            return;
+        }
+        
         // Create candidate particles for each constraint.
         for (Constraint constraint : Constraint.values()) {
 
             // Generate a candidate vertex and particle.
-            BilliorVertex vtxFit = fitVertex(constraint, electron, positron);
+            vtxFit = fitVertex(constraint, electron, positron);
 
-            ReconstructedParticle candidate = makeReconstructedParticle(electron, positron, vtxFit);
-
-            if (candidate.getMomentum().magnitude() > cuts.getMaxVertexP()) {
-                continue;
-            }
-
-            if (candidate.getStartVertex().getProbability() < cuts.getMinVertexChisqProb()) {
-                continue;
-            }
+            candidate = makeReconstructedParticle(electron, positron, vtxFit);
 
             // Add the candidate vertex and particle to the
             // appropriate LCIO collection.


### PR DESCRIPTION
Basically, if you write one, you should write all of them, so any cuts should be done outside the loop. Currently the checks for chi-square and MaxVertexP are done on the UNCONSTRAINED collection.