### PR TITLE
Iss 374

### DIFF
--- a/analysis/src/main/java/org/hps/analysis/tuple/FittedSVTHitsTupleDriver.java
+++ b/analysis/src/main/java/org/hps/analysis/tuple/FittedSVTHitsTupleDriver.java
@@ -1,0 +1,250 @@
+package org.hps.analysis.tuple;
+
+import hep.physics.vec.BasicHep3Vector;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.hps.recon.tracking.FittedRawTrackerHit;
+import org.hps.recon.tracking.ShapeFitParameters;
+import org.lcsim.event.EventHeader;
+import org.hps.recon.tracking.TrackerHitUtils;
+import org.hps.recon.utils.TrackClusterMatcher;
+import org.lcsim.detector.converter.compact.subdetector.SvtStereoLayer;
+import org.lcsim.detector.tracker.silicon.HpsSiSensor;
+import org.lcsim.event.LCRelation;
+import org.lcsim.event.RawTrackerHit;
+import org.lcsim.event.RelationalTable;
+import org.lcsim.event.base.BaseRelationalTable;
+import org.lcsim.geometry.Detector;
+import org.lcsim.geometry.FieldMap;
+
+// driver for investigating the SVT raw and fitted hits
+//  author = matt graham
+//  date created = 2/5/2019
+// 
+public class FittedSVTHitsTupleDriver extends MCTupleMaker {
+
+    private static Logger LOGGER = Logger.getLogger(FittedSVTHitsTupleDriver.class.getPackage().getName());
+
+    String finalStateParticlesColName = "FinalStateParticles";
+    String mcParticlesColName = "MCParticle";
+    String readoutHitCollectionName = "EcalReadoutHits";//these are in ADC counts
+    String calibratedHitCollectionName = "EcalCalHits";//these are in energy
+    String clusterCollectionName = "EcalClustersCorr";
+    private String helicalTrackHitCollectionName = "HelicalTrackHits";
+    private String rotatedTrackHitCollectionName = "RotatedHelicalTrackHits";
+    private String unconstrainedV0CandidatesColName = "UnconstrainedV0Candidates";
+    private String beamConV0CandidatesColName = "BeamspotConstrainedV0Candidates";
+    private String targetV0ConCandidatesColName = "TargetConstrainedV0Candidates";
+    private String rawTrackerHitCollectionName = "SVTRawTrackerHits";
+    private String fittedTrackerHitCollectionName = "SVTFittedRawTrackerHits";
+    private String trackerHitCollectionName = "StripClusterer_SiTrackerHitStrip1D";
+    String[] fpQuantNames = {"nEle_per_Event", "nPos_per_Event", "nPhoton_per_Event", "nUnAssociatedTracks_per_Event", "avg_delX_at_ECal", "avg_delY_at_ECal", "avg_E_Over_P", "avg_mom_beam_elec", "sig_mom_beam_elec"};
+    private TrackClusterMatcher matcher = new TrackClusterMatcher();
+    //private Map<SiSensor, Map<Integer, Hep3Vector>> stripPositions = new HashMap<SiSensor, Map<Integer, Hep3Vector>>(); 
+    private List<HpsSiSensor> sensors = null;
+    private Map<Integer, List<SvtStereoLayer>> topStereoLayers = new HashMap<Integer, List<SvtStereoLayer>>();
+    private Map<Integer, List<SvtStereoLayer>> bottomStereoLayers = new HashMap<Integer, List<SvtStereoLayer>>();
+    // Constants
+    public static final double SENSOR_LENGTH = 98.33; // mm
+    public static final double SENSOR_WIDTH = 38.3399; // mm
+    private static final String SUBDETECTOR_NAME = "Tracker";
+    boolean doSkim = false;
+    TrackerHitUtils trackerHitUtils = new TrackerHitUtils();
+    //some counters
+    int nRecoEvents = 0;
+    int nTotEle = 0;
+    int nTotPos = 0;
+    int nTotPhotons = 0;
+    int nTotUnAss = 0;
+    int nTotAss = 0;
+    //some summers
+    double sumdelX = 0.0;
+    double sumdelY = 0.0;
+    double sumEoverP = 0.0;
+    // double beamEnergy = 1.05; //GeV
+    double clTimeMin = 30;//ns
+    double clTimeMax = 50;//ns
+    double deltaTimeMax = 4;//ns
+    double coplanMean = 180;//degrees
+    double coplanWidth = 10;//degrees
+    double esumMin = 0.4;
+    double esumMax = 1.2;
+    double phot_nom_x = 42.52;//nominal photon position (px=0)
+    boolean requirePositron = false;
+    double maxPairs = 5;
+    boolean requireSuperFiducial = false;
+    int nbins = 50;
+    double B_FIELD = 0.23;//Tesla
+
+    protected final Map<Integer, String> layerMap = new HashMap<Integer, String>();
+
+    double[] hthHitTime = new double[6];
+    double[] SiClHitTime = new double[12];
+    double[] SiHitClHitTime = new double[12];
+
+    protected double[] beamSize = {0.001, 0.130, 0.050}; //rough estimate from harp scans during engineering run production running
+    // Beam position variables.
+    // The beamPosition array is in the tracking frame
+    /* TODO get the beam position from the conditions db */
+    protected double[] beamPosition = {0.0, 0.0, 0.0}; //
+
+    double minPhi = -0.25;
+    double maxPhi = 0.25;
+    boolean isFirst = true;
+
+    @Override
+    boolean passesCuts() {
+        return true;
+    }
+
+    private enum Constraint {
+
+        /**
+         * Represents a fit with no constraints.
+         */
+        UNCONSTRAINED,
+        /**
+         * Represents a fit with beam spot constraints.
+         */
+        BS_CONSTRAINED,
+        /**
+         * Represents a fit with target constraints.
+         */
+        TARGET_CONSTRAINED
+    }
+
+    String detName;
+
+    /**
+     * The B field map
+     */
+    FieldMap bFieldMap = null;
+    /**
+     * Position of the Ecal face
+     */
+    private double ecalPosition = 0; // mm
+
+    /**
+     * Z position to start extrapolation from
+     */
+    double extStartPos = 700; // mm
+
+    /**
+     * The extrapolation step size
+     */
+    double stepSize = 5.0; // mm
+    /**
+     * Name of the constant denoting the position of the Ecal face in the
+     * compact description.
+     */
+    private static final String ECAL_POSITION_CONSTANT_NAME = "ecal_dface";
+
+    @Override
+    protected void setupVariables() {
+        tupleVariables.clear();
+       
+
+        // String[] ADCVals = new String[]{"L/D","AxSt/D","HoSl/D","S1/D","S2/D","S3/D","S4/D","S5/D","S6/D"};
+        String[] FitVals = new String[]{"L/D", "AxSt/D", "TopBot/D","ChiProb/D", "T0/D", "Amp/D", "T0Err/D", "AmpErr/D"};
+
+        tupleVariables.addAll(Arrays.asList(FitVals));
+        /*
+        tupleVariables.addAll(Arrays.asList(L1aADC));
+        tupleVariables.addAll(Arrays.asList(L2aADC));
+        tupleVariables.addAll(Arrays.asList(L3aADC));
+        tupleVariables.addAll(Arrays.asList(L4aADC));
+        tupleVariables.addAll(Arrays.asList(L5aADC));
+        tupleVariables.addAll(Arrays.asList(L6aADC));
+
+        tupleVariables.addAll(Arrays.asList(L1sADC));
+        tupleVariables.addAll(Arrays.asList(L2sADC));
+        tupleVariables.addAll(Arrays.asList(L3sADC));
+        tupleVariables.addAll(Arrays.asList(L4sADC));
+        tupleVariables.addAll(Arrays.asList(L5sADC));
+        tupleVariables.addAll(Arrays.asList(L6sADC));
+         */
+    }
+
+    protected void detectorChanged(Detector detector) {
+
+        super.detectorChanged(detector);
+        layerMap.put(1, "L1");
+        layerMap.put(2, "L2");
+        layerMap.put(3, "L3");
+        layerMap.put(4, "L4");
+        layerMap.put(5, "L5");
+        layerMap.put(6, "L6");
+        detName = detector.getName();
+        double maxFactor = 1.5;
+        double feeMomentumCut = 0.75; //this number, multiplied by the beam energy, is the actual cut
+        B_FIELD = detector.getFieldMap().getField(new BasicHep3Vector(0, 0, 500)).y();
+        // Get the field map from the detector object
+        bFieldMap = detector.getFieldMap();
+        // Get the position of the Ecal from the compact description
+        ecalPosition = detector.getConstants().get(ECAL_POSITION_CONSTANT_NAME).getValue();       
+        LOGGER.setLevel(Level.ALL);
+        LOGGER.info("B_FIELD=" + B_FIELD);
+        LOGGER.info("Setting up the plotter");
+
+    }
+
+    @Override
+    public void process(EventHeader event) {
+
+        if (!event.hasCollection(FittedRawTrackerHit.class, fittedTrackerHitCollectionName))
+            return;
+        List<LCRelation> fittedTrackerHits = event.get(LCRelation.class, fittedTrackerHitCollectionName);
+        RelationalTable rthtofit = new BaseRelationalTable(RelationalTable.Mode.ONE_TO_ONE, RelationalTable.Weighting.UNWEIGHTED);
+        for (LCRelation hit : fittedTrackerHits)
+            rthtofit.add(FittedRawTrackerHit.getRawTrackerHit(hit), FittedRawTrackerHit.getShapeFitParameters(hit));
+
+        String axStLabel = "";
+        String tString = "";
+        String layerLabel = "";
+        Double hosl = 0.0;
+        Double axst = 0.0;
+        Double topbot=0.0;
+        for (LCRelation fth : fittedTrackerHits) {
+            RawTrackerHit rthDummy = FittedRawTrackerHit.getRawTrackerHit(fth);
+            ShapeFitParameters shape=(ShapeFitParameters)FittedRawTrackerHit.getShapeFitParameters(fth);
+            HpsSiSensor sensor = ((HpsSiSensor) rthDummy.getDetectorElement());            
+            int layer = rthDummy.getLayerNumber();
+            layerLabel = layerMap.get(layer);
+            double[] dummyPosition=rthDummy.getPosition();
+//            System.out.println("hit time = "+shape.getT0());
+//            System.out.println("hit position = ("+dummyPosition[0]+","+dummyPosition[1]+","+dummyPosition[2]+")");
+//            System.out.println("sensor.isTop() = "+sensor.isTopLayer());
+            hosl = 0.0;
+            axst = 0.0;
+            topbot=1.0;
+            if (sensor.getSide() == "POSITRON")
+                hosl = 1.0;
+            if (sensor.isStereo())
+                axst = 1.0;
+            if(dummyPosition[1]<0)
+                topbot=0.0;
+            tupleMap.put("L/D", layer / 1.0);
+            tupleMap.put("AxSt/D", axst);
+            tupleMap.put("TopBot/D", topbot);
+            tupleMap.put("T0/D", shape.getT0());
+            tupleMap.put("T0Err/D", shape.getT0Err());
+            tupleMap.put("Amp/D", shape.getAmp());
+            tupleMap.put("AmpErr/D", shape.getAmpErr());
+            tupleMap.put("ChiProb/D", shape.getChiProb());
+            if (tupleWriter != null) {
+//                System.out.println("writing tuple");
+                writeTuple();
+            }
+        }
+
+    }
+
+    private int moduleNumber(int layer) {
+        return (int) (layer + 1) / 2;
+    }
+
+}

--- a/analysis/src/main/java/org/hps/analysis/tuple/RawSVTHitsTupleDriver.java
+++ b/analysis/src/main/java/org/hps/analysis/tuple/RawSVTHitsTupleDriver.java
@@ -1,0 +1,261 @@
+package org.hps.analysis.tuple;
+
+import hep.physics.vec.BasicHep3Vector;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.hps.recon.tracking.FittedRawTrackerHit;
+import org.lcsim.event.EventHeader;
+import org.hps.recon.tracking.TrackerHitUtils;
+import org.hps.recon.utils.TrackClusterMatcher;
+import org.lcsim.detector.converter.compact.subdetector.SvtStereoLayer;
+import org.lcsim.detector.tracker.silicon.HpsSiSensor;
+import org.lcsim.event.LCRelation;
+import org.lcsim.event.RawTrackerHit;
+import org.lcsim.event.RelationalTable;
+import org.lcsim.event.base.BaseRelationalTable;
+import org.lcsim.geometry.Detector;
+import org.lcsim.geometry.FieldMap;
+
+// driver for investigating the SVT raw and fitted hits
+//  author = matt graham
+//  date created = 2/5/2019
+// 
+public class RawSVTHitsTupleDriver extends MCTupleMaker {
+
+    private static Logger LOGGER = Logger.getLogger(RawSVTHitsTupleDriver.class.getPackage().getName());
+
+    String finalStateParticlesColName = "FinalStateParticles";
+    String mcParticlesColName = "MCParticle";
+    String readoutHitCollectionName = "EcalReadoutHits";//these are in ADC counts
+    String calibratedHitCollectionName = "EcalCalHits";//these are in energy
+    String clusterCollectionName = "EcalClustersCorr";
+    private String helicalTrackHitCollectionName = "HelicalTrackHits";
+    private String rotatedTrackHitCollectionName = "RotatedHelicalTrackHits";
+    private String unconstrainedV0CandidatesColName = "UnconstrainedV0Candidates";
+    private String beamConV0CandidatesColName = "BeamspotConstrainedV0Candidates";
+    private String targetV0ConCandidatesColName = "TargetConstrainedV0Candidates";
+    private String rawTrackerHitCollectionName = "SVTRawTrackerHits";
+    private String fittedTrackerHitCollectionName = "SVTFittedRawTrackerHits";
+    private String trackerHitCollectionName = "StripClusterer_SiTrackerHitStrip1D";
+    String[] fpQuantNames = {"nEle_per_Event", "nPos_per_Event", "nPhoton_per_Event", "nUnAssociatedTracks_per_Event", "avg_delX_at_ECal", "avg_delY_at_ECal", "avg_E_Over_P", "avg_mom_beam_elec", "sig_mom_beam_elec"};
+    private TrackClusterMatcher matcher = new TrackClusterMatcher();
+    //private Map<SiSensor, Map<Integer, Hep3Vector>> stripPositions = new HashMap<SiSensor, Map<Integer, Hep3Vector>>(); 
+    private List<HpsSiSensor> sensors = null;
+    private Map<Integer, List<SvtStereoLayer>> topStereoLayers = new HashMap<Integer, List<SvtStereoLayer>>();
+    private Map<Integer, List<SvtStereoLayer>> bottomStereoLayers = new HashMap<Integer, List<SvtStereoLayer>>();
+    // Constants
+    public static final double SENSOR_LENGTH = 98.33; // mm
+    public static final double SENSOR_WIDTH = 38.3399; // mm
+    private static final String SUBDETECTOR_NAME = "Tracker";
+    boolean doSkim = false;
+    TrackerHitUtils trackerHitUtils = new TrackerHitUtils();
+    //some counters
+    int nRecoEvents = 0;
+    int nTotEle = 0;
+    int nTotPos = 0;
+    int nTotPhotons = 0;
+    int nTotUnAss = 0;
+    int nTotAss = 0;
+    //some summers
+    double sumdelX = 0.0;
+    double sumdelY = 0.0;
+    double sumEoverP = 0.0;
+    // double beamEnergy = 1.05; //GeV
+    double clTimeMin = 30;//ns
+    double clTimeMax = 50;//ns
+    double deltaTimeMax = 4;//ns
+    double coplanMean = 180;//degrees
+    double coplanWidth = 10;//degrees
+    double esumMin = 0.4;
+    double esumMax = 1.2;
+    double phot_nom_x = 42.52;//nominal photon position (px=0)
+    boolean requirePositron = false;
+    double maxPairs = 5;
+    boolean requireSuperFiducial = false;
+    int nbins = 50;
+    double B_FIELD = 0.23;//Tesla
+
+    protected final Map<Integer, String> layerMap = new HashMap<Integer, String>();
+
+    double[] hthHitTime = new double[6];
+    double[] SiClHitTime = new double[12];
+    double[] SiHitClHitTime = new double[12];
+
+    protected double[] beamSize = {0.001, 0.130, 0.050}; //rough estimate from harp scans during engineering run production running
+    // Beam position variables.
+    // The beamPosition array is in the tracking frame
+    /* TODO get the beam position from the conditions db */
+    protected double[] beamPosition = {0.0, 0.0, 0.0}; //
+
+    double minPhi = -0.25;
+    double maxPhi = 0.25;
+    boolean isFirst = true;
+
+    @Override
+    boolean passesCuts() {
+        return true;
+    }
+
+    private enum Constraint {
+
+        /**
+         * Represents a fit with no constraints.
+         */
+        UNCONSTRAINED,
+        /**
+         * Represents a fit with beam spot constraints.
+         */
+        BS_CONSTRAINED,
+        /**
+         * Represents a fit with target constraints.
+         */
+        TARGET_CONSTRAINED
+    }
+
+    String detName;
+
+    /**
+     * The B field map
+     */
+    FieldMap bFieldMap = null;
+    /**
+     * Position of the Ecal face
+     */
+    private double ecalPosition = 0; // mm
+
+    /**
+     * Z position to start extrapolation from
+     */
+    double extStartPos = 700; // mm
+
+    /**
+     * The extrapolation step size
+     */
+    double stepSize = 5.0; // mm
+    /**
+     * Name of the constant denoting the position of the Ecal face in the
+     * compact description.
+     */
+    private static final String ECAL_POSITION_CONSTANT_NAME = "ecal_dface";
+
+    @Override
+    protected void setupVariables() {
+        tupleVariables.clear();
+
+        String[] L1aADC = new String[]{"L1aS1/D", "L1aS2/D", "L1aS3/D", "L1aS4/D", "L1aS5/D", "L1aS6/D"};
+        String[] L2aADC = new String[]{"L2aS1/D", "L2aS2/D", "L2aS3/D", "L2aS4/D", "L2aS5/D", "L2aS6/D"};
+        String[] L3aADC = new String[]{"L3aS1/D", "L3aS2/D", "L3aS3/D", "L3aS4/D", "L3aS5/D", "L3aS6/D"};
+        String[] L4aADC = new String[]{"L4aS1/D", "L4aS2/D", "L4aS3/D", "L4aS4/D", "L4aS5/D", "L4aS6/D"};
+        String[] L5aADC = new String[]{"L5aS1/D", "L5aS2/D", "L5aS3/D", "L5aS4/D", "L5aS5/D", "L5aS6/D"};
+        String[] L6aADC = new String[]{"L6aS1/D", "L6aS2/D", "L6aS3/D", "L6aS4/D", "L6aS5/D", "L6aS6/D"};
+
+        String[] L1sADC = new String[]{"L1sS1/D", "L1sS2/D", "L1sS3/D", "L1sS4/D", "L1sS5/D", "L1sS6/D"};
+        String[] L2sADC = new String[]{"L2sS1/D", "L2sS2/D", "L2sS3/D", "L2sS4/D", "L2sS5/D", "L2sS6/D"};
+        String[] L3sADC = new String[]{"L3sS1/D", "L3sS2/D", "L3sS3/D", "L3sS4/D", "L3sS5/D", "L3sS6/D"};
+        String[] L4sADC = new String[]{"L4sS1/D", "L4sS2/D", "L4sS3/D", "L4sS4/D", "L4sS5/D", "L4sS6/D"};
+        String[] L5sADC = new String[]{"L5sS1/D", "L5sS2/D", "L5sS3/D", "L5sS4/D", "L5sS5/D", "L5sS6/D"};
+        String[] L6sADC = new String[]{"L6sS1/D", "L6sS2/D", "L6sS3/D", "L6sS4/D", "L6sS5/D", "L6sS6/D"};
+
+        // String[] ADCVals = new String[]{"L/D","AxSt/D","HoSl/D","S1/D","S2/D","S3/D","S4/D","S5/D","S6/D"};
+        String[] ADCVals = new String[]{"L/D", "AxSt/D", "S1/D", "S2/D", "S3/D", "S4/D", "S5/D", "S6/D"};
+
+        tupleVariables.addAll(Arrays.asList(ADCVals));
+        /*
+        tupleVariables.addAll(Arrays.asList(L1aADC));
+        tupleVariables.addAll(Arrays.asList(L2aADC));
+        tupleVariables.addAll(Arrays.asList(L3aADC));
+        tupleVariables.addAll(Arrays.asList(L4aADC));
+        tupleVariables.addAll(Arrays.asList(L5aADC));
+        tupleVariables.addAll(Arrays.asList(L6aADC));
+
+        tupleVariables.addAll(Arrays.asList(L1sADC));
+        tupleVariables.addAll(Arrays.asList(L2sADC));
+        tupleVariables.addAll(Arrays.asList(L3sADC));
+        tupleVariables.addAll(Arrays.asList(L4sADC));
+        tupleVariables.addAll(Arrays.asList(L5sADC));
+        tupleVariables.addAll(Arrays.asList(L6sADC));
+         */
+    }
+
+    protected void detectorChanged(Detector detector) {
+
+        super.detectorChanged(detector);
+        layerMap.put(1, "L1");
+        layerMap.put(2, "L2");
+        layerMap.put(3, "L3");
+        layerMap.put(4, "L4");
+        layerMap.put(5, "L5");
+        layerMap.put(6, "L6");
+        detName = detector.getName();
+        double maxFactor = 1.5;
+        double feeMomentumCut = 0.75; //this number, multiplied by the beam energy, is the actual cut
+        B_FIELD = detector.getFieldMap().getField(new BasicHep3Vector(0, 0, 500)).y();
+        // Get the field map from the detector object
+        bFieldMap = detector.getFieldMap();
+        // Get the position of the Ecal from the compact description
+        ecalPosition = detector.getConstants().get(ECAL_POSITION_CONSTANT_NAME).getValue();
+        // Get the position of the Ecal from the compact description
+        ecalPosition = detector.getConstants().get(ECAL_POSITION_CONSTANT_NAME).getValue();
+        LOGGER.setLevel(Level.ALL);
+        LOGGER.info("B_FIELD=" + B_FIELD);
+        LOGGER.info("Setting up the plotter");
+
+    }
+
+    @Override
+    public void process(EventHeader event) {
+
+        if (!event.hasCollection(RawTrackerHit.class, rawTrackerHitCollectionName))
+//            System.out.println("No raw tracker hits???");
+            return;
+
+        List<RawTrackerHit> rawHits = event.get(RawTrackerHit.class, rawTrackerHitCollectionName);
+        if (rawHits == null)
+            throw new RuntimeException("Event is missing SVT hits collection!");
+        else
+            System.out.println("RawSVTHitsTupleDriver::process  number of raw hits = " + rawHits.size());
+        String axStLabel = "";
+        String tString = "";
+        String layerLabel = "";
+        Double hosl = 0.0;
+        Double axst = 0.0;
+        for (RawTrackerHit rth : rawHits) {
+            short[] samples = rth.getADCValues();
+            int layer = rth.getLayerNumber();
+            layerLabel = layerMap.get(layer);
+            HpsSiSensor sensor = ((HpsSiSensor) rth.getDetectorElement());
+            hosl = 0.0;
+            axst = 0.0;
+            if (sensor.getSide() == "POSITRON")
+                hosl = 1.0;
+            if (sensor.isStereo())
+                axst = 1.0;
+//            if (sensor.())
+//                axst=1.0;
+//            System.out.println("RawSVTHitsTupleDriver::process  filling samples for l=" + layer + axStLabel);
+            tupleMap.put("L/D", layer / 1.0);
+            tupleMap.put("AxSt/D", axst);
+            for (int i = 0; i < 6; i++) {
+//              tString = "L" + layerLabel + axStLabel + "S" + String.valueOf(i) + "/D";
+                tString = "S" + String.valueOf(i + 1) + "/D";
+                // System.out.println(tString+" "+(double) (samples[i] / 1.0));
+                tupleMap.put(tString, (double) (samples[i] / 1.0));
+            }
+            if (tupleWriter != null) {
+//                System.out.println("writing tuple");
+                writeTuple();
+
+            }
+        }     
+
+    }
+
+    private int moduleNumber(int layer) {
+        return (int) (layer + 1) / 2;
+    }
+
+}

--- a/analysis/src/main/java/org/hps/analysis/tuple/RawSVTHitsTupleDriver.java
+++ b/analysis/src/main/java/org/hps/analysis/tuple/RawSVTHitsTupleDriver.java
@@ -7,16 +7,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import org.hps.recon.tracking.FittedRawTrackerHit;
 import org.lcsim.event.EventHeader;
 import org.hps.recon.tracking.TrackerHitUtils;
 import org.hps.recon.utils.TrackClusterMatcher;
 import org.lcsim.detector.converter.compact.subdetector.SvtStereoLayer;
 import org.lcsim.detector.tracker.silicon.HpsSiSensor;
-import org.lcsim.event.LCRelation;
 import org.lcsim.event.RawTrackerHit;
-import org.lcsim.event.RelationalTable;
-import org.lcsim.event.base.BaseRelationalTable;
 import org.lcsim.geometry.Detector;
 import org.lcsim.geometry.FieldMap;
 

--- a/analysis/src/main/java/org/hps/analysis/tuple/SVTTimingTupleDriver.java
+++ b/analysis/src/main/java/org/hps/analysis/tuple/SVTTimingTupleDriver.java
@@ -1,0 +1,470 @@
+package org.hps.analysis.tuple;
+
+import hep.physics.vec.BasicHep3Vector;
+import hep.physics.vec.Hep3Vector;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.hps.recon.ecal.cluster.ClusterUtilities;
+import org.hps.recon.ecal.cluster.TriggerTime;
+import org.hps.record.triggerbank.AbstractIntData;
+import org.hps.record.triggerbank.TIData;
+import org.lcsim.event.EventHeader;
+import org.lcsim.event.GenericObject;
+import org.lcsim.event.ReconstructedParticle;
+import org.lcsim.event.Track;
+import org.hps.recon.tracking.FittedRawTrackerHit;
+import org.hps.recon.tracking.ShapeFitParameters;
+import org.hps.recon.tracking.TrackData;
+import org.hps.recon.tracking.TrackType;
+import org.hps.recon.tracking.TrackerHitUtils;
+import org.hps.recon.utils.TrackClusterMatcher;
+import org.hps.record.triggerbank.SSPData;
+import org.lcsim.detector.converter.compact.subdetector.SvtStereoLayer;
+import org.lcsim.detector.tracker.silicon.HpsSiSensor;
+import org.lcsim.event.Cluster;
+import org.lcsim.event.LCRelation;
+import org.lcsim.event.MCParticle;
+import org.lcsim.event.RawTrackerHit;
+import org.lcsim.event.RelationalTable;
+import org.lcsim.event.TrackerHit;
+import org.lcsim.event.base.BaseRelationalTable;
+import org.lcsim.fit.helicaltrack.HelicalTrackCross;
+import org.lcsim.fit.helicaltrack.HelicalTrackStrip;
+import org.lcsim.geometry.Detector;
+import org.lcsim.geometry.FieldMap;
+
+// driver for investigating the SVT timing (from single strips, strip clusters, 3d hits, and tracks)
+// each entry in the tuple is a single track
+public class SVTTimingTupleDriver extends MCTupleMaker {
+
+    private static Logger LOGGER = Logger.getLogger(SVTTimingTupleDriver.class.getPackage().getName());
+
+    String finalStateParticlesColName = "FinalStateParticles";
+    String mcParticlesColName = "MCParticle";
+    String readoutHitCollectionName = "EcalReadoutHits";//these are in ADC counts
+    String calibratedHitCollectionName = "EcalCalHits";//these are in energy
+    String clusterCollectionName = "EcalClustersCorr";
+    private String helicalTrackHitCollectionName = "HelicalTrackHits";
+    private String rotatedTrackHitCollectionName = "RotatedHelicalTrackHits";
+    private String unconstrainedV0CandidatesColName = "UnconstrainedV0Candidates";
+    private String beamConV0CandidatesColName = "BeamspotConstrainedV0Candidates";
+    private String targetV0ConCandidatesColName = "TargetConstrainedV0Candidates";
+    private String rawTrackerHitCollectionName = "SVTRawTrackerHits";
+    private String fittedTrackerHitCollectionName = "SVTFittedRawTrackerHits";
+    private String trackerHitCollectionName = "StripClusterer_SiTrackerHitStrip1D";
+    String[] fpQuantNames = {"nEle_per_Event", "nPos_per_Event", "nPhoton_per_Event", "nUnAssociatedTracks_per_Event", "avg_delX_at_ECal", "avg_delY_at_ECal", "avg_E_Over_P", "avg_mom_beam_elec", "sig_mom_beam_elec"};
+    private TrackClusterMatcher matcher = new TrackClusterMatcher();
+    //private Map<SiSensor, Map<Integer, Hep3Vector>> stripPositions = new HashMap<SiSensor, Map<Integer, Hep3Vector>>(); 
+    private List<HpsSiSensor> sensors = null;
+    private Map<Integer, List<SvtStereoLayer>> topStereoLayers = new HashMap<Integer, List<SvtStereoLayer>>();
+    private Map<Integer, List<SvtStereoLayer>> bottomStereoLayers = new HashMap<Integer, List<SvtStereoLayer>>();
+    // Constants
+    public static final double SENSOR_LENGTH = 98.33; // mm
+    public static final double SENSOR_WIDTH = 38.3399; // mm
+    private static final String SUBDETECTOR_NAME = "Tracker";
+    boolean doSkim = false;
+    TrackerHitUtils trackerHitUtils = new TrackerHitUtils();
+    //some counters
+    int nRecoEvents = 0;
+    int nTotEle = 0;
+    int nTotPos = 0;
+    int nTotPhotons = 0;
+    int nTotUnAss = 0;
+    int nTotAss = 0;
+    //some summers
+    double sumdelX = 0.0;
+    double sumdelY = 0.0;
+    double sumEoverP = 0.0;
+    // double beamEnergy = 1.05; //GeV
+    double clTimeMin = 30;//ns
+    double clTimeMax = 50;//ns
+    double deltaTimeMax = 4;//ns
+    double coplanMean = 180;//degrees
+    double coplanWidth = 10;//degrees
+    double esumMin = 0.4;
+    double esumMax = 1.2;
+    double phot_nom_x = 42.52;//nominal photon position (px=0)
+    boolean requirePositron = false;
+    double maxPairs = 5;
+    boolean requireSuperFiducial = false;
+    int nbins = 50;
+    double B_FIELD = 0.23;//Tesla
+
+    protected final Map<Integer, String> layerMap = new HashMap<Integer, String>();
+
+    double[] hthHitTime = new double[6];
+    double[] SiClHitTime = new double[12];
+    double[] SiHitClHitTime = new double[12];
+
+    protected double[] beamSize = {0.001, 0.130, 0.050}; //rough estimate from harp scans during engineering run production running
+    // Beam position variables.
+    // The beamPosition array is in the tracking frame
+    /* TODO get the beam position from the conditions db */
+    protected double[] beamPosition = {0.0, 0.0, 0.0}; //
+
+    double minPhi = -0.25;
+    double maxPhi = 0.25;
+    boolean isFirst = true;
+
+    @Override
+    boolean passesCuts() {
+        return true;
+    }
+
+    private enum Constraint {
+
+        /**
+         * Represents a fit with no constraints.
+         */
+        UNCONSTRAINED,
+        /**
+         * Represents a fit with beam spot constraints.
+         */
+        BS_CONSTRAINED,
+        /**
+         * Represents a fit with target constraints.
+         */
+        TARGET_CONSTRAINED
+    }
+
+    String detName;
+
+    /**
+     * The B field map
+     */
+    FieldMap bFieldMap = null;
+    /**
+     * Position of the Ecal face
+     */
+    private double ecalPosition = 0; // mm
+
+    /**
+     * Z position to start extrapolation from
+     */
+    double extStartPos = 700; // mm
+
+    /**
+     * The extrapolation step size
+     */
+    double stepSize = 5.0; // mm
+    /**
+     * Name of the constant denoting the position of the Ecal face in the
+     * compact description.
+     */
+    private static final String ECAL_POSITION_CONSTANT_NAME = "ecal_dface";
+
+    @Override
+    protected void setupVariables() {
+        tupleVariables.clear();
+        String[] mcVars = new String[]{"apMass/D", "vtxXMC/D", "vtxYMC/D", "vtxZMC/D",
+            "pEleXMC/D", "pEleYMC/D", "pEleZMC/D",
+            "pPosXMC/D", "pPosYMC/D", "pPosZMC/D",
+            "pApXMC/D", "pApYMC/D", "pApZMC/D",
+            "apTarX/D", "apTarY/D", "apOrigX/D", "apOrigY/D", "apOrigZ/D"};
+        tupleVariables.addAll(Arrays.asList(mcVars));
+
+        String[] StripHitVars = new String[]{"StrL1aTime/D", "StrL1sTime/D", "StrL2aTime/D", "StrL2sTime/D", "StrL3aTime/D", "StrL3sTime/D",
+            "StrL4aTime/D", "StrL4sTime/D", "StrL5aTime/D", "StrL5sTime/D", "StrL6aTime/D", "StrL6sTime/D",
+            "StrL1aChiSq/D", "StrL1sChiSq/D", "StrL2aChiSq/D", "StrL2sChiSq/D", "StrL3aChiSq/D", "StrL3sChiSq/D",
+            "StrL4aChiSq/D", "StrL4sChiSq/D", "StrL5aChiSq/D", "StrL5sChiSq/D", "StrL6aChiSq/D", "StrL6sChiSq/D",
+            "StrL1aAmp/D", "StrL1sAmp/D", "StrL2aAmp/D", "StrL2sAmp/D", "StrL3aAmp/D", "StrL3sAmp/D",
+            "StrL4aAmp/D", "StrL4sAmp/D", "StrL5aAmp/D", "StrL5sAmp/D", "StrL6aAmp/D", "StrL6sAmp/D"};
+//         "StrL4aToBoSlHo/b", "StrL4sToBoSlHo/b",
+//            "StrL5aToBoSlHo/b", "StrL5sToBoSlHo/b", "StrL6aToBoSlHo/b", "StrL6sToBoSlHo/b"};
+        tupleVariables.addAll(Arrays.asList(StripHitVars));
+
+        String[] SiClusterHitVars = new String[]{"ClL1aTime/D", "ClL1sTime/D", "ClL2aTime/D", "ClL2sTime/D", "ClL3aTime/D", "ClL3sTime/D",
+            "ClL4aTime/D", "ClL4sTime/D", "ClL5aTime/D", "ClL5sTime/D", "ClL6aTime/D", "ClL6sTime/D", "ClL1aNHit/I", "ClL1sNHit/I",
+            "ClL2aNHit/I", "ClL2sNHit/I", "ClL3aNHit/I", "ClL3sNHit/I", "ClL4aNHit/I", "ClL4sNHit/I", "ClL5aNHit/I", "ClL5sNHit/I",
+            "ClL6aNHit/I", "ClL6sNHit/I",};
+        tupleVariables.addAll(Arrays.asList(SiClusterHitVars));
+
+        String[] ThreeDClusterHitVars = new String[]{"Cl3dL1Time/D", "Cl3dL2Time/D", "Cl3dL3Time/D",
+            "Cl3dL4Time/D", "Cl3dL5Time/D", "Cl3dL6Time/D"};
+        tupleVariables.addAll(Arrays.asList(ThreeDClusterHitVars));
+
+        String[] TrackVars = new String[]{"TrTime/D", "TrPx/D", "TrCharge/I", "TrPy/D", "TrPz/D",
+            "TrOmegaErr/D", "TrD0Err/D", "TrPhi0Err/D", "TrSlopeErr/D", "TrZ0Err/D",
+            "TrOmega/D", "TrD0/D", "TrPhi0/D", "TrSlope/D", "TrZ0/D", "ECalClTime"};
+        tupleVariables.addAll(Arrays.asList(TrackVars));
+
+        String[] EventVars = new String[]{"rfT1/D", "rfT1/D", "TrigTime/D","RFJitter/D"};
+         tupleVariables.addAll(Arrays.asList(EventVars));
+
+        addEventVariables();
+        addVertexVariables();
+        addParticleVariables("ele");
+        addParticleVariables("pos");
+        String[] newVars = new String[]{"minPositiveIso/D", "minNegativeIso/D", "minIso/D"};
+        tupleVariables.addAll(Arrays.asList(newVars));
+        addMCTridentVariables();
+
+    }
+
+    protected void detectorChanged(Detector detector) {
+
+        super.detectorChanged(detector);
+        layerMap.put(1, "L1");
+        layerMap.put(2, "L2");
+        layerMap.put(3, "L3");
+        layerMap.put(4, "L4");
+        layerMap.put(5, "L5");
+        layerMap.put(6, "L6");
+        detName = detector.getName();
+        double maxFactor = 1.5;
+        double feeMomentumCut = 0.75; //this number, multiplied by the beam energy, is the actual cut
+        B_FIELD = detector.getFieldMap().getField(new BasicHep3Vector(0, 0, 500)).y();
+        // Get the field map from the detector object
+        bFieldMap = detector.getFieldMap();
+        // Get the position of the Ecal from the compact description
+        ecalPosition = detector.getConstants().get(ECAL_POSITION_CONSTANT_NAME).getValue();
+        // Get the position of the Ecal from the compact description
+        ecalPosition = detector.getConstants().get(ECAL_POSITION_CONSTANT_NAME).getValue();
+        LOGGER.setLevel(Level.ALL);
+        LOGGER.info("B_FIELD=" + B_FIELD);
+        LOGGER.info("Setting up the plotter");
+
+    }
+
+    @Override
+    public void process(EventHeader event) {
+
+        if (!event.hasCollection(LCRelation.class, fittedTrackerHitCollectionName)) {
+            System.out.println("No fitted hits???");
+            return;
+        }
+
+        List<LCRelation> fittedTrackerHits = event.get(LCRelation.class, fittedTrackerHitCollectionName);
+        RelationalTable rthtofit = new BaseRelationalTable(RelationalTable.Mode.ONE_TO_ONE, RelationalTable.Weighting.UNWEIGHTED);
+        for (LCRelation hit : fittedTrackerHits)
+            rthtofit.add(FittedRawTrackerHit.getRawTrackerHit(hit), FittedRawTrackerHit.getShapeFitParameters(hit));
+
+        TIData triggerData = null;
+        if (event.hasCollection(GenericObject.class, "TriggerBank"))
+            for (GenericObject data : event.get(GenericObject.class, "TriggerBank"))
+                if (AbstractIntData.getTag(data) == TIData.BANK_TAG)
+                    triggerData = new TIData(data);
+
+        if (!event.hasCollection(TrackData.class, TrackData.TRACK_DATA_COLLECTION)
+                || !event.hasCollection(LCRelation.class, TrackData.TRACK_DATA_RELATION_COLLECTION)) {
+            System.out.println("No TrackData");
+            return;
+        }
+
+//
+//        List<TrackData> trkDataList = (List<TrackData>) event.get(TrackData.class, TrackData.TRACK_DATA_COLLECTION);
+//        List<LCRelation> trkDataRelationList = (List<LCRelation>) event.get(LCRelation.class, TrackData.TRACK_DATA_RELATION_COLLECTION);
+////
+//        if (!event.hasCollection(ReconstructedParticle.class, finalStateParticlesColName)) {
+//            if (debug)
+//                LOGGER.info(finalStateParticlesColName + " collection not found???");
+//            return;
+//        }
+//
+//        if (!event.hasCollection(MCParticle.class, mcParticlesColName)) {
+//            if (debug)
+//                LOGGER.info(mcParticlesColName + " collection not found???");
+//            return;
+//        }
+        //check to see if this event is from the correct trigger (or "all");
+        if (triggerData != null && !matchTriggerType(triggerData))
+            return;
+
+        nRecoEvents++;
+        if (debug)
+            LOGGER.info("##########  Start of SVTTimngTuple   ##############");
+        List<ReconstructedParticle> finalStateParticles = event.get(ReconstructedParticle.class, finalStateParticlesColName);
+        if (debug)
+            LOGGER.info("This events has " + finalStateParticles.size() + " final state particles");
+        List<ReconstructedParticle> unconstrainedV0List = event.get(ReconstructedParticle.class, unconstrainedV0CandidatesColName);
+        if (debug)
+            LOGGER.info("This events has " + unconstrainedV0List.size() + " unconstrained V0s");
+        List<ReconstructedParticle> BSCV0List = event.get(ReconstructedParticle.class, beamConV0CandidatesColName);
+        if (debug)
+            LOGGER.info("This events has " + BSCV0List.size() + " BSC V0s");
+
+        if (event.hasCollection(MCParticle.class, mcParticlesColName)) {
+            List<MCParticle> MCParticleList = event.get(MCParticle.class, mcParticlesColName);
+
+            //find electron and positron MCParticles
+            Hep3Vector vertexPositionMC = null;
+            double apMassMC = -9999;
+            MCParticle ap = null;
+            MCParticle eleMC = null;
+            MCParticle posMC = null;
+
+            for (MCParticle mcp : MCParticleList)
+                if (mcp.getPDGID() == 622 && mcp.getDaughters().size() == 2) {
+                    ap = mcp;
+                    vertexPositionMC = mcp.getEndPoint();
+                    apMassMC = mcp.getMass();
+                    List<MCParticle> daugList = mcp.getDaughters();
+                    for (MCParticle daug : daugList)
+                        if (daug.getPDGID() == 11)
+                            eleMC = daug;
+                        else if (daug.getPDGID() == -11)
+                            posMC = daug;
+                }
+        }
+//        if (eleMC == null || posMC == null) {
+//            if (debug)
+//                LOGGER.info("Couldn't find the MC e+e- from A'?????  Quitting.");
+//            return;
+//        }
+        double bestMom = 99999;
+        int layer;
+        String layerLabel;
+        String typeLabel;
+        String axStLabel;
+        String tString;
+        System.out.println("Event has " + finalStateParticles.size() + " final state particles");
+        for (ReconstructedParticle fsp : finalStateParticles) {
+            tupleMap.clear();
+            //if (!TrackType.isGBL(fsp.getType())) // we only care about GBL vertices
+
+            if (event.hasCollection(GenericObject.class, "TriggerBank")) {
+                List<GenericObject> triggerList = event.get(GenericObject.class, "TriggerBank");
+                for (GenericObject data : triggerList)
+                    if (AbstractIntData.getTag(data) == SSPData.BANK_TAG) {
+                        SSPData sspData = new SSPData(data);
+                        double trigTime = sspData.getTime();
+                         tupleMap.put("TrigTime/D", trigTime);
+                    }
+            }
+
+            if (event.hasCollection(GenericObject.class, "RFHits")) {
+                List<GenericObject> rfTimes = event.get(GenericObject.class, "RFHits");
+                if (rfTimes.size() > 0) {
+                    tupleMap.put("rfT1/D", rfTimes.get(0).getDoubleVal(0));
+                    tupleMap.put("rfT2/D", rfTimes.get(0).getDoubleVal(1));
+                }
+            }
+            //does the track have a matched cluster?              
+            System.out.println("# clusters = " + fsp.getClusters().size());
+            System.out.println("# tracks = " + fsp.getTracks().size());
+            if (fsp.getTracks().size() != 1)
+                continue;
+
+            if (!TrackType.isGBL(fsp.getTracks().get(0).getType())) // we only care about GBL tracks
+                continue;
+            System.out.println("Found GBL Track");
+//            System.out.println("Got a cluster and track");
+            Track trk = fsp.getTracks().get(0);
+            if (trk.getTrackerHits().size() != 6)
+                continue;
+            System.out.println("Got 6-hit track");
+            if (fsp.getClusters().size() == 1) {
+                Cluster clu = fsp.getClusters().get(0);
+                double cltime = ClusterUtilities.findSeedHit(clu).getTime();
+                tupleMap.put("ECalClTime", cltime);
+            }
+            //include track stuff
+            typeLabel = "Tr";
+            //   TrackData trkData = (TrackData) TrackData.getTrackData(event, trk);
+            double trkTime = TrackData.getTrackTime(TrackData.getTrackData(event, trk));
+            tString = typeLabel + "Time/D";
+            tupleMap.put(tString, trkTime);
+            double trkMom = fsp.getMomentum().z();
+            tString = typeLabel + "Pz/D";
+            tupleMap.put(tString, trkMom);
+            trkMom = fsp.getMomentum().x();
+            tString = typeLabel + "Px/D";
+            tupleMap.put(tString, trkMom);
+            trkMom = fsp.getMomentum().y();
+            tString = typeLabel + "Py/D";
+            tupleMap.put(tString, trkMom);
+            double trkCharge = fsp.getCharge();
+            tString = typeLabel + "Pz/I";
+            tupleMap.put(tString, trkCharge);
+
+            List<TrackerHit> trHits = trk.getTrackerHits();
+            for (TrackerHit trHit : trHits) {
+
+                HelicalTrackCross hth = (HelicalTrackCross) trHit; //need to run full recon for this!!!
+                //stuff with 3d hits
+                typeLabel = "Cl3d";
+                layer = moduleNumber(hth.Layer());
+                layerLabel = layerMap.get(layer);
+                double hthTime = hth.getTime();
+                tString = typeLabel + layerLabel + "Time/D";
+                tupleMap.put(tString, hthTime);
+                //                
+                List<HelicalTrackStrip> htsList = hth.getStrips();
+                for (HelicalTrackStrip hts : htsList) {
+                    //do strip cluster stuff
+                    typeLabel = "Cl";
+                    layer = moduleNumber(hts.layer());
+                    layerLabel = layerMap.get(layer);
+
+                    List<RawTrackerHit> rthList = hts.rawhits();
+                    RawTrackerHit rthDummy = (RawTrackerHit) hts.rawhits().get(0);
+                    HpsSiSensor sensor = ((HpsSiSensor) rthDummy.getDetectorElement());
+
+                    axStLabel = "s";
+                    if (sensor.isAxial())
+                        axStLabel = "a";
+                    tString = typeLabel + layerLabel + axStLabel + "Time/D";
+                    double htsTime = hts.time();
+                    tupleMap.put(tString, htsTime);
+                    double htsNHit = hts.rawhits().size();
+                    tString = typeLabel + layerLabel + axStLabel + "NHit/D";
+                    tupleMap.put(tString, htsNHit);
+                    //  
+                    RawTrackerHit rthSeed = null;
+                    GenericObject parsSeed = null;
+                    double peak = -99999;
+                    for (RawTrackerHit rth : rthList) {
+                        GenericObject pars = (GenericObject) rthtofit.to(rth);
+                        // get the highest amplitude hit
+
+                        double amp = ShapeFitParameters.getAmp(pars);
+                        if (amp > peak) {
+                            peak = amp;
+                            parsSeed = pars;
+                            rthSeed = rth;
+                        }
+                    }
+                    //found the seed; now do strip hit stuff
+                    typeLabel = "Str";
+                    double t0 = ShapeFitParameters.getT0(parsSeed);
+                    double amp = ShapeFitParameters.getAmp(parsSeed);
+                    double chiProb = ShapeFitParameters.getChiProb(parsSeed);
+                    tString = typeLabel + layerLabel + axStLabel + "Time/D";
+                    tupleMap.put(tString, t0);
+                    tString = typeLabel + layerLabel + axStLabel + "Amp/D";
+                    tupleMap.put(tString, amp);
+                    tString = typeLabel + layerLabel + axStLabel + "ChiSq/D";
+                    tupleMap.put(tString, chiProb);
+                }
+            }
+            
+            if (event.hasCollection(TriggerTime.class, "TriggerTime")) {
+                System.out.println("Getting TriggerTime Object");
+                List<TriggerTime> jitterList = event.get(TriggerTime.class, "TriggerTime");
+                 if (debug) System.out.println("TriggerTime List Size = " + jitterList.size());
+                TriggerTime jitterObject = jitterList.get(0);
+                double jitter = jitterObject.getDoubleVal();
+                 if (debug) System.out.println("RF time jitter " + jitter);
+                 tupleMap.put("RFJitter/D",jitter);
+
+            } else {
+                System.out.println("Requested RF Time correction but TriggerTime Collection doesn't exist!!!");
+               
+            }
+            if (tupleWriter != null) {
+                System.out.println("writing tuple");
+                writeTuple();
+            }
+        }
+
+    }
+
+    private int moduleNumber(int layer) {
+        return (int) (layer + 1) / 2;
+    }
+
+}

--- a/analysis/src/main/java/org/hps/analysis/tuple/SVTTimingTupleDriver.java
+++ b/analysis/src/main/java/org/hps/analysis/tuple/SVTTimingTupleDriver.java
@@ -192,8 +192,8 @@ public class SVTTimingTupleDriver extends MCTupleMaker {
             "TrOmega/D", "TrD0/D", "TrPhi0/D", "TrSlope/D", "TrZ0/D", "ECalClTime"};
         tupleVariables.addAll(Arrays.asList(TrackVars));
 
-        String[] EventVars = new String[]{"rfT1/D", "rfT1/D", "TrigTime/D","RFJitter/D"};
-         tupleVariables.addAll(Arrays.asList(EventVars));
+        String[] EventVars = new String[]{"rfT1/D", "rfT1/D", "TrigTime/D", "RFJitter/D"};
+        tupleVariables.addAll(Arrays.asList(EventVars));
 
         addEventVariables();
         addVertexVariables();
@@ -332,7 +332,7 @@ public class SVTTimingTupleDriver extends MCTupleMaker {
                     if (AbstractIntData.getTag(data) == SSPData.BANK_TAG) {
                         SSPData sspData = new SSPData(data);
                         double trigTime = sspData.getTime();
-                         tupleMap.put("TrigTime/D", trigTime);
+                        tupleMap.put("TrigTime/D", trigTime);
                     }
             }
 
@@ -441,20 +441,20 @@ public class SVTTimingTupleDriver extends MCTupleMaker {
                     tupleMap.put(tString, chiProb);
                 }
             }
-            
+
             if (event.hasCollection(TriggerTime.class, "TriggerTime")) {
                 System.out.println("Getting TriggerTime Object");
                 List<TriggerTime> jitterList = event.get(TriggerTime.class, "TriggerTime");
-                 if (debug) System.out.println("TriggerTime List Size = " + jitterList.size());
+                if (debug)
+                    System.out.println("TriggerTime List Size = " + jitterList.size());
                 TriggerTime jitterObject = jitterList.get(0);
                 double jitter = jitterObject.getDoubleVal();
-                 if (debug) System.out.println("RF time jitter " + jitter);
-                 tupleMap.put("RFJitter/D",jitter);
+                if (debug)
+                    System.out.println("RF time jitter " + jitter);
+                tupleMap.put("RFJitter/D", jitter);
 
-            } else {
+            } else
                 System.out.println("Requested RF Time correction but TriggerTime Collection doesn't exist!!!");
-               
-            }
             if (tupleWriter != null) {
                 System.out.println("writing tuple");
                 writeTuple();

--- a/recon/src/main/java/org/hps/recon/particle/ReconParticleDriver.java
+++ b/recon/src/main/java/org/hps/recon/particle/ReconParticleDriver.java
@@ -693,6 +693,8 @@ public abstract class ReconParticleDriver extends Driver {
         if (trackCollectionNames != null) {
             for (String collectionName : trackCollectionNames) {
                 if (event.hasCollection(Track.class, collectionName)) {
+                         // VERBOSE :: Output the number of clusters in the event.
+                    printDebug("Tracks :: " + event.get(Track.class, collectionName).size());
                     trackCollections.add(event.get(Track.class, collectionName));
                 }
             }

--- a/recon/src/main/java/org/hps/recon/particle/ReconParticleDriver.java
+++ b/recon/src/main/java/org/hps/recon/particle/ReconParticleDriver.java
@@ -498,8 +498,13 @@ public abstract class ReconParticleDriver extends Driver {
                     double clusTime = ClusterUtilities.getSeedHitTime(cluster);
                     double trkT = TrackUtils.getTrackTime(track, hitToStrips, hitToRotated);
                     
-                    if (Math.abs(clusTime - trkT - cuts.getTrackClusterTimeOffset()) > cuts.getMaxMatchDt())
+                    if (Math.abs(clusTime - trkT - cuts.getTrackClusterTimeOffset()) > cuts.getMaxMatchDt()){
+                        if (debug) {
+                            System.out.println("Failed cluster-track deltaT!");
+                            System.out.println(clusTime + "  " + trkT + "  " + cuts.getTrackClusterTimeOffset() + ">" + cuts.getMaxMatchDt());
+                        }
                         continue;
+                    }
                     
                     //if the option to use corrected cluster positions is selected, then
                     //create a copy of the current cluster, and apply corrections to it
@@ -519,13 +524,23 @@ public abstract class ReconParticleDriver extends Driver {
                     }
 
                     // ignore if matching quality doesn't make the cut:
-                    if (thisNSigma > MAXNSIGMAPOSITIONMATCH)
+                    if (thisNSigma > MAXNSIGMAPOSITIONMATCH){
+                        if (debug) {
+                            System.out.println("Failed cluster-track NSigma Cut!");
+                            System.out.println("match NSigma = "+thisNSigma + "; Max NSigma =  " + MAXNSIGMAPOSITIONMATCH );
+                        }
                         continue;
+                    }
+                        
 
                     // ignore if we already found a cluster that's a better match:
-                    if (thisNSigma > smallestNSigma)
+                    if (thisNSigma > smallestNSigma) {
+                        if (debug) {
+                            System.out.println("Already found a better match than this!");
+                            System.out.println("match NSigma = "+thisNSigma + "; smallest NSigma =  " + smallestNSigma );
+                        }
                         continue;
-
+                    }
                     // we found a new best cluster candidate for this track:
                     smallestNSigma = thisNSigma;
                     matchedCluster = originalCluster;

--- a/steering-files/src/main/resources/org/hps/steering/recon/EngineeringRun2015FullReconMC.lcsim
+++ b/steering-files/src/main/resources/org/hps/steering/recon/EngineeringRun2015FullReconMC.lcsim
@@ -49,14 +49,19 @@
         --> 
         <driver name="TrackReconSeed123Conf5Extd46"/>
         <!-- 
-            TrackDataDriver needs to be run before ReconParticleDriver so the
-            ReconstructedParticle types are properly set.
-         -->
+           TrackDataDriver needs to be run before ReconParticleDriver so the
+           ReconstructedParticle types are properly set.
+        -->
         <driver name="MergeTrackCollections"/>
         <driver name="GBLRefitterDriver" />
         <driver name="TrackDataDriver" />
         <driver name="ReconParticleDriver" />   
         <driver name="LCIOWriter"/>
+        
+        <driver name="RawSVTHitsTupleDriver"/>
+        <driver name="FittedSVTHitsTupleDriver"/>  
+        <driver name="SVTTimingTuple"/>  
+        
         <driver name="CleanupDriver"/>
     </execute>    
     <drivers>    
@@ -68,36 +73,38 @@
         </driver>
         <driver name="RawTrackerHitFitterDriver" type="org.hps.recon.tracking.RawTrackerHitFitterDriver">
             <fitAlgorithm>Pileup</fitAlgorithm>
-            <useTimestamps>false</useTimestamps>
+            <!--<useTimestamps>false</useTimestamps>
             <correctTimeOffset>true</correctTimeOffset>
             <correctT0Shift>false</correctT0Shift>
             <useTruthTime>false</useTruthTime>
             <subtractTOF>true</subtractTOF>
             <subtractTriggerTime>true</subtractTriggerTime>
-            <correctChanT0>false</correctChanT0>
+            <correctChanT0>false</correctChanT0>-->
 
-      <!-- new, better  settings -->           
+            
+            <!-- new, better  settings -->           
             <!--use this to correct for trigger time in MC instead of subtractTriggerTime-->   
-            <!--<useTimestamps>true</useTimestamps>-->     
+            <useTimestamps>true</useTimestamps>     
             <!--offset to get times centered at 0 after timestamp correction-->                 
-            <!--<tsCorrectionScale>240</tsCorrectionScale>-->    
+            <tsCorrectionScale>239</tsCorrectionScale>    
             <!--correct for the SVT fit time offset...this should be on if <useTimingConditions> is turned on in readout-->        
-            <!--<correctTimeOffset>true</correctTimeOffset>-->   
+            <correctTimeOffset>true</correctTimeOffset>   
             <!--per sensor shift...set false becasue it's not in readout sim-->       
-            <!--<correctT0Shift>false</correctT0Shift>-->      
+            <correctT0Shift>false</correctT0Shift>      
             <!--use truth time for MC???  typically not used-->             
-            <!--<useTruthTime>false</useTruthTime>-->    
+            <useTruthTime>false</useTruthTime>    
             <!--time of flight corrections-->              
-            <!--<subtractTOF>true</subtractTOF>-->     
+            <subtractTOF>true</subtractTOF>     
             <!--set this false for MC, true for data-->              
-            <!--<subtractTriggerTime>false</subtractTriggerTime>-->           
+            <subtractTriggerTime>false</subtractTriggerTime>           
             <!--per-strip timing correction from database...this should be on i f <useTimingConditions> is turned on in readout  -->  
-            <!--<correctChanT0>true</correctChanT0>-->          
-
-            <debug>false</debug>
+            <correctChanT0>true</correctChanT0>          
+            <debug>false</debug>        
+         
         </driver>
         <driver name="TrackerHitDriver" type="org.hps.recon.tracking.DataTrackerHitDriver">
             <neighborDeltaT>8.0</neighborDeltaT>
+            <debug>false</debug>
         </driver>
         <driver name="HelicalTrackHitDriver" type="org.hps.recon.tracking.HelicalTrackHitDriver">
             <debug>false</debug>
@@ -105,7 +112,7 @@
             <maxDt>16.0</maxDt>
             <clusterAmplitudeCut>400.0</clusterAmplitudeCut>
         </driver>
-          <!-- SVT Track finding -->
+        <!-- SVT Track finding -->
         <driver name="TrackReconSeed345Conf2Extd16" type="org.hps.recon.tracking.TrackerReconDriver">
             <trackCollectionName>Tracks_s345_c2_e16</trackCollectionName>
             <strategyResource>HPS_s345_c2_e16.xml</strategyResource>
@@ -154,11 +161,18 @@
             <inputCollectionName>EcalClusters</inputCollectionName>
             <outputCollectionName>EcalClustersCorr</outputCollectionName>
         </driver>       
-        <driver name="ReconParticleDriver" type="org.hps.recon.particle.HpsReconParticleDriver"> 
-            <ecalClusterCollectionName>EcalClustersCorr</ecalClusterCollectionName>         
-            <trackCollectionNames>MatchedTracks GBLTracks</trackCollectionNames>
-	        <isMC>true</isMC>
-        </driver>
+        <driver name="ReconParticleDriver" type="org.hps.recon.particle.HpsReconParticleDriver" > 
+            <ecalClusterCollectionName>EcalClustersCorr</ecalClusterCollectionName>        
+            <trackCollectionNames>GBLTracks</trackCollectionNames>          
+            <beamPositionX> -0.246 </beamPositionX>
+            <beamSigmaX> 0.125 </beamSigmaX>
+            <beamPositionY> -0.138 </beamPositionY>
+            <beamSigmaY> 0.030 </beamSigmaY>
+            <beamPositionZ> -3.9 </beamPositionZ>
+            <trackClusterTimeOffset>43</trackClusterTimeOffset>
+            <isMC>true</isMC>      
+            <debug>true</debug>
+        </driver>         
         <driver name="TrackDataDriver" type="org.hps.recon.tracking.TrackDataDriver" />
         <driver name="LCIOWriter" type="org.lcsim.util.loop.LCIODriver">
             <outputFilePath>${outputFile}.slcio</outputFilePath>
@@ -166,6 +180,21 @@
         <driver name="CleanupDriver" type="org.lcsim.recon.tracking.digitization.sisim.config.ReadoutCleanupDriver"/>
         <driver name="AidaSaveDriver" type="org.lcsim.job.AidaSaveDriver">
             <outputFileName>${outputFile}.root</outputFileName>
+        </driver>
+        
+        <driver name="RawSVTHitsTupleDriver" type="org.hps.analysis.tuple.RawSVTHitsTupleDriver">
+            <debug>false</debug>
+            <tupleFile>${outputFile}_rawhits.txt</tupleFile>
+        </driver>
+        <driver name="FittedSVTHitsTupleDriver" type="org.hps.analysis.tuple.FittedSVTHitsTupleDriver">
+            <debug>false</debug>
+            <tupleFile>${outputFile}_fittedhits.txt</tupleFile>
+        </driver>
+        <driver name="SVTTimingTuple" type="org.hps.analysis.tuple.SVTTimingTupleDriver">
+            <triggerType>pairs1</triggerType>
+            <!--            <triggerType>all</triggerType> -->
+            <debug>true</debug>
+            <tupleFile>${outputFile}_svttime.txt</tupleFile>
         </driver>
     </drivers>
 </lcsim>

--- a/steering-files/src/main/resources/org/hps/steering/recon/EngineeringRun2015FullReconMC.lcsim
+++ b/steering-files/src/main/resources/org/hps/steering/recon/EngineeringRun2015FullReconMC.lcsim
@@ -56,12 +56,7 @@
         <driver name="GBLRefitterDriver" />
         <driver name="TrackDataDriver" />
         <driver name="ReconParticleDriver" />   
-        <driver name="LCIOWriter"/>
-        
-        <driver name="RawSVTHitsTupleDriver"/>
-        <driver name="FittedSVTHitsTupleDriver"/>  
-        <driver name="SVTTimingTuple"/>  
-        
+        <driver name="LCIOWriter"/>        
         <driver name="CleanupDriver"/>
     </execute>    
     <drivers>    
@@ -73,20 +68,10 @@
         </driver>
         <driver name="RawTrackerHitFitterDriver" type="org.hps.recon.tracking.RawTrackerHitFitterDriver">
             <fitAlgorithm>Pileup</fitAlgorithm>
-            <!--<useTimestamps>false</useTimestamps>
-            <correctTimeOffset>true</correctTimeOffset>
-            <correctT0Shift>false</correctT0Shift>
-            <useTruthTime>false</useTruthTime>
-            <subtractTOF>true</subtractTOF>
-            <subtractTriggerTime>true</subtractTriggerTime>
-            <correctChanT0>false</correctChanT0>-->
-
-            
-            <!-- new, better  settings -->           
             <!--use this to correct for trigger time in MC instead of subtractTriggerTime-->   
             <useTimestamps>true</useTimestamps>     
             <!--offset to get times centered at 0 after timestamp correction-->                 
-            <tsCorrectionScale>239</tsCorrectionScale>    
+            <tsCorrectionScale>235</tsCorrectionScale>    
             <!--correct for the SVT fit time offset...this should be on if <useTimingConditions> is turned on in readout-->        
             <correctTimeOffset>true</correctTimeOffset>   
             <!--per sensor shift...set false becasue it's not in readout sim-->       
@@ -96,8 +81,8 @@
             <!--time of flight corrections-->              
             <subtractTOF>true</subtractTOF>     
             <!--set this false for MC, true for data-->              
-            <subtractTriggerTime>false</subtractTriggerTime>           
-            <!--per-strip timing correction from database...this should be on i f <useTimingConditions> is turned on in readout  -->  
+            <!--<subtractTriggerTime>false</subtractTriggerTime>-->           
+            <!--per-strip timing correction from database...this should be on iff <useTimingConditions> is turned on in readout  -->  
             <correctChanT0>true</correctChanT0>          
             <debug>false</debug>        
          
@@ -169,7 +154,7 @@
             <beamPositionY> -0.138 </beamPositionY>
             <beamSigmaY> 0.030 </beamSigmaY>
             <beamPositionZ> -3.9 </beamPositionZ>
-            <trackClusterTimeOffset>43</trackClusterTimeOffset>
+            <trackClusterTimeOffset>40</trackClusterTimeOffset>
             <isMC>true</isMC>      
             <debug>true</debug>
         </driver>         
@@ -180,21 +165,6 @@
         <driver name="CleanupDriver" type="org.lcsim.recon.tracking.digitization.sisim.config.ReadoutCleanupDriver"/>
         <driver name="AidaSaveDriver" type="org.lcsim.job.AidaSaveDriver">
             <outputFileName>${outputFile}.root</outputFileName>
-        </driver>
-        
-        <driver name="RawSVTHitsTupleDriver" type="org.hps.analysis.tuple.RawSVTHitsTupleDriver">
-            <debug>false</debug>
-            <tupleFile>${outputFile}_rawhits.txt</tupleFile>
-        </driver>
-        <driver name="FittedSVTHitsTupleDriver" type="org.hps.analysis.tuple.FittedSVTHitsTupleDriver">
-            <debug>false</debug>
-            <tupleFile>${outputFile}_fittedhits.txt</tupleFile>
-        </driver>
-        <driver name="SVTTimingTuple" type="org.hps.analysis.tuple.SVTTimingTupleDriver">
-            <triggerType>pairs1</triggerType>
-            <!--            <triggerType>all</triggerType> -->
-            <debug>true</debug>
-            <tupleFile>${outputFile}_svttime.txt</tupleFile>
-        </driver>
+        </driver>     
     </drivers>
 </lcsim>

--- a/steering-files/src/main/resources/org/hps/steering/recon/EngineeringRun2015FullReconMC.lcsim
+++ b/steering-files/src/main/resources/org/hps/steering/recon/EngineeringRun2015FullReconMC.lcsim
@@ -75,6 +75,25 @@
             <subtractTOF>true</subtractTOF>
             <subtractTriggerTime>true</subtractTriggerTime>
             <correctChanT0>false</correctChanT0>
+
+      <!-- new, better  settings -->           
+            <!--use this to correct for trigger time in MC instead of subtractTriggerTime-->   
+            <!--<useTimestamps>true</useTimestamps>-->     
+            <!--offset to get times centered at 0 after timestamp correction-->                 
+            <!--<tsCorrectionScale>240</tsCorrectionScale>-->    
+            <!--correct for the SVT fit time offset...this should be on if <useTimingConditions> is turned on in readout-->        
+            <!--<correctTimeOffset>true</correctTimeOffset>-->   
+            <!--per sensor shift...set false becasue it's not in readout sim-->       
+            <!--<correctT0Shift>false</correctT0Shift>-->      
+            <!--use truth time for MC???  typically not used-->             
+            <!--<useTruthTime>false</useTruthTime>-->    
+            <!--time of flight corrections-->              
+            <!--<subtractTOF>true</subtractTOF>-->     
+            <!--set this false for MC, true for data-->              
+            <!--<subtractTriggerTime>false</subtractTriggerTime>-->           
+            <!--per-strip timing correction from database...this should be on i f <useTimingConditions> is turned on in readout  -->  
+            <!--<correctChanT0>true</correctChanT0>-->          
+
             <debug>false</debug>
         </driver>
         <driver name="TrackerHitDriver" type="org.hps.recon.tracking.DataTrackerHitDriver">

--- a/steering-files/src/main/resources/org/hps/steering/recon/PhysicsRun2016FullReconMC.lcsim
+++ b/steering-files/src/main/resources/org/hps/steering/recon/PhysicsRun2016FullReconMC.lcsim
@@ -58,6 +58,10 @@
         <driver name="TrackDataDriver" />
         <driver name="ReconParticleDriver" />   
         <driver name="LCIOWriter"/>
+        <driver name="RawSVTHitsTupleDriver"/>
+        <driver name="FittedSVTHitsTupleDriver"/>  
+        <driver name="SVTTimingTuple"/>  
+       
         <driver name="CleanupDriver"/>
     </execute>    
     <drivers>   
@@ -95,13 +99,32 @@
         </driver>
         <driver name="RawTrackerHitFitterDriver" type="org.hps.recon.tracking.RawTrackerHitFitterDriver">
             <fitAlgorithm>Pileup</fitAlgorithm>
-            <useTimestamps>false</useTimestamps>
+            <!-- current default settings --> 
+<!--            <useTimestamps>false</useTimestamps>
             <correctTimeOffset>true</correctTimeOffset>
             <correctT0Shift>false</correctT0Shift>
             <useTruthTime>false</useTruthTime>
             <subtractTOF>true</subtractTOF>
             <subtractTriggerTime>true</subtractTriggerTime>
-            <correctChanT0>false</correctChanT0>
+            <correctChanT0>false</correctChanT0>-->
+            
+            <!-- new, better  settings -->           
+            <!--use this to correct for trigger time in MC instead of subtractTriggerTime-->   
+            <useTimestamps>true</useTimestamps>     
+            <!--offset to get times centered at 0 after timestamp correction-->                 
+            <tsCorrectionScale>240</tsCorrectionScale>    
+            <!--correct for the SVT fit time offset...this should be on if <useTimingConditions> is turned on in readout-->        
+            <correctTimeOffset>true</correctTimeOffset>   
+            <!--per sensor shift...set false becasue it's not in readout sim-->       
+            <correctT0Shift>false</correctT0Shift>      
+            <!--use truth time for MC???  typically not used-->             
+            <useTruthTime>false</useTruthTime>    
+            <!--time of flight corrections-->              
+            <subtractTOF>true</subtractTOF>     
+            <!--set this false for MC, true for data-->              
+            <subtractTriggerTime>false</subtractTriggerTime>           
+            <!--per-strip timing correction from database...this should be on i f <useTimingConditions> is turned on in readout  -->  
+            <correctChanT0>true</correctChanT0>          
             <debug>false</debug>
         </driver>
         <driver name="TrackerHitDriver" type="org.hps.recon.tracking.DataTrackerHitDriver">
@@ -152,5 +175,21 @@
         <driver name="AidaSaveDriver" type="org.lcsim.job.AidaSaveDriver">
             <outputFileName>${outputFile}.root</outputFileName>
         </driver>       
+        <driver name="RawSVTHitsTupleDriver" type="org.hps.analysis.tuple.RawSVTHitsTupleDriver">
+            <debug>false</debug>
+            <tupleFile>${outputFile}_rawhits.txt</tupleFile>
+        </driver>
+        <driver name="FittedSVTHitsTupleDriver" type="org.hps.analysis.tuple.FittedSVTHitsTupleDriver">
+            <debug>false</debug>
+            <tupleFile>${outputFile}_fittedhits.txt</tupleFile>
+        </driver>
+        <driver name="SVTTimingTuple" type="org.hps.analysis.tuple.SVTTimingTupleDriver">
+            <triggerType>pairs1</triggerType>
+            <!--            <triggerType>all</triggerType> -->
+            <debug>false</debug>
+            <tupleFile>${outputFile}_svttime.txt</tupleFile>
+        </driver>
+
+
     </drivers>
 </lcsim>

--- a/steering-files/src/main/resources/org/hps/steering/recon/PhysicsRun2016FullReconMC.lcsim
+++ b/steering-files/src/main/resources/org/hps/steering/recon/PhysicsRun2016FullReconMC.lcsim
@@ -57,11 +57,7 @@
         <driver name="GBLRefitterDriver" />
         <driver name="TrackDataDriver" />
         <driver name="ReconParticleDriver" />   
-        <driver name="LCIOWriter"/>
-        <driver name="RawSVTHitsTupleDriver"/>
-        <driver name="FittedSVTHitsTupleDriver"/>  
-        <driver name="SVTTimingTuple"/>  
-       
+        <driver name="LCIOWriter"/>            
         <driver name="CleanupDriver"/>
     </execute>    
     <drivers>   
@@ -112,7 +108,7 @@
             <!--use this to correct for trigger time in MC instead of subtractTriggerTime-->   
             <useTimestamps>true</useTimestamps>     
             <!--offset to get times centered at 0 after timestamp correction-->                 
-            <tsCorrectionScale>240</tsCorrectionScale>    
+            <tsCorrectionScale>239</tsCorrectionScale>    
             <!--correct for the SVT fit time offset...this should be on if <useTimingConditions> is turned on in readout-->        
             <correctTimeOffset>true</correctTimeOffset>   
             <!--per sensor shift...set false becasue it's not in readout sim-->       
@@ -165,8 +161,15 @@
         <driver name="TrackDataDriver" type="org.hps.recon.tracking.TrackDataDriver" />
         <driver name="ReconParticleDriver" type="org.hps.recon.particle.HpsReconParticleDriver" > 
             <ecalClusterCollectionName>EcalClustersCorr</ecalClusterCollectionName>        
-            <trackCollectionNames>GBLTracks</trackCollectionNames>
-        </driver>  
+            <trackCollectionNames>GBLTracks</trackCollectionNames>          
+            <beamPositionX> -0.246 </beamPositionX>
+            <beamSigmaX> 0.125 </beamSigmaX>
+            <beamPositionY> -0.138 </beamPositionY>
+            <beamSigmaY> 0.030 </beamSigmaY>
+            <beamPositionZ> -3.9 </beamPositionZ>
+            <trackClusterTimeOffset>43</trackClusterTimeOffset>
+            <isMC>true</isMC>      
+        </driver>         
         <driver name="GBLRefitterDriver" type="org.hps.recon.tracking.gbl.GBLRefitterDriver"/>
         <driver name="LCIOWriter" type="org.lcsim.util.loop.LCIODriver">
             <outputFilePath>${outputFile}.slcio</outputFilePath>
@@ -174,22 +177,6 @@
         <driver name="CleanupDriver" type="org.lcsim.recon.tracking.digitization.sisim.config.ReadoutCleanupDriver"/>
         <driver name="AidaSaveDriver" type="org.lcsim.job.AidaSaveDriver">
             <outputFileName>${outputFile}.root</outputFileName>
-        </driver>       
-        <driver name="RawSVTHitsTupleDriver" type="org.hps.analysis.tuple.RawSVTHitsTupleDriver">
-            <debug>false</debug>
-            <tupleFile>${outputFile}_rawhits.txt</tupleFile>
-        </driver>
-        <driver name="FittedSVTHitsTupleDriver" type="org.hps.analysis.tuple.FittedSVTHitsTupleDriver">
-            <debug>false</debug>
-            <tupleFile>${outputFile}_fittedhits.txt</tupleFile>
-        </driver>
-        <driver name="SVTTimingTuple" type="org.hps.analysis.tuple.SVTTimingTupleDriver">
-            <triggerType>pairs1</triggerType>
-            <!--            <triggerType>all</triggerType> -->
-            <debug>false</debug>
-            <tupleFile>${outputFile}_svttime.txt</tupleFile>
-        </driver>
-
-
+        </driver>             
     </drivers>
 </lcsim>

--- a/steering-files/src/main/resources/org/hps/steering/recon/PhysicsRun2016FullReconMC.lcsim
+++ b/steering-files/src/main/resources/org/hps/steering/recon/PhysicsRun2016FullReconMC.lcsim
@@ -95,16 +95,6 @@
         </driver>
         <driver name="RawTrackerHitFitterDriver" type="org.hps.recon.tracking.RawTrackerHitFitterDriver">
             <fitAlgorithm>Pileup</fitAlgorithm>
-            <!-- current default settings --> 
-<!--            <useTimestamps>false</useTimestamps>
-            <correctTimeOffset>true</correctTimeOffset>
-            <correctT0Shift>false</correctT0Shift>
-            <useTruthTime>false</useTruthTime>
-            <subtractTOF>true</subtractTOF>
-            <subtractTriggerTime>true</subtractTriggerTime>
-            <correctChanT0>false</correctChanT0>-->
-            
-            <!-- new, better  settings -->           
             <!--use this to correct for trigger time in MC instead of subtractTriggerTime-->   
             <useTimestamps>true</useTimestamps>     
             <!--offset to get times centered at 0 after timestamp correction-->                 

--- a/tracking/src/main/java/org/hps/recon/tracking/DataTrackerHitDriver.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/DataTrackerHitDriver.java
@@ -8,6 +8,8 @@ import java.util.Set;
 import org.lcsim.detector.IDetectorElement;
 import org.lcsim.detector.tracker.silicon.SiSensor;
 import org.lcsim.event.EventHeader;
+import org.lcsim.event.LCRelation;
+import org.lcsim.event.SimTrackerHit;
 import org.lcsim.geometry.Detector;
 import org.lcsim.lcio.LCIOUtil;
 import org.lcsim.recon.tracking.digitization.sisim.CDFSiSensorSim;
@@ -16,21 +18,21 @@ import org.lcsim.recon.tracking.digitization.sisim.SiTrackerHitStrip1D;
 import org.lcsim.util.Driver;
 
 /**
- * 
+ *
  * @author Matt Graham
  */
 // TODO: Add documentation about what this Driver does. --JM
 public class DataTrackerHitDriver extends Driver {
 
     // Debug switch for development.
-
     private boolean debug = false;
     // Collection name.
-    // private String readoutCollectionName = "TrackerHits";
+    private String readoutCollectionName = "TrackerHits";
     // Subdetector name.
     private String subdetectorName = "Tracker";
-    // Name of RawTrackerHit output collection.
-    // private String rawTrackerHitOutputCollectionName = "RawTrackerHitMaker_RawTrackerHits";
+    // Name of FittedTrackerHit output collection.
+    private String fittedTrackerHitCollectionName = "SVTFittedRawTrackerHits";
+
     // Name of StripHit1D output collection.
     private String stripHitOutputCollectionName = "StripClusterer_SiTrackerHitStrip1D";
     // Clustering parameters.
@@ -129,10 +131,10 @@ public class DataTrackerHitDriver extends Driver {
         this.fiveClusterErr = fiveClusterErr;
     }
 
-    public void setUseWeights(boolean useWeights){
+    public void setUseWeights(boolean useWeights) {
         this.useWeights = useWeights;
     }
-    
+
     /**
      * Creates a new instance of TrackerHitDriver.
      */
@@ -152,19 +154,15 @@ public class DataTrackerHitDriver extends Driver {
         // detector
         IDetectorElement deDetector = detector.getDetectorElement();
 
-        for (String path : processPaths) {
+        for (String path : processPaths)
             processDEs.add(deDetector.findDetectorElement(path));
-        }
 
-        if (processDEs.isEmpty()) {
+        if (processDEs.isEmpty())
             processDEs.add(deDetector);
-        }
 
-        for (IDetectorElement detectorElement : processDEs) {
-            processSensors.addAll(detectorElement.findDescendants(SiSensor.class));
-            // if (debug)
-            // System.out.println("added " + processSensors.size() + " sensors");
-        }
+        for (IDetectorElement detectorElement : processDEs)
+            processSensors.addAll(detectorElement.findDescendants(SiSensor.class)); // if (debug)
+        // System.out.println("added " + processSensors.size() + " sensors");
 
         // Create the sensor simulation.
         CDFSiSensorSim stripSim = new CDFSiSensorSim();
@@ -184,9 +182,9 @@ public class DataTrackerHitDriver extends Driver {
 
         stripClusterer.setMaxClusterSize(clusterMaxSize);
         stripClusterer.setCentralStripAveragingThreshold(clusterCentralStripAveragingThreshold);
-
+        stripClusterer.setDebug(debug);
         // Set the cluster errors.
-        
+
         DefaultSiliconResolutionModel model = new DefaultSiliconResolutionModel();
 
         model.setOneClusterErr(oneClusterErr);
@@ -195,9 +193,8 @@ public class DataTrackerHitDriver extends Driver {
         model.setFourClusterErr(fourClusterErr);
         model.setFiveClusterErr(fiveClusterErr);
         model.setUseWeights(useWeights);
-        
+
         stripClusterer.setResolutionModel(model);
-        
 
         // Set the detector to process.
         processPaths.add(subdetectorName);
@@ -211,49 +208,36 @@ public class DataTrackerHitDriver extends Driver {
         // Call sub-Driver processing.
         // super.process(event);
 
-        // Make new lists for output.
-        // List<HPSFittedRawTrackerHit> rawHits = new ArrayList<HPSFittedRawTrackerHit>();
+        // Make new lists for output.    
         List<SiTrackerHit> stripHits1D = new ArrayList<SiTrackerHit>();
 
-        // // Make HPS hits.
-        // for (SiSensor sensor : processSensors) {
-        // rawHits.addAll(hitMaker.makeHits(sensor));
-        // }
-
         // Make strip hits.
-        for (SiSensor sensor : processSensors) {
+        for (SiSensor sensor : processSensors)
             stripHits1D.addAll(stripClusterer.makeHits(sensor));
-        }
 
         // Debug prints.
         if (debug) {
-            // List<SimTrackerHit> simHits = event.get(SimTrackerHit.class,
-            // this.readoutCollectionName);
-            // System.out.println("SimTrackerHit collection " + this.readoutCollectionName +
-            // " has " + simHits.size() + " hits.");
-            // System.out.println("RawTrackerHit collection " +
-            // this.rawTrackerHitOutputCollectionName + " has " + rawHits.size() + " hits.");
+            if (event.hasCollection(SimTrackerHit.class, this.readoutCollectionName))
+                System.out.println("SimTrackerHit collection " + this.readoutCollectionName
+                        + " has " + event.get(SimTrackerHit.class, this.readoutCollectionName).size() + " hits.");
+            if (event.hasCollection(FittedRawTrackerHit.class, fittedTrackerHitCollectionName))
+                System.out.println("FittedRawTrackerHit collection "
+                        + this.fittedTrackerHitCollectionName + " has " + event.get(LCRelation.class, fittedTrackerHitCollectionName).size() + " hits.");
             System.out.println("TrackerHit collection " + this.stripHitOutputCollectionName + " has " + stripHits1D.size() + " hits.");
         }
 
         // Put output hits into collection.
-        int flag = LCIOUtil.bitSet(0, 31, true); // Turn on 64-bit cell ID.
-        // event.put(this.rawTrackerHitOutputCollectionName, rawHits, RawTrackerHit.class, flag,
-        // toString());
+        int flag = LCIOUtil.bitSet(0, 31, true); // Turn on 64-bit cell ID.        
         event.put(this.stripHitOutputCollectionName, stripHits1D, SiTrackerHitStrip1D.class, 0, toString());
-        if (debug) {
+        if (debug)
             System.out.println("[ DataTrackerHitDriver ] - " + this.stripHitOutputCollectionName + " has " + stripHits1D.size() + " hits.");
-        }
     }
 
     @Override
     public void endOfData() {
-        if (debug) {
-            for (int mod = 0; mod < 2; mod++) {
-                for (int layer = 0; layer < 10; layer++) {
+        if (debug)
+            for (int mod = 0; mod < 2; mod++)
+                for (int layer = 0; layer < 10; layer++)
                     System.out.format("mod %d, layer %d, count %d\n", mod, layer, counts[mod][layer]);
-                }
-            }
-        }
     }
 }

--- a/tracking/src/main/java/org/hps/recon/tracking/RawTrackerHitFitterDriver.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/RawTrackerHitFitterDriver.java
@@ -38,6 +38,8 @@ public class RawTrackerHitFitterDriver extends Driver {
     private boolean subtractTriggerTime = false;
     private boolean correctChanT0 = true;
 
+    private double tsCorrectionScale=240;
+    
     /**
      * Report time relative to the nearest expected truth event time.
      *
@@ -61,6 +63,10 @@ public class RawTrackerHitFitterDriver extends Driver {
 
     public void setUseTimestamps(boolean useTimestamps) {
         this.useTimestamps = useTimestamps;
+    }
+    
+       public void setTsCorrectionScale(double tsCorrectionScale) {
+        this.tsCorrectionScale = tsCorrectionScale;
     }
 
     public void setSubtractTOF(boolean subtractTOF) {
@@ -164,7 +170,8 @@ public class RawTrackerHitFitterDriver extends Driver {
                 if (useTimestamps) {
                     double t0Svt = ReadoutTimestamp.getTimestamp(ReadoutTimestamp.SYSTEM_TRACKER, event);
                     double t0Trig = ReadoutTimestamp.getTimestamp(ReadoutTimestamp.SYSTEM_TRIGGERBITS, event);
-                    double corMod = (t0Svt - t0Trig) + 200.0;
+                   // double corMod = (t0Svt - t0Trig) + 200.0;///where does 200.0 come from?  for 2016 MC, looks like should be 240
+                      double corMod = (t0Svt - t0Trig) + tsCorrectionScale;
                     fit.setT0(fit.getT0() + corMod);
                 }
                 if (useTruthTime) {

--- a/tracking/src/main/java/org/hps/recon/tracking/StripMaker.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/StripMaker.java
@@ -44,15 +44,18 @@ public class StripMaker {
     SiTrackerIdentifierHelper _sid_helper;
     // Temporary map connecting hits to strip numbers for sake of speed (reset once per sensor)
     Map<FittedRawTrackerHit, Integer> _strip_map = new HashMap<FittedRawTrackerHit, Integer>();
-    
 
     boolean _debug = false;
     private SiliconResolutionModel _res_model = new DefaultSiliconResolutionModel();
 
-    public void setResolutionModel(SiliconResolutionModel model){
+    public void setResolutionModel(SiliconResolutionModel model) {
         _res_model = model;
     }
-    
+
+    public void setDebug(boolean debug) {
+        this._debug = debug;
+    }
+
     public StripMaker(ClusteringAlgorithm algo) {
         _clustering = algo;
     }
@@ -73,11 +76,9 @@ public class StripMaker {
         List<SiSensor> sensors = detector.findDescendants(SiSensor.class);
 
         // Loop over all sensors
-        for (SiSensor sensor : sensors) {
-            if (sensor.hasStrips()) {
+        for (SiSensor sensor : sensors)
+            if (sensor.hasStrips())
                 hits.addAll(makeHits(sensor));
-            }
-        }
 
         // Return hit list
         return hits;
@@ -99,7 +100,8 @@ public class StripMaker {
         List<FittedRawTrackerHit> hps_hits = ro.getHits(FittedRawTrackerHit.class);
 
         Map<SiSensorElectrodes, List<FittedRawTrackerHit>> electrode_hits = new LinkedHashMap<SiSensorElectrodes, List<FittedRawTrackerHit>>();
-
+        if (_debug)
+            System.out.println(this.getClass().getSimpleName() + "::makeHits  looping over " + hps_hits.size() + " hits on sensor");
         for (FittedRawTrackerHit hps_hit : hps_hits) {
 
             // get id and create strip map, get electrodes.
@@ -111,21 +113,19 @@ public class StripMaker {
             // DetectorElementStore.getInstance().find(raw_hit.getIdentifier()).get(0).getName());
             ChargeCarrier carrier = ChargeCarrier.getCarrier(_sid_helper.getSideValue(id));
             SiSensorElectrodes electrodes = ((SiSensor) hps_hit.getRawTrackerHit().getDetectorElement()).getReadoutElectrodes(carrier);
-            if (!(electrodes instanceof SiStrips)) {
+            if (!(electrodes instanceof SiStrips))
                 continue;
-            }
 
-            if (electrode_hits.get(electrodes) == null) {
+            if (electrode_hits.get(electrodes) == null)
                 electrode_hits.put(electrodes, new ArrayList<FittedRawTrackerHit>());
-            }
 
             electrode_hits.get(electrodes).add(hps_hit);
         }
 
-        for (Map.Entry entry : electrode_hits.entrySet()) {
+        for (Map.Entry entry : electrode_hits.entrySet())
             hits.addAll(makeHits(sensor, (SiStrips) entry.getKey(), (List<FittedRawTrackerHit>) entry.getValue()));
-        }
-
+        if (_debug)
+            System.out.println(this.getClass().getSimpleName() + "::makeHits returning " + hits.size() + " clusters from sensor");
         return hits;
     }
 
@@ -133,12 +133,13 @@ public class StripMaker {
 
         // Call the clustering algorithm to make clusters
         List<List<FittedRawTrackerHit>> cluster_list = _clustering.findClusters(hps_hits);
-
+        if (_debug)
+            System.out.println(this.getClass().getSimpleName() + "::makeHits2 found clusters = " + cluster_list.size());
         // Create an empty list for the pixel hits to be formed from clusters
         List<SiTrackerHit> hits = new ArrayList<SiTrackerHit>();
 
         // Make a pixel hit from this cluster
-        for (List<FittedRawTrackerHit> cluster : cluster_list) {
+        for (List<FittedRawTrackerHit> cluster : cluster_list)
 
             // Make a TrackerHit from the cluster if it meets max cluster size requirement
             if (cluster.size() <= _max_cluster_nstrips) {
@@ -148,12 +149,10 @@ public class StripMaker {
                 hits.add(hit);
                 sensor.getReadout().addHit(hit);
             }
-        }
-
+        if (_debug)
+            System.out.println(this.getClass().getSimpleName() + "::makeHits2 returning " + hits.size() + " hits ");
         return hits;
     }
-
-    
 
     public void setCentralStripAveragingThreshold(int max_noaverage_nstrips) {
         _max_noaverage_nstrips = max_noaverage_nstrips;
@@ -164,42 +163,36 @@ public class StripMaker {
     }
 
     private SiTrackerHitStrip1D makeTrackerHit(List<FittedRawTrackerHit> cluster, SiSensorElectrodes electrodes) {
-        if (_debug) {
+        if (_debug)
             System.out.println(this.getClass().getSimpleName() + " makeTrackerHit ");
-        }
         Hep3Vector position = getPosition(cluster, electrodes);
         SymmetricMatrix covariance = getCovariance(cluster, electrodes);
         double time = getTime(cluster);
         double energy = getEnergy(cluster);
         TrackerHitType type = new TrackerHitType(TrackerHitType.CoordinateSystem.GLOBAL, TrackerHitType.MeasurementType.STRIP_1D);
         List<RawTrackerHit> rth_cluster = new ArrayList<RawTrackerHit>();
-        for (FittedRawTrackerHit bth : cluster) {
+        for (FittedRawTrackerHit bth : cluster)
             rth_cluster.add(bth.getRawTrackerHit());
-        }
         SiTrackerHitStrip1D hit = new SiTrackerHitStrip1D(position, covariance, energy, time, rth_cluster, type);
-        if (_debug) {
+        if (_debug)
             System.out.println(this.getClass().getSimpleName() + " SiTrackerHitStrip1D created at " + position + "(" + hit.getPositionAsVector().toString() + ")" + " E " + energy + " time " + time);
-        }
         return hit;
     }
 
     private Hep3Vector getPosition(List<FittedRawTrackerHit> cluster, SiSensorElectrodes electrodes) {
-        if (_debug) {
+        if (_debug)
             System.out.println(this.getClass().getSimpleName() + " getPosition for cluster size " + cluster.size());
-        }
         List<Double> signals = new ArrayList<Double>();
         List<Hep3Vector> positions = new ArrayList<Hep3Vector>();
 
-        if (_debug) {
+        if (_debug)
             System.out.println(this.getClass().getSimpleName() + " Loop of " + cluster.size() + " and add signals and positions to vectors");
-        }
 
         for (FittedRawTrackerHit hit : cluster) {
             signals.add(hit.getAmp());
             positions.add(((SiStrips) electrodes).getStripCenter(_strip_map.get(hit)));
-            if (_debug) {
+            if (_debug)
                 System.out.println(this.getClass().getSimpleName() + " Added hit with signal " + hit.getAmp() + " at strip center posiiton " + (((SiStrips) electrodes).getStripCenter(_strip_map.get(hit))));
-            }
         }
 
         // Average charge on central strips of longer clusters
@@ -208,46 +201,38 @@ public class StripMaker {
 
             // collect sum of charges on center strips
             double center_charge_sum = 0.0;
-            for (int istrip = 1; istrip < signals.size() - 1; istrip++) {
+            for (int istrip = 1; istrip < signals.size() - 1; istrip++)
                 center_charge_sum += signals.get(istrip);
-            }
 
             // distribute evenly on center strips
             double center_charge_strip = center_charge_sum / nstrips_center;
-            for (int istrip = 1; istrip < signals.size() - 1; istrip++) {
+            for (int istrip = 1; istrip < signals.size() - 1; istrip++)
                 signals.set(istrip, center_charge_strip);
-            }
         }
 
-        if (_debug) {
+        if (_debug)
             System.out.println(this.getClass().getSimpleName() + " Calculate charge weighted mean for " + signals.size() + " signals");
-        }
 
-        
         Hep3Vector position = _res_model.weightedAveragePosition(signals, positions);
-        
-        if (_debug) {
+
+        if (_debug)
             System.out.println(this.getClass().getSimpleName() + " charge weighted position " + position.toString() + " (before trans)");
-        }
         electrodes.getParentToLocal().inverse().transform(position);
-        if (_debug) {
+        if (_debug)
             System.out.println(this.getClass().getSimpleName() + " charge weighted position " + position.toString() + " (after trans)");
-        }
 
         // Swim position back through lorentz drift direction to midpoint between bias surfaces
         if (_simulation != null) {
             _simulation.setSensor((SiSensor) electrodes.getDetectorElement());
             _simulation.lorentzCorrect(position, electrodes.getChargeCarrier());
-            if (_debug) {
+            if (_debug)
                 System.out.println(this.getClass().getSimpleName() + ": Position " + position.toString() + " ( after Lorentz)");
-            }
         }
 
         // return position in global coordinates
         Hep3Vector newpos = ((SiSensor) electrodes.getDetectorElement()).getGeometry().getLocalToGlobal().transformed(position);
-        if (_debug) {
+        if (_debug)
             System.out.println(this.getClass().getSimpleName() + " final cluster position " + newpos.toString());
-        }
 
         return ((SiSensor) electrodes.getDetectorElement()).getGeometry().getLocalToGlobal().transformed(position);
         // return electrodes.getLocalToGlobal().transformed(position);
@@ -298,8 +283,6 @@ public class StripMaker {
         //
         // return new SymmetricMatrix((Matrix)covariance_global);
     }
-
-    
 
     private double getEnergy(List<FittedRawTrackerHit> cluster) {
         double total_charge = 0.0;


### PR DESCRIPTION
Mostly, and most importantly, this changes the SVT timing corrections applied in the MC recon steering file.  Before this fix, we were seeing 2 peaks in the t0 for SVT hits separated by 24ns (somehow) due to the phase-adjustment correction which is not simulated in MC (so shouldn't be corrected for).  This 24-ns, two-peak structure isn't seen in the 2015 MC...though possible it's run condition (i.e. the value of the phase correction) dependent; I didn't try running the recon with different run assumptions (2015 I used the usual 5772, for 2016 I used 7796.  Anyway, the new steering file corrects just for the trigger timestamp

Here's what I need reviewers to do: 
Bradley -- make sure this builds & recos MC in a reasonable way e.g. how many reco SVT hit/tracks per event before and after change.  It would be great if you could do this for both some 2015 and 2016 data; I know what these changes should be so we can compare.  No new readout needed, just recon!

Norman & Rafo -- could you guys check the MC readout and recon files and see if they make sense compared to the data recon we are doing?  And that the readout constants put in for MC readout make sense?  Maybe this should be another issue...