### PR TITLE
Iss451: Add Hodoscope Detector Conditions Classes

### DIFF
--- a/conditions/src/main/java/org/hps/conditions/database/DatabaseConditionsManager.java
+++ b/conditions/src/main/java/org/hps/conditions/database/DatabaseConditionsManager.java
@@ -26,6 +26,7 @@ import org.hps.conditions.api.TableRegistry;
 import org.hps.conditions.ecal.EcalConditions;
 import org.hps.conditions.ecal.EcalConditionsConverter;
 import org.hps.conditions.ecal.TestRunEcalConditionsConverter;
+import org.hps.conditions.hodoscope.HodoscopeConditionsConverter;
 import org.hps.conditions.svt.SvtConditions;
 import org.hps.conditions.svt.SvtConditionsConverter;
 import org.hps.conditions.svt.TestRunSvtConditionsConverter;
@@ -264,6 +265,8 @@ public final class DatabaseConditionsManager extends ConditionsManagerImplementa
      */
     private final Set<String> tags = new HashSet<String>();
 
+    private ConditionsConverter hodoscopeConverter;
+    
     /**
      * Class constructor. Calling this will automatically register this manager as
      * the global default.
@@ -724,6 +727,10 @@ public final class DatabaseConditionsManager extends ConditionsManagerImplementa
             // Remove old ECAL converter.
             this.removeConditionsConverter(this.ecalConverter);
         }
+        
+        if (this.hodoscopeConverter != null) {
+            this.removeConditionsConverter(this.hodoscopeConverter);
+        }
 
         // Is configured for TestRun?
         if (this.isTestRun()) {
@@ -734,9 +741,11 @@ public final class DatabaseConditionsManager extends ConditionsManagerImplementa
             // Load the default converters.
             this.svtConverter = new SvtConditionsConverter();
             this.ecalConverter = new EcalConditionsConverter();
+            this.hodoscopeConverter = new HodoscopeConditionsConverter();
         }
         this.registerConditionsConverter(this.svtConverter);
         this.registerConditionsConverter(this.ecalConverter);
+        this.registerConditionsConverter(this.hodoscopeConverter);
     }
 
     /**

--- a/conditions/src/main/java/org/hps/conditions/hodoscope/HodoscopeCalibration.java
+++ b/conditions/src/main/java/org/hps/conditions/hodoscope/HodoscopeCalibration.java
@@ -1,0 +1,28 @@
+package org.hps.conditions.hodoscope;
+
+import org.hps.conditions.api.BaseConditionsObject;
+import org.hps.conditions.api.BaseConditionsObjectCollection;
+import org.hps.conditions.database.Field;
+import org.hps.conditions.database.Table;
+
+@Table(names = {"hodo_calibrations"})
+public final class HodoscopeCalibration extends BaseConditionsObject {
+
+    public static class HodoscopeCalibrationCollection extends BaseConditionsObjectCollection<HodoscopeCalibration> {
+    }
+
+    @Field(names = {"hodo_channel_id"})
+    public Integer getChannelId() {
+        return this.getFieldValue("hodo_channel_id");
+    }
+
+    @Field(names = {"noise"})
+    public Double getNoise() {
+        return this.getFieldValue("noise");
+    }
+
+    @Field(names = {"pedestal"})
+    public Double getPedestal() {
+        return this.getFieldValue("pedestal");
+    }
+}

--- a/conditions/src/main/java/org/hps/conditions/hodoscope/HodoscopeChannel.java
+++ b/conditions/src/main/java/org/hps/conditions/hodoscope/HodoscopeChannel.java
@@ -69,7 +69,7 @@ public final class HodoscopeChannel extends BaseConditionsObject {
 
     @Field(names = {"hole"})
     public Integer getHole() {
-        return this.getFieldValue("Hole");
+        return this.getFieldValue("hole");
     }
 
     @Field(names = {"name"})

--- a/conditions/src/main/java/org/hps/conditions/hodoscope/HodoscopeChannel.java
+++ b/conditions/src/main/java/org/hps/conditions/hodoscope/HodoscopeChannel.java
@@ -1,0 +1,53 @@
+package org.hps.conditions.hodoscope;
+
+import org.hps.conditions.api.BaseConditionsObject;
+import org.hps.conditions.api.BaseConditionsObjectCollection;
+import org.hps.conditions.database.Field;
+import org.hps.conditions.database.Table;
+
+@Table(names = {"hodo_channels"})
+public final class HodoscopeChannel extends BaseConditionsObject {
+    
+    public static class HodoscopeChannelCollection extends BaseConditionsObjectCollection<HodoscopeChannel> {
+    }
+
+    @Field(names = {"channel_id"})
+    public Integer getChannelId() {
+        return this.getFieldValue("channel_id");
+    }
+     
+    @Field(names = {"layer"})
+    public Integer getLayer() {
+        return this.getFieldValue("layer");
+    }
+    
+    @Field(names = {"x"})
+    public Integer getX() {
+        return this.getFieldValue("x");
+    }
+    
+    @Field(names = {"y"})
+    public Integer getY() {
+        return this.getFieldValue("y");
+    }
+    
+    @Field(names = {"top"})
+    public Integer getTop() {
+        return this.getFieldValue("top");
+    }
+    
+    @Field(names = {"channel"})
+    public Integer getChannel() {
+        return this.getFieldValue("channel");
+    }
+
+    @Field(names = {"hole"})
+    public Integer getHole() {
+        return this.getFieldValue("Hole");
+    }
+
+    @Field(names = {"name"})
+    public String getName() {
+        return this.getFieldValue("name");
+    }
+}

--- a/conditions/src/main/java/org/hps/conditions/hodoscope/HodoscopeChannel.java
+++ b/conditions/src/main/java/org/hps/conditions/hodoscope/HodoscopeChannel.java
@@ -35,6 +35,18 @@ public final class HodoscopeChannel extends BaseConditionsObject {
             }
             return foundIt;
         }
+
+        // TODO: Implement a fast lookup method using bit-packed DAQ ID similar to EcalChannel.
+        public HodoscopeChannel findChannel(int crate, int slot, int channel) {
+            HodoscopeChannel foundIt = null;
+            for (HodoscopeChannel c : this) {
+                if (c.getCrate() == crate && c.getSlot() == slot && c.getChannel() == channel) {
+                    foundIt = c;
+                    break;
+                }
+            }
+            return foundIt;
+        }
     }
     
     @Field(names = {"channel_id"})

--- a/conditions/src/main/java/org/hps/conditions/hodoscope/HodoscopeChannel.java
+++ b/conditions/src/main/java/org/hps/conditions/hodoscope/HodoscopeChannel.java
@@ -89,6 +89,16 @@ public final class HodoscopeChannel extends BaseConditionsObject {
         return this.getFieldValue("name");
     }
     
+    @Field(names = {"crate"})
+    public Integer getCrate() {
+        return this.getFieldValue("crate");
+    }
+    
+    @Field(names = {"slot"})
+    public Integer getSlot() {
+        return this.getFieldValue("slot");
+    }
+        
     /**
      * Implementation of equals.
      *
@@ -107,11 +117,14 @@ public final class HodoscopeChannel extends BaseConditionsObject {
             return true;
         }
         final HodoscopeChannel c = (HodoscopeChannel) o;
+        // FIXME: This is overkill!
         return c.getLayer() == this.getLayer() &&
                 c.getX() == this.getX() &&
                 c.getY() == this.getY() &&
                 c.getTop() == this.getTop() &&
-                c.getChannel() == this.getChannel() &
-                c.getHole() == this.getHole();                                
+                c.getChannel() == this.getChannel() &&
+                c.getHole() == this.getHole() &&
+                c.getCrate() == this.getCrate() &&
+                c.getSlot() == this.getSlot();                                
     }
 }

--- a/conditions/src/main/java/org/hps/conditions/hodoscope/HodoscopeChannel.java
+++ b/conditions/src/main/java/org/hps/conditions/hodoscope/HodoscopeChannel.java
@@ -1,5 +1,7 @@
 package org.hps.conditions.hodoscope;
 
+import java.util.Comparator;
+
 import org.hps.conditions.api.BaseConditionsObject;
 import org.hps.conditions.api.BaseConditionsObjectCollection;
 import org.hps.conditions.database.Field;
@@ -9,8 +11,32 @@ import org.hps.conditions.database.Table;
 public final class HodoscopeChannel extends BaseConditionsObject {
     
     public static class HodoscopeChannelCollection extends BaseConditionsObjectCollection<HodoscopeChannel> {
-    }
+        
+        class ChannelIdComparator implements Comparator<HodoscopeChannel> {
 
+            public int compare(final HodoscopeChannel c1, final HodoscopeChannel c2) {
+                if (c1.getChannelId() < c2.getChannelId()) {
+                    return -1;
+                } else if (c1.getChannelId() > c2.getChannelId()) {
+                    return 1;
+                } else {
+                    return 0;
+                }
+            }            
+        }
+        
+        public HodoscopeChannel findChannel(int channelId) {
+            HodoscopeChannel foundIt = null;
+            for (HodoscopeChannel channel : this) {
+                if (channel.getChannelId() == channelId) {
+                    foundIt = channel;
+                    break;
+                }
+            }
+            return foundIt;
+        }
+    }
+    
     @Field(names = {"channel_id"})
     public Integer getChannelId() {
         return this.getFieldValue("channel_id");
@@ -49,5 +75,31 @@ public final class HodoscopeChannel extends BaseConditionsObject {
     @Field(names = {"name"})
     public String getName() {
         return this.getFieldValue("name");
+    }
+    
+    /**
+     * Implementation of equals.
+     *
+     * @param o the object to compare equality to
+     * @return <code>true</code> if objects are equal
+     */
+    @Override
+    public boolean equals(final Object o) {
+        if (o == null) {
+            return false;
+        }
+        if (!(o instanceof HodoscopeChannel)) {
+            return false;
+        }
+        if (o == this) {
+            return true;
+        }
+        final HodoscopeChannel c = (HodoscopeChannel) o;
+        return c.getLayer() == this.getLayer() &&
+                c.getX() == this.getX() &&
+                c.getY() == this.getY() &&
+                c.getTop() == this.getTop() &&
+                c.getChannel() == this.getChannel() &
+                c.getHole() == this.getHole();                                
     }
 }

--- a/conditions/src/main/java/org/hps/conditions/hodoscope/HodoscopeChannelConstants.java
+++ b/conditions/src/main/java/org/hps/conditions/hodoscope/HodoscopeChannelConstants.java
@@ -1,0 +1,33 @@
+package org.hps.conditions.hodoscope;
+
+public class HodoscopeChannelConstants {
+
+    private HodoscopeCalibration calibration = null;
+    private HodoscopeGain gain = null;
+    private HodoscopeTimeShift timeShift = null;
+    
+    public HodoscopeCalibration getCalibration() {
+        return calibration;
+    }
+    
+    public HodoscopeGain getGain() {
+        return gain;
+    }
+    
+    public HodoscopeTimeShift getTimeShift() {
+        return timeShift;
+    }
+
+    void setCalibration(HodoscopeCalibration calibration) {
+        this.calibration = calibration;
+    }
+    
+    void setGain(HodoscopeGain gain) {
+        this.gain = gain;
+    }
+    
+    void setTimeShift(HodoscopeTimeShift timeShift) {
+        this.timeShift = timeShift;
+    }
+    
+}

--- a/conditions/src/main/java/org/hps/conditions/hodoscope/HodoscopeConditions.java
+++ b/conditions/src/main/java/org/hps/conditions/hodoscope/HodoscopeConditions.java
@@ -23,5 +23,9 @@ public class HodoscopeConditions {
     
     HodoscopeChannelConstants getChannelConstants(HodoscopeChannel channel) {
         return channelConstants.get(channel);
-    }    
+    }   
+    
+    public HodoscopeChannelCollection getChannels() {
+        return channels;
+    }
 }

--- a/conditions/src/main/java/org/hps/conditions/hodoscope/HodoscopeConditions.java
+++ b/conditions/src/main/java/org/hps/conditions/hodoscope/HodoscopeConditions.java
@@ -1,0 +1,27 @@
+package org.hps.conditions.hodoscope;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.hps.conditions.hodoscope.HodoscopeChannel.HodoscopeChannelCollection;
+
+public class HodoscopeConditions {
+
+    private final Map<HodoscopeChannel, HodoscopeChannelConstants> channelConstants = 
+            new HashMap<HodoscopeChannel, HodoscopeChannelConstants>();
+    
+    private HodoscopeChannelCollection channels = null;
+    
+    void setChannelCollection(HodoscopeChannelCollection channels) {
+        this.channels = channels;
+        
+        // Build channel map.
+        for (HodoscopeChannel channel : this.channels) {
+            channelConstants.put(channel, new HodoscopeChannelConstants());
+        }
+    }
+    
+    HodoscopeChannelConstants getChannelConstants(HodoscopeChannel channel) {
+        return channelConstants.get(channel);
+    }    
+}

--- a/conditions/src/main/java/org/hps/conditions/hodoscope/HodoscopeConditionsConverter.java
+++ b/conditions/src/main/java/org/hps/conditions/hodoscope/HodoscopeConditionsConverter.java
@@ -1,0 +1,52 @@
+package org.hps.conditions.hodoscope;
+
+import org.hps.conditions.hodoscope.HodoscopeCalibration.HodoscopeCalibrationCollection;
+import org.hps.conditions.hodoscope.HodoscopeChannel.HodoscopeChannelCollection;
+import org.hps.conditions.hodoscope.HodoscopeGain.HodoscopeGainCollection;
+import org.hps.conditions.hodoscope.HodoscopeTimeShift.HodoscopeTimeShiftCollection;
+import org.lcsim.conditions.ConditionsConverter;
+import org.lcsim.conditions.ConditionsManager;
+
+public class HodoscopeConditionsConverter implements ConditionsConverter<HodoscopeConditions> {
+              
+    public final HodoscopeConditions getData(final ConditionsManager manager, final String name) {
+       
+        final HodoscopeChannelCollection channels = 
+                manager.getCachedConditions(HodoscopeChannelCollection.class, "hodo_channels").getCachedData();
+        
+        if (channels == null) {
+            throw new IllegalStateException("The Hodoscope channels collection is null.");
+        }
+                      
+        final HodoscopeConditions conditions = new HodoscopeConditions();
+
+        conditions.setChannelCollection(channels);
+
+        final HodoscopeGainCollection gains = 
+                manager.getCachedConditions(HodoscopeGainCollection.class, "hodo_gains").getCachedData();
+        for (final HodoscopeGain gain : gains) {
+            final HodoscopeChannel channel = channels.findChannel(gain.getChannelId());
+            conditions.getChannelConstants(channel).setGain(gain);
+        }
+
+        final HodoscopeCalibrationCollection calibrations = 
+                manager.getCachedConditions(HodoscopeCalibrationCollection.class, "hodo_calibrations").getCachedData();
+        for (final HodoscopeCalibration calibration : calibrations) {
+            final HodoscopeChannel channel = channels.findChannel(calibration.getChannelId());
+            conditions.getChannelConstants(channel).setCalibration(calibration);
+        }
+
+        final HodoscopeTimeShiftCollection timeShifts = 
+                manager.getCachedConditions(HodoscopeTimeShiftCollection.class, "hodo_time_shifts").getCachedData();
+        for (final HodoscopeTimeShift timeShift : timeShifts) {
+            final HodoscopeChannel channel = channels.findChannel(timeShift.getChannelId());
+            conditions.getChannelConstants(channel).setTimeShift(timeShift);
+        }
+        
+        return conditions;
+    }
+
+    public Class<HodoscopeConditions> getType() {
+        return HodoscopeConditions.class;
+    }
+}

--- a/conditions/src/main/java/org/hps/conditions/hodoscope/HodoscopeGain.java
+++ b/conditions/src/main/java/org/hps/conditions/hodoscope/HodoscopeGain.java
@@ -1,0 +1,32 @@
+package org.hps.conditions.hodoscope;
+
+import org.hps.conditions.api.BaseConditionsObject;
+import org.hps.conditions.api.BaseConditionsObjectCollection;
+import org.hps.conditions.database.Field;
+import org.hps.conditions.database.Table;
+
+@Table(names = {"hodo_gains"})
+public final class HodoscopeGain extends BaseConditionsObject {
+
+    /**
+     * The collection implementation for this class.
+     */
+    @SuppressWarnings("serial")
+    public static final class HodoscopeGainCollection extends BaseConditionsObjectCollection<HodoscopeGain> {
+    }
+
+    @Field(names = {"hodo_channel_id"})
+    public Integer getChannelId() {
+        return this.getFieldValue("hodo_channel_id");
+    }
+
+    /**
+     * Get the gain value in units of MeV/ADC count.
+     *
+     * @return the gain value
+     */
+    @Field(names = {"gain"})
+    public Double getGain() {
+        return this.getFieldValue("gain");
+    }
+}

--- a/conditions/src/main/java/org/hps/conditions/hodoscope/HodoscopeTimeShift.java
+++ b/conditions/src/main/java/org/hps/conditions/hodoscope/HodoscopeTimeShift.java
@@ -1,0 +1,23 @@
+package org.hps.conditions.hodoscope;
+
+import org.hps.conditions.api.BaseConditionsObject;
+import org.hps.conditions.api.BaseConditionsObjectCollection;
+import org.hps.conditions.database.Field;
+import org.hps.conditions.database.Table;
+
+@Table(names = {"hodo_time_shifts"})
+public final class HodoscopeTimeShift extends BaseConditionsObject {
+
+    public static final class HodoscopeTimeShiftCollection extends BaseConditionsObjectCollection<HodoscopeTimeShift> {
+    }
+
+    @Field(names = {"hodo_channel_id"})
+    public Integer getChannelId() {
+        return this.getFieldValue("hodo_channel_id");
+    }
+
+    @Field(names = {"time_shift"})
+    public Double getTimeShift() {
+        return this.getFieldValue("time_shift");
+    }
+}

--- a/conditions/src/test/java/org/hps/conditions/hodoscope/HodoscopeConditionsTest.java
+++ b/conditions/src/test/java/org/hps/conditions/hodoscope/HodoscopeConditionsTest.java
@@ -49,6 +49,18 @@ public class HodoscopeConditionsTest extends TestCase {
         for (HodoscopeTimeShift timeShift : timeShifts) {
             System.out.println(timeShift);
         }
+        
+        System.out.println("Printing Hodoscope channel constants ...");
+        final HodoscopeConditions conditions =
+                mgr.getCachedConditions(HodoscopeConditions.class, "hodo_conditions").getCachedData();
+        for (HodoscopeChannel channel : channels) {
+            HodoscopeChannelConstants channelData = conditions.getChannelConstants(channel);
+            System.out.println("Channel constants for ID " + channel.getChannelId());
+            System.out.println(channelData.getCalibration());
+            System.out.println(channelData.getGain());
+            System.out.println(channelData.getTimeShift());
+            System.out.println();
+        }
     }
 
 }

--- a/conditions/src/test/java/org/hps/conditions/hodoscope/HodoscopeConditionsTest.java
+++ b/conditions/src/test/java/org/hps/conditions/hodoscope/HodoscopeConditionsTest.java
@@ -3,6 +3,7 @@ package org.hps.conditions.hodoscope;
 import org.hps.conditions.database.DatabaseConditionsManager;
 import org.hps.conditions.hodoscope.HodoscopeCalibration.HodoscopeCalibrationCollection;
 import org.hps.conditions.hodoscope.HodoscopeChannel.HodoscopeChannelCollection;
+import org.hps.conditions.hodoscope.HodoscopeGain.HodoscopeGainCollection;
 import org.lcsim.conditions.ConditionsManager.ConditionsNotFoundException;
 
 import junit.framework.TestCase;
@@ -33,6 +34,13 @@ public class HodoscopeConditionsTest extends TestCase {
         System.out.println("Printing Hodoscope calibrations ...");
         for (HodoscopeCalibration calibration : calibrations) {
             System.out.println(calibration);
+        }
+        
+        final HodoscopeGainCollection gains = 
+                mgr.getCachedConditions(HodoscopeGainCollection.class, "hodo_gains").getCachedData();
+        System.out.println("Printing Hodoscope gains ...");
+        for (HodoscopeGain gain : gains) {
+            System.out.println(gain);
         }
     }
 

--- a/conditions/src/test/java/org/hps/conditions/hodoscope/HodoscopeConditionsTest.java
+++ b/conditions/src/test/java/org/hps/conditions/hodoscope/HodoscopeConditionsTest.java
@@ -53,7 +53,7 @@ public class HodoscopeConditionsTest extends TestCase {
         System.out.println("Printing Hodoscope channel constants ...");
         final HodoscopeConditions conditions =
                 mgr.getCachedConditions(HodoscopeConditions.class, "hodo_conditions").getCachedData();
-        for (HodoscopeChannel channel : channels) {
+        for (HodoscopeChannel channel : conditions.getChannels()) {
             HodoscopeChannelConstants channelData = conditions.getChannelConstants(channel);
             System.out.println("Channel constants for ID " + channel.getChannelId());
             System.out.println(channelData.getCalibration());

--- a/conditions/src/test/java/org/hps/conditions/hodoscope/HodoscopeConditionsTest.java
+++ b/conditions/src/test/java/org/hps/conditions/hodoscope/HodoscopeConditionsTest.java
@@ -1,6 +1,7 @@
 package org.hps.conditions.hodoscope;
 
 import org.hps.conditions.database.DatabaseConditionsManager;
+import org.hps.conditions.hodoscope.HodoscopeCalibration.HodoscopeCalibrationCollection;
 import org.hps.conditions.hodoscope.HodoscopeChannel.HodoscopeChannelCollection;
 import org.lcsim.conditions.ConditionsManager.ConditionsNotFoundException;
 
@@ -26,7 +27,13 @@ public class HodoscopeConditionsTest extends TestCase {
         for (HodoscopeChannel channel : channels) {
             System.out.println(channel);
         }
-        
+     
+        final HodoscopeCalibrationCollection calibrations =
+                mgr.getCachedConditions(HodoscopeCalibrationCollection.class, "hodo_calibrations").getCachedData();
+        System.out.println("Printing Hodoscope calibrations ...");
+        for (HodoscopeCalibration calibration : calibrations) {
+            System.out.println(calibration);
+        }
     }
 
 }

--- a/conditions/src/test/java/org/hps/conditions/hodoscope/HodoscopeConditionsTest.java
+++ b/conditions/src/test/java/org/hps/conditions/hodoscope/HodoscopeConditionsTest.java
@@ -11,7 +11,7 @@ import junit.framework.TestCase;
 
 public class HodoscopeConditionsTest extends TestCase {
     
-    private static final String DETECTOR = "HPS-HodoscopeTest-v1";
+    private static final String DETECTOR = "HPS-PhysicsRun2019-v1-4pt5";
     private static final int RUN = 1000000;
     
     public void testHodoscopeConditions() {

--- a/conditions/src/test/java/org/hps/conditions/hodoscope/HodoscopeConditionsTest.java
+++ b/conditions/src/test/java/org/hps/conditions/hodoscope/HodoscopeConditionsTest.java
@@ -1,0 +1,32 @@
+package org.hps.conditions.hodoscope;
+
+import org.hps.conditions.database.DatabaseConditionsManager;
+import org.hps.conditions.hodoscope.HodoscopeChannel.HodoscopeChannelCollection;
+import org.lcsim.conditions.ConditionsManager.ConditionsNotFoundException;
+
+import junit.framework.TestCase;
+
+public class HodoscopeConditionsTest extends TestCase {
+    
+    private static final String DETECTOR = "HPS-HodoscopeTest-v1";
+    private static final int RUN = 1000000;
+    
+    public void testHodoscopeConditions() {
+        
+        final DatabaseConditionsManager mgr = DatabaseConditionsManager.getInstance();
+        try {
+            mgr.setDetector(DETECTOR, RUN);
+        } catch (ConditionsNotFoundException e) {
+            throw new RuntimeException(e);
+        }
+        
+        final HodoscopeChannelCollection channels = 
+                mgr.getCachedConditions(HodoscopeChannelCollection.class, "hodo_channels").getCachedData();
+        System.out.println("Printing Hodoscope channels ...");
+        for (HodoscopeChannel channel : channels) {
+            System.out.println(channel);
+        }
+        
+    }
+
+}

--- a/conditions/src/test/java/org/hps/conditions/hodoscope/HodoscopeConditionsTest.java
+++ b/conditions/src/test/java/org/hps/conditions/hodoscope/HodoscopeConditionsTest.java
@@ -4,6 +4,7 @@ import org.hps.conditions.database.DatabaseConditionsManager;
 import org.hps.conditions.hodoscope.HodoscopeCalibration.HodoscopeCalibrationCollection;
 import org.hps.conditions.hodoscope.HodoscopeChannel.HodoscopeChannelCollection;
 import org.hps.conditions.hodoscope.HodoscopeGain.HodoscopeGainCollection;
+import org.hps.conditions.hodoscope.HodoscopeTimeShift.HodoscopeTimeShiftCollection;
 import org.lcsim.conditions.ConditionsManager.ConditionsNotFoundException;
 
 import junit.framework.TestCase;
@@ -41,6 +42,12 @@ public class HodoscopeConditionsTest extends TestCase {
         System.out.println("Printing Hodoscope gains ...");
         for (HodoscopeGain gain : gains) {
             System.out.println(gain);
+        }
+        
+        final HodoscopeTimeShiftCollection timeShifts = 
+                mgr.getCachedConditions(HodoscopeTimeShiftCollection.class, "hodo_time_shifts").getCachedData();
+        for (HodoscopeTimeShift timeShift : timeShifts) {
+            System.out.println(timeShift);
         }
     }
 


### PR DESCRIPTION
I cherry picked the following commits from `iss420` into the #451 branch:

```
a8c6aab9ae8aa072bf39b365790efdf93a687735
f7df8248d0eda868ae491781c547ce1be8253f3f
446a40381f43a2546583ac69adecfe66198c45db
9b788bf31646513752fa0aa665862c1bc2957f04
4d488244d36ab87ea811c54ad354ffb6ef215f6e
9a81adc60c1fce53e57d63441616d7067d853a8a
e83e72547c39d84af1337b03d2728c187acfaf77
0e809066c2ec71a4c63f506141c9cef2fa5d53d8
283999a002c331b88e424eb6ddf07f4260c47e8c
```

To test these changes:

```
cd hps-java/conditions
mvn test -Dtest=HodoscopeConditionsTest
```

This should print out all the Hodoscope detector conditions for run 1000000 which is used for MC.