### PR TITLE
Fix to un-initialized matrix in gbl when interpolating 

### DIFF
--- a/tracking/src/main/java/org/hps/recon/tracking/gbl/GblTrajectory.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/gbl/GblTrajectory.java
@@ -358,11 +358,10 @@ public class GblTrajectory {
             Matrix matN = new Matrix(2, 2);
             Vector prevWd = new Vector(2);
             Vector nextWd = new Vector(2);
-            int ierr;
             aPoint.getDerivatives(0, prevW, prevWJ, prevWd); // W-, W- * J-, W- * d-
             aPoint.getDerivatives(1, nextW, nextWJ, nextWd); // W-, W- * J-, W- * d-
             Matrix sumWJ = prevWJ.plus(nextWJ);
-            // ? matN = sumWJ.inverse(ierr); // N = (W- * J- + W+ * J+)^-1
+            matN = sumWJ.inverse(); // N = (W- * J- + W+ * J+)^-1
             // derivatives for u_int
             Matrix prevNW = matN.times(prevW); // N * W-
             Matrix nextNW = matN.times(nextW); // N * W+


### PR DESCRIPTION
This fix will not affect track reconstruction (nOffset is >=0 in hps track reconstruction), however some derivative matrices are computed with matrices that are zero. This affects when checking the GBL internal math with the gbl examples. 
After this fix I am able to reproduce the results of C++ implementation of the gbl examples on svn desy repo. 
Fix should be trivial. Checked that the results are correct using gbl C++ example code. 