### PR TITLE
Iss601

### DIFF
--- a/evio/src/main/java/org/hps/evio/AugmentedSvtEvioReader.java
+++ b/evio/src/main/java/org/hps/evio/AugmentedSvtEvioReader.java
@@ -1,6 +1,3 @@
-/**
- * 
- */
 package org.hps.evio;
 
 import java.util.List;
@@ -14,8 +11,10 @@ import org.hps.record.svt.SvtHeaderDataInfo;
 import org.lcsim.event.EventHeader;
 
 /**
+ * This is essentially the same as {@link SvtEvioReader} except that it 
+ * performs error checking of the SVT EVIO event headers.
+ * 
  * @author Per Hansson Adrian <phansson@slac.stanford.edu>
- *
  */
 public class AugmentedSvtEvioReader extends SvtEvioReader {
 
@@ -45,10 +44,16 @@ public class AugmentedSvtEvioReader extends SvtEvioReader {
         super();
         this.throwHeaderExceptions = throwHeaderExceptions;
     }
-                  
+
+    /**
+     * Process SVT headers, handling any errors if they occur.
+     * @param headers The list of SVT headers
+     * @param lcsimEvent The full lcsim event
+     */
     @Override
     protected void processSvtHeaders(List<SvtHeaderDataInfo> headers, EventHeader lcsimEvent) throws SvtEvioHeaderException {
-
+        // Note that the superclass method being overridden is not called because it doesn't do anything.
+        
         LOGGER.info("Processing " + headers.size() + " SVT headers for run " + lcsimEvent.getRunNumber() + " and event " + lcsimEvent.getEventNumber());
         
         // Get a list of any SVT header errors.
@@ -59,7 +64,7 @@ public class AugmentedSvtEvioReader extends SvtEvioReader {
             final int nerrors = errors.size();
                                                                         
             Set<String> errorNames = EvioHeaderError.getUniqueNames(errors);
-            LOGGER.warning("Found " + nerrors + " SVT header errors for event " + lcsimEvent.getEventNumber()
+            LOGGER.warning("Found " + nerrors + " SVT header errors in event " + lcsimEvent.getEventNumber()
                     + " with types: " + errorNames.toString());
  
             // Print all errors to the log if logging level is fine or more.

--- a/evio/src/main/java/org/hps/evio/SvtEvioReader.java
+++ b/evio/src/main/java/org/hps/evio/SvtEvioReader.java
@@ -188,7 +188,6 @@ public class SvtEvioReader extends AbstractSvtEvioReader {
     @Override
     protected List< int[] > extractMultiSamples(int sampleCount, int[] data) {
         
-
         List<int[]> sampleList = new ArrayList<int[]>();
         // Loop through all of the samples and make hits
         for (int samplesN = 0; samplesN < sampleCount; samplesN += 4) {
@@ -208,6 +207,9 @@ public class SvtEvioReader extends AbstractSvtEvioReader {
 
         // Process the headers
         this.processSvtHeaders(headers, lcsimEvent);
+        
+        // Clear header data list after processing. This was a big memory leak! --JM
+        headers.clear();
         
         return true; 
     }

--- a/logging/src/main/resources/org/hps/logging/config/logging.properties
+++ b/logging/src/main/resources/org/hps/logging/config/logging.properties
@@ -43,6 +43,8 @@ org.hps.monitoring.plotting.level = INFO
 
 # evio
 org.hps.evio.level = CONFIG
+# This will print header errors if they occur but not the details.
+org.hps.evio.AugmentedSvtEvioReader.level = WARNING
 
 # analysis
 org.hps.analysis.trigger.level = INFO

--- a/logging/src/main/resources/org/hps/logging/config/test_logging.properties
+++ b/logging/src/main/resources/org/hps/logging/config/test_logging.properties
@@ -43,6 +43,7 @@ org.hps.monitoring.plotting.level = WARNING
 
 # evio
 org.hps.evio.level = WARNING
+org.hps.evio.AugmentedSvtEvioReader.level = WARNING
 
 # analysis
 org.hps.analysis.trigger.level = WARNING

--- a/record-util/src/main/java/org/hps/record/svt/EvioHeaderError.java
+++ b/record-util/src/main/java/org/hps/record/svt/EvioHeaderError.java
@@ -7,8 +7,10 @@ import java.util.Set;
 /**
  * Represents information about errors found in SVT EVIO headers.
  * 
+ * Replaces direct usage of {@link SvtEvioExceptions.SvtEvioHeaderException} when
+ * checking event header information using {@link SvtEventHeaderCheckerNew}.
+ * 
  * @author jeremym
- *
  */
 public class EvioHeaderError {
    
@@ -49,13 +51,13 @@ public class EvioHeaderError {
             "A multisample header error bit was set.");
     
     public static final EvioHeaderError SYNC = new EvioHeaderError(ErrorType.Sync,
-            "This header had a sync error.");
+            "The header had a sync error.");
     
     public static final EvioHeaderError OVERFLOW = new EvioHeaderError(ErrorType.Overflow,
-            "This header had an overflow error.");
+            "The header had an overflow error.");
     
     public static final EvioHeaderError SKIP_COUNT = new EvioHeaderError(ErrorType.SkipCount,
-            "This header had a skipCount.");
+            "The header had a skipCount.");
     
     private final String debugString;
     
@@ -63,6 +65,11 @@ public class EvioHeaderError {
     
     private final String message;
     
+    /**
+     * Get a list of unique error names from a list.
+     * @param errors The list of errors
+     * @return The set of unique error names
+     */
     public static Set<String> getUniqueNames(List<EvioHeaderError> errors) {
         Set<String> uniqueErrorNames = new HashSet<String>();
         for (EvioHeaderError error : errors) {
@@ -71,26 +78,49 @@ public class EvioHeaderError {
         return uniqueErrorNames;
     }
     
+    /**
+     * Create with type and message and blank debug string.
+     * @param errorType The type of header error
+     * @param message The specific error message
+     */
     public EvioHeaderError(ErrorType errorType, String message) {
         this.errorType = errorType;
         this.message = message;
         this.debugString = "";
     }
     
+    /**
+     * Create with type and message and a populated debug string.
+     * @param errorType The type of header error
+     * @param message The specific error message
+     * @param debugString The detailed debug string 
+     */
     public EvioHeaderError(ErrorType errorType, String message, String debugString) {
         this.errorType = errorType;
         this.message = message;
         this.debugString = debugString;
     }    
     
+    /**
+     * Get the detailed debug string 
+     * @return The detailed debug string
+     */
     String getDebugString() {
         return debugString;
     }    
     
+    /**
+     * Get the error message
+     * @return The error message
+     */
     String getMessage() {
         return message;
     }
     
+    /**
+     * Get the type of the error
+     * @return The type of the error
+     */
     ErrorType getType() {
         return errorType;
     }        

--- a/record-util/src/main/java/org/hps/record/svt/EvioHeaderError.java
+++ b/record-util/src/main/java/org/hps/record/svt/EvioHeaderError.java
@@ -57,7 +57,7 @@ public class EvioHeaderError {
             "The header had an overflow error.");
     
     public static final EvioHeaderError SKIP_COUNT = new EvioHeaderError(ErrorType.SkipCount,
-            "The header had a skipCount.");
+            "The header had a skip count.");
     
     private final String debugString;
     

--- a/record-util/src/main/java/org/hps/record/svt/EvioHeaderError.java
+++ b/record-util/src/main/java/org/hps/record/svt/EvioHeaderError.java
@@ -1,0 +1,97 @@
+package org.hps.record.svt;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Represents information about errors found in SVT EVIO headers.
+ * 
+ * @author jeremym
+ *
+ */
+public class EvioHeaderError {
+   
+    /**
+     * The basic error types.
+     */
+    public enum ErrorType {
+        ApvBufferAddress,
+        ApvFrameCount,
+        ApvRead,
+        MultisampleErrorBit,
+        Overflow,
+        SkipCount,
+        Sync
+    }
+    
+    /*
+     * A set of static class instances are provided here with default error messages to avoid creating new objects when
+     * it isn't necessary.
+     */
+    
+    public static final EvioHeaderError APV_BUFFER_ADDRESS_COUNT = new EvioHeaderError(ErrorType.ApvBufferAddress, 
+            "Invalid number of APV buffer addresses.");
+        
+    public static final EvioHeaderError APV_BUFFER_ADDRESS_MISMATCH = new EvioHeaderError(ErrorType.ApvBufferAddress,
+            "The APV buffer addresses in this event do not match");
+    
+    public static final EvioHeaderError APV_FRAME_COUNT = new EvioHeaderError(ErrorType.ApvFrameCount, 
+            "Invalid number of APV frame counts.");
+    
+    public static final EvioHeaderError APV_FRAME_COUNT_MISMATCH = new EvioHeaderError(ErrorType.ApvFrameCount, 
+            "The APV frame counts in this event do not match.");
+   
+    public static final EvioHeaderError APV_READ_ERRORS = new EvioHeaderError(ErrorType.ApvRead, 
+            "Invalid number of read errors.");
+    
+    public static final EvioHeaderError MULTISAMPLE_ERROR_BIT = new EvioHeaderError(ErrorType.MultisampleErrorBit, 
+            "A multisample header error bit was set.");
+    
+    public static final EvioHeaderError SYNC = new EvioHeaderError(ErrorType.Sync,
+            "This header had a sync error.");
+    
+    public static final EvioHeaderError OVERFLOW = new EvioHeaderError(ErrorType.Overflow,
+            "This header had an overflow error.");
+    
+    public static final EvioHeaderError SKIP_COUNT = new EvioHeaderError(ErrorType.SkipCount,
+            "This header had a skipCount.");
+    
+    private final String debugString;
+    
+    private final ErrorType errorType;
+    
+    private final String message;
+    
+    public static Set<String> getUniqueNames(List<EvioHeaderError> errors) {
+        Set<String> uniqueErrorNames = new HashSet<String>();
+        for (EvioHeaderError error : errors) {
+            uniqueErrorNames.add(error.getType().name());
+        }
+        return uniqueErrorNames;
+    }
+    
+    public EvioHeaderError(ErrorType errorType, String message) {
+        this.errorType = errorType;
+        this.message = message;
+        this.debugString = "";
+    }
+    
+    public EvioHeaderError(ErrorType errorType, String message, String debugString) {
+        this.errorType = errorType;
+        this.message = message;
+        this.debugString = debugString;
+    }    
+    
+    String getDebugString() {
+        return debugString;
+    }    
+    
+    String getMessage() {
+        return message;
+    }
+    
+    ErrorType getType() {
+        return errorType;
+    }        
+}

--- a/record-util/src/main/java/org/hps/record/svt/SvtEventHeaderCheckerNew.java
+++ b/record-util/src/main/java/org/hps/record/svt/SvtEventHeaderCheckerNew.java
@@ -14,7 +14,7 @@ import org.hps.record.svt.EvioHeaderError.ErrorType;
  * <ul>
  * <li>Allow class to be instantiated so methods can be called non-statically.</li>
  * <li>Change primary public methods to be non-static.</li>
- * <li>Instead of directly generating exceptions, which uses an enormous amount of memory, 
+ * <li>Instead of directly generating exceptions, which uses an enormous amount of memory generating the tracebacks, 
  *     use a more lightweight class to represent the errors.</li>
  * <li>Where possible, use static instances of error checking classes so they don't need to be continually recreated.</li>
  * <li>Make generation of large debug strings optional. Errors are reported generically without debug strings when this is turned off.</li>
@@ -61,8 +61,6 @@ public class SvtEventHeaderCheckerNew {
     }
 
     public List<EvioHeaderError> getHeaderErrors(List<SvtHeaderDataInfo> headers) {
-
-        LOGGER.info("Checking " + headers.size() + " SVT headers for errors ...");
 
         int[] bufferAddresses = new int[6];
         int[] firstFrameCounts = new int[6];
@@ -164,7 +162,6 @@ public class SvtEventHeaderCheckerNew {
                 count = -1;
                 for (int iFrame = 0; iFrame < frameCounts.length; ++iFrame) {
                     if (checkApvFrameCount(frameCounts, count, iFrame)) {
-
                         if (this.generateDebugStrings) {
                             errors.add(new EvioHeaderError(ErrorType.ApvFrameCount,
                                     EvioHeaderError.APV_FRAME_COUNT.getMessage(),
@@ -180,9 +177,6 @@ public class SvtEventHeaderCheckerNew {
                 }
 
                 for (int iReadError = 0; iReadError < readError.length; ++iReadError) {
-                    //LOGGER.finest("read error " + iReadError + "  " + readError[iReadError] + " ( "
-                    //        + Integer.toHexString(readError[iReadError]) + " )");
-
                     if (readError[iReadError] != 1) {// active low
                         if (this.generateDebugStrings) {
                             errors.add(
@@ -205,6 +199,13 @@ public class SvtEventHeaderCheckerNew {
         return errors;
     }
 
+    /**
+     * Return true if APV frame count has error.
+     * @param frameCounts
+     * @param count
+     * @param iFrame
+     * @return
+     */
     private static boolean checkApvFrameCount(int[] frameCounts, int count, int iFrame) {
         return frameCounts[iFrame] > 15 || (count < 15 && frameCounts[iFrame] < count)
                 || (count == 15 && frameCounts[iFrame] != 0);
@@ -213,12 +214,7 @@ public class SvtEventHeaderCheckerNew {
     private void addSvtHeaderDataErrors(SvtHeaderDataInfo header, List<EvioHeaderError> errors)  {
         
         int tail = header.getTail();
-        //LOGGER.finest("checkSvtHeaderData tail " + tail + "( " + Integer.toHexString(tail) + " ) " +
-        //                                         " errorbit   " +  Integer.toHexString(SvtEvioUtils.getSvtTailSyncErrorBit(tail)) +
-        //                                         " OFerrorbit " +  Integer.toHexString(SvtEvioUtils.getSvtTailOFErrorBit(tail)) + 
-        //                                         " checkSvtHeaderData skipcount  " +  Integer.toHexString(SvtEvioUtils.getSvtTailMultisampleSkipCount(tail)));
-               
-        // FIXME: Should this really be else/if or can these all occur separately?
+
         if( SvtEvioUtils.getSvtTailSyncErrorBit(tail) != 0) {
             if (this.generateDebugStrings) {
                 errors.add(new EvioHeaderError(ErrorType.Sync, EvioHeaderError.SYNC.getMessage(), 
@@ -226,7 +222,6 @@ public class SvtEventHeaderCheckerNew {
             } else {
                 errors.add(EvioHeaderError.SYNC);
             }
-
         } else if(SvtEvioUtils.getSvtTailOFErrorBit(tail) != 0) {
             if (this.generateDebugStrings) {
                 errors.add(new EvioHeaderError(ErrorType.Overflow, EvioHeaderError.OVERFLOW.getMessage(), 

--- a/record-util/src/main/java/org/hps/record/svt/SvtEventHeaderCheckerNew.java
+++ b/record-util/src/main/java/org/hps/record/svt/SvtEventHeaderCheckerNew.java
@@ -1,0 +1,337 @@
+package org.hps.record.svt;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.hps.record.svt.EvioHeaderError.ErrorType;
+import org.hps.record.svt.SvtEvioExceptions.SvtEvioHeaderApvBufferAddressException;
+import org.hps.record.svt.SvtEvioExceptions.SvtEvioHeaderApvFrameCountException;
+import org.hps.record.svt.SvtEvioExceptions.SvtEvioHeaderApvReadErrorException;
+import org.hps.record.svt.SvtEvioExceptions.SvtEvioHeaderException;
+import org.hps.record.svt.SvtEvioExceptions.SvtEvioHeaderMultisampleErrorBitException;
+import org.hps.record.svt.SvtEvioExceptions.SvtEvioHeaderOFErrorException;
+import org.hps.record.svt.SvtEvioExceptions.SvtEvioHeaderSkipCountException;
+import org.hps.record.svt.SvtEvioExceptions.SvtEvioHeaderSyncErrorException;
+
+/**
+ * Fork of {@link SvtEventHeaderChecker} to remove memory leaks.
+ * 
+ * Changes to original class:
+ * <ul>
+ * <li>Allow class to be instantiated rather than only called statically.</li>
+ * <li>Change primary methods to be non-static.</li>
+ * <li>Instead of directly generating exceptions which uses an enormous amount of memory, 
+ *     use a more lightweight class to represent the errors.</li>
+ * <li>Where possible, use static instances of error checking classes so they don't need to be continually recreated.</li>
+ * <li>Make generation of large debug strings optional. Errors are reported generically without debug strings when this is turned off.</li>
+ * <li>For now, use a class rather than package logger for more granular debugging options.</li>
+ * <li>Do not hard-code a default log level. This should be done in prop files from command line instead.</li>
+ * </ul>
+ * 
+ * @author jeremym
+ */
+public class SvtEventHeaderCheckerNew {
+
+    /*
+    private static Logger LOGGER = Logger.getLogger(SvtEventHeaderChecker.class.getPackage().getName());
+    static {
+        LOGGER.setLevel(Level.INFO);
+    }
+    */
+    
+    private static Logger LOGGER = Logger.getLogger(SvtEventHeaderChecker.class.getCanonicalName());
+
+    private static String getHeaderDebugString(SvtHeaderDataInfo headerDataInfo) {
+        return headerDataInfo.toString();
+    }
+
+    private static String getMultisampleDebugString(SvtHeaderDataInfo headerDataInfo, int multisampleHeaderTailWord) {
+        String s = getHeaderDebugString(headerDataInfo) + " multisample: feb "
+                + SvtEvioUtils.getFebIDFromMultisampleTail(multisampleHeaderTailWord) + " hybrid "
+                + SvtEvioUtils.getFebHybridIDFromMultisampleTail(multisampleHeaderTailWord) + " apv "
+                + SvtEvioUtils.getApvFromMultisampleTail(multisampleHeaderTailWord) + " ";
+        return s;
+    }
+
+    private static String getDebugString(int[] bufAddresses, int[] frameCounts, int[] readError) {
+        String s = "";
+        for (int i = 0; i < bufAddresses.length; ++i)
+            s += "\nbuffer address " + i + "  " + bufAddresses[i] + " ( " + Integer.toHexString(bufAddresses[i]) + " )";
+        for (int i = 0; i < frameCounts.length; ++i)
+            s += "\nframe count    " + i + "  " + frameCounts[i] + " ( " + Integer.toHexString(frameCounts[i]) + " )";
+        for (int i = 0; i < readError.length; ++i)
+            s += "\nread error     " + i + "  " + readError[i] + " ( " + Integer.toHexString(readError[i]) + " )";
+        return s;
+    }
+
+    public static int getDAQComponentFromExceptionMsg(SvtEvioHeaderException exception, String type) {
+        // Clean up character return before proceeding, I don't know why the regexp
+        // fails but whatever
+
+        String str;
+        int charRet_idx = exception.getMessage().indexOf('\n');
+        if (charRet_idx != -1)
+            str = exception.getMessage().substring(0, exception.getMessage().indexOf('\n'));
+        else
+            str = exception.getMessage();
+
+        // now match
+        Matcher m = Pattern.compile(".*\\s" + type + "\\s(\\d+)\\s.*").matcher(str);
+        int id = -1;
+        try {
+            if (m.matches())
+                id = Integer.parseInt(m.group(1));
+            else
+                id = -2;
+        } catch (Exception e) {
+            throw new RuntimeException(
+                    "exception when matching \"" + str + "\" with \"" + m.pattern().toString() + "\"", e);
+        }
+        // System.out.println("got " + id + " from " + m.pattern().toString() + " for
+        // \""+ str + "\"");
+        return id;
+    }
+
+    // This is apparently unused in hps-java. --JM
+    /*
+    public static String getSvtEvioHeaderExceptionCompactMessage(SvtEvioHeaderException e) {
+        String str = "Exception type " + e.getClass().getSimpleName();
+        int roc = getDAQComponentFromExceptionMsg(e, "num");
+        if (roc < 0)
+            throw new RuntimeException(
+                    "Got " + roc + " from matching \"" + e.getMessage() + " seem to have failed. Shouldn't happen?");
+        int feb = getDAQComponentFromExceptionMsg(e, "feb");
+        int hybrid = getDAQComponentFromExceptionMsg(e, "hybrid");
+        int apv = getDAQComponentFromExceptionMsg(e, "apv");
+        str += " for roc " + roc + " feb " + feb + " hybrid " + hybrid + " apv " + apv;
+        return str;
+    }
+    */
+
+    public static String getSvtEvioHeaderExceptionName(SvtEvioHeaderException e) {
+        return e.getClass().getSimpleName();
+    }
+
+    public static List<String> getSvtEvioHeaderExceptionNames(List<SvtEvioHeaderException> exceptions) {
+        List<String> l = new ArrayList<String>();
+        for (SvtEvioHeaderException e : exceptions) {
+            String name = getSvtEvioHeaderExceptionName(e);
+            if (!l.contains(name))
+                l.add(name);
+        }
+        return l;
+    }
+
+    private boolean generateDebugStrings = true;
+
+    SvtEventHeaderCheckerNew() {
+    }
+
+    SvtEventHeaderCheckerNew(boolean generateDebugStrings) {
+        this.generateDebugStrings = generateDebugStrings;
+    }
+
+    public List<EvioHeaderError> getHeaderErrors(List<SvtHeaderDataInfo> headers) {
+
+        LOGGER.fine("check " + headers.size() + " headers  ");
+
+        int[] bufferAddresses = new int[6];
+        int[] firstFrameCounts = new int[6];
+        boolean firstHeader = true;
+        int[] multisampleHeader;
+        int[] bufAddresses;
+        int[] frameCounts;
+        int[] readError;
+        int count;
+        int multisampleHeaderTailErrorBit;
+
+        // create a list to hold all active exceptions
+        // List<SvtEvioHeaderException> exceptions = new
+        // ArrayList<SvtEvioHeaderException>();
+
+        List<EvioHeaderError> errors = new ArrayList<EvioHeaderError>();
+
+        for (SvtHeaderDataInfo headerDataInfo : headers) {
+            LOGGER.fine("checking header: " + headerDataInfo.toString());
+
+            // Check the multisample header information
+            int nMultisampleHeaders = headerDataInfo.getNumberOfMultisampleHeaders();
+            for (int iMultisampleHeader = 0; iMultisampleHeader < nMultisampleHeaders; iMultisampleHeader++) {
+                LOGGER.fine("iMultisampleHeader " + iMultisampleHeader);
+
+                multisampleHeader = SvtHeaderDataInfo.getMultisampleHeader(iMultisampleHeader, headerDataInfo);
+
+                // get multisample tail error bit
+                multisampleHeaderTailErrorBit = SvtEvioUtils
+                        .getErrorBitFromMultisampleHeader(SvtEvioUtils.getMultisampleTailWord(multisampleHeader));
+
+                // get buffer addresses
+                bufAddresses = SvtEvioUtils.getApvBufferAddresses(multisampleHeader);
+
+                // get frame counts
+                frameCounts = SvtEvioUtils.getApvFrameCount(multisampleHeader);
+
+                // check if there was any read errors
+                readError = SvtEvioUtils.getApvReadErrors(multisampleHeader);
+
+                if (bufAddresses.length != 6) {
+                    errors.add(EvioHeaderError.APV_BUFFER_ADDRESS_COUNT);
+                }
+
+                if (frameCounts.length != 6) {
+                    errors.add(EvioHeaderError.APV_FRAME_COUNT);
+                }
+
+                if (readError.length != 6) {
+                    errors.add(EvioHeaderError.APV_READ_ERRORS);
+                }
+
+                // Check for error bit
+                if (multisampleHeaderTailErrorBit != 0) {
+                    if (this.generateDebugStrings) {
+                        errors.add(new EvioHeaderError(ErrorType.MultisampleErrorBit,
+                                EvioHeaderError.MULTISAMPLE_ERROR_BIT.getMessage(),
+                                getMultisampleDebugString(headerDataInfo,
+                                        SvtEvioUtils.getMultisampleTailWord(multisampleHeader))
+                                        + getDebugString(bufAddresses, frameCounts, readError)));
+                    } else {
+                        errors.add(EvioHeaderError.MULTISAMPLE_ERROR_BIT);
+                    }
+                }
+
+                // print debug
+                LOGGER.finest(getMultisampleDebugString(headerDataInfo,
+                        SvtEvioUtils.getMultisampleTailWord(multisampleHeader))
+                        + getDebugString(bufAddresses, frameCounts, readError));
+
+                // Get a reference for comparison
+                if (firstHeader) {
+                    System.arraycopy(bufAddresses, 0, bufferAddresses, 0, bufAddresses.length);
+                    System.arraycopy(frameCounts, 0, firstFrameCounts, 0, frameCounts.length);
+                    firstHeader = false;
+                } else {
+
+                    // Check that apv buffer addresses match
+                    if (!Arrays.equals(bufferAddresses, bufAddresses)) {
+                        if (this.generateDebugStrings) {
+                            errors.add(new EvioHeaderError(ErrorType.ApvBufferAddress,
+                                    EvioHeaderError.APV_BUFFER_ADDRESS_MISMATCH.getMessage(),
+                                    getMultisampleDebugString(headerDataInfo,
+                                            SvtEvioUtils.getMultisampleTailWord(multisampleHeader))
+                                            + getDebugString(bufAddresses, frameCounts, readError) + " compared to "
+                                            + getDebugString(bufferAddresses, firstFrameCounts, readError)));
+                        } else {
+                            errors.add(EvioHeaderError.APV_BUFFER_ADDRESS_MISMATCH);
+                        }
+
+                    }
+
+                    // Check that apv frame count match
+                    if (!Arrays.equals(firstFrameCounts, frameCounts)) {
+                        if (this.generateDebugStrings) {
+                            errors.add(new EvioHeaderError(
+                                    ErrorType.ApvBufferAddress,
+                                    EvioHeaderError.APV_FRAME_COUNT_MISMATCH.getMessage(),
+                                    getMultisampleDebugString(headerDataInfo,
+                                            SvtEvioUtils.getMultisampleTailWord(multisampleHeader)) + 
+                                            getDebugString(bufAddresses, frameCounts, readError) + " compared to " + 
+                                            getDebugString(bufferAddresses, firstFrameCounts, readError))
+                                    );
+                        } else {
+                            errors.add(EvioHeaderError.APV_FRAME_COUNT_MISMATCH);
+                        }
+                    }
+                }
+
+                // Check that the APV frame counts are incrementing
+                // remember to take into account the 2-bit rollover (duh!)
+
+                count = -1;
+                for (int iFrame = 0; iFrame < frameCounts.length; ++iFrame) {
+                    LOGGER.fine("frame count " + iFrame + "  " + frameCounts[iFrame] + " ( "
+                            + Integer.toHexString(frameCounts[iFrame]) + " )");
+
+                    if (frameCounts[iFrame] > 15 || (count < 15 && frameCounts[iFrame] < count)
+                            || (count == 15 && frameCounts[iFrame] != 0)) {
+
+                        if (this.generateDebugStrings) {
+                            errors.add(
+                                    new EvioHeaderError(ErrorType.ApvFrameCount,
+                                            EvioHeaderError.APV_FRAME_COUNT.getMessage(),
+                                            getMultisampleDebugString(headerDataInfo,
+                                                    SvtEvioUtils.getMultisampleTailWord(multisampleHeader))
+                                                    + getDebugString(bufAddresses, frameCounts, readError))
+                                    );
+                        } else {
+                            // FIXME: Is this error type specific enough here?
+                            errors.add(EvioHeaderError.APV_FRAME_COUNT);
+                        }
+                    }
+                    count = frameCounts[iFrame];
+                }
+
+                for (int iReadError = 0; iReadError < readError.length; ++iReadError) {
+                    LOGGER.finest("read error " + iReadError + "  " + readError[iReadError] + " ( "
+                            + Integer.toHexString(readError[iReadError]) + " )");
+
+                    if (readError[iReadError] != 1) {// active low
+                        if (this.generateDebugStrings) {
+                            errors.add(
+                                    new EvioHeaderError(ErrorType.ApvRead, EvioHeaderError.APV_READ_ERRORS.getMessage(),
+                                            getMultisampleDebugString(headerDataInfo,
+                                                    SvtEvioUtils.getMultisampleTailWord(multisampleHeader))
+                                                    + getDebugString(bufAddresses, frameCounts, readError)));                        
+                        } else {
+                            errors.add(EvioHeaderError.APV_READ_ERRORS);
+                        }
+                    }
+                }
+
+            } // multisampleheaders
+
+            // Add additional errors from header data.
+            addSvtHeaderDataErrors(headerDataInfo, errors);
+        }
+
+        return errors;
+    }
+    
+    private void addSvtHeaderDataErrors(SvtHeaderDataInfo header, List<EvioHeaderError> errors)  {
+        
+        int tail = header.getTail();
+        LOGGER.finest("checkSvtHeaderData tail " + tail + "( " + Integer.toHexString(tail) + " ) " +
+                                                 " errorbit   " +  Integer.toHexString(SvtEvioUtils.getSvtTailSyncErrorBit(tail)) +
+                                                 " OFerrorbit " +  Integer.toHexString(SvtEvioUtils.getSvtTailOFErrorBit(tail)) + 
+                                                 " checkSvtHeaderData skipcount  " +  Integer.toHexString(SvtEvioUtils.getSvtTailMultisampleSkipCount(tail)));
+               
+        // FIXME: Should this really be else/if or can these all occur separately?
+        if( SvtEvioUtils.getSvtTailSyncErrorBit(tail) != 0) {
+            if (this.generateDebugStrings) {
+                errors.add(new EvioHeaderError(ErrorType.Sync, EvioHeaderError.SYNC.getMessage(), 
+                        getHeaderDebugString(header)));
+            } else {
+                errors.add(EvioHeaderError.SYNC);
+            }
+
+        } else if(SvtEvioUtils.getSvtTailOFErrorBit(tail) != 0) {
+            if (this.generateDebugStrings) {
+                errors.add(new EvioHeaderError(ErrorType.Overflow, EvioHeaderError.OVERFLOW.getMessage(), 
+                        getHeaderDebugString(header)));
+            } else {
+                errors.add(EvioHeaderError.OVERFLOW);
+            }
+        } else if(SvtEvioUtils.getSvtTailMultisampleSkipCount(tail) != 0) {
+            if (this.generateDebugStrings) {
+                errors.add(new EvioHeaderError(ErrorType.SkipCount, EvioHeaderError.SKIP_COUNT.getMessage(), 
+                        SvtEvioUtils.getSvtTailMultisampleSkipCount(tail) + " error " + getHeaderDebugString(header)));               
+            } else {
+                errors.add(EvioHeaderError.SKIP_COUNT);
+            }
+        } 
+    }
+}

--- a/record-util/src/main/java/org/hps/record/svt/SvtEvioExceptions.java
+++ b/record-util/src/main/java/org/hps/record/svt/SvtEvioExceptions.java
@@ -30,7 +30,7 @@ public class SvtEvioExceptions {
          * @param error The header error that occurred
          */
         public SvtEvioHeaderException(EvioHeaderError error) {
-            super(error.getType() + ": " + error.getMessage() + '\n' + error.getDebugString());
+            super(error.getType().name() + ": " + error.getMessage() + '\n' + error.getDebugString());
         }
 
         public SvtEvioHeaderException(SvtEvioHeaderException e) {

--- a/record-util/src/main/java/org/hps/record/svt/SvtEvioExceptions.java
+++ b/record-util/src/main/java/org/hps/record/svt/SvtEvioExceptions.java
@@ -25,11 +25,19 @@ public class SvtEvioExceptions {
             super(message);
         }
 
+        /**
+         * Add constructor that takes an {@link EvioHeaderError} instance
+         * @param error The header error that occurred
+         */
+        public SvtEvioHeaderException(EvioHeaderError error) {
+            super(error.getType() + ": " + error.getMessage() + '\n' + error.getDebugString());
+        }
+
         public SvtEvioHeaderException(SvtEvioHeaderException e) {
             super(e);
         }
     }
-
+    
     public static class SvtEvioHeaderSyncErrorException extends SvtEvioHeaderException {
 
         public SvtEvioHeaderSyncErrorException(String message) {


### PR DESCRIPTION
This PR revises a number of classes involved with SVT EVIO data conversion so that they no longer cause severe memory leaks and hanging of data processing. 

Direct generation of exceptions was removed from header error checking in favor of using a more lightweight data class. 

A memory leak in the SVT EVIO reader where header data was not being cleared between events was found and corrected.

The recon ITs on 2015 and 2016 data work now from Run2019Master and no longer hang indefinitely. Processing time is about 14 events a second, and 4000 events from the 2016 run were processed in under 5 minutes, including initialization time.