### PR TITLE
adding return null to MakeGBLTracks

### DIFF
--- a/tracking/src/main/java/org/hps/recon/tracking/gbl/MakeGblTracks.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/gbl/MakeGblTracks.java
@@ -240,8 +240,12 @@ public class MakeGblTracks {
             }
             HpsSiSensor sensor = (HpsSiSensor) ((RawTrackerHit) stripHit.getRawHits().get(0)).getDetectorElement();
             MultipleScattering.ScatterPoint temp = scatters.getScatterPoint(((RawTrackerHit) strip.getStrip().rawhits().get(0)).getDetectorElement());
-            if (temp == null)
+            if (temp == null){
                 temp = getScatterPointGbl(sensor, strip, htf, _scattering, _B);
+                if(temp == null){
+                    return null;
+                }
+            }
             GBLStripClusterData stripData = makeStripData(sensor, strip, htf, temp);
             if (stripData != null)
                 stripClusterDataList.add(stripData);


### PR DESCRIPTION
I simply added a "return null" in a function in MakeGblTracks so that if the GBL refit fails it doesn't crash the whole code.