### PR TITLE
Iss622

### DIFF
--- a/detector-model/src/main/java/org/lcsim/geometry/compact/converter/HPSTracker2014GeometryDefinition.java
+++ b/detector-model/src/main/java/org/lcsim/geometry/compact/converter/HPSTracker2014GeometryDefinition.java
@@ -2200,7 +2200,7 @@ public class HPSTracker2014GeometryDefinition extends HPSTrackerGeometryDefiniti
                 layerOffset = 7;
             }
             
-            l = 7 + (layer - 4) * 4;
+            l = layerOffset + (layer - 4) * 4;
             int s = -1;
             if (isTopLayer) {
                 s = 0;

--- a/detector-model/src/main/java/org/lcsim/geometry/compact/converter/HPSTracker2014GeometryDefinition.java
+++ b/detector-model/src/main/java/org/lcsim/geometry/compact/converter/HPSTracker2014GeometryDefinition.java
@@ -2185,7 +2185,21 @@ public class HPSTracker2014GeometryDefinition extends HPSTrackerGeometryDefiniti
             // axial - slot: 9
             // stereo - hole: 8
             // axial - slot: 10
-
+            
+            int layerOffset = -1;
+            String detType = node.getAttributeValue("type");
+            if (detType.contains("2019")) {
+                layerOffset = 5;
+            }
+            else if (detType.contains("2016")) {
+                layerOffset = 7;
+            }
+            //Defaulting to 2016 in the case the year is not specified in the compact
+            else {
+                //System.out.printf("WARNING: %s getMillepedeLayer:: couldn't read tracker year from compact.xml. Default to 2016 tracker geo. ", getClass().getSimpleName());
+                layerOffset = 7;
+            }
+            
             l = 7 + (layer - 4) * 4;
             int s = -1;
             if (isTopLayer) {


### PR DESCRIPTION
The millepedeLayer ID was off alignment for 2019 geometry because IDs 9 and 10 were skipped, while they should have been assigned to Layer 5. Added a check on the compact.xml in getMillepedeLayer in HPSTracker2014GeometryDefinition that tries to get the year. 
*Assumption*: The compact.xml specifies the year in the tracker subdetector type attribute, otherwise 2016 geometry is assumed. 

