### PR TITLE
Iss630

### DIFF
--- a/tracking/src/main/java/org/hps/recon/tracking/gbl/GBLRefitterDriver.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/gbl/GBLRefitterDriver.java
@@ -1,9 +1,7 @@
 package org.hps.recon.tracking.gbl;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import org.apache.commons.math3.util.Pair;
 import org.hps.recon.tracking.MaterialSupervisor;

--- a/tracking/src/main/java/org/hps/recon/tracking/gbl/GBLRefitterDriver.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/gbl/GBLRefitterDriver.java
@@ -49,6 +49,18 @@ public class GBLRefitterDriver extends Driver {
     private String milleBinaryFileName = MilleBinary.DEFAULT_OUTPUT_FILE_NAME;
     private boolean writeMilleBinary = false;
     private double writeMilleChi2Cut = 20;
+    private boolean includeNoHitScatters = false;
+    
+    //Setting 0 is a single refit, 1 refit twice and so on..
+    private int gblRefitIterations = 5; 
+
+    public void setIncludeNoHitScatters(boolean val) {
+        includeNoHitScatters = val;
+    }
+    
+    public void setGblRefitIterations(int val) {
+        gblRefitIterations = val;
+    }
 
     public void setWriteMilleChi2Cut(int input) {
         writeMilleChi2Cut = input;
@@ -151,15 +163,15 @@ public class GBLRefitterDriver extends Driver {
 
         List<GBLKinkData> kinkDataCollection = new ArrayList<GBLKinkData>();
         List<LCRelation> kinkDataRelations = new ArrayList<LCRelation>();
-
-        Map<Track, Track> inputToRefitted = new HashMap<Track, Track>();
+        
+        //Map<Track, Track> inputToRefitted = new HashMap<Track, Track>();
         for (Track track : tracks) {
             List<TrackerHit> temp = TrackUtils.getStripHits(track, hitToStrips, hitToRotated);
             if (temp.size() == 0)
                 //               System.out.println("GBLRefitterDriver::process  did not find any strip hits on this track???");
                 continue;
 
-            Pair<Pair<Track, GBLKinkData>, FittedGblTrajectory> newTrackTraj = MakeGblTracks.refitTrackWithTraj(TrackUtils.getHTF(track), temp, track.getTrackerHits(), 5, track.getType(), _scattering, bfield, storeTrackStates);
+            Pair<Pair<Track, GBLKinkData>, FittedGblTrajectory> newTrackTraj = MakeGblTracks.refitTrackWithTraj(TrackUtils.getHTF(track), temp, track.getTrackerHits(), gblRefitIterations, track.getType(), _scattering, bfield, storeTrackStates,includeNoHitScatters);
             if (newTrackTraj == null) {
                 System.out.println("GBLRefitterDriver::process() -- Aborted refit of track -- null pointer for newTrackTraj returned from MakeGblTracks.refitTrackWithTraj .");
                 continue;
@@ -177,7 +189,8 @@ public class GBLRefitterDriver extends Driver {
                 continue;
             refittedTracks.add(gblTrk);
             trackRelations.add(new BaseLCRelation(track, gblTrk));
-            inputToRefitted.put(track, gblTrk);
+            //PF :: unused
+            //inputToRefitted.put(track, gblTrk);
             kinkDataCollection.add(newTrack.getSecond());
             kinkDataRelations.add(new BaseLCRelation(newTrack.getSecond(), gblTrk));
         }

--- a/tracking/src/main/java/org/hps/recon/tracking/gbl/GBLStripClusterData.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/gbl/GBLStripClusterData.java
@@ -17,9 +17,17 @@ public class GBLStripClusterData implements GenericObject {
      * Interface enumerator to access the correct data
      */
     public static class GBLINT {
-
+        
+        //Millepede ID + Volume will identify the sensor where the strip cluster data is located
+        
+        //The millepede ID
         public static final int ID = 0;
-        public static final int BANK_INT_SIZE = 1;
+        //Top or bottom (0 if top volume, 1 if bottom volume)
+        public static final int VOL = 1;
+        //Is it a scatterOnly stripCluster
+        public static final int SCAT_ONLY = 2;
+        
+        public static final int BANK_INT_SIZE = 3;
     }
 
     public static class GBLDOUBLE {
@@ -77,19 +85,50 @@ public class GBLStripClusterData implements GenericObject {
     }
 
     /**
-     * @param val set track id to val
+     * @param val set gbl strip cluster id to val
      */
     public void setId(int val) {
         bank_int[GBLINT.ID] = val;
     }
 
     /**
-     * @return track id for this object
+     * @return get gbl strip cluster id for this object
      */
     public int getId() {
         return this.getIntVal(GBLINT.ID);
     }
 
+    /**
+     * @param val set volume to val
+     */
+    public void setVolume(int val) {
+        bank_int[GBLINT.VOL] = val;
+    }
+    
+    /** 
+     * @return volume for this object
+     */
+    
+    public int getVolume() {
+        return this.getIntVal(GBLINT.VOL);
+    }
+
+    
+    /**
+     * @param val set scatterOnly to val
+     */
+    public void setScatterOnly(int val) {
+        bank_int[GBLINT.SCAT_ONLY] = val;
+    }
+    
+    /** 
+     * @return volume for this object
+     */
+    
+    public int getScatterOnly() {
+        return this.getIntVal(GBLINT.SCAT_ONLY);
+    }
+    
     /**
      * Set path length to this strip cluster
      * 

--- a/tracking/src/main/java/org/hps/recon/tracking/gbl/GlobalDers.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/gbl/GlobalDers.java
@@ -1,0 +1,139 @@
+package org.hps.recon.tracking.gbl;
+
+import java.util.List;
+import java.util.ArrayList;
+
+import hep.physics.vec.Hep3Vector;
+import hep.physics.vec.VecOp;
+
+import org.hps.recon.tracking.gbl.matrix.Matrix;
+import org.lcsim.geometry.compact.converter.MilleParameter;
+
+
+public class GlobalDers {
+    
+    private final int _layer;
+    private final Hep3Vector _t; // track direction
+    private final Hep3Vector _p; // track prediction
+    private final Hep3Vector _n; // normal to plane
+    private final Matrix _dm_dg; // Global derivaties of the local measurements
+    private final Matrix _dr_dm; // Derivatives of residuals w.r.t. measurement
+    private final Matrix _dr_dg; // Derivatives of residuals w.r.t. global parameters
+    
+    public GlobalDers(int layer, double umeas, double vmeas, double wmeas, Hep3Vector tDir, Hep3Vector tPred, Hep3Vector normal) {
+        _layer = layer;
+        _t = tDir;
+        _p = tPred;
+        _n = normal;
+        // Derivatives of residuals w.r.t. perturbed measurement
+        _dr_dm = getResDers();
+        // Derivatives of perturbed measurement w.r.t. global parameters
+        _dm_dg = getMeasDers();
+        // Calculate, by chain rule, derivatives of residuals w.r.t. global parameters
+        _dr_dg = _dr_dm.times(_dm_dg);
+
+    }
+
+    /**
+     * Derivative of mt, the perturbed measured coordinate vector m w.r.t. to global parameters:
+     * u,v,w,alpha,beta,gamma
+     */
+    private Matrix getMeasDers() {
+
+        // Derivative of the local measurement for a translation in u
+        double dmu_du = 1.;
+        double dmv_du = 0.;
+        double dmw_du = 0.;
+        // Derivative of the local measurement for a translation in v
+        double dmu_dv = 0.;
+        double dmv_dv = 1.;
+        double dmw_dv = 0.;
+        // Derivative of the local measurement for a translation in w
+        double dmu_dw = 0.;
+        double dmv_dw = 0.;
+        double dmw_dw = 1.;
+        // Derivative of the local measurement for a rotation around u-axis (alpha)
+        double dmu_dalpha = 0.;
+        double dmv_dalpha = _p.z(); // self.wmeas
+        double dmw_dalpha = -1.0 * _p.y(); // -1.0 * self.vmeas
+        // Derivative of the local measurement for a rotation around v-axis (beta)
+        double dmu_dbeta = -1.0 * _p.z(); // -1.0 * self.wmeas
+        double dmv_dbeta = 0.;
+        double dmw_dbeta = _p.x(); // self.umeas
+        // Derivative of the local measurement for a rotation around w-axis (gamma)
+        double dmu_dgamma = _p.y(); // self.vmeas
+        double dmv_dgamma = -1.0 * _p.x(); // -1.0 * self.umeas 
+        double dmw_dgamma = 0.;
+        // put into matrix
+        Matrix dm_dg = new Matrix(3, 6);
+        dm_dg.set(0, 0, dmu_du);
+        dm_dg.set(0, 1, dmu_dv);
+        dm_dg.set(0, 2, dmu_dw);
+        dm_dg.set(0, 3, dmu_dalpha);
+        dm_dg.set(0, 4, dmu_dbeta);
+        dm_dg.set(0, 5, dmu_dgamma);
+        dm_dg.set(1, 0, dmv_du);
+        dm_dg.set(1, 1, dmv_dv);
+        dm_dg.set(1, 2, dmv_dw);
+        dm_dg.set(1, 3, dmv_dalpha);
+        dm_dg.set(1, 4, dmv_dbeta);
+        dm_dg.set(1, 5, dmv_dgamma);
+        dm_dg.set(2, 0, dmw_du);
+        dm_dg.set(2, 1, dmw_dv);
+        dm_dg.set(2, 2, dmw_dw);
+        dm_dg.set(2, 3, dmw_dalpha);
+        dm_dg.set(2, 4, dmw_dbeta);
+        dm_dg.set(2, 5, dmw_dgamma);
+
+        return dm_dg;
+    }
+
+    /**
+     * Derivatives of the local perturbed residual w.r.t. the measurements m (u,v,w)'
+     */
+    private Matrix getResDers() {
+        double tdotn = VecOp.dot(_t, _n);
+        Matrix dr_dm = Matrix.identity(3, 3);
+
+        double delta, val;
+        for (int i = 0; i < 3; ++i) {
+            for (int j = 0; j < 3; ++j) {
+                delta = i == j ? 1. : 0.;
+                val = delta - _t.v()[i] * _n.v()[j] / tdotn;
+                dr_dm.set(i, j, val);
+            }
+        }
+        return dr_dm;
+    }
+
+    /**
+     * Turn derivative matrix into @Milleparameter
+     *
+     * @param isTop - top or bottom track
+     * @return list of @Milleparameters
+     */
+    public List<MilleParameter> getDers(boolean isTop) {
+        int transRot;
+        int direction;
+        int label;
+        double value;
+        List<MilleParameter> milleParameters = new ArrayList<MilleParameter>();
+        int topBot = isTop == true ? 1 : 2;
+        for (int ip = 1; ip < 7; ++ip) {
+            if (ip > 3) {
+                transRot = 2;
+                direction = ((ip - 1) % 3) + 1;
+            } else {
+                transRot = 1;
+                direction = ip;
+            }
+            label = topBot * MilleParameter.half_offset + transRot * MilleParameter.type_offset + direction * MilleParameter.dimension_offset + _layer;
+            value = _dr_dg.get(0, ip - 1);
+            MilleParameter milleParameter = new MilleParameter(label, value, 0.0);
+            milleParameters.add(milleParameter);
+        }
+        return milleParameters;
+    }
+
+}
+

--- a/tracking/src/main/java/org/hps/recon/tracking/gbl/HpsGblRefitter.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/gbl/HpsGblRefitter.java
@@ -17,6 +17,7 @@ import org.hps.recon.tracking.gbl.matrix.Matrix;
 import org.hps.recon.tracking.gbl.matrix.Vector;
 import org.lcsim.geometry.compact.converter.MilleParameter;
 
+
 /**
  * A Driver which refits tracks using GBL. Modeled on the hps-dst code written by Per Hansson and Omar Moreno. Requires
  * the GBL Collections and Relations to be present in the event.
@@ -83,6 +84,10 @@ public class HpsGblRefitter {
             if (debug) {
                 System.out.println("HpsGblFitter: " + "Path length step " + step + " from " + s + " to " + strip.getPath3D());
             }
+            
+            if (strip.getScatterOnly() == 1 && debug) {
+                System.out.println("This is scatter only on sensor: MPID " + strip.getId());
+            }
 
             // get measurement frame unit vectors
             Hep3Vector u = strip.getU();
@@ -138,7 +143,10 @@ public class HpsGblRefitter {
 
             // projection from local (uv) to measurement directions (dm/duv)
             Matrix proL2m = proM2l.copy();
-            proL2m = proL2m.inverse();
+            
+            //Invertible
+            if (strip.getScatterOnly() == 0)
+                proL2m = proL2m.inverse();
 
             if (debug) {
                 System.out.println("HpsGblFitter: " + "proM2l:");
@@ -181,7 +189,9 @@ public class HpsGblRefitter {
 
             GblPoint point = new GblPoint(jacPointToPoint);
             // Add measurement to the point
-            point.addMeasurement(proL2m, meas, measPrec, 0.);
+
+            if (strip.getScatterOnly()==0)
+                point.addMeasurement(proL2m, meas, measPrec, 0.);
             // Add scatterer in curvilinear frame to the point
             // no direction in this frame
             Vector scat = new Vector(2);
@@ -306,132 +316,5 @@ public class HpsGblRefitter {
         jac.set(3, 2, ds * cosl);
         jac.set(4, 1, ds);
         return jac;
-    }
-
-    private static class GlobalDers {
-
-        private final int _layer;
-        private final Hep3Vector _t; // track direction
-        private final Hep3Vector _p; // track prediction
-        private final Hep3Vector _n; // normal to plane
-        private final Matrix _dm_dg; // Global derivaties of the local measurements
-        private final Matrix _dr_dm; // Derivatives of residuals w.r.t. measurement
-        private final Matrix _dr_dg; // Derivatives of residuals w.r.t. global parameters
-
-        public GlobalDers(int layer, double umeas, double vmeas, double wmeas, Hep3Vector tDir, Hep3Vector tPred, Hep3Vector normal) {
-            _layer = layer;
-            _t = tDir;
-            _p = tPred;
-            _n = normal;
-            // Derivatives of residuals w.r.t. perturbed measurement
-            _dr_dm = getResDers();
-            // Derivatives of perturbed measurement w.r.t. global parameters
-            _dm_dg = getMeasDers();
-            // Calculate, by chain rule, derivatives of residuals w.r.t. global parameters
-            _dr_dg = _dr_dm.times(_dm_dg);
-
-        }
-
-        /**
-         * Derivative of mt, the perturbed measured coordinate vector m w.r.t. to global parameters:
-         * u,v,w,alpha,beta,gamma
-         */
-        private Matrix getMeasDers() {
-
-            // Derivative of the local measurement for a translation in u
-            double dmu_du = 1.;
-            double dmv_du = 0.;
-            double dmw_du = 0.;
-            // Derivative of the local measurement for a translation in v
-            double dmu_dv = 0.;
-            double dmv_dv = 1.;
-            double dmw_dv = 0.;
-            // Derivative of the local measurement for a translation in w
-            double dmu_dw = 0.;
-            double dmv_dw = 0.;
-            double dmw_dw = 1.;
-            // Derivative of the local measurement for a rotation around u-axis (alpha)
-            double dmu_dalpha = 0.;
-            double dmv_dalpha = _p.z(); // self.wmeas
-            double dmw_dalpha = -1.0 * _p.y(); // -1.0 * self.vmeas
-            // Derivative of the local measurement for a rotation around v-axis (beta)
-            double dmu_dbeta = -1.0 * _p.z(); // -1.0 * self.wmeas
-            double dmv_dbeta = 0.;
-            double dmw_dbeta = _p.x(); // self.umeas
-            // Derivative of the local measurement for a rotation around w-axis (gamma)
-            double dmu_dgamma = _p.y(); // self.vmeas
-            double dmv_dgamma = -1.0 * _p.x(); // -1.0 * self.umeas 
-            double dmw_dgamma = 0.;
-            // put into matrix
-            Matrix dm_dg = new Matrix(3, 6);
-            dm_dg.set(0, 0, dmu_du);
-            dm_dg.set(0, 1, dmu_dv);
-            dm_dg.set(0, 2, dmu_dw);
-            dm_dg.set(0, 3, dmu_dalpha);
-            dm_dg.set(0, 4, dmu_dbeta);
-            dm_dg.set(0, 5, dmu_dgamma);
-            dm_dg.set(1, 0, dmv_du);
-            dm_dg.set(1, 1, dmv_dv);
-            dm_dg.set(1, 2, dmv_dw);
-            dm_dg.set(1, 3, dmv_dalpha);
-            dm_dg.set(1, 4, dmv_dbeta);
-            dm_dg.set(1, 5, dmv_dgamma);
-            dm_dg.set(2, 0, dmw_du);
-            dm_dg.set(2, 1, dmw_dv);
-            dm_dg.set(2, 2, dmw_dw);
-            dm_dg.set(2, 3, dmw_dalpha);
-            dm_dg.set(2, 4, dmw_dbeta);
-            dm_dg.set(2, 5, dmw_dgamma);
-
-            return dm_dg;
-        }
-
-        /**
-         * Derivatives of the local perturbed residual w.r.t. the measurements m (u,v,w)'
-         */
-        private Matrix getResDers() {
-            double tdotn = VecOp.dot(_t, _n);
-            Matrix dr_dm = Matrix.identity(3, 3);
-
-            double delta, val;
-            for (int i = 0; i < 3; ++i) {
-                for (int j = 0; j < 3; ++j) {
-                    delta = i == j ? 1. : 0.;
-                    val = delta - _t.v()[i] * _n.v()[j] / tdotn;
-                    dr_dm.set(i, j, val);
-                }
-            }
-            return dr_dm;
-        }
-
-        /**
-         * Turn derivative matrix into @Milleparameter
-         *
-         * @param isTop - top or bottom track
-         * @return list of @Milleparameters
-         */
-        private List<MilleParameter> getDers(boolean isTop) {
-            int transRot;
-            int direction;
-            int label;
-            double value;
-            List<MilleParameter> milleParameters = new ArrayList<MilleParameter>();
-            int topBot = isTop == true ? 1 : 2;
-            for (int ip = 1; ip < 7; ++ip) {
-                if (ip > 3) {
-                    transRot = 2;
-                    direction = ((ip - 1) % 3) + 1;
-                } else {
-                    transRot = 1;
-                    direction = ip;
-                }
-                label = topBot * MilleParameter.half_offset + transRot * MilleParameter.type_offset + direction * MilleParameter.dimension_offset + _layer;
-                value = _dr_dg.get(0, ip - 1);
-                MilleParameter milleParameter = new MilleParameter(label, value, 0.0);
-                milleParameters.add(milleParameter);
-            }
-            return milleParameters;
-        }
-
     }
 }

--- a/tracking/src/main/java/org/hps/recon/tracking/gbl/MakeGblTracks.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/gbl/MakeGblTracks.java
@@ -19,6 +19,7 @@ import org.hps.recon.tracking.TrackType;
 import org.hps.recon.tracking.TrackUtils;
 import org.lcsim.constants.Constants;
 import org.lcsim.detector.ITransform3D;
+import org.lcsim.detector.IDetectorElement;
 import org.lcsim.detector.tracker.silicon.ChargeCarrier;
 import org.lcsim.detector.tracker.silicon.HpsSiSensor;
 import org.lcsim.detector.tracker.silicon.SiSensor;
@@ -172,23 +173,23 @@ public class MakeGblTracks {
      * @return The refitted track.
      */
     public static Pair<Track, GBLKinkData> refitTrack(HelicalTrackFit helix, Collection<TrackerHit> stripHits, Collection<TrackerHit> hth, int nIterations, int trackType, MultipleScattering scattering, double bfield, boolean storeTrackStates) {
-        Pair<Pair<Track, GBLKinkData>, FittedGblTrajectory> refitTrack = refitTrackWithTraj(helix, stripHits, hth, nIterations, trackType, scattering, bfield, storeTrackStates);
+        Pair<Pair<Track, GBLKinkData>, FittedGblTrajectory> refitTrack = refitTrackWithTraj(helix, stripHits, hth, nIterations, trackType, scattering, bfield, storeTrackStates,false);
         if(refitTrack == null)
             return null;
         else
             return refitTrack.getFirst();
     }
 
-    public static Pair<Pair<Track, GBLKinkData>, FittedGblTrajectory> refitTrackWithTraj(HelicalTrackFit helix, Collection<TrackerHit> stripHits, Collection<TrackerHit> hth, int nIterations, int trackType, MultipleScattering scattering, double bfield, boolean storeTrackStates) {
+    public static Pair<Pair<Track, GBLKinkData>, FittedGblTrajectory> refitTrackWithTraj(HelicalTrackFit helix, Collection<TrackerHit> stripHits, Collection<TrackerHit> hth, int nIterations, int trackType, MultipleScattering scattering, double bfield, boolean storeTrackStates,boolean includeMS) {
 
         List<TrackerHit> allHthList = TrackUtils.sortHits(hth);
         List<TrackerHit> sortedStripHits = TrackUtils.sortHits(stripHits);
-        FittedGblTrajectory fit = doGBLFit(helix, sortedStripHits, scattering, bfield, 0);
+        FittedGblTrajectory fit = doGBLFit(helix, sortedStripHits, scattering, bfield, 0,includeMS);
         if(fit==null) return null;
         for (int i = 0; i < nIterations; i++) {
             Pair<Track, GBLKinkData> newTrack = makeCorrectedTrack(fit, helix, allHthList, trackType, bfield);
             helix = TrackUtils.getHTF(newTrack.getFirst());
-            fit = doGBLFit(helix, sortedStripHits, scattering, bfield, 0);
+            fit = doGBLFit(helix, sortedStripHits, scattering, bfield, 0,includeMS);
             if (fit == null)
                 return null;
         }
@@ -208,8 +209,8 @@ public class MakeGblTracks {
      * @param debug - debug flag.
      * @return the fitted GBL trajectory
      */
-    public static FittedGblTrajectory doGBLFit(HelicalTrackFit htf, List<TrackerHit> stripHits, MultipleScattering _scattering, double bfield, int debug) {
-        List<GBLStripClusterData> stripData = makeStripData(htf, stripHits, _scattering, bfield, debug);
+    public static FittedGblTrajectory doGBLFit(HelicalTrackFit htf, List<TrackerHit> stripHits, MultipleScattering _scattering, double bfield, int debug,boolean includeMS) {
+        List<GBLStripClusterData> stripData = makeStripData(htf, stripHits, _scattering, bfield, debug, includeMS);
         if (stripData == null)
             return null;
         double bfac = Constants.fieldConversion * bfield;
@@ -228,33 +229,111 @@ public class MakeGblTracks {
      * @param _debug
      * @return the list of GBL strip cluster data
      */
-    public static List<GBLStripClusterData> makeStripData(HelicalTrackFit htf, List<TrackerHit> stripHits, MultipleScattering _scattering, double _B, int _debug) {
+    public static List<GBLStripClusterData> makeStripData(HelicalTrackFit htf, List<TrackerHit> stripHits, MultipleScattering _scattering, double _B, int _debug,boolean includeMS) {
         List<GBLStripClusterData> stripClusterDataList = new ArrayList<GBLStripClusterData>();
 
         // Find scatter points along the path
+        //In principle I could use this to add the hits - TODO ?
         MultipleScattering.ScatterPoints scatters = _scattering.FindHPSScatterPoints(htf);
+        
+        //Loop over the Scatters
+        
+        //Two things can happen here at each iteration:
+        //1) Nscatters >= Nhits on tracks =>
+        //   Build GBLStripClusterData for both measurements and scatters
+        //2) Nscatters < Nhits on track =>
+        //   The hit has been associated to the track but couldn't find the scatter on the volume => create a scatter at that sensor
+        //   Does this makes sense?
 
-        for (TrackerHit stripHit : stripHits) {
-            HelicalTrackStripGbl strip;
-            if (stripHit instanceof SiTrackerHitStrip1D) {
-                strip = new HelicalTrackStripGbl(makeDigiStrip((SiTrackerHitStrip1D) stripHit), true);
-            } else {
-                SiTrackerHitStrip1D newHit = new SiTrackerHitStrip1D(stripHit);
-                strip = new HelicalTrackStripGbl(makeDigiStrip(newHit), true);
-            }
-            HpsSiSensor sensor = (HpsSiSensor) ((RawTrackerHit) stripHit.getRawHits().get(0)).getDetectorElement();
-            MultipleScattering.ScatterPoint temp = scatters.getScatterPoint(((RawTrackerHit) strip.getStrip().rawhits().get(0)).getDetectorElement());
-            if (temp == null){
-                temp = getScatterPointGbl(sensor, strip, htf, _scattering, _B);
-                if(temp == null){
-                    return null;
+        //Case (1)
+        //Check if the scatter has a measurement => then use the usual way to build the HelicalTrackStripGbl
+        
+        int nhits = 0;
+        int nscatters = 0;
+        boolean addScatters = true;
+            
+        if (scatters.getPoints().size() >= stripHits.size() && includeMS) {
+            
+            for (MultipleScattering.ScatterPoint scatter : scatters.getPoints()) {
+            
+                boolean MeasOnScatter = false;
+            
+                //This is bit inefficient as it always loop on all the stripHits
+                //TODO: optimize and only check hit once if is in the scatters.
+                
+                HpsSiSensor scatter_sensor = (HpsSiSensor) scatter.getDet();
+            
+                for (TrackerHit stripHit : stripHits) {
+                
+                    if (MeasOnScatter)
+                        continue;
+                
+                    IDetectorElement det_element = ((RawTrackerHit) stripHit.getRawHits().get(0)).getDetectorElement();
+                
+                    if (det_element.equals(scatter.getDet())) {
+                        MeasOnScatter = true;
+                        HpsSiSensor hit_sensor = (HpsSiSensor) det_element;
+                        nhits+=1;
+                        HelicalTrackStripGbl gbl_strip;
+                        if (stripHit instanceof SiTrackerHitStrip1D) {
+                            gbl_strip = new HelicalTrackStripGbl(makeDigiStrip((SiTrackerHitStrip1D) stripHit),true);
+                        } else {
+                            SiTrackerHitStrip1D newHit = new SiTrackerHitStrip1D(stripHit);
+                            gbl_strip = new HelicalTrackStripGbl(makeDigiStrip(newHit), true);
+                        }
+                        //hit_sensor or scatter_sensor, they are the same here
+                        GBLStripClusterData stripData = makeStripData(hit_sensor, gbl_strip, htf, scatter);
+                        if (stripData != null) {
+                            stripClusterDataList.add(stripData); 
+                        }
+                        else {
+                            System.out.printf("WARNING::MakeGblTracks::Couldn't make stripClusterData for hps sensor. Skipping scatter");
+                        }
+                    }
                 }
+            
+                if (!MeasOnScatter && addScatters) {
+                    //No measurement
+                    nscatters+=1;
+                    //If the scatter has no measurement => then only build a scatter point 
+                    //Here only scatter sensor is available
+                    GBLStripClusterData stripData = makeScatterOnlyData(scatter_sensor,htf,scatter);
+                    
+                    if (stripData != null) {
+                        stripClusterDataList.add(stripData);
+                    }
+                }
+            } // loop on scatters
+        } // more scatters than hits
+        
+        else { //more hits than scatters 
+            
+   
+            for (TrackerHit stripHit : stripHits) {
+                HelicalTrackStripGbl strip;
+                if (stripHit instanceof SiTrackerHitStrip1D) {
+                    strip = new HelicalTrackStripGbl(makeDigiStrip((SiTrackerHitStrip1D) stripHit), true);
+                } else {
+                    SiTrackerHitStrip1D newHit = new SiTrackerHitStrip1D(stripHit);
+                    strip = new HelicalTrackStripGbl(makeDigiStrip(newHit),true);
+                }
+                HpsSiSensor sensor = (HpsSiSensor) ((RawTrackerHit) stripHit.getRawHits().get(0)).getDetectorElement();
+                MultipleScattering.ScatterPoint temp = scatters.getScatterPoint(((RawTrackerHit) strip.getStrip().rawhits().get(0)).getDetectorElement());
+                
+                //This is done to correct the fact that the helical fit might not hit a volume
+                //But hit is associated to the track => must scatter
+                if (temp == null){
+                    temp = getScatterPointGbl(sensor, strip, htf, _scattering, _B);
+                    if(temp == null){
+                        return null;
+                    }
+                }
+                GBLStripClusterData stripData = makeStripData(sensor, strip, htf, temp);
+                if (stripData != null)
+                    stripClusterDataList.add(stripData);
             }
-            GBLStripClusterData stripData = makeStripData(sensor, strip, htf, temp);
-            if (stripData != null)
-                stripClusterDataList.add(stripData);
         }
-
+        
         return stripClusterDataList;
     }
 
@@ -274,6 +353,46 @@ public class MakeGblTracks {
 
         return temp;
     }
+    
+    public static GBLStripClusterData makeScatterOnlyData(HpsSiSensor sensor, HelicalTrackFit htf, MultipleScattering.ScatterPoint temp) {
+        
+        if (temp ==null)
+            return null;
+        
+        // find Millepede layer definition from DetectorElement
+        int millepedeId = sensor.getMillepedeId();
+        // find volume of the sensor (top or bottom)
+        int volume = sensor.isTopLayer() ? 0 : 1;
+                                                
+        // GBLDATA
+        GBLStripClusterData stripData = new GBLStripClusterData(millepedeId);
+        stripData.setVolume(volume);
+        
+        //This GBLStripData doesn't hold a measurement
+        stripData.setScatterOnly(1);
+
+        double s3D = temp.getScatterAngle().PathLen() / Math.cos(Math.atan(htf.slope()));
+        stripData.setPath(temp.getScatterAngle().PathLen());
+        stripData.setPath3D(s3D);
+        
+        //Do not set U,V,W
+        
+        // Print track direction at intercept
+        double phi = htf.phi0() - temp.getScatterAngle().PathLen() / htf.R();
+        double lambda = Math.atan(htf.slope());
+        
+        stripData.setTrackDir(temp.getDirection());
+        stripData.setTrackPhi(phi);
+        stripData.setTrackLambda(lambda);
+        
+        //Do not set the measurement. 
+        //Set a negative large error
+        stripData.setMeasErr(-9999);
+
+        stripData.setScatterAngle(temp.getScatterAngle().Angle());
+        
+        return stripData;
+    }
 
     public static GBLStripClusterData makeStripData(HpsSiSensor sensor, HelicalTrackStripGbl strip, HelicalTrackFit htf, MultipleScattering.ScatterPoint temp) {
         if (temp == null)
@@ -281,12 +400,21 @@ public class MakeGblTracks {
 
         // find Millepede layer definition from DetectorElement
         int millepedeId = sensor.getMillepedeId();
+        // find volume of the sensor (top or bottom)
+        int volume = sensor.isTopLayer() ? 0 : 1;
 
         // Center of the sensor
         Hep3Vector origin = strip.origin();
 
         // GBLDATA
         GBLStripClusterData stripData = new GBLStripClusterData(millepedeId);
+
+        // Add the volume
+        stripData.setVolume(volume);
+
+        //This GBLStripData holds a measurement
+        stripData.setScatterOnly(0);
+        
         // Add to output list
 
         // path length to intercept


### PR DESCRIPTION
The changes in this merge request are for adding the Multiple Coulomb Scattering  computation for traversed sensors where hit-on-track is not present:
- Before MCS was only added for measurements on track, while now it's added also for holes-on-track (track hypothesis traverses a sensor but there isn't a hit associated). 
- This "new" behaviour is OFF by default (original behaviour is used) but can be turned on by setting includeMS flag in the GBLRefitterDriver.
- Checked that doesn't break things and the effect (see:
https://confluence.slac.stanford.edu/display/hpsg/10.28.2019+Weekly)
- Added control on GBL refit iterations from steering file
- Moved out GlobalDers from the refitter to stand-alone .java just to clean up code
- Modified GBLStripClusterData to hold information on millepedeID, volume and if it's a hit+scatter or scatter only

- Tested compilation and run-time 