### PR TITLE
Iss544

### DIFF
--- a/tracking/src/main/java/org/hps/recon/tracking/gbl/GBLRefitterDriver.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/gbl/GBLRefitterDriver.java
@@ -138,8 +138,8 @@ public class GBLRefitterDriver extends Driver {
 
             Pair<Pair<Track, GBLKinkData>, FittedGblTrajectory> newTrackTraj = MakeGblTracks.refitTrackWithTraj(TrackUtils.getHTF(track), temp, track.getTrackerHits(), 5, track.getType(), _scattering, bfield, storeTrackStates);
             if( newTrackTraj == null) {
-            	System.out.println("GBLRefitterDriver::process() -- Aborted refit of track -- null pointer for newTrackTraj returned from MakeGblTracks.refitTrackWithTraj .");
-            	continue;
+                System.out.println("GBLRefitterDriver::process() -- Aborted refit of track -- null pointer for newTrackTraj returned from MakeGblTracks.refitTrackWithTraj .");
+                continue;
             }
             Pair<Track, GBLKinkData> newTrack = newTrackTraj.getFirst();
             if (newTrack == null)

--- a/tracking/src/main/java/org/hps/recon/tracking/gbl/GBLRefitterDriver.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/gbl/GBLRefitterDriver.java
@@ -137,6 +137,7 @@ public class GBLRefitterDriver extends Driver {
                 continue;
 
             Pair<Pair<Track, GBLKinkData>, FittedGblTrajectory> newTrackTraj = MakeGblTracks.refitTrackWithTraj(TrackUtils.getHTF(track), temp, track.getTrackerHits(), 5, track.getType(), _scattering, bfield, storeTrackStates);
+            if( newTrackTraj == null) continue;
             Pair<Track, GBLKinkData> newTrack = newTrackTraj.getFirst();
             if (newTrack == null)
                 continue;

--- a/tracking/src/main/java/org/hps/recon/tracking/gbl/GBLRefitterDriver.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/gbl/GBLRefitterDriver.java
@@ -137,7 +137,10 @@ public class GBLRefitterDriver extends Driver {
                 continue;
 
             Pair<Pair<Track, GBLKinkData>, FittedGblTrajectory> newTrackTraj = MakeGblTracks.refitTrackWithTraj(TrackUtils.getHTF(track), temp, track.getTrackerHits(), 5, track.getType(), _scattering, bfield, storeTrackStates);
-            if( newTrackTraj == null) continue;
+            if( newTrackTraj == null) {
+            	System.out.println("GBLRefitterDriver::process() -- Aborted refit of track -- null pointer for newTrackTraj returned from MakeGblTracks.refitTrackWithTraj .");
+            	continue;
+            }
             Pair<Track, GBLKinkData> newTrack = newTrackTraj.getFirst();
             if (newTrack == null)
                 continue;

--- a/tracking/src/main/java/org/hps/recon/tracking/gbl/MakeGblTracks.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/gbl/MakeGblTracks.java
@@ -181,6 +181,7 @@ public class MakeGblTracks {
         List<TrackerHit> allHthList = TrackUtils.sortHits(hth);
         List<TrackerHit> sortedStripHits = TrackUtils.sortHits(stripHits);
         FittedGblTrajectory fit = doGBLFit(helix, sortedStripHits, scattering, bfield, 0);
+        if(fit==null) return null;
         for (int i = 0; i < nIterations; i++) {
             Pair<Track, GBLKinkData> newTrack = makeCorrectedTrack(fit, helix, allHthList, trackType, bfield);
             helix = TrackUtils.getHTF(newTrack.getFirst());


### PR DESCRIPTION
Allow the code to carry on when a bad MakeGblTrack call returns a null pointer. Simple fix.
Merges into Run2019Master.

Norman will be looking into the details of why that null pointer is there is the first place, but it is likely from some invalid or poor seed track, so nothing to worry about.