### PR TITLE
Change version to avoid deployment conflicts with master.

### DIFF
--- a/analysis/pom.xml
+++ b/analysis/pom.xml
@@ -8,7 +8,7 @@
     <groupId>org.hps</groupId>
     <artifactId>hps-java</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>4.4-SNAPSHOT</version>
+    <version>4.4-2019-SNAPSHOT</version>
   </parent>
   <dependencies>
     <dependency>

--- a/conditions/pom.xml
+++ b/conditions/pom.xml
@@ -8,7 +8,7 @@
     <groupId>org.hps</groupId>
     <artifactId>hps-java</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>4.4-SNAPSHOT</version>
+    <version>4.4-2019-SNAPSHOT</version>
   </parent>
   <build>
     <plugins>

--- a/crawler/pom.xml
+++ b/crawler/pom.xml
@@ -7,7 +7,7 @@
     <groupId>org.hps</groupId>
     <artifactId>hps-java</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>4.4-SNAPSHOT</version>
+    <version>4.4-2019-SNAPSHOT</version>
   </parent>
   <dependencies>
     <dependency>

--- a/datacat/pom.xml
+++ b/datacat/pom.xml
@@ -7,7 +7,7 @@
     <groupId>org.hps</groupId>
     <artifactId>hps-java</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>4.4-SNAPSHOT</version>
+    <version>4.4-2019-SNAPSHOT</version>
   </parent>
   <dependencies>
     <dependency>

--- a/detector-data/pom.xml
+++ b/detector-data/pom.xml
@@ -8,7 +8,7 @@
     <groupId>org.hps</groupId>
     <artifactId>hps-java</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>4.4-SNAPSHOT</version>
+    <version>4.4-2019-SNAPSHOT</version>
   </parent>
   <build>
     <resources>

--- a/detector-model/pom.xml
+++ b/detector-model/pom.xml
@@ -8,7 +8,7 @@
     <groupId>org.hps</groupId>
     <artifactId>hps-java</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>4.4-SNAPSHOT</version>
+    <version>4.4-2019-SNAPSHOT</version>
   </parent>
   <build>
     <plugins>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -13,7 +13,7 @@
     <groupId>org.hps</groupId>
     <artifactId>hps-java</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>4.4-SNAPSHOT</version>
+    <version>4.4-2019-SNAPSHOT</version>
   </parent>
   <build>
     <defaultGoal>install</defaultGoal>

--- a/ecal-event-display/pom.xml
+++ b/ecal-event-display/pom.xml
@@ -7,7 +7,7 @@
     <groupId>org.hps</groupId>
     <artifactId>hps-java</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>4.4-SNAPSHOT</version>
+    <version>4.4-2019-SNAPSHOT</version>
   </parent>
   <dependencies>
     <dependency>

--- a/ecal-readout-sim/pom.xml
+++ b/ecal-readout-sim/pom.xml
@@ -8,7 +8,7 @@
     <groupId>org.hps</groupId>
     <artifactId>hps-java</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>4.4-SNAPSHOT</version>
+    <version>4.4-2019-SNAPSHOT</version>
   </parent>
   <dependencies>
     <dependency>

--- a/ecal-recon/pom.xml
+++ b/ecal-recon/pom.xml
@@ -8,7 +8,7 @@
     <groupId>org.hps</groupId>
     <artifactId>hps-java</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>4.4-SNAPSHOT</version>
+    <version>4.4-2019-SNAPSHOT</version>
   </parent>
   <dependencies>
     <dependency>

--- a/evio/pom.xml
+++ b/evio/pom.xml
@@ -8,7 +8,7 @@
     <groupId>org.hps</groupId>
     <artifactId>hps-java</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>4.4-SNAPSHOT</version>
+    <version>4.4-2019-SNAPSHOT</version>
   </parent>
   <dependencies>
     <dependency>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -7,7 +7,7 @@
     <groupId>org.hps</groupId>
     <artifactId>hps-java</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>4.4-SNAPSHOT</version>
+    <version>4.4-2019-SNAPSHOT</version>
   </parent>
   <dependencies>
     <dependency>

--- a/job/pom.xml
+++ b/job/pom.xml
@@ -7,7 +7,7 @@
     <groupId>org.hps</groupId>
     <artifactId>hps-java</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>4.4-SNAPSHOT</version>
+    <version>4.4-2019-SNAPSHOT</version>
   </parent>
   <dependencies>
     <dependency>

--- a/logging/pom.xml
+++ b/logging/pom.xml
@@ -7,7 +7,7 @@
     <groupId>org.hps</groupId>
     <artifactId>hps-java</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>4.4-SNAPSHOT</version>
+    <version>4.4-2019-SNAPSHOT</version>
   </parent>
   <build>
     <plugins>

--- a/monitoring-app/pom.xml
+++ b/monitoring-app/pom.xml
@@ -7,7 +7,7 @@
     <groupId>org.hps</groupId>
     <artifactId>hps-java</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>4.4-SNAPSHOT</version>
+    <version>4.4-2019-SNAPSHOT</version>
   </parent>
   <build>
     <plugins>

--- a/monitoring-drivers/pom.xml
+++ b/monitoring-drivers/pom.xml
@@ -7,7 +7,7 @@
     <groupId>org.hps</groupId>
     <artifactId>hps-java</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>4.4-SNAPSHOT</version>
+    <version>4.4-2019-SNAPSHOT</version>
   </parent>
   <dependencies>
     <dependency>

--- a/monitoring-util/pom.xml
+++ b/monitoring-util/pom.xml
@@ -7,7 +7,7 @@
     <groupId>org.hps</groupId>
     <artifactId>hps-java</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>4.4-SNAPSHOT</version>
+    <version>4.4-2019-SNAPSHOT</version>
   </parent>
   <dependencies>
     <dependency>

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -7,7 +7,7 @@
     <groupId>org.hps</groupId>
     <artifactId>hps-java</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>4.4-SNAPSHOT</version>
+    <version>4.4-2019-SNAPSHOT</version>
   </parent>
   <build>
     <resources>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
   <artifactId>hps-java</artifactId>
   <groupId>org.hps</groupId>
   <packaging>pom</packaging>
-  <version>4.4-SNAPSHOT</version>
+  <version>4.4-2019-SNAPSHOT</version>
   <name>HPS Java</name>
   <description>HPS Java Maven Project</description>
   <url>http://www.lcsim.org/sites/hps/</url>

--- a/recon/pom.xml
+++ b/recon/pom.xml
@@ -8,7 +8,7 @@
     <groupId>org.hps</groupId>
     <artifactId>hps-java</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>4.4-SNAPSHOT</version>
+    <version>4.4-2019-SNAPSHOT</version>
   </parent>
   <dependencies>
     <!-- This will pull in the ECAL recon module transitively. -->

--- a/record-util/pom.xml
+++ b/record-util/pom.xml
@@ -7,7 +7,7 @@
     <groupId>org.hps</groupId>
     <artifactId>hps-java</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>4.4-SNAPSHOT</version>
+    <version>4.4-2019-SNAPSHOT</version>
   </parent>
   <build>
     <plugins>

--- a/run-database/pom.xml
+++ b/run-database/pom.xml
@@ -7,7 +7,7 @@
     <groupId>org.hps</groupId>
     <artifactId>hps-java</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>4.4-SNAPSHOT</version>
+    <version>4.4-2019-SNAPSHOT</version>
   </parent>
   <dependencies>
     <dependency>

--- a/steering-files/pom.xml
+++ b/steering-files/pom.xml
@@ -8,7 +8,7 @@
     <groupId>org.hps</groupId>
     <artifactId>hps-java</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>4.4-SNAPSHOT</version>
+    <version>4.4-2019-SNAPSHOT</version>
   </parent>
   <build>
     <resources>

--- a/tracking/pom.xml
+++ b/tracking/pom.xml
@@ -8,7 +8,7 @@
     <groupId>org.hps</groupId>
     <artifactId>hps-java</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>4.4-SNAPSHOT</version>
+    <version>4.4-2019-SNAPSHOT</version>
   </parent>
   <build>
     <plugins>

--- a/util/pom.xml
+++ b/util/pom.xml
@@ -7,7 +7,7 @@
     <groupId>org.hps</groupId>
     <artifactId>hps-java</artifactId>
     <relativePath>../pom.xml</relativePath>
-    <version>4.4-SNAPSHOT</version>
+    <version>4.4-2019-SNAPSHOT</version>
   </parent>
   <dependencies>
     <dependency>


### PR DESCRIPTION
This change is necessary for enabling automatic Jenkins builds with the Run2019Master so that builds of the hps-java master do not have the same version number.  In this case, they would conflict and 4.4-SNAPSHOT will be ambiguous so this fixes that problem.

Some counting house scripts may need to be updated if they have hard-coded locations to the 4.4-SNAPSHOT jar.