### PR TITLE
Handle NaN exception thrown by HelixFitter

### DIFF
--- a/tracking/src/main/java/org/hps/recon/tracking/SeedTracker.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/SeedTracker.java
@@ -172,7 +172,17 @@ public class SeedTracker extends org.lcsim.recon.tracking.seedtracker.SeedTracke
                 SeedStrategy strategy = seed.getSeedStrategy();
                 boolean success = false;
                 for (int iterFit = 0; iterFit < _iterativeConfirmedFits; ++iterFit) {
-                    success = _helixfitter.FitCandidate(seed, strategy);
+                    try {
+                        success = _helixfitter.FitCandidate(seed, strategy);
+                    } catch (Exception e) {
+                        System.out.printf("ERROR -- Exception in SeedTracker:: \n");
+                        if (e.getMessage().equals("NaN in track direction")) {
+                            System.out.printf("Known error - Nan in tack direction ... carry on, nothing to see.\n");
+                            e.printStackTrace();
+                        } else {
+                            throw (e); // Re-throw.
+                        }
+                    }
                 }
                 if (!success) {
                     seedsToRemove.add(seed);


### PR DESCRIPTION
After iss544, this can skips the next issues: NaN in the helix parameters for specific seed.

The problem was briefly discussed in the tracking meeting. It is probably not worth actually fixing this issue, since there are most likely deeper issues with the seed that caused the helix fit to fail so that it adds NaN for the parameters.