### PR TITLE
[iss512] Fix issue with conditions when running multiple monitoring s…

### DIFF
--- a/monitoring-app/src/main/java/org/hps/monitoring/application/EventProcessing.java
+++ b/monitoring-app/src/main/java/org/hps/monitoring/application/EventProcessing.java
@@ -472,6 +472,11 @@ final class EventProcessing {
             // Create the job manager. A new conditions manager is instantiated from this call but not configured.
             this.sessionState.jobManager = new JobManager();
 
+            // Reset the conditions system because if run and detector name are the same in multiple sessions, it
+            // will not be activated in subsequent sessions after the first one.
+            this.logger.config("Resetting the conditions system for new session");
+            DatabaseConditionsManager.reset();
+            
             // Setup class for conditions system.
             DatabaseConditionsManagerSetup conditions = new DatabaseConditionsManagerSetup();
 


### PR DESCRIPTION
Fix problem reported by @mholtrop where multiple sessions had conditions errors from manager not initializing.  I added a single LoC to reset the conditions system, and multiple sessions seem to function fine now.

I successfully tested connecting/disconnecting several times with this configuration using a local ET system with the EVIO file producer:

```
MaxEvents=-1
SteeringType=RESOURCE
Verbose=true
Port=11111
FreezeConditions=true
DataSourcePath=/work/slac/data/skim_hpsecal_000084.evio.00000
LogLevel=ALL
RecentFiles=/work/slac/data/skim_hpsecal_000084.evio.00000
SteeringResource=/org/hps/steering/monitoring/EcalMonitoringFinal.lcsim
QueueSize=0
StationName=ECAL_MON_STAT
DataSourceType=ET_SERVER
StationPosition=1
EventBuilderClassName=org.hps.evio.LCSimEngRunEventBuilder
DisconnectOnError=true
Prescale=1
LogLevelFilter=ALL
Blocking=false
DisconnectOnEndRun=true
ProcessingStage=LCIO
Host=localhost
WaitMode=SLEEP
LogToFile=false
ChunkSize=1
UserRunNumber=9000
WaitTime=1000000000
DetectorName=HPS-PhysicsRun2019-beta1-4pt5
EtName=ETBuffer
```

It also seems to work fine with an EVIO file source and no ET system.

Locally I have things configured with ET 16.2 as the 14 release is not available for download anymore, but as long as the Java/C versions are consistent, I don't think it should matter (this change is not included in this PR).

Probably a good idea if reviewers confirm this fix locally before approving.  