### PR TITLE
Iss #663 and #662 - Guards around bad SVT hit codes.

### DIFF
--- a/evio/src/main/java/org/hps/evio/AbstractSvtEvioReader.java
+++ b/evio/src/main/java/org/hps/evio/AbstractSvtEvioReader.java
@@ -299,14 +299,18 @@ public abstract class AbstractSvtEvioReader extends EvioReader {
         // Get the sensor associated with this sample
         HpsSiSensor sensor = this.getSensor(data);
         
-        // Use the channel number to create the cell ID
-        long cellID = sensor.makeChannelID(channel);
+        if (sensor != null) {
+            // Use the channel number to create the cell ID
+            long cellID = sensor.makeChannelID(channel);
+            
+            // Set the hit time.  For now this will be zero
+            int hitTime = 0;
         
-        // Set the hit time.  For now this will be zero
-        int hitTime = 0;
-    
-        // Create and return a RawTrackerHit
-        return new BaseRawTrackerHit(hitTime, cellID, SvtEvioUtils.getSamples(data), null, sensor);
+            // Create and return a RawTrackerHit
+            return new BaseRawTrackerHit(hitTime, cellID, SvtEvioUtils.getSamples(data), null, sensor);
+        }else {
+            return(null);
+        }
     }
 
 }

--- a/evio/src/main/java/org/hps/evio/AbstractSvtEvioReader.java
+++ b/evio/src/main/java/org/hps/evio/AbstractSvtEvioReader.java
@@ -309,6 +309,7 @@ public abstract class AbstractSvtEvioReader extends EvioReader {
             // Create and return a RawTrackerHit
             return new BaseRawTrackerHit(hitTime, cellID, SvtEvioUtils.getSamples(data), null, sensor);
         }else {
+            LOGGER.warning("makeHit: Bad sensor codes in hit evio data: " + data.toString());
             return(null);
         }
     }

--- a/evio/src/main/java/org/hps/evio/AbstractSvtEvioReader.java
+++ b/evio/src/main/java/org/hps/evio/AbstractSvtEvioReader.java
@@ -309,7 +309,7 @@ public abstract class AbstractSvtEvioReader extends EvioReader {
             // Create and return a RawTrackerHit
             return new BaseRawTrackerHit(hitTime, cellID, SvtEvioUtils.getSamples(data), null, sensor);
         }else {
-            LOGGER.warning("makeHit: Bad sensor codes in hit evio data: " + data.toString());
+            LOGGER.warning("makeHit: Bad sensor codes in hit evio data. " );
             return(null);
         }
     }

--- a/evio/src/main/java/org/hps/evio/Phys2019SvtEvioReader.java
+++ b/evio/src/main/java/org/hps/evio/Phys2019SvtEvioReader.java
@@ -171,7 +171,11 @@ public class Phys2019SvtEvioReader extends AbstractSvtEvioReader {
         List< int[] > multiSamples = extractMultiSamples(0, data);
 
         for (int[] samples : multiSamples) { 
-            rawHits.add(this.makeHit(samples)); 
+//            rawHits.add(this.makeHit(samples)); 
+            RawTrackerHit hit = this.makeHit(samples);
+            if (hit != null) {
+                rawHits.add(hit); 
+            }
         }
 
         return rawHits;

--- a/evio/src/main/java/org/hps/evio/SvtEvioReader.java
+++ b/evio/src/main/java/org/hps/evio/SvtEvioReader.java
@@ -267,7 +267,10 @@ public class SvtEvioReader extends AbstractSvtEvioReader {
             if (!this.isValidSampleSet(samples)) continue;
         
             // Create raw hits and add them to the list of raw hits
-            rawHits.add(this.makeHit(samples));
+            RawTrackerHit hit = this.makeHit(samples);
+            if (hit != null) {
+                rawHits.add(hit);
+            }
         }
 
         //System.out.println("[ SvtEvioReader ][ processMultiSamples ]: Got " 


### PR DESCRIPTION
This sets a null pointer guard around the problem reported by Andrea (iss #662). The null propagates so needs to be tested for in several other location. 

Tested on hps_010022.evio.00050 and hps_010022.evio.00107, both files have several thousand events with this error.