### PR TITLE
Hodoscope Readout Minor Fixes

### DIFF
--- a/analysis/src/main/java/org/hps/analysis/util/PrintCollectionsUtility.java
+++ b/analysis/src/main/java/org/hps/analysis/util/PrintCollectionsUtility.java
@@ -288,8 +288,8 @@ public class PrintCollectionsUtility {
         StringBuffer outputBuffer = new StringBuffer();
         String indent = getIndent(indentLevel);
         
-        outputBuffer.append(String.format(indent + "Type     :: " + yellow("%d") + " GeV%n", particle.getPDGID()));
-        outputBuffer.append(String.format(indent + "Time     :: " + yellow("%f") + " GeV%n", particle.getProductionTime()));
+        outputBuffer.append(String.format(indent + "Type     :: " + yellow("%d") + "%n", particle.getPDGID()));
+        outputBuffer.append(String.format(indent + "Time     :: " + yellow("%f") + " ns%n", particle.getProductionTime()));
         outputBuffer.append(String.format(indent + "Momentum :: " + yellow("%f") + " GeV%n", particle.getMomentum().magnitude()));
         outputBuffer.append(String.format(indent + "Origin   :: <" + yellow("%f") + ", " + yellow("%f") + ", " + yellow("%f") + ">%n",
                 particle.getOriginX(), particle.getOriginY(), particle.getOriginZ()));

--- a/analysis/src/main/java/org/hps/analysis/util/PrintCollectionsUtility.java
+++ b/analysis/src/main/java/org/hps/analysis/util/PrintCollectionsUtility.java
@@ -134,6 +134,12 @@ public class PrintCollectionsUtility {
                     + BashParameter.format(Integer.toString(event.getEventNumber()), BashParameter.TEXT_GREEN, BashParameter.PROPERTY_BOLD));
             collectionPrintLoop:
             for(int i = 0; i < printCollections.size(); i++) {
+                // Get the class type of the collection.
+                Class<?> collectionType = collectionMap.get(printCollections.get(i));
+                
+                // Do nothing unless the event contains the collection.
+                if(!event.hasCollection(collectionType, printCollections.get(i))) { continue; }
+                
                 // Indicate the current collection.
                 System.out.println("\tPrinting data for collection \""
                         + BashParameter.format(printCollections.get(i), BashParameter.TEXT_YELLOW, BashParameter.PROPERTY_BOLD) + "\"...");
@@ -143,9 +149,6 @@ public class PrintCollectionsUtility {
                     System.out.println("\t\tCollection does not exist.");
                     continue collectionPrintLoop;
                 }
-                
-                // Get the class type of the collection.
-                Class<?> collectionType = collectionMap.get(printCollections.get(i));
                 
                 // Get the collection data.
                 List<?> collectionData = event.get(collectionType, printCollections.get(i));

--- a/ecal-readout-sim/src/main/java/org/hps/readout/DigitizationReadoutDriver.java
+++ b/ecal-readout-sim/src/main/java/org/hps/readout/DigitizationReadoutDriver.java
@@ -20,7 +20,6 @@ import org.hps.readout.util.collection.LCIOCollection;
 import org.hps.readout.util.collection.LCIOCollectionFactory;
 import org.hps.readout.util.collection.TriggeredLCIOData;
 import org.hps.recon.ecal.EcalUtils;
-import org.hps.util.BashParameter;
 import org.hps.util.RandomGaussian;
 import org.lcsim.event.CalorimeterHit;
 import org.lcsim.event.EventHeader;


### PR DESCRIPTION
Fixed some minor issues:
- The collections printer utility would fail if a collection that was marked for printing did not exist in a given event. This is changed so that it now skips that event entirely.
- The collections printer utility would incorrectly mark the particle ID and time for an `MCParticle` as having units of GeV. This has been corrected - particle ID is now unitless and time is now in units of ns.
- The digitization driver would fail if truth information was persisted and an MCParticle or one of progenitor particles had multiple parents. The driver now correctly handles particles with multiple parents.