### PR TITLE
Fix Steering File Issues

### DIFF
--- a/steering-files/src/main/resources/org/hps/steering/readout/EngineeringRun2015TrigPairs0_Pass2.lcsim
+++ b/steering-files/src/main/resources/org/hps/steering/readout/EngineeringRun2015TrigPairs0_Pass2.lcsim
@@ -11,8 +11,8 @@
         <driver name="SVTReadoutDriver" />
         
         <!-- Readout Simulation Drivers -->
-        <driver name="EcalReadoutDriver"/>
-        <driver name="RawConverterReadoutDriver"/>
+        <driver name="EcalDigitizationDriver"/>
+        <driver name="EcalRawConverterDriver"/>
         <driver name="GTPReadoutDriver"/>
         <driver name="Pair0TriggerDriver"/>
         
@@ -112,7 +112,7 @@
              same collection name as the input truth data. If a truth handler
              driver also outputs data into this collection, the two will merge.
           -->
-        <driver name="EcalReadoutDriver" type="org.hps.readout.ecal.updated.EcalDigitizationReadoutDriver">
+        <driver name="EcalDigitizationDriver" type="org.hps.readout.ecal.updated.EcalDigitizationReadoutDriver">
             <!-- LCIO Collection Names -->
             <inputHitCollectionName>EcalHits</inputHitCollectionName>
             <outputHitCollectionName>EcalRawHits</outputHitCollectionName>
@@ -167,7 +167,7 @@
              since the clusterer will automatically output the hits which appear in
              GTP clusters if cluster output is enabled.
           -->
-        <driver name="RawConverterReadoutDriver" type="org.hps.readout.ecal.updated.EcalReadoutRawConverterDriver">
+        <driver name="EcalRawConverterDriver" type="org.hps.readout.ecal.updated.EcalRawConverterReadoutDriver">
             <!--
                 NSA and NSB must match the digitization driver settings.
             -->
@@ -182,15 +182,6 @@
                 persisted.
             -->
             <persistent>false</persistent>
-            
-            <!--
-                If set to true, and readout truth information was included in
-                the EcalReadoutDriver, then the calorimeter hits produced for
-                the clusterer and trigger will be output as truth hits which
-                contain the compiled information from all relevant data that
-                contributed to the integrated pulse.
-            -->
-            <persistTruth>false</persistTruth>
         </driver>
         
         <!--

--- a/steering-files/src/main/resources/org/hps/steering/readout/EngineeringRun2015TrigPairs1_Pass2.lcsim
+++ b/steering-files/src/main/resources/org/hps/steering/readout/EngineeringRun2015TrigPairs1_Pass2.lcsim
@@ -11,8 +11,8 @@
         <driver name="SVTReadoutDriver" />
         
         <!-- Readout Simulation Drivers -->
-        <driver name="EcalReadoutDriver"/>
-        <driver name="RawConverterReadoutDriver"/>
+        <driver name="EcalDigitizationDriver"/>
+        <driver name="EcalRawConverterDriver"/>
         <driver name="GTPReadoutDriver"/>
         <driver name="Pair1TriggerDriver"/>
         
@@ -112,7 +112,7 @@
              same collection name as the input truth data. If a truth handler
              driver also outputs data into this collection, the two will merge.
           -->
-        <driver name="EcalReadoutDriver" type="org.hps.readout.ecal.updated.EcalDigitizationReadoutDriver">
+        <driver name="EcalDigitizationDriver" type="org.hps.readout.ecal.updated.EcalDigitizationReadoutDriver">
             <!-- LCIO Collection Names -->
             <inputHitCollectionName>EcalHits</inputHitCollectionName>
             <outputHitCollectionName>EcalRawHits</outputHitCollectionName>
@@ -167,7 +167,7 @@
              since the clusterer will automatically output the hits which appear in
              GTP clusters if cluster output is enabled.
           -->
-        <driver name="RawConverterReadoutDriver" type="org.hps.readout.ecal.updated.EcalReadoutRawConverterDriver">
+        <driver name="EcalRawConverterDriver" type="org.hps.readout.ecal.updated.EcalRawConverterReadoutDriver">
             <!--
                 NSA and NSB must match the digitization driver settings.
             -->
@@ -182,15 +182,6 @@
                 persisted.
             -->
             <persistent>false</persistent>
-            
-            <!--
-                If set to true, and readout truth information was included in
-                the EcalReadoutDriver, then the calorimeter hits produced for
-                the clusterer and trigger will be output as truth hits which
-                contain the compiled information from all relevant data that
-                contributed to the integrated pulse.
-            -->
-            <persistTruth>false</persistTruth>
         </driver>
         
         <!--

--- a/steering-files/src/main/resources/org/hps/steering/readout/EngineeringRun2015TrigSingles0_Pass2.lcsim
+++ b/steering-files/src/main/resources/org/hps/steering/readout/EngineeringRun2015TrigSingles0_Pass2.lcsim
@@ -11,8 +11,8 @@
         <driver name="SVTReadoutDriver" />
         
         <!-- Readout Simulation Drivers -->
-        <driver name="EcalReadoutDriver"/>
-        <driver name="RawConverterReadoutDriver"/>
+        <driver name="EcalDigitizationDriver"/>
+        <driver name="EcalRawConverterDriver"/>
         <driver name="GTPReadoutDriver"/>
         <driver name="Singles0TriggerDriver"/>
         
@@ -112,7 +112,7 @@
              same collection name as the input truth data. If a truth handler
              driver also outputs data into this collection, the two will merge.
           -->
-        <driver name="EcalReadoutDriver" type="org.hps.readout.ecal.updated.EcalDigitizationReadoutDriver">
+        <driver name="EcalDigitizationDriver" type="org.hps.readout.ecal.updated.EcalDigitizationReadoutDriver">
             <!-- LCIO Collection Names -->
             <inputHitCollectionName>EcalHits</inputHitCollectionName>
             <outputHitCollectionName>EcalRawHits</outputHitCollectionName>
@@ -167,7 +167,7 @@
              since the clusterer will automatically output the hits which appear in
              GTP clusters if cluster output is enabled.
           -->
-        <driver name="RawConverterReadoutDriver" type="org.hps.readout.ecal.updated.EcalReadoutRawConverterDriver">
+        <driver name="EcalRawConverterDriver" type="org.hps.readout.ecal.updated.EcalRawConverterReadoutDriver">
             <!--
                 NSA and NSB must match the digitization driver settings.
             -->
@@ -182,15 +182,6 @@
                 persisted.
             -->
             <persistent>false</persistent>
-            
-            <!--
-                If set to true, and readout truth information was included in
-                the EcalReadoutDriver, then the calorimeter hits produced for
-                the clusterer and trigger will be output as truth hits which
-                contain the compiled information from all relevant data that
-                contributed to the integrated pulse.
-            -->
-            <persistTruth>false</persistTruth>
         </driver>
         
         <!--

--- a/steering-files/src/main/resources/org/hps/steering/readout/EngineeringRun2015TrigSingles1_Pass2.lcsim
+++ b/steering-files/src/main/resources/org/hps/steering/readout/EngineeringRun2015TrigSingles1_Pass2.lcsim
@@ -11,8 +11,8 @@
         <driver name="SVTReadoutDriver" />
         
         <!-- Readout Simulation Drivers -->
-        <driver name="EcalReadoutDriver"/>
-        <driver name="RawConverterReadoutDriver"/>
+        <driver name="EcalDigitizationDriver"/>
+        <driver name="EcalRawConverterDriver"/>
         <driver name="GTPReadoutDriver"/>
         <driver name="Singles1TriggerDriver"/>
         
@@ -112,7 +112,7 @@
              same collection name as the input truth data. If a truth handler
              driver also outputs data into this collection, the two will merge.
           -->
-        <driver name="EcalReadoutDriver" type="org.hps.readout.ecal.updated.EcalDigitizationReadoutDriver">
+        <driver name="EcalDigitizationDriver" type="org.hps.readout.ecal.updated.EcalDigitizationReadoutDriver">
             <!-- LCIO Collection Names -->
             <inputHitCollectionName>EcalHits</inputHitCollectionName>
             <outputHitCollectionName>EcalRawHits</outputHitCollectionName>
@@ -167,7 +167,7 @@
              since the clusterer will automatically output the hits which appear in
              GTP clusters if cluster output is enabled.
           -->
-        <driver name="RawConverterReadoutDriver" type="org.hps.readout.ecal.updated.EcalReadoutRawConverterDriver">
+        <driver name="EcalRawConverterDriver" type="org.hps.readout.ecal.updated.EcalRawConverterReadoutDriver">
             <!--
                 NSA and NSB must match the digitization driver settings.
             -->
@@ -182,15 +182,6 @@
                 persisted.
             -->
             <persistent>false</persistent>
-            
-            <!--
-                If set to true, and readout truth information was included in
-                the EcalReadoutDriver, then the calorimeter hits produced for
-                the clusterer and trigger will be output as truth hits which
-                contain the compiled information from all relevant data that
-                contributed to the integrated pulse.
-            -->
-            <persistTruth>false</persistTruth>
         </driver>
         
         <!--

--- a/steering-files/src/main/resources/org/hps/steering/readout/PhysicsRun2016TrigPair0.lcsim
+++ b/steering-files/src/main/resources/org/hps/steering/readout/PhysicsRun2016TrigPair0.lcsim
@@ -11,8 +11,8 @@
         <driver name="SVTReadoutDriver" />
         
         <!-- Readout Simulation Drivers -->
-        <driver name="EcalReadoutDriver"/>
-        <driver name="RawConverterReadoutDriver"/>
+        <driver name="EcalDigitizationDriver"/>
+        <driver name="EcalRawConverterDriver"/>
         <driver name="GTPReadoutDriver"/>
         <driver name="Pair0TriggerDriver"/>
         
@@ -112,7 +112,7 @@
              same collection name as the input truth data. If a truth handler
              driver also outputs data into this collection, the two will merge.
           -->
-        <driver name="EcalReadoutDriver" type="org.hps.readout.ecal.updated.EcalDigitizationReadoutDriver">
+        <driver name="EcalDigitizationDriver" type="org.hps.readout.ecal.updated.EcalDigitizationReadoutDriver">
             <!-- LCIO Collection Names -->
             <inputHitCollectionName>EcalHits</inputHitCollectionName>
             <outputHitCollectionName>EcalRawHits</outputHitCollectionName>
@@ -167,7 +167,7 @@
              since the clusterer will automatically output the hits which appear in
              GTP clusters if cluster output is enabled.
           -->
-        <driver name="RawConverterReadoutDriver" type="org.hps.readout.ecal.updated.EcalReadoutRawConverterDriver">
+        <driver name="EcalRawConverterDriver" type="org.hps.readout.ecal.updated.EcalRawConverterReadoutDriver">
             <!--
                 NSA and NSB must match the digitization driver settings.
             -->
@@ -182,15 +182,6 @@
                 persisted.
             -->
             <persistent>false</persistent>
-            
-            <!--
-                If set to true, and readout truth information was included in
-                the EcalReadoutDriver, then the calorimeter hits produced for
-                the clusterer and trigger will be output as truth hits which
-                contain the compiled information from all relevant data that
-                contributed to the integrated pulse.
-            -->
-            <persistTruth>false</persistTruth>
         </driver>
         
         <!--

--- a/steering-files/src/main/resources/org/hps/steering/readout/PhysicsRun2016TrigPairs1.lcsim
+++ b/steering-files/src/main/resources/org/hps/steering/readout/PhysicsRun2016TrigPairs1.lcsim
@@ -11,8 +11,8 @@
         <driver name="SVTReadoutDriver" />
         
         <!-- Readout Simulation Drivers -->
-        <driver name="EcalReadoutDriver"/>
-        <driver name="RawConverterReadoutDriver"/>
+        <driver name="EcalDigitizationDriver"/>
+        <driver name="EcalRawConverterDriver"/>
         <driver name="GTPReadoutDriver"/>
         <driver name="Pair1TriggerDriver"/>
         
@@ -112,7 +112,7 @@
              same collection name as the input truth data. If a truth handler
              driver also outputs data into this collection, the two will merge.
           -->
-        <driver name="EcalReadoutDriver" type="org.hps.readout.ecal.updated.EcalDigitizationReadoutDriver">
+        <driver name="EcalDigitizationDriver" type="org.hps.readout.ecal.updated.EcalDigitizationReadoutDriver">
             <!-- LCIO Collection Names -->
             <inputHitCollectionName>EcalHits</inputHitCollectionName>
             <outputHitCollectionName>EcalRawHits</outputHitCollectionName>
@@ -167,7 +167,7 @@
              since the clusterer will automatically output the hits which appear in
              GTP clusters if cluster output is enabled.
           -->
-        <driver name="RawConverterReadoutDriver" type="org.hps.readout.ecal.updated.EcalReadoutRawConverterDriver">
+        <driver name="EcalRawConverterDriver" type="org.hps.readout.ecal.updated.EcalRawConverterReadoutDriver">
             <!--
                 NSA and NSB must match the digitization driver settings.
             -->
@@ -182,15 +182,6 @@
                 persisted.
             -->
             <persistent>false</persistent>
-            
-            <!--
-                If set to true, and readout truth information was included in
-                the EcalReadoutDriver, then the calorimeter hits produced for
-                the clusterer and trigger will be output as truth hits which
-                contain the compiled information from all relevant data that
-                contributed to the integrated pulse.
-            -->
-            <persistTruth>false</persistTruth>
         </driver>
         
         <!--

--- a/steering-files/src/main/resources/org/hps/steering/readout/PhysicsRun2016TrigSingles0.lcsim
+++ b/steering-files/src/main/resources/org/hps/steering/readout/PhysicsRun2016TrigSingles0.lcsim
@@ -11,8 +11,8 @@
         <driver name="SVTReadoutDriver" />
         
         <!-- Readout Simulation Drivers -->
-        <driver name="EcalReadoutDriver"/>
-        <driver name="RawConverterReadoutDriver"/>
+        <driver name="EcalDigitizationDriver"/>
+        <driver name="EcalRawConverterDriver"/>
         <driver name="GTPReadoutDriver"/>
         <driver name="Singles0TriggerDriver"/>
         
@@ -112,7 +112,7 @@
              same collection name as the input truth data. If a truth handler
              driver also outputs data into this collection, the two will merge.
           -->
-        <driver name="EcalReadoutDriver" type="org.hps.readout.ecal.updated.EcalDigitizationReadoutDriver">
+        <driver name="EcalDigitizationDriver" type="org.hps.readout.ecal.updated.EcalDigitizationReadoutDriver">
             <!-- LCIO Collection Names -->
             <inputHitCollectionName>EcalHits</inputHitCollectionName>
             <outputHitCollectionName>EcalRawHits</outputHitCollectionName>
@@ -167,7 +167,7 @@
              since the clusterer will automatically output the hits which appear in
              GTP clusters if cluster output is enabled.
           -->
-        <driver name="RawConverterReadoutDriver" type="org.hps.readout.ecal.updated.EcalReadoutRawConverterDriver">
+        <driver name="EcalRawConverterDriver" type="org.hps.readout.ecal.updated.EcalRawConverterReadoutDriver">
             <!--
                 NSA and NSB must match the digitization driver settings.
             -->
@@ -182,15 +182,6 @@
                 persisted.
             -->
             <persistent>false</persistent>
-            
-            <!--
-                If set to true, and readout truth information was included in
-                the EcalReadoutDriver, then the calorimeter hits produced for
-                the clusterer and trigger will be output as truth hits which
-                contain the compiled information from all relevant data that
-                contributed to the integrated pulse.
-            -->
-            <persistTruth>false</persistTruth>
         </driver>
         
         <!--

--- a/steering-files/src/main/resources/org/hps/steering/readout/PhysicsRun2016TrigSingles1.lcsim
+++ b/steering-files/src/main/resources/org/hps/steering/readout/PhysicsRun2016TrigSingles1.lcsim
@@ -11,8 +11,8 @@
         <driver name="SVTReadoutDriver" />
         
         <!-- Readout Simulation Drivers -->
-        <driver name="EcalReadoutDriver"/>
-        <driver name="RawConverterReadoutDriver"/>
+        <driver name="EcalDigitizationDriver"/>
+        <driver name="EcalRawConverterDriver"/>
         <driver name="GTPReadoutDriver"/>
         <driver name="Singles1TriggerDriver"/>
         
@@ -112,7 +112,7 @@
              same collection name as the input truth data. If a truth handler
              driver also outputs data into this collection, the two will merge.
           -->
-        <driver name="EcalReadoutDriver" type="org.hps.readout.ecal.updated.EcalDigitizationReadoutDriver">
+        <driver name="EcalDigitizationDriver" type="org.hps.readout.ecal.updated.EcalDigitizationReadoutDriver">
             <!-- LCIO Collection Names -->
             <inputHitCollectionName>EcalHits</inputHitCollectionName>
             <outputHitCollectionName>EcalRawHits</outputHitCollectionName>
@@ -167,7 +167,7 @@
              since the clusterer will automatically output the hits which appear in
              GTP clusters if cluster output is enabled.
           -->
-        <driver name="RawConverterReadoutDriver" type="org.hps.readout.ecal.updated.EcalReadoutRawConverterDriver">
+        <driver name="EcalRawConverterDriver" type="org.hps.readout.ecal.updated.EcalRawConverterReadoutDriver">
             <!--
                 NSA and NSB must match the digitization driver settings.
             -->
@@ -182,15 +182,6 @@
                 persisted.
             -->
             <persistent>false</persistent>
-            
-            <!--
-                If set to true, and readout truth information was included in
-                the EcalReadoutDriver, then the calorimeter hits produced for
-                the clusterer and trigger will be output as truth hits which
-                contain the compiled information from all relevant data that
-                contributed to the integrated pulse.
-            -->
-            <persistTruth>false</persistTruth>
         </driver>
         
         <!--

--- a/steering-files/src/main/resources/org/hps/steering/readout/TrigPulser.lcsim
+++ b/steering-files/src/main/resources/org/hps/steering/readout/TrigPulser.lcsim
@@ -11,8 +11,8 @@
         <driver name="SVTReadoutDriver" />
         
         <!-- Readout Simulation Drivers -->
-        <driver name="EcalReadoutDriver"/>
-        <driver name="RawConverterReadoutDriver"/>
+        <driver name="EcalDigitizationDriver"/>
+        <driver name="EcalRawConverterDriver"/>
         <driver name="GTPReadoutDriver"/>
         <driver name="PulserTrigger"/>
         
@@ -112,7 +112,7 @@
              same collection name as the input truth data. If a truth handler
              driver also outputs data into this collection, the two will merge.
           -->
-        <driver name="EcalReadoutDriver" type="org.hps.readout.ecal.updated.EcalDigitizationReadoutDriver">
+        <driver name="EcalDigitizationDriver" type="org.hps.readout.ecal.updated.EcalDigitizationReadoutDriver">
             <!-- LCIO Collection Names -->
             <inputHitCollectionName>EcalHits</inputHitCollectionName>
             <outputHitCollectionName>EcalRawHits</outputHitCollectionName>
@@ -167,7 +167,7 @@
              since the clusterer will automatically output the hits which appear in
              GTP clusters if cluster output is enabled.
           -->
-        <driver name="RawConverterReadoutDriver" type="org.hps.readout.ecal.updated.EcalReadoutRawConverterDriver">
+        <driver name="EcalRawConverterDriver" type="org.hps.readout.ecal.updated.EcalRawConverterReadoutDriver">
             <!--
                 NSA and NSB must match the digitization driver settings.
             -->
@@ -182,15 +182,6 @@
                 persisted.
             -->
             <persistent>false</persistent>
-            
-            <!--
-                If set to true, and readout truth information was included in
-                the EcalReadoutDriver, then the calorimeter hits produced for
-                the clusterer and trigger will be output as truth hits which
-                contain the compiled information from all relevant data that
-                contributed to the integrated pulse.
-            -->
-            <persistTruth>false</persistTruth>
         </driver>
         
         <!--


### PR DESCRIPTION
A few changes to drivers were not propagated into the steering files during the iss420 merge. This corrects it. All changes are to the readout steering files only.