### PR TITLE
Iss461: Fix detector converter for recent JDK

### DIFF
--- a/detector-model/src/main/java/org/hps/detector/DetectorConverter.java
+++ b/detector-model/src/main/java/org/hps/detector/DetectorConverter.java
@@ -10,8 +10,7 @@ import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
-
-import javax.imageio.spi.ServiceRegistry;
+import java.util.ServiceLoader;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.DefaultParser;
@@ -62,7 +61,7 @@ public class DetectorConverter {
     }
 
     private static <T> Iterator<T> getServices(Class<T> providerClass) {
-        return ServiceRegistry.lookupProviders(providerClass, DetectorConverter.class.getClassLoader());
+        return ServiceLoader.load(providerClass, DetectorConverter.class.getClassLoader()).iterator();
     }
 
     private void run(String args[]) throws Exception {


### PR DESCRIPTION
This should fix problems with converting detector files for more recent JDK (tested with jdk-12).