### PR TITLE
VTP bank rocIDs are changed, the values before was for simulated data

### DIFF
--- a/record-util/src/main/java/org/hps/record/evio/EvioEventConstants.java
+++ b/record-util/src/main/java/org/hps/record/evio/EvioEventConstants.java
@@ -28,8 +28,8 @@ public final class EvioEventConstants {
      */
     public static final int VTP_BANK_TAG = 57634;
 
-    public static final int VTP_TOP_RocID = 60011;
-    public static final int VTP_BOT_RocID = 60012;
+    public static final int VTP_TOP_RocID = 11;
+    public static final int VTP_BOT_RocID = 12;
 
     
     /**


### PR DESCRIPTION
A minimal change.

VTP rocIDs values were wrong, it was for simulated data.
these two numbers are updated.