### PR TITLE
iss338: Change all uses of DatabaseConditionsManager ctor to use getInstance() method

### DIFF
--- a/analysis/src/test/java/org/hps/analysis/MC/TrackExtrapTest.java
+++ b/analysis/src/test/java/org/hps/analysis/MC/TrackExtrapTest.java
@@ -51,7 +51,7 @@ public class TrackExtrapTest extends TestCase {
         String aidaOutput = "target/test-output/TrackExtrapPlots_" + fileName.replaceAll("slcio", "aida");
         LCSimLoop loop2 = new LCSimLoop();
         
-        final DatabaseConditionsManager manager = new DatabaseConditionsManager();
+        final DatabaseConditionsManager manager = DatabaseConditionsManager.getInstance();
         manager.addConditionsListener(new SvtDetectorSetup());
 
         loop2.setLCIORecordSource(inputFile);

--- a/analysis/src/test/java/org/hps/analysis/TupleDriverTest.java
+++ b/analysis/src/test/java/org/hps/analysis/TupleDriverTest.java
@@ -41,7 +41,7 @@ abstract public class TupleDriverTest extends TestCase {
         LCSimLoop loop = new LCSimLoop();
         loop.setLCIORecordSource(lcioInputFile);
         
-        final DatabaseConditionsManager manager = new DatabaseConditionsManager();
+        final DatabaseConditionsManager manager = DatabaseConditionsManager.getInstance();
         manager.addConditionsListener(new SvtDetectorSetup());
         
         loop.add(new org.lcsim.recon.tracking.digitization.sisim.config.ReadoutCleanupDriver());

--- a/conditions/src/main/java/org/hps/conditions/cli/CommandLineTool.java
+++ b/conditions/src/main/java/org/hps/conditions/cli/CommandLineTool.java
@@ -170,7 +170,7 @@ public final class CommandLineTool {
         LOGGER.info("Setting up the conditions manager ...");
 
         // Create new manager.
-        this.conditionsManager = new DatabaseConditionsManager();
+        this.conditionsManager = DatabaseConditionsManager.getInstance();
 
         // User specified tag of conditions records.
         if (commandLine.hasOption("t")) {

--- a/conditions/src/main/java/org/hps/conditions/database/DatabaseConditionsManager.java
+++ b/conditions/src/main/java/org/hps/conditions/database/DatabaseConditionsManager.java
@@ -71,6 +71,8 @@ public final class DatabaseConditionsManager extends ConditionsManagerImplementa
      */
     private static Logger LOG = Logger.getLogger(DatabaseConditionsManager.class.getPackage().getName());
 
+    private static DatabaseConditionsManager INSTANCE = null;
+
     /**
      * The max value for a run to be considered Test Run.
      */
@@ -188,7 +190,10 @@ public final class DatabaseConditionsManager extends ConditionsManagerImplementa
      * @return the static instance of the manager
      */
     public static DatabaseConditionsManager getInstance() {
-        return DatabaseConditionsManager.class.cast(ConditionsManager.defaultInstance());
+        if (INSTANCE == null) {
+            INSTANCE = new DatabaseConditionsManager();
+        }
+        return INSTANCE;
     }
 
     /**
@@ -263,7 +268,7 @@ public final class DatabaseConditionsManager extends ConditionsManagerImplementa
      * Class constructor. Calling this will automatically register this manager as
      * the global default.
      */
-    public DatabaseConditionsManager() {
+    private DatabaseConditionsManager() {
 
         // Register detector conditions converter.
         this.registerConditionsConverter(new DetectorConditionsConverter());

--- a/conditions/src/main/java/org/hps/conditions/database/DatabaseConditionsManager.java
+++ b/conditions/src/main/java/org/hps/conditions/database/DatabaseConditionsManager.java
@@ -631,6 +631,14 @@ public final class DatabaseConditionsManager extends ConditionsManagerImplementa
         return this.isInitialized;
     }
 
+
+    /**
+     * Reset the static instance..
+     */
+    public static void reset() {
+        INSTANCE = new DatabaseConditionsManager();
+    }
+
     /**
      * Return <code>true</code> if Test Run configuration is active
      *

--- a/conditions/src/test/java/org/hps/conditions/HPSJAVA_529_Test.java
+++ b/conditions/src/test/java/org/hps/conditions/HPSJAVA_529_Test.java
@@ -6,7 +6,7 @@ import org.hps.conditions.database.DatabaseConditionsManager;
 public class HPSJAVA_529_Test {
            
     public void test() throws Exception {
-        DatabaseConditionsManager conditionsManager = new DatabaseConditionsManager();
+        DatabaseConditionsManager conditionsManager = DatabaseConditionsManager.getInstance();
         int startRun = 5000;
         int stopRun = 5772;
         for (int run = startRun; run < stopRun; run++) {

--- a/conditions/src/test/java/org/hps/conditions/RunNumberTest.java
+++ b/conditions/src/test/java/org/hps/conditions/RunNumberTest.java
@@ -32,7 +32,7 @@ public final class RunNumberTest extends TestCase {
         /**
          * Reference to conditions manager.
          */
-        private static DatabaseConditionsManager conditionsManager = new DatabaseConditionsManager();
+        private static DatabaseConditionsManager conditionsManager = DatabaseConditionsManager.getInstance();
 
         /**
          * Number of times {@link #detectorChanged(Detector)} was called.

--- a/conditions/src/test/java/org/hps/conditions/api/ConditionsTagTest.java
+++ b/conditions/src/test/java/org/hps/conditions/api/ConditionsTagTest.java
@@ -92,7 +92,7 @@ public class ConditionsTagTest extends TestCase {
     @Override
     public void setUp() {
         // Configure the conditions system.
-        MANAGER = new DatabaseConditionsManager();
+        MANAGER = DatabaseConditionsManager.getInstance();
     }
     
     /**

--- a/conditions/src/test/java/org/hps/conditions/beam/BeamEnergyTest.java
+++ b/conditions/src/test/java/org/hps/conditions/beam/BeamEnergyTest.java
@@ -17,7 +17,7 @@ public class BeamEnergyTest extends TestCase {
     private static final String DETECTOR = "HPS-dummy-detector";
     
     public void testBeamEnergy() throws Exception {
-        DatabaseConditionsManager manager = new DatabaseConditionsManager();        
+        DatabaseConditionsManager manager = DatabaseConditionsManager.getInstance();        
         for (int i = 0; i < BEAM_ENERGIES.length; i++) {
             double expectedBeamEnergy = BEAM_ENERGIES[i];
             for (int j = 0; j < 3; j++) {

--- a/conditions/src/test/java/org/hps/conditions/database/DatabaseConditionsManagerTest.java
+++ b/conditions/src/test/java/org/hps/conditions/database/DatabaseConditionsManagerTest.java
@@ -23,7 +23,7 @@ public class DatabaseConditionsManagerTest extends TestCase {
      */
     public void testDatabaseConditionsManager() throws Exception {
         
-        DatabaseConditionsManager manager = new DatabaseConditionsManager();
+        DatabaseConditionsManager manager = DatabaseConditionsManager.getInstance();
         
         // Check initial state.
         TestCase.assertTrue("The conditions manager instance is null.", manager != null);

--- a/conditions/src/test/java/org/hps/conditions/database/OfflineConditionsManagerTest.java
+++ b/conditions/src/test/java/org/hps/conditions/database/OfflineConditionsManagerTest.java
@@ -15,7 +15,7 @@ public class OfflineConditionsManagerTest extends TestCase {
     public void testOfflineDatabaseConditionsManager() throws Exception {
        
         System.setProperty("org.hps.conditions.url", "jdbc:sqlite:hps_conditions.db"); 
-        DatabaseConditionsManager manager = new DatabaseConditionsManager();
+        DatabaseConditionsManager manager = DatabaseConditionsManager.getInstance();
         manager.openConnection();
 
         manager.setDetector("HPS-EngRun2015-Nominal-v2", 5772);

--- a/conditions/src/test/java/org/hps/conditions/dummy/DummyConditionsObjectCollectionTest.java
+++ b/conditions/src/test/java/org/hps/conditions/dummy/DummyConditionsObjectCollectionTest.java
@@ -26,7 +26,7 @@ public class DummyConditionsObjectCollectionTest extends TestCase {
     @Override
     public void setUp() {
         // Configure the conditions system.
-        final DatabaseConditionsManager manager = new DatabaseConditionsManager();
+        final DatabaseConditionsManager manager = DatabaseConditionsManager.getInstance();
         //manager.setConnectionResource("/org/hps/conditions/config/jeremym_dev_connection.prop");
         this.connection = manager.getConnection();
     }

--- a/conditions/src/test/java/org/hps/conditions/dummy/DummyConditionsObjectConverterTest.java
+++ b/conditions/src/test/java/org/hps/conditions/dummy/DummyConditionsObjectConverterTest.java
@@ -16,7 +16,7 @@ public class DummyConditionsObjectConverterTest extends TestCase {
 
     public void testConditionsObjectConverter() throws Exception {
 
-        final DatabaseConditionsManager manager = new DatabaseConditionsManager();
+        final DatabaseConditionsManager manager = DatabaseConditionsManager.getInstance();
         //manager.setConnectionResource("/org/hps/conditions/config/jeremym_dev_connection.prop");
         manager.registerConditionsConverter(new DummyConditionsObjectConverter());
         manager.setDetector("HPS-dummy-detector", 1);

--- a/conditions/src/test/java/org/hps/conditions/dummy/DummyConditionsObjectTest.java
+++ b/conditions/src/test/java/org/hps/conditions/dummy/DummyConditionsObjectTest.java
@@ -33,7 +33,7 @@ public final class DummyConditionsObjectTest extends TestCase {
     @Override
     public void setUp() {
         // Configure the conditions system. This uses a local development database that is not globally accessible.
-        manager = new DatabaseConditionsManager();
+        manager = DatabaseConditionsManager.getInstance();
         //manager.setConnectionResource("/org/hps/conditions/config/jeremym_dev_connection.prop");
     }
 

--- a/conditions/src/test/java/org/hps/conditions/ecal/EcalLedTest.java
+++ b/conditions/src/test/java/org/hps/conditions/ecal/EcalLedTest.java
@@ -30,7 +30,7 @@ public final class EcalLedTest extends TestCase {
      */
     @Override
     public void setUp() {
-        conditionsManager = new DatabaseConditionsManager();
+        conditionsManager = DatabaseConditionsManager.getInstance();
         try {
             conditionsManager.setDetector("HPS-ECalCommissioning-v2", RUN_NUMBER);
         } catch (final ConditionsNotFoundException e) {

--- a/conditions/src/test/java/org/hps/conditions/svt/SvtConfigurationTest.java
+++ b/conditions/src/test/java/org/hps/conditions/svt/SvtConfigurationTest.java
@@ -20,7 +20,7 @@ public final class SvtConfigurationTest extends TestCase {
      * Load an SVT XML configuration from the database.
      */
     public void testSvtConfiguration() {
-        final DatabaseConditionsManager manager = new DatabaseConditionsManager();
+        final DatabaseConditionsManager manager = DatabaseConditionsManager.getInstance();
         final SvtConfigurationCollection collection = manager.getCachedConditions(SvtConfigurationCollection.class,
                 "svt_configurations").getCachedData();
         for (final SvtConfiguration config : collection) {

--- a/conditions/src/test/java/org/hps/conditions/svt/SvtTimingConstantsTest.java
+++ b/conditions/src/test/java/org/hps/conditions/svt/SvtTimingConstantsTest.java
@@ -33,7 +33,7 @@ public class SvtTimingConstantsTest extends TestCase {
      * @throws Exception if any error occurs
      */
     public void testSvtTimingConstants() throws Exception {
-        final DatabaseConditionsManager manager = new DatabaseConditionsManager();
+        final DatabaseConditionsManager manager = DatabaseConditionsManager.getInstance();
         // manager.setConnectionResource("/org/hps/conditions/config/jeremym_dev_connection.prop");
         for (final int run : RUNS) {
             manager.setDetector(DETECTOR, run);

--- a/conditions/src/test/java/org/hps/conditions/svt/TestRunSvtBadChannelsTest.java
+++ b/conditions/src/test/java/org/hps/conditions/svt/TestRunSvtBadChannelsTest.java
@@ -48,7 +48,7 @@ public final class TestRunSvtBadChannelsTest extends TestCase {
      */
     public void testSvtBadChannels() throws ConditionsNotFoundException {
 
-        final DatabaseConditionsManager conditionsManager = new DatabaseConditionsManager();
+        final DatabaseConditionsManager conditionsManager = DatabaseConditionsManager.getInstance();
 
         for (int i = 0; i < RUN_NUMBERS.length; i++) {
 

--- a/conditions/src/test/java/org/hps/conditions/svt/TestRunSvtConditionsConverterTest.java
+++ b/conditions/src/test/java/org/hps/conditions/svt/TestRunSvtConditionsConverterTest.java
@@ -22,7 +22,7 @@ public final class TestRunSvtConditionsConverterTest extends TestCase {
      * @throws Exception if there is a conditions system error
      */
     public void test() throws Exception {
-        final DatabaseConditionsManager conditionsManager = new DatabaseConditionsManager();
+        final DatabaseConditionsManager conditionsManager = DatabaseConditionsManager.getInstance();
         conditionsManager.setDetector("HPS-TestRun-v5", RUN_NUMBER);
 
         final TestRunSvtConditions svtConditions = conditionsManager.getCachedConditions(TestRunSvtConditions.class,

--- a/conditions/src/test/java/org/hps/conditions/svt/TestRunSvtDaqMappingTest.java
+++ b/conditions/src/test/java/org/hps/conditions/svt/TestRunSvtDaqMappingTest.java
@@ -69,7 +69,7 @@ public final class TestRunSvtDaqMappingTest extends TestCase {
      */
     public void test() throws Exception {
 
-        final DatabaseConditionsManager conditionsManager = new DatabaseConditionsManager();
+        final DatabaseConditionsManager conditionsManager = DatabaseConditionsManager.getInstance();
         conditionsManager.setDetector("HPS-TestRun-v5", RUN_NUMBER);
 
         final TestRunSvtDaqMappingCollection daqMappingCollection = conditionsManager.getCachedConditions(

--- a/conditions/src/test/java/org/hps/conditions/trigger/TiTimeOffsetTest.java
+++ b/conditions/src/test/java/org/hps/conditions/trigger/TiTimeOffsetTest.java
@@ -12,7 +12,7 @@ public final class TiTimeOffsetTest extends TestCase {
     private static DatabaseConditionsManager conditionsManager;
 
     public void setUp() {
-        conditionsManager = new DatabaseConditionsManager();
+        conditionsManager = DatabaseConditionsManager.getInstance();
         try {
             conditionsManager.setDetector("HPS-PhysicsRun2016-Nominal-v4-4", RUN_NUMBER);
         } catch (final ConditionsNotFoundException e) {

--- a/conditions/src/test/java/org/hps/conditions/trigger/TriggerTimeWindowTest.java
+++ b/conditions/src/test/java/org/hps/conditions/trigger/TriggerTimeWindowTest.java
@@ -14,7 +14,7 @@ public final class TriggerTimeWindowTest extends TestCase {
 
     @Override
     public void setUp() {
-        conditionsManager = new DatabaseConditionsManager();
+        conditionsManager = DatabaseConditionsManager.getInstance();
         try {
             conditionsManager.setDetector("HPS-PhysicsRun2016-Nominal-v4-4", RUN_NUMBER);
         } catch (final ConditionsNotFoundException e) {

--- a/detector-model/src/main/java/org/hps/detector/DetectorConverter.java
+++ b/detector-model/src/main/java/org/hps/detector/DetectorConverter.java
@@ -103,7 +103,7 @@ public class DetectorConverter {
             throw new IllegalArgumentException("No converter found for format: " + outputFormat);
 
         if (runNumber != null) {
-            DatabaseConditionsManager mgr = new DatabaseConditionsManager();
+            DatabaseConditionsManager mgr = DatabaseConditionsManager.getInstance();
             String name = "DUMMY";
             ConditionsReader dummyReader = ConditionsReader.createDummy();
             ((ConditionsManagerImplementation) mgr).setConditionsReader(dummyReader, name);

--- a/detector-model/src/test/java/org/hps/detector/svt/SvtDaqMappingTest.java
+++ b/detector-model/src/test/java/org/hps/detector/svt/SvtDaqMappingTest.java
@@ -35,7 +35,7 @@ public final class SvtDaqMappingTest extends TestCase {
      * @throws Exception if there is a test error
      */
     public void test() throws Exception {
-        final DatabaseConditionsManager conditionsManager = new DatabaseConditionsManager();
+        final DatabaseConditionsManager conditionsManager = DatabaseConditionsManager.getInstance();
         conditionsManager.setDetector("HPS-Proposal2014-v7-2pt2", 0);
         final SvtDaqMappingCollection daqMappingCollection = conditionsManager.getCachedConditions(
                 SvtDaqMappingCollection.class, "svt_daq_map").getCachedData();

--- a/detector-model/src/test/java/org/hps/detector/svt/SvtDetectorSetupTest.java
+++ b/detector-model/src/test/java/org/hps/detector/svt/SvtDetectorSetupTest.java
@@ -61,7 +61,7 @@ public final class SvtDetectorSetupTest extends TestCase {
      */
     public void test() throws Exception {
 
-        final DatabaseConditionsManager conditionsManager = new DatabaseConditionsManager();
+        final DatabaseConditionsManager conditionsManager = DatabaseConditionsManager.getInstance();
         conditionsManager.addConditionsListener(new SvtDetectorSetup());
         //conditionsManager.setDetector("HPS-Proposal2014-v7-2pt2", 0);
         conditionsManager.setDetector("HPS-EngRun2015-Nominal-v3", 5772);

--- a/detector-model/src/test/java/org/lcsim/detector/converter/compact/HPSEcal4ConverterTest.java
+++ b/detector-model/src/test/java/org/lcsim/detector/converter/compact/HPSEcal4ConverterTest.java
@@ -37,7 +37,7 @@ public class HPSEcal4ConverterTest extends TestCase {
 
     private static final String resource = "/org/lcsim/geometry/subdetector/HPSEcal4Test.xml";
     public void setUp() throws ConditionsManager.ConditionsNotFoundException {
-        DatabaseConditionsManager mgr = new DatabaseConditionsManager();
+        DatabaseConditionsManager mgr = DatabaseConditionsManager.getInstance();
         mgr.setDetector("HPS-PhysicsRun2016-Nominal-v4-4", 0); /* any run number and detector will work here */
       
         InputStream in = this.getClass().getResourceAsStream(resource);

--- a/detector-model/src/test/java/org/lcsim/geometry/compact/converter/lcdd/HPSEcal4LCDDTest.java
+++ b/detector-model/src/test/java/org/lcsim/geometry/compact/converter/lcdd/HPSEcal4LCDDTest.java
@@ -26,7 +26,7 @@ public class HPSEcal4LCDDTest extends TestCase {
     }
 
     public void test_converter() throws Exception {
-        DatabaseConditionsManager mgr = new DatabaseConditionsManager();
+        DatabaseConditionsManager mgr = DatabaseConditionsManager.getInstance();
         mgr.setDetector("HPS-PhysicsRun2016-Nominal-v4-4", 0); /*
          * any run number and detector will work here
          */

--- a/evio/src/test/java/org/hps/evio/LCSimTestRunEventBuilderTest.java
+++ b/evio/src/test/java/org/hps/evio/LCSimTestRunEventBuilderTest.java
@@ -25,7 +25,7 @@ public class LCSimTestRunEventBuilderTest extends TestCase {
     public void testLCSimTestRunEventBuilder() throws Exception { 
     
         // Configure the conditions system to retrieve test run conditions for run 1351.
-        DatabaseConditionsManager conditionsManager = new DatabaseConditionsManager();
+        DatabaseConditionsManager conditionsManager = DatabaseConditionsManager.getInstance();
         
         // Create the test run event builder
         LCSimTestRunEventBuilder builder = new LCSimTestRunEventBuilder();

--- a/evio/src/test/java/org/hps/evio/ScalersTest.java
+++ b/evio/src/test/java/org/hps/evio/ScalersTest.java
@@ -41,7 +41,7 @@ public class ScalersTest extends TestCase {
         File inputFile = cache.getCachedFile(new URL(TEST_FILE_URL));
         
         // Setup conditions and event building.
-        DatabaseConditionsManager manager = new DatabaseConditionsManager();
+        DatabaseConditionsManager manager = DatabaseConditionsManager.getInstance();
         LCSimEventBuilder builder = new LCSimEngRunEventBuilder();
         manager.addConditionsListener(builder);
         

--- a/integration-tests/src/test/java/org/hps/test/it/ClustererTest.java
+++ b/integration-tests/src/test/java/org/hps/test/it/ClustererTest.java
@@ -140,7 +140,7 @@ public class ClustererTest extends TestCase {
         testOutputDir.mkdir();
 
         // Initialize the conditions system.
-        final DatabaseConditionsManager dbManager = new DatabaseConditionsManager();
+        final DatabaseConditionsManager dbManager = DatabaseConditionsManager.getInstance();
         ConditionsManager.setDefaultConditionsManager(dbManager);
     }
 

--- a/integration-tests/src/test/java/org/hps/test/it/ClustererTest.java
+++ b/integration-tests/src/test/java/org/hps/test/it/ClustererTest.java
@@ -140,8 +140,7 @@ public class ClustererTest extends TestCase {
         testOutputDir.mkdir();
 
         // Initialize the conditions system.
-        final DatabaseConditionsManager dbManager = DatabaseConditionsManager.getInstance();
-        ConditionsManager.setDefaultConditionsManager(dbManager);
+        DatabaseConditionsManager.getInstance();
     }
 
     /**
@@ -248,6 +247,7 @@ public class ClustererTest extends TestCase {
          * Run the job to create clusters and write to LCIO file. *
          **********************************************************/               
         System.out.println("testing Clusterer " + config.clustererName + " ...");
+
         // Configure the loop.
         LCSimLoop loop = new LCSimLoop();
         try {
@@ -256,6 +256,7 @@ public class ClustererTest extends TestCase {
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
+        DatabaseConditionsManager.reset();
 
         // Setup event number print outs.
         EventMarkerDriver eventMarkerDriver = new EventMarkerDriver();

--- a/integration-tests/src/test/java/org/hps/test/it/ConditionsIT.java
+++ b/integration-tests/src/test/java/org/hps/test/it/ConditionsIT.java
@@ -24,7 +24,7 @@ public class ConditionsIT extends TestCase {
      * Resets the conditions system before each test method runs.
      */
     public void setUp() {
-        new DatabaseConditionsManager();
+        DatabaseConditionsManager.getInstance();
     }
     
     /**

--- a/job/src/main/java/org/hps/job/DatabaseConditionsManagerSetup.java
+++ b/job/src/main/java/org/hps/job/DatabaseConditionsManagerSetup.java
@@ -23,7 +23,7 @@ public final class DatabaseConditionsManagerSetup extends DefaultConditionsSetup
     private DatabaseConditionsManager manager = null;
     
     public DatabaseConditionsManagerSetup() {        
-        manager = new DatabaseConditionsManager();
+        manager = DatabaseConditionsManager.getInstance();
     }
     
     /**

--- a/monitoring-app/src/main/java/org/hps/monitoring/application/util/ResourceUtil.java
+++ b/monitoring-app/src/main/java/org/hps/monitoring/application/util/ResourceUtil.java
@@ -37,7 +37,7 @@ public final class ResourceUtil {
      */
     public static String[] getConditionsTags() {
         // FIXME: New database manager should probably not be instantiated here.
-        DatabaseConditionsManager mgr = new DatabaseConditionsManager();
+        DatabaseConditionsManager mgr = DatabaseConditionsManager.getInstance();
         String[] tags = mgr.getAvailableTags().toArray(new String[]{});
         try {
             mgr.getConnection().close();

--- a/recon/src/test/java/org/hps/recon/filtering/V0CandidateFilter2015Pass7Test.java
+++ b/recon/src/test/java/org/hps/recon/filtering/V0CandidateFilter2015Pass7Test.java
@@ -22,7 +22,7 @@ public class V0CandidateFilter2015Pass7Test extends TestCase {
         FileCache cache = new FileCache();
         File inputFile = cache.getCachedFile(testURL);
         LCSimLoop loop = new LCSimLoop();
-        new DatabaseConditionsManager();
+        DatabaseConditionsManager.getInstance();
         V0CandidateFilter2015Pass7 driver = new V0CandidateFilter2015Pass7();
         loop.add(driver);
         try {

--- a/tracking/src/test/java/org/hps/recon/tracking/ReconGBLoutputTest.java
+++ b/tracking/src/test/java/org/hps/recon/tracking/ReconGBLoutputTest.java
@@ -51,7 +51,7 @@ public class ReconGBLoutputTest extends TestCase {
         LCSimLoop loop = new LCSimLoop();
         loop.setLCIORecordSource(inputFile);
 
-        final DatabaseConditionsManager manager = new DatabaseConditionsManager();
+        final DatabaseConditionsManager manager = DatabaseConditionsManager.getInstance();
         manager.addConditionsListener(new SvtDetectorSetup());
 
         loop.add(new MainTrackingDriver());

--- a/tracking/src/test/java/org/hps/recon/tracking/ReconTestSkeleton.java
+++ b/tracking/src/test/java/org/hps/recon/tracking/ReconTestSkeleton.java
@@ -53,7 +53,7 @@ public class ReconTestSkeleton extends TestCase {
         LCSimLoop loop = new LCSimLoop();
         loop.setLCIORecordSource(inputFile);
 
-        final DatabaseConditionsManager manager = new DatabaseConditionsManager();
+        final DatabaseConditionsManager manager = DatabaseConditionsManager.getInstance();
         manager.addConditionsListener(new SvtDetectorSetup());
 
         loop.add(new MainTrackingDriver());

--- a/tracking/src/test/java/org/hps/recon/tracking/TrackingReconstructionPlotsTest.java
+++ b/tracking/src/test/java/org/hps/recon/tracking/TrackingReconstructionPlotsTest.java
@@ -35,7 +35,7 @@ public class TrackingReconstructionPlotsTest extends TestCase {
             inputFile = cache.getCachedFile(testURL);
         }
 
-        final DatabaseConditionsManager manager = new DatabaseConditionsManager();
+        final DatabaseConditionsManager manager = DatabaseConditionsManager.getInstance();
         manager.addConditionsListener(new SvtDetectorSetup());
 
         LCSimLoop loop2 = new LCSimLoop();


### PR DESCRIPTION
The DatabaseConditionsManager constructor was made private, and public access is now achieved using the method `DatabaseConditionsManager.getInstance()` instead.  There is a single `INSTANCE` variable in the DatabaseConditionsManager class which will be instantiated if it does not exist.  The same conditions manager will then be used for the lifetime of the job/process.

I have checked that running the following tools seem to function properly with this change using OpenJDK:

- Evio2Lcio to output raw LCIO from EVIO
- JobManager to produce recon events from raw LCIO
- Conditions command line interface `print` command
- Detector converter from compact to LCDD (Sun JRE 1.8)

For detector converter, I used the class `org.lcsim.geometry.compact.converter.Main` as the HPS DetectorConverter seems to be broken, but it does not look like an issue having to do with the DatabaseConditionsManager.

Additional independent testing by a reviewer would be a good idea before merging this.