### PR TITLE
[iss554] Fix wrong Y range. (Run2019Master)

### DIFF
--- a/monitoring-drivers/src/main/java/org/hps/monitoring/drivers/svt/SensorOccupancyPlotsDriver.java
+++ b/monitoring-drivers/src/main/java/org/hps/monitoring/drivers/svt/SensorOccupancyPlotsDriver.java
@@ -112,7 +112,8 @@ public class SensorOccupancyPlotsDriver extends Driver {
     private boolean saveRootFile = true;
     
     // Max Y range for occupancy plots.
-    private double occupancyYRange = 0.03;
+    private double occupancyYRange1 = 0.03;
+    private double occupancyYRange2 = 0.003;
 
     public SensorOccupancyPlotsDriver() {
         maxSampleStatus = new SystemStatusImpl(Subsystem.SVT, "Checks that SVT is timed in (max sample plot)", true);
@@ -205,8 +206,12 @@ public class SensorOccupancyPlotsDriver extends Driver {
         this.saveRootFile = saveRootFile;
     }
 
-    public void setOccupancyYRange(double occupancyYRange) {
-        this.occupancyYRange = occupancyYRange;
+    public void setOccupancyYRange1(double occupancyYRange1) {
+        this.occupancyYRange1 = occupancyYRange1;
+    }
+    
+    public void setOccupancyYRange2(double occupancyYRange2) {
+        this.occupancyYRange2 = occupancyYRange2;
     }
     
     /**
@@ -450,12 +455,12 @@ public class SensorOccupancyPlotsDriver extends Driver {
 
         IPlotter plotter = plotters.get("Occupancy: L0-L3");
         for (int i = 0; i < plotter.numberOfRegions(); i++) {
-            plotter.region(i).setYLimits(occupancyYRange);
+            plotter.region(i).setYLimits(occupancyYRange1);
         }
 
         plotter = plotters.get("Occupancy: L4-L6");
         for (int i = 0; i < plotter.numberOfRegions(); i++) {
-            plotter.region(i).setYLimits(occupancyYRange);
+            plotter.region(i).setYLimits(occupancyYRange2);
         }
                 
         for (IPlotter plotterShow : plotters.values())

--- a/monitoring-drivers/src/main/java/org/hps/monitoring/drivers/svt/SensorOccupancyPlotsDriver.java
+++ b/monitoring-drivers/src/main/java/org/hps/monitoring/drivers/svt/SensorOccupancyPlotsDriver.java
@@ -15,6 +15,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.logging.Logger;
 
 import org.hps.monitoring.subsys.StatusCode;
 import org.hps.monitoring.subsys.Subsystem;
@@ -50,10 +51,9 @@ import org.lcsim.util.aida.AIDA;
  */
 public class SensorOccupancyPlotsDriver extends Driver {
 
-    // TODO: Add documentation
-    // static {
-    // hep.aida.jfree.AnalysisFactory.register();
-    // }
+    // Logger
+    private static Logger LOGGER = Logger.getLogger(SensorOccupancyPlotsDriver.class.getCanonicalName());
+    
     // Plotting
     private static ITree tree = null;
     private IAnalysisFactory analysisFactory = AIDA.defaultInstance().analysisFactory();
@@ -108,8 +108,11 @@ public class SensorOccupancyPlotsDriver extends Driver {
     private boolean enableClusterTimeCuts = true;
     private double clusterTimeCutMax = 4.0;
     private double clusterTimeCutMin = -4.0;
-
+       
     private boolean saveRootFile = true;
+    
+    // Max Y range for occupancy plots.
+    private double occupancyYRange = 0.03;
 
     public SensorOccupancyPlotsDriver() {
         maxSampleStatus = new SystemStatusImpl(Subsystem.SVT, "Checks that SVT is timed in (max sample plot)", true);
@@ -202,6 +205,10 @@ public class SensorOccupancyPlotsDriver extends Driver {
         this.saveRootFile = saveRootFile;
     }
 
+    public void setOccupancyYRange(double occupancyYRange) {
+        this.occupancyYRange = occupancyYRange;
+    }
+    
     /**
      * Get the global strip position of a physical channel number for a given
      * sensor.
@@ -355,7 +362,7 @@ public class SensorOccupancyPlotsDriver extends Driver {
         // }
         // tree = analysisFactory.createTreeFactory().create();
         tree = AIDA.defaultInstance().tree();
-        tree.cd("/");// aida.tree().cd("/");
+        tree.cd("/");
         histogramFactory = analysisFactory.createHistogramFactory(tree);
 
         plotters.put("Occupancy: L0-L3", plotterFactory.create("Occupancy: L0-L3"));
@@ -441,8 +448,18 @@ public class SensorOccupancyPlotsDriver extends Driver {
             }
         }
 
-        for (IPlotter plotter : plotters.values())
-            plotter.show();
+        IPlotter plotter = plotters.get("Occupancy: L0-L3");
+        for (int i = 0; i < plotter.numberOfRegions(); i++) {
+            plotter.region(i).setYLimits(occupancyYRange);
+        }
+
+        plotter = plotters.get("Occupancy: L4-L6");
+        for (int i = 0; i < plotter.numberOfRegions(); i++) {
+            plotter.region(i).setYLimits(occupancyYRange);
+        }
+                
+        for (IPlotter plotterShow : plotters.values())
+            plotterShow.show();
     }
 
     private boolean passTriggerFilter(List<GenericObject> triggerBanks) {
@@ -477,7 +494,7 @@ public class SensorOccupancyPlotsDriver extends Driver {
         if (runNumber == -1)
             runNumber = event.getRunNumber();
         if (enableTriggerFilter && event.hasCollection(GenericObject.class, triggerBankCollectionName)) {
-            System.out.println("SensorOccupancyPlotsDriver::  Filtering Event");
+            LOGGER.info("Filtering Event");
             // Get the list of trigger banks from the event
             List<GenericObject> triggerBanks = event.get(GenericObject.class, triggerBankCollectionName);
 
@@ -488,7 +505,7 @@ public class SensorOccupancyPlotsDriver extends Driver {
 
         // If the event doesn't have a collection of RawTrackerHit's, skip it.
         if (!event.hasCollection(RawTrackerHit.class, rawTrackerHitCollectionName)) {
-            System.out.println("No SVT RawTrackerHits in this event???");
+            LOGGER.warning("No SVT RawTrackerHits in this event.");
             return;
         }
         // Get RawTrackerHit collection from event.
@@ -653,8 +670,9 @@ public class SensorOccupancyPlotsDriver extends Driver {
 
             boolean isSensorOK = isOccupancyOK(apvOccupancy);
             if (!isSensorOK) {
-                System.out.format("%s: %f %f %f %f %f\n", SvtPlotUtils.fixSensorNumberLabel(sensor.getName()), apvOccupancy[0], apvOccupancy[1],
-                        apvOccupancy[2], apvOccupancy[3], apvOccupancy[4]);
+                LOGGER.info(String.format("%s: %f %f %f %f %f\n",
+                        SvtPlotUtils.fixSensorNumberLabel(sensor.getName()), apvOccupancy[0], apvOccupancy[1],
+                        apvOccupancy[2], apvOccupancy[3], apvOccupancy[4]));
                 isSystemOK = false;
                 if (oldStatus != StatusCode.ALARM)
                     occupancyStatus.setStatus(StatusCode.ALARM, "Sensor " + SvtPlotUtils.fixSensorNumberLabel(sensor.getName()) + " occupancy abnormal.");
@@ -684,11 +702,11 @@ public class SensorOccupancyPlotsDriver extends Driver {
                 highestApv = i;
             }
         if (highestApv != 0 && highestApv != 4) {
-            System.out.println("peak occupancy not at edge");
+            LOGGER.warning("peak occupancy not at edge");
             return false;
         }
         if (peakOccupancy > maxPeakOccupancy || peakOccupancy < minPeakOccupancy) {
-            System.out.println("peak occupancy out of range");
+            LOGGER.warning("peak occupancy out of range");
             return false;
         }
         if (highestApv == 0)
@@ -696,7 +714,7 @@ public class SensorOccupancyPlotsDriver extends Driver {
                 if (apvOccupancy[i] < 0.1 * peakOccupancy || apvOccupancy[i] < minPeakOccupancy)
                     continue; // skip through the tail end of the sensor
                 if (0.9 * apvOccupancy[i] > apvOccupancy[i - 1]) {
-                    System.out.println("occupancy not monotonic");
+                    LOGGER.warning("occupancy not monotonic");
                     return false;
                 }
             }
@@ -705,7 +723,7 @@ public class SensorOccupancyPlotsDriver extends Driver {
                 if (apvOccupancy[i] < 0.1 * peakOccupancy || apvOccupancy[i] < minPeakOccupancy)
                     continue; // skip through the tail end of the sensor
                 if (0.9 * apvOccupancy[i] > apvOccupancy[i + 1]) {
-                    System.out.println("occupancy not monotonic");
+                    LOGGER.warning("occupancy not monotonic");
                     return false;
                 }
             }


### PR DESCRIPTION
Set Y range on occupancy plots to workaround auto-ranging not functioning properly.

Also, convert some System.out printouts to log messages.

To set the Y ranges in the driver parameters use a setting like this for the L0-L3 plots:

```
<occupancyYRange1>0.05</occupancyYRange1>
```

And a setting like this for L4-L6:

```
<occupancyYRange2>0.005</occupancyYRange2>
```

There shouldn't be any need to modify the driver file to change these settings.