### PR TITLE
Move the jfreechart-experimental to 1.9.1-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -337,7 +337,7 @@
       <dependency>
         <groupId>jfreechart-aida-experimental</groupId>
         <artifactId>jfreechart-aida-experimental</artifactId>
-        <version>1.9.0</version>
+        <version>1.9.1-SNAPSHOT</version>
         <exclusions>
           <exclusion>
             <groupId>jdom</groupId>


### PR DESCRIPTION
Moves the jfreechart to 1.9.1-SNAPSHOT, as advertised.