### PR TITLE
iss659d -> bring KF into hps-java Reco chain

### DIFF
--- a/analysis/src/main/java/org/hps/analysis/MC/TrackToMCParticleRelationsDriver.java
+++ b/analysis/src/main/java/org/hps/analysis/MC/TrackToMCParticleRelationsDriver.java
@@ -116,14 +116,8 @@ public class TrackToMCParticleRelationsDriver extends Driver {
         //Truth Tracks and Relations
         List<LCRelation> trackToTruthTrackRelations    =  new ArrayList<LCRelation>();
         List<Track>      truthTrackCollection          =  new ArrayList<Track>();
-                
+        
         for (Track track : trackCollection) {
-
-            if (debug) {
-                        System.out.println("-----PRINTING TRACK------- " + trackCollectionName);
-                        System.out.println(trackCollectionName+" Track:");
-                        System.out.printf("d0 %f z0 %f R %f phi %f lambda %s\n", trk_htf.dca(), trk_htf.z0(), trk_htf.R(), trk_htf.phi0(), trk_htf.slope());
-            }
             
             //Truth Matching tool
             TrackTruthMatching ttm = new TrackTruthMatching(track, rawtomc, allsimhits, kalmanTracks);

--- a/analysis/src/main/java/org/hps/analysis/MC/TrackToMCParticleRelationsDriver.java
+++ b/analysis/src/main/java/org/hps/analysis/MC/TrackToMCParticleRelationsDriver.java
@@ -118,49 +118,69 @@ public class TrackToMCParticleRelationsDriver extends Driver {
         List<Track>      truthTrackCollection          =  new ArrayList<Track>();
                 
         for (Track track : trackCollection) {
+
+            if (debug) {
+                        System.out.println("-----PRINTING TRACK------- " + trackCollectionName);
+                        System.out.println(trackCollectionName+" Track:");
+                        System.out.printf("d0 %f z0 %f R %f phi %f lambda %s\n", trk_htf.dca(), trk_htf.z0(), trk_htf.R(), trk_htf.phi0(), trk_htf.slope());
+            }
+            
             //Truth Matching tool
             TrackTruthMatching ttm = new TrackTruthMatching(track, rawtomc, allsimhits, kalmanTracks);
             if (ttm != null) {
                 MCParticle mcp = ttm.getMCParticle();
-                trackToMCParticleRelations.add(new BaseLCRelation(track,mcp));
                 
-                //Hep3Vector origin = new BasicHep3Vector(0.,0.,0.);
-                HelicalTrackFit mcp_htf  = TrackUtils.getHTF(mcp,bfield);
-                HelicalTrackFit trk_htf  = TrackUtils.getHTF(track);
-                
-                if (debug) {
-                    System.out.println("--------------------");
-                    System.out.println(trackCollectionName+" Track:");
-                    System.out.printf("d0 %f z0 %f R %f phi %f lambda %s\n", trk_htf.dca(), trk_htf.z0(), trk_htf.R(), trk_htf.phi0(), trk_htf.slope());
-                    System.out.printf("Nhits = %d \n",ttm.getNHits());
-                    System.out.printf("NGoodHits = %d  purity = %f\n",ttm.getNGoodHits(),ttm.getPurity());
+                if (mcp != null) {
+                    trackToMCParticleRelations.add(new BaseLCRelation(track,mcp));
                     
-                }
-                BaseTrack truth_trk  = new BaseTrack();
-                truth_trk.setTrackParameters(mcp_htf.parameters(),bfield);
-                truth_trk.getTrackStates().clear();
-                double[] ref = new double[] { 0., 0., 0. };
-                SymmetricMatrix cov = new SymmetricMatrix(5);
-                TrackState stateIP = new BaseTrackState(mcp_htf.parameters(),ref,cov.asPackedArray(true),TrackState.AtIP,bfield);
-                truth_trk.getTrackStates().add(stateIP);
-                truth_trk.setChisq(-1);
-                truth_trk.setNDF(-1);
-                truth_trk.setFitSuccess(false);
-                truth_trk.setRefPointIsDCA(true);
-                truth_trk.setTrackType(-1);
-                truthTrackCollection.add(truth_trk);
-                trackToTruthTrackRelations.add(new BaseLCRelation(track,truth_trk));
+                    //Hep3Vector origin = new BasicHep3Vector(0.,0.,0.);
+                    HelicalTrackFit mcp_htf  = TrackUtils.getHTF(mcp,bfield);
+                    HelicalTrackFit trk_htf  = TrackUtils.getHTF(track);
                 
-
-                if (debug) {
-                    double d0    = truth_trk.getTrackStates().get(0).getD0();
-                    double z0    = truth_trk.getTrackStates().get(0).getZ0();
-                    double C     = truth_trk.getTrackStates().get(0).getOmega();
-                    double phi   = truth_trk.getTrackStates().get(0).getPhi();
-                    double slope = truth_trk.getTrackStates().get(0).getTanLambda();
-                    System.out.printf("TruthTrack \n");
-                    System.out.printf("d0 %f z0 %f R %f phi %f lambda %s\n", d0, z0, 1./C, phi, slope);
-                    System.out.println("--------------------");
+                    if (debug) {
+                        System.out.println("--------------------");
+                        System.out.println(trackCollectionName+" Track:");
+                        System.out.printf("d0 %f z0 %f R %f phi %f lambda %s\n", trk_htf.dca(), trk_htf.z0(), trk_htf.R(), trk_htf.phi0(), trk_htf.slope());
+                        System.out.printf("Nhits = %d \n",ttm.getNHits());
+                        System.out.printf("NGoodHits = %d  purity = %f\n",ttm.getNGoodHits(),ttm.getPurity());
+                        
+                    }
+                    BaseTrack truth_trk  = new BaseTrack();
+                    truth_trk.setTrackParameters(mcp_htf.parameters(),bfield);
+                    truth_trk.getTrackStates().clear();
+                    double[] ref = new double[] { 0., 0., 0. };
+                    SymmetricMatrix cov = new SymmetricMatrix(5);
+                    TrackState stateIP = new BaseTrackState(mcp_htf.parameters(),ref,cov.asPackedArray(true),TrackState.AtIP,bfield);
+                    truth_trk.getTrackStates().add(stateIP);
+                    truth_trk.setChisq(-1);
+                    truth_trk.setNDF(-1);
+                    truth_trk.setFitSuccess(false);
+                    truth_trk.setRefPointIsDCA(true);
+                    truth_trk.setTrackType(-1);
+                    truthTrackCollection.add(truth_trk);
+                    trackToTruthTrackRelations.add(new BaseLCRelation(track,truth_trk));
+                    
+                    
+                    if (debug) {
+                        double d0    = truth_trk.getTrackStates().get(0).getD0();
+                        double z0    = truth_trk.getTrackStates().get(0).getZ0();
+                        double C     = truth_trk.getTrackStates().get(0).getOmega();
+                        double phi   = truth_trk.getTrackStates().get(0).getPhi();
+                        double slope = truth_trk.getTrackStates().get(0).getTanLambda();
+                        System.out.printf("TruthTrack \n");
+                        System.out.printf("d0 %f z0 %f R %f phi %f lambda %s\n", d0, z0, 1./C, phi, slope);
+                        System.out.printf("MCParticle  \n");
+                        Hep3Vector pVec = mcp.getMomentum();
+                        System.out.printf("ptTrue = %f \n", Math.sqrt(pVec.x()*pVec.x() + pVec.z()*pVec.z()));
+                        double mom_param = 2.99792458e-04;
+                        double trkMom = trk_htf.R() * bfield * mom_param;
+                        System.out.printf("pt = %f \n", trkMom);
+                        
+                        System.out.println("--------------------");
+                    }
+                }//mcp not null
+                else {
+                    System.out.printf("PF::FakeTrack");
                 }
             } //ttm not null
             else {

--- a/analysis/src/main/java/org/hps/analysis/MC/TrackToMCParticleRelationsDriver.java
+++ b/analysis/src/main/java/org/hps/analysis/MC/TrackToMCParticleRelationsDriver.java
@@ -1,0 +1,176 @@
+package org.hps.analysis.MC;
+
+
+import hep.physics.vec.Hep3Vector;
+//import hep.physics.vec.BasicHep3Vector;
+import hep.physics.matrix.SymmetricMatrix;
+
+import java.util.List;
+import java.util.ArrayList;
+
+import org.lcsim.event.LCRelation;
+import org.lcsim.event.RelationalTable;
+import org.lcsim.event.base.BaseLCRelation;
+import org.lcsim.event.base.BaseRelationalTable;
+
+
+import org.lcsim.event.MCParticle;
+import org.lcsim.event.Track;
+import org.lcsim.event.TrackState;
+import org.lcsim.event.base.BaseTrack;
+import org.lcsim.event.base.BaseTrackState;
+import org.hps.recon.tracking.TrackUtils;
+import org.lcsim.fit.helicaltrack.HelicalTrackFit;
+
+//import org.lcsim.event.TrackerHit;
+import org.lcsim.event.SimTrackerHit;
+import org.lcsim.util.Driver;
+import org.lcsim.geometry.Detector;
+import org.lcsim.event.EventHeader;
+import org.lcsim.lcio.LCIOConstants;
+
+
+/**
+ * @author PF
+ * This driver creates an MCParticle relation to be persisted for each track collection
+ * It also saves a TruthTrack
+ */
+
+
+public class TrackToMCParticleRelationsDriver extends Driver {
+    
+    //Collection Names
+    private String trackCollectionName = "GBLTracks";
+    
+    //If the tracks are kalman tracks
+    private boolean kalmanTracks     = true;
+
+    private double bfield;
+    private double bfield_y;
+
+    private boolean debug = false;
+    private boolean saveTruthTracks = true;
+    
+    
+    public void setTrackCollectionName(String trackCollectionName) {
+        this.trackCollectionName = trackCollectionName;
+    }
+
+    public void setKalmanTracks(boolean val) {
+        kalmanTracks = val;
+    }
+
+    public void setDebug(boolean val) {
+        debug = val;
+    }
+    
+    public void setSaveTruthTracks(boolean val) {
+        saveTruthTracks = val;
+    }
+    
+    /*
+      public void setTrackCollectionNames(String [] trackCollectionNames) {
+      this.trackCollectionNames = trackCollectionNames;
+      }
+    */
+    
+    @Override
+    protected void detectorChanged(Detector detector) {
+        Hep3Vector fieldInTracker = TrackUtils.getBField(detector);
+        bfield = Math.abs(fieldInTracker.y());
+        bfield_y = fieldInTracker.y();
+    }
+    
+    @Override 
+    protected void process(EventHeader event) {
+        
+        //Retrieve track collection
+        List<Track> trackCollection = new ArrayList<Track>();
+        if (trackCollectionName != null) {
+            if (event.hasCollection(Track.class, trackCollectionName)) {
+                trackCollection = event.get(Track.class, trackCollectionName);
+            }
+        }
+        
+        //Retrieve rawhits to mc
+        
+        RelationalTable rawtomc = new BaseRelationalTable(RelationalTable.Mode.MANY_TO_MANY, RelationalTable.Weighting.UNWEIGHTED);
+        if (event.hasCollection(LCRelation.class, "SVTTrueHitRelations")) {
+            List<LCRelation> trueHitRelations = event.get(LCRelation.class, "SVTTrueHitRelations");
+            for (LCRelation relation : trueHitRelations)
+                if (relation != null && relation.getFrom() != null && relation.getTo() != null)
+                    rawtomc.add(relation.getFrom(), relation.getTo());
+        }
+        else
+            return;
+
+        //Retrieve all simulated hits
+        String MCHitInputCollectionName = "TrackerHits";
+        List<SimTrackerHit> allsimhits = event.get(SimTrackerHit.class, MCHitInputCollectionName);
+
+
+        //MCParticleRelations
+        
+        List<LCRelation> trackToMCParticleRelations    =  new ArrayList<LCRelation>();
+        
+        //Truth Tracks and Relations
+        List<LCRelation> trackToTruthTrackRelations    =  new ArrayList<LCRelation>();
+        List<Track>      truthTrackCollection          =  new ArrayList<Track>();
+                
+        for (Track track : trackCollection) {
+            //Truth Matching tool
+            TrackTruthMatching ttm = new TrackTruthMatching(track, rawtomc, allsimhits, kalmanTracks);
+            if (ttm != null) {
+                MCParticle mcp = ttm.getMCParticle();
+                trackToMCParticleRelations.add(new BaseLCRelation(track,mcp));
+                
+                //Hep3Vector origin = new BasicHep3Vector(0.,0.,0.);
+                HelicalTrackFit mcp_htf  = TrackUtils.getHTF(mcp,bfield);
+                HelicalTrackFit trk_htf  = TrackUtils.getHTF(track);
+                
+                if (debug) {
+                    System.out.println("--------------------");
+                    System.out.println(trackCollectionName+" Track:");
+                    System.out.printf("d0 %f z0 %f R %f phi %f lambda %s\n", trk_htf.dca(), trk_htf.z0(), trk_htf.R(), trk_htf.phi0(), trk_htf.slope());
+                    System.out.printf("Nhits = %d \n",ttm.getNHits());
+                    System.out.printf("NGoodHits = %d  purity = %f\n",ttm.getNGoodHits(),ttm.getPurity());
+                    
+                }
+                BaseTrack truth_trk  = new BaseTrack();
+                truth_trk.setTrackParameters(mcp_htf.parameters(),bfield);
+                truth_trk.getTrackStates().clear();
+                double[] ref = new double[] { 0., 0., 0. };
+                SymmetricMatrix cov = new SymmetricMatrix(5);
+                TrackState stateIP = new BaseTrackState(mcp_htf.parameters(),ref,cov.asPackedArray(true),TrackState.AtIP,bfield);
+                truth_trk.getTrackStates().add(stateIP);
+                truth_trk.setChisq(-1);
+                truth_trk.setNDF(-1);
+                truth_trk.setFitSuccess(false);
+                truth_trk.setRefPointIsDCA(true);
+                truth_trk.setTrackType(-1);
+                truthTrackCollection.add(truth_trk);
+                trackToTruthTrackRelations.add(new BaseLCRelation(track,truth_trk));
+                
+
+                if (debug) {
+                    double d0    = truth_trk.getTrackStates().get(0).getD0();
+                    double z0    = truth_trk.getTrackStates().get(0).getZ0();
+                    double C     = truth_trk.getTrackStates().get(0).getOmega();
+                    double phi   = truth_trk.getTrackStates().get(0).getPhi();
+                    double slope = truth_trk.getTrackStates().get(0).getTanLambda();
+                    System.out.printf("TruthTrack \n");
+                    System.out.printf("d0 %f z0 %f R %f phi %f lambda %s\n", d0, z0, 1./C, phi, slope);
+                    System.out.println("--------------------");
+                }
+            } //ttm not null
+            else {
+                System.out.printf("Error::TrackTruthMatching returns null \n");
+            }
+        }
+        
+        int flag = 1 << LCIOConstants.TRBIT_HITS;
+        event.put(trackCollectionName+"Truth", truthTrackCollection, Track.class, flag);
+        event.put(trackCollectionName+"ToTruthTrackRelations", trackToTruthTrackRelations, LCRelation.class, 0);
+        event.put(trackCollectionName+"ToMCParticleRelations", trackToMCParticleRelations, LCRelation.class, 0);
+    }//closes process
+}

--- a/analysis/src/main/java/org/hps/analysis/MC/TrackTruthMatching.java
+++ b/analysis/src/main/java/org/hps/analysis/MC/TrackTruthMatching.java
@@ -43,17 +43,25 @@ public class TrackTruthMatching {
     private List<Integer> trackerlayerhitlist = new ArrayList<Integer>();
     
     /**
-     * Creates a new instance of TrackAnalysis
+     * Creates a new instance of TrackAnalysis. If the track is Kalman do not multiply the hits by 2
      * @return 
      */
     
     public TrackTruthMatching(Track trk, RelationalTable rawtomc, List<SimTrackerHit> allsimhits) {
-        doAnalysis(trk, rawtomc, allsimhits);
+        doAnalysis(trk,rawtomc,allsimhits,false);
     }
-
-    private void doAnalysis(Track trk, RelationalTable rawtomc, List<SimTrackerHit> allsimhits){
+    
+    public TrackTruthMatching(Track trk, RelationalTable rawtomc, List<SimTrackerHit> allsimhits, boolean isKalman) {
+        doAnalysis(trk, rawtomc, allsimhits, isKalman);
+    }
+    
+    private void doAnalysis(Track trk, RelationalTable rawtomc, List<SimTrackerHit> allsimhits, boolean isKalman){
         //  Get the number of hits on the track
-        _nhits = trk.getTrackerHits().size()*2;
+        _nhits = trk.getTrackerHits().size();
+        
+        if (!isKalman)
+            _nhits = _nhits*2;
+        
         _isTop = trk.getTrackStates().get(0).getTanLambda() > 0;
 
         for (TrackerHit hit : trk.getTrackerHits()) {
@@ -267,4 +275,5 @@ public class TrackTruthMatching {
     public Set<SimTrackerHit> getHitListNotMatched() {
         return _hitListNotMatched;
     }
+    
 }

--- a/recon/src/main/java/org/hps/recon/particle/HpsReconParticleDriver.java
+++ b/recon/src/main/java/org/hps/recon/particle/HpsReconParticleDriver.java
@@ -376,12 +376,7 @@ public class HpsReconParticleDriver extends ReconParticleDriver {
                 if (TrackType.isGBL(positron.getType()) != TrackType.isGBL(electron.getType())) {
                     continue;
                 }
-                // Only vertex two particles if at least one strategy found both tracks. Take out this check once we reduce the number of tracks.
-                // This is dumb so I took it out. - Matt Solt
-                /*if ((positron.getType() & electron.getType() & 0x1f) == 0) {
-                 continue;
-                 }*/
-
+                
                 // Make V0 candidates
                 this.makeV0Candidates(electron, positron);
             }
@@ -572,9 +567,14 @@ public class HpsReconParticleDriver extends ReconParticleDriver {
      *
      */
     private void makeV0Candidates(ReconstructedParticle electron, ReconstructedParticle positron) {
-        boolean eleIsTop = (electron.getTracks().get(0).getTrackerHits().get(0).getPosition()[2] > 0);
-        boolean posIsTop = (positron.getTracks().get(0).getTrackerHits().get(0).getPosition()[2] > 0);
-
+        
+        //boolean eleIsTop = (electron.getTracks().get(0).getTrackerHits().get(0).getPosition()[2] > 0);
+        //boolean posIsTop = (positron.getTracks().get(0).getTrackerHits().get(0).getPosition()[2] > 0);
+        
+        //This eleIsTop/posIsTop logic is valid for all track types [both Helix+GBL and Kalman]
+        boolean eleIsTop = (electron.getTracks().get(0).getTrackStates().get(0).getTanLambda() > 0);
+        boolean posIsTop = (positron.getTracks().get(0).getTrackStates().get(0).getTanLambda() > 0);
+        
         if ((eleIsTop == posIsTop) && (!makeConversionCols)) {
             return;
         }

--- a/recon/src/main/java/org/hps/recon/particle/ReconParticleDriver.java
+++ b/recon/src/main/java/org/hps/recon/particle/ReconParticleDriver.java
@@ -719,7 +719,7 @@ public abstract class ReconParticleDriver extends Driver {
         }
 
         // VERBOSE :: Note that a new event is being read.
-        printDebug("\nProcessing Event...");
+        printDebug("\nProcessing Event..." + event.getEventNumber());
 
         // Get the list of Ecal clusters from an event.
         List<Cluster> clusters = event.get(Cluster.class, ecalClustersCollectionName);
@@ -737,6 +737,7 @@ public abstract class ReconParticleDriver extends Driver {
         List<List<Track>> trackCollections = new ArrayList<List<Track>>();
         if (trackCollectionNames != null) {
             for (String collectionName : trackCollectionNames) {
+                printDebug("CollectionName ::" + collectionName);
                 if (event.hasCollection(Track.class, collectionName)) {
                     // VERBOSE :: Output the number of clusters in the event.
                     printDebug("Tracks :: " + event.get(Track.class, collectionName).size());

--- a/steering-files/src/main/resources/org/hps/steering/recon/KalmanAndGBLRecoMC.lcsim
+++ b/steering-files/src/main/resources/org/hps/steering/recon/KalmanAndGBLRecoMC.lcsim
@@ -1,0 +1,197 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lcsim xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/lcsim/1.0/lcsim.xsd">
+    <!-- 
+      @brief Steering file that runs the Kalman and GBL reconstruction pipeline
+      @author <a href="mailto:pbutti@slac.stanford.edu">PF</a>
+    -->
+    <execute>
+
+        <!--RF driver-->
+        <driver name="RfFitter"/>
+        <driver name="PreCleanupDriver"/>
+        <driver name="RawTrackerHitSensorSetup"/>
+        <driver name="RawTrackerHitFitterDriver" />
+        <driver name="TrackerHitDriver"/>
+        <!-- <driver name="HelicalTrackHitDriver"/> -->
+        <driver name="KalmanPatRecDriver"/> 
+        <!-- <driver name="GBLRefitterDriver" /> -->
+        <!-- <driver name="TrackDataDriver" /> -->
+        <driver name="ReconParticleDriver_Kalman" />  
+        <driver name="ReconParticleDriver_GBL" />
+        <driver name="LCIOWriter"/>            
+        <driver name="CleanupDriver"/>
+    </execute>    
+    <drivers>   
+        <driver name="RfFitter" type="org.hps.evio.RfFitterDriver"/>       
+
+        <!-- Ecal reconstruction drivers -->
+        <!--<driver name="EcalRunningPedestal" type="org.hps.recon.ecal.EcalRunningPedestalDriver">
+            <logLevel>CONFIG</logLevel>
+        </driver>-->
+
+        <!--<driver name="EcalRawConverter" type="org.hps.recon.ecal.EcalRawConverter2Driver">
+        </driver>-->
+
+        <driver name="EcalRawConverter" type="org.hps.recon.ecal.EcalRawConverterDriver">
+            <ecalCollectionName>EcalCalHits</ecalCollectionName>
+            <fixShapeParameter>true</fixShapeParameter>
+            <globalFixedPulseWidth>2.4</globalFixedPulseWidth>
+        </driver>
+
+        <driver name="PreCleanupDriver" type="org.hps.analysis.dataquality.ReadoutCleanupDriver">
+<!--           <collectionNames>EcalCalHits EcalClusters EcalClustersCorr FinalStateParticles UnconstrainedMollerCandidates UnconstrainedMollerVertices UnconstrainedV0Candidates UnconstrainedV0Vertices TargetConstrainedMollerCandidates TargetConstrainedMollerVertices TargetConstrainedV0Candidates TargetConstrainedV0Vertices BeamspotConstrainedMollerCandidates BeamspotConstrainedMollerVertices BeamspotConstrainedV0Candidates BeamspotConstrainedV0Vertices GBLKinkData GBLKinkDataRelations MatchedToGBLTrackRelations HelicalTrackHits HelicalTrackHitRelations MatchedTracks GBLTracks MatchedToGBLTrackRelations PartialTracks RotatedHelicalTrackHits RotatedHelicalTrackHitRelations SVTFittedRawTrackerHits  SVTShapeFitParameters StripClusterer_SiTrackerHitStrip1D TrackData TrackDataRelations TrackResiduals TrackResidualsRelations</collectionNames> -->
+<!--     <collectionNames> FinalStateParticles UnconstrainedMollerCandidates UnconstrainedMollerVertices UnconstrainedV0Candidates UnconstrainedV0Vertices TargetConstrainedMollerCandidates TargetConstrainedMollerVertices TargetConstrainedV0Candidates TargetConstrainedV0Vertices BeamspotConstrainedMollerCandidates BeamspotConstrainedMollerVertices BeamspotConstrainedV0Candidates BeamspotConstrainedV0Vertices GBLTracks GBLKinkData GBLKinkDataRelations MatchedToGBLTrackRelations HelicalTrackHits HelicalTrackHitRelations MatchedTracks MatchedToGBLTrackRelations RotatedHelicalTrackHits RotatedHelicalTrackHitRelations StripClusterer_SiTrackerHitStrip1D TrackData TrackDataRelations TrackResiduals TrackResidualsRelations</collectionNames> -->
+
+<!--                   <collectionNames> FinalStateParticles UnconstrainedMollerCandidates UnconstrainedMollerVertices UnconstrainedV0Candidates UnconstrainedV0Vertices TargetConstrainedMollerCandidates TargetConstrainedMollerVertices TargetConstrainedV0Candidates TargetConstrainedV0Vertices BeamspotConstrainedMollerCandidates BeamspotConstrainedMollerVertices BeamspotConstrainedV0Candidates BeamspotConstrainedV0Vertices HelicalTrackHits HelicalTrackHitRelations MatchedTracks RotatedHelicalTrackHits RotatedHelicalTrackHitRelations StripClusterer_SiTrackerHitStrip1D TrackResiduals TrackResidualsRelations</collectionNames> -->
+
+<collectionNames> FinalStateParticles UnconstrainedMollerCandidates UnconstrainedMollerVertices UnconstrainedV0Candidates UnconstrainedV0Vertices TargetConstrainedMollerCandidates TargetConstrainedMollerVertices TargetConstrainedV0Candidates TargetConstrainedV0Vertices BeamspotConstrainedMollerCandidates BeamspotConstrainedMollerVertices BeamspotConstrainedV0Candidates StripClusterer_SiTrackerHitStrip1D BeamspotConstrainedV0Vertices </collectionNames>
+
+
+       
+        </driver>
+
+        <driver name="HitTimeSmear" type="org.hps.recon.ecal.cluster.HitTMCSmearDriver">
+        </driver>
+
+        <driver name="ReconClusterer" type="org.hps.recon.ecal.cluster.ReconClusterDriver">
+            <logLevel>WARNING</logLevel>
+            <outputClusterCollectionName>EcalClusters</outputClusterCollectionName>
+        </driver>
+        <driver name="CopyCluster" type="org.hps.recon.ecal.cluster.CopyClusterCollectionDriver">
+            <inputCollectionName>EcalClusters</inputCollectionName>
+            <outputCollectionName>EcalClustersCorr</outputCollectionName>
+        </driver>
+        
+        <!-- SVT reconstruction drivers -->
+        <driver name="RawTrackerHitSensorSetup" type="org.lcsim.recon.tracking.digitization.sisim.config.RawTrackerHitSensorSetup">
+            <readoutCollections>SVTRawTrackerHits</readoutCollections>
+        </driver>
+        <driver name="RawTrackerHitFitterDriver" type="org.hps.recon.tracking.RawTrackerHitFitterDriver">
+            <fitAlgorithm>Pileup</fitAlgorithm>
+            <!--use this to correct for trigger time in MC instead of subtractTriggerTime-->   
+            <useTimestamps>true</useTimestamps>     
+            <!--offset to get times centered at 0 after timestamp correction-->                 
+            <tsCorrectionScale>171.</tsCorrectionScale>
+            <!--correct for the SVT fit time offset...this should be on if <useTimingConditions> is turned on in readout-->        
+            <correctTimeOffset>true</correctTimeOffset>   
+            <!--per sensor shift...set false becasue it's not in readout sim-->       
+            <correctT0Shift>false</correctT0Shift>      
+            <!--use truth time for MC???  typically not used-->             
+            <useTruthTime>false</useTruthTime>    
+            <!--time of flight corrections-->              
+            <subtractTOF>true</subtractTOF>     
+            <!--set this false for MC, true for data-->              
+            <subtractTriggerTime>false</subtractTriggerTime>           
+            <!--per-strip timing correction from database...this should be on i f <useTimingConditions> is turned on in readout  -->  
+            <correctChanT0>true</correctChanT0>          
+            <debug>false</debug>
+        </driver>
+        <driver name="TrackerHitDriver" type="org.hps.recon.tracking.DataTrackerHitDriver">
+            <neighborDeltaT>8.0</neighborDeltaT>
+            <debug>false</debug>
+        </driver>
+        <driver name="HelicalTrackHitDriver" type="org.hps.recon.tracking.HelicalTrackHitDriver">
+            <debug>false</debug>
+            <clusterTimeCut>12.0</clusterTimeCut>
+            <maxDt>16.0</maxDt>
+            <clusterAmplitudeCut>400.0</clusterAmplitudeCut>
+        </driver>
+        <!-- SVT Track finding -->
+        <driver name="TrackReconSeed345Conf2Extd16" type="org.hps.recon.tracking.TrackerReconDriver">
+            <trackCollectionName>Tracks_s345_c2_e16</trackCollectionName>
+            <strategyResource>HPS_s345_c2_e16.xml</strategyResource>
+            <debug>false</debug>
+            <rmsTimeCut>8.0</rmsTimeCut>
+        </driver>                
+        <driver name="TrackReconSeed456Conf3Extd21" type="org.hps.recon.tracking.TrackerReconDriver">
+            <trackCollectionName>Tracks_s456_c3_e21</trackCollectionName>
+            <strategyResource>HPS_s456_c3_e21.xml</strategyResource>
+            <debug>false</debug>
+            <rmsTimeCut>8.0</rmsTimeCut>
+        </driver>                
+        <driver name="TrackReconSeed123Conf4Extd56" type="org.hps.recon.tracking.TrackerReconDriver">
+            <trackCollectionName>Tracks_s123_c4_e56</trackCollectionName>
+            <strategyResource>HPS_s123_c4_e56.xml</strategyResource>
+            <debug>false</debug>
+            <rmsTimeCut>8.0</rmsTimeCut>
+        </driver>                
+        <driver name="TrackReconSeed123Conf5Extd46" type="org.hps.recon.tracking.TrackerReconDriver">
+            <trackCollectionName>Tracks_s123_c5_e46</trackCollectionName>
+            <strategyResource>HPS_s123_c5_e46.xml</strategyResource>
+            <debug>false</debug>
+            <rmsTimeCut>8.0</rmsTimeCut>
+        </driver> 
+
+        <driver name="KalmanPatRecDriver" type="org.hps.recon.tracking.kalman.KalmanPatRecDriver">
+          </driver>
+          
+        <driver name="MergeTrackCollections" type="org.hps.recon.tracking.MergeTrackCollections" />
+        <driver name="TrackDataDriver" type="org.hps.recon.tracking.TrackDataDriver"/>
+        
+        <driver name="ReconParticleDriver_Kalman" type="org.hps.recon.particle.HpsReconParticleDriver" > 
+          <ecalClusterCollectionName>EcalClustersCorr</ecalClusterCollectionName>
+          <trackCollectionNames>KalmanFullTracks</trackCollectionNames>
+          <unconstrainedV0CandidatesColName>UnconstrainedV0Candidates_KF</unconstrainedV0CandidatesColName>
+          <unconstrainedV0VerticesColName>UnconstrainedV0Vertices_KF</unconstrainedV0VerticesColName>
+          <beamConV0CandidatesColName>BeamspotConstrainedV0Candidates_KF</beamConV0CandidatesColName>
+          <beamConV0VerticesColName>BeamspotConstrainedV0Vertices_KF</beamConV0VerticesColName>
+          <targetConV0CandidatesColName>TargetConstrainedV0Candidates_KF</targetConV0CandidatesColName>
+          <targetConV0VerticesColName>TargetConstrainedV0Vertices_KF</targetConV0VerticesColName>
+          <beamPositionX> -0.224 </beamPositionX>
+          <beamSigmaX> 0.125 </beamSigmaX>
+          <beamPositionY> -0.08 </beamPositionY>
+          <beamSigmaY> 0.030 </beamSigmaY>
+          <beamPositionZ> -4.3 </beamPositionZ>
+          <trackClusterTimeOffset>44.8</trackClusterTimeOffset>
+          <isMC>true</isMC>
+          <useInternalVertexXYPositions>false</useInternalVertexXYPositions>
+          <minVertexChisqProb> 0.0 </minVertexChisqProb>
+          <maxElectronP> 2.15 </maxElectronP>
+          <maxVertexP> 2.8 </maxVertexP>
+          <maxVertexClusterDt>5.0</maxVertexClusterDt>
+          <maxMatchDt>10</maxMatchDt>
+          <includeUnmatchedTracksInFSP>true</includeUnmatchedTracksInFSP>
+          <disablePID>true</disablePID>
+          <debug>false</debug>
+          <requireClustersForV0>false</requireClustersForV0>
+        </driver>
+
+        <driver name="ReconParticleDriver_GBL" type="org.hps.recon.particle.HpsReconParticleDriver" > 
+          <ecalClusterCollectionName>EcalClustersCorr</ecalClusterCollectionName>
+          <!--<trackCollectionNames>${trackColl}</trackCollectionNames> -->
+          <trackCollectionNames>GBLTracks</trackCollectionNames>
+          <beamPositionX> -0.224 </beamPositionX>
+          <beamSigmaX> 0.125 </beamSigmaX>
+          <beamPositionY> -0.08 </beamPositionY>
+          <beamSigmaY> 0.030 </beamSigmaY>
+          <beamPositionZ> -4.3 </beamPositionZ>
+          <trackClusterTimeOffset>44.8</trackClusterTimeOffset>
+          <isMC>true</isMC>
+          <useInternalVertexXYPositions>false</useInternalVertexXYPositions>
+          <minVertexChisqProb> 0.0 </minVertexChisqProb>
+          <maxElectronP> 2.15 </maxElectronP>
+          <maxVertexP> 2.8 </maxVertexP>
+          <maxVertexClusterDt>5.0</maxVertexClusterDt>
+          <maxMatchDt>10</maxMatchDt>
+          <includeUnmatchedTracksInFSP>true</includeUnmatchedTracksInFSP>
+          <disablePID>true</disablePID>
+          <debug>false</debug>
+          <requireClustersForV0>false</requireClustersForV0>
+        </driver>
+        
+	<driver name="GBLRefitterDriver" type="org.hps.recon.tracking.gbl.GBLRefitterDriver" >
+          <maxTrackChisq5hits> 60. </maxTrackChisq5hits>
+          <maxTrackChisq6hits> 84. </maxTrackChisq6hits>
+          <outputCollectionName>GBLRefittedTracks</outputCollectionName>
+        </driver>
+        <driver name="LCIOWriter" type="org.lcsim.util.loop.LCIODriver">
+          <!--<outputFilePath>${outputFile}_${trackColl}.slcio</outputFilePath>-->
+          <outputFilePath>${outputFile}.slcio</outputFilePath>
+        </driver>
+        <driver name="CleanupDriver" type="org.lcsim.recon.tracking.digitization.sisim.config.ReadoutCleanupDriver"/>
+        <driver name="AidaSaveDriver" type="org.lcsim.job.AidaSaveDriver">
+            <!--<outputFileName>${outputFile}_${trackColl}.root</outputFileName> -->
+            <outputFileName>${outputFile}.root</outputFileName>
+        </driver>             
+    </drivers>
+</lcsim>

--- a/steering-files/src/main/resources/org/hps/steering/recon/KalmanAndGBLRecoMC.lcsim
+++ b/steering-files/src/main/resources/org/hps/steering/recon/KalmanAndGBLRecoMC.lcsim
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml_ version="1.0" encoding="UTF-8"?>
 <lcsim xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/lcsim/1.0/lcsim.xsd">
     <!-- 
       @brief Steering file that runs the Kalman and GBL reconstruction pipeline
@@ -19,7 +19,7 @@
         <driver name="TrackTruthMatching_KF" />
         <driver name="ReconParticleDriver_Kalman" />  
         <driver name="TrackTruthMatching_GBL" />
-        <!-- <driver name="ReconParticleDriver_GBL" /> -->
+        <driver name="ReconParticleDriver_GBL" />
         <driver name="LCIOWriter"/>            
         <driver name="CleanupDriver"/>
     </execute>    
@@ -125,6 +125,8 @@
         </driver> 
 
         <driver name="KalmanPatRecDriver" type="org.hps.recon.tracking.kalman.KalmanPatRecDriver">
+          <ptCut>0.3</ptCut>
+          <nMinHits>8</nMinHits>
           </driver>
           
         <driver name="MergeTrackCollections" type="org.hps.recon.tracking.MergeTrackCollections" />

--- a/steering-files/src/main/resources/org/hps/steering/recon/KalmanAndGBLRecoMC.lcsim
+++ b/steering-files/src/main/resources/org/hps/steering/recon/KalmanAndGBLRecoMC.lcsim
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <lcsim xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/lcsim/1.0/lcsim.xsd">
     <!-- 
-      @brief Steering file that runs the Kalman and GBL reconstruction pipeline
+      @brief Steering file that runs the Kalman and GBL reconstruction pipeline from LCIOs. Only Final State particles and vertices are going to be formed again.
       @author <a href="mailto:pbutti@slac.stanford.edu">PF</a>
     -->
     <execute>
@@ -10,8 +10,8 @@
         <driver name="RfFitter"/>
         <driver name="PreCleanupDriver"/>
         <driver name="RawTrackerHitSensorSetup"/>
-        <driver name="RawTrackerHitFitterDriver" />
-        <driver name="TrackerHitDriver"/>
+        <!-- <driver name="RawTrackerHitFitterDriver" /> -->
+        <!-- <driver name="TrackerHitDriver"/> -->
         <!-- <driver name="HelicalTrackHitDriver"/> -->
         <driver name="KalmanPatRecDriver"/> 
         <!-- <driver name="GBLRefitterDriver" /> -->
@@ -44,7 +44,7 @@
 
 <!--                   <collectionNames> FinalStateParticles UnconstrainedMollerCandidates UnconstrainedMollerVertices UnconstrainedV0Candidates UnconstrainedV0Vertices TargetConstrainedMollerCandidates TargetConstrainedMollerVertices TargetConstrainedV0Candidates TargetConstrainedV0Vertices BeamspotConstrainedMollerCandidates BeamspotConstrainedMollerVertices BeamspotConstrainedV0Candidates BeamspotConstrainedV0Vertices HelicalTrackHits HelicalTrackHitRelations MatchedTracks RotatedHelicalTrackHits RotatedHelicalTrackHitRelations StripClusterer_SiTrackerHitStrip1D TrackResiduals TrackResidualsRelations</collectionNames> -->
 
-<collectionNames> FinalStateParticles UnconstrainedMollerCandidates UnconstrainedMollerVertices UnconstrainedV0Candidates UnconstrainedV0Vertices TargetConstrainedMollerCandidates TargetConstrainedMollerVertices TargetConstrainedV0Candidates TargetConstrainedV0Vertices BeamspotConstrainedMollerCandidates BeamspotConstrainedMollerVertices BeamspotConstrainedV0Candidates StripClusterer_SiTrackerHitStrip1D BeamspotConstrainedV0Vertices </collectionNames>
+<collectionNames> FinalStateParticles UnconstrainedMollerCandidates UnconstrainedMollerVertices UnconstrainedV0Candidates UnconstrainedV0Vertices TargetConstrainedMollerCandidates TargetConstrainedMollerVertices TargetConstrainedV0Candidates TargetConstrainedV0Vertices BeamspotConstrainedMollerCandidates BeamspotConstrainedMollerVertices BeamspotConstrainedV0Candidates BeamspotConstrainedV0Vertices </collectionNames>
 
 
        

--- a/steering-files/src/main/resources/org/hps/steering/recon/KalmanAndGBLRecoMC.lcsim
+++ b/steering-files/src/main/resources/org/hps/steering/recon/KalmanAndGBLRecoMC.lcsim
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <lcsim xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/lcsim/1.0/lcsim.xsd">
     <!-- 
-      @brief Steering file that runs the Kalman and GBL reconstruction pipeline from LCIOs. Only Final State particles and vertices are going to be formed again.
+      @brief Steering file that runs the Kalman and GBL reconstruction pipeline
       @author <a href="mailto:pbutti@slac.stanford.edu">PF</a>
     -->
     <execute>
@@ -16,8 +16,10 @@
         <driver name="KalmanPatRecDriver"/> 
         <!-- <driver name="GBLRefitterDriver" /> -->
         <!-- <driver name="TrackDataDriver" /> -->
+        <driver name="TrackTruthMatching_KF" />
         <driver name="ReconParticleDriver_Kalman" />  
-        <driver name="ReconParticleDriver_GBL" />
+        <driver name="TrackTruthMatching_GBL" />
+        <!-- <driver name="ReconParticleDriver_GBL" /> -->
         <driver name="LCIOWriter"/>            
         <driver name="CleanupDriver"/>
     </execute>    
@@ -44,7 +46,7 @@
 
 <!--                   <collectionNames> FinalStateParticles UnconstrainedMollerCandidates UnconstrainedMollerVertices UnconstrainedV0Candidates UnconstrainedV0Vertices TargetConstrainedMollerCandidates TargetConstrainedMollerVertices TargetConstrainedV0Candidates TargetConstrainedV0Vertices BeamspotConstrainedMollerCandidates BeamspotConstrainedMollerVertices BeamspotConstrainedV0Candidates BeamspotConstrainedV0Vertices HelicalTrackHits HelicalTrackHitRelations MatchedTracks RotatedHelicalTrackHits RotatedHelicalTrackHitRelations StripClusterer_SiTrackerHitStrip1D TrackResiduals TrackResidualsRelations</collectionNames> -->
 
-<collectionNames> FinalStateParticles UnconstrainedMollerCandidates UnconstrainedMollerVertices UnconstrainedV0Candidates UnconstrainedV0Vertices TargetConstrainedMollerCandidates TargetConstrainedMollerVertices TargetConstrainedV0Candidates TargetConstrainedV0Vertices BeamspotConstrainedMollerCandidates BeamspotConstrainedMollerVertices BeamspotConstrainedV0Candidates BeamspotConstrainedV0Vertices </collectionNames>
+<collectionNames> FinalStateParticles UnconstrainedMollerCandidates UnconstrainedMollerVertices UnconstrainedV0Candidates UnconstrainedV0Vertices TargetConstrainedMollerCandidates TargetConstrainedMollerVertices TargetConstrainedV0Candidates TargetConstrainedV0Vertices BeamspotConstrainedMollerCandidates BeamspotConstrainedMollerVertices BeamspotConstrainedV0Candidates  BeamspotConstrainedV0Vertices </collectionNames>
 
 
        
@@ -177,6 +179,18 @@
           <disablePID>true</disablePID>
           <debug>false</debug>
           <requireClustersForV0>false</requireClustersForV0>
+        </driver>
+
+        <driver name="TrackTruthMatching_KF" type="org.hps.analysis.MC.TrackToMCParticleRelationsDriver">
+          <trackCollectionName>KalmanFullTracks</trackCollectionName>
+          <kalmanTracks>true</kalmanTracks>
+          <debug>false</debug>
+        </driver>
+        
+        <driver name="TrackTruthMatching_GBL" type="org.hps.analysis.MC.TrackToMCParticleRelationsDriver">
+          <trackCollectionName>GBLTracks</trackCollectionName>
+          <kalmanTracks>false</kalmanTracks>
+          <debug>false</debug>
         </driver>
         
 	<driver name="GBLRefitterDriver" type="org.hps.recon.tracking.gbl.GBLRefitterDriver" >

--- a/tracking/src/main/java/org/hps/recon/tracking/TrackDataDriver.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/TrackDataDriver.java
@@ -221,7 +221,7 @@ public final class TrackDataDriver extends Driver {
                         track.getTrackStates().add(stateEcal);
                 }
 
-                // Extrapolate the track to the face of the Ecal and get the TrackState
+                // Extrapolate the track to the face of the Hodoscope and get the TrackState
                 if (TrackType.isGBL(track.getType())) {
                     TrackState stateHodo1 = TrackUtils.getTrackExtrapAtHodoRK(track, bFieldMap, 1);
                     if (stateHodo1 != null)

--- a/tracking/src/main/java/org/hps/recon/tracking/kalman/HelixPlaneIntersect.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/kalman/HelixPlaneIntersect.java
@@ -82,7 +82,10 @@ class HelixPlaneIntersect { // Calculates intersection of a helix with a nearly 
         // Note: this call to planeIntersect fills in X0 and a
         double phiInt = planeIntersect(helix, X1local, alpha, pLocal); // helix intersection
         if (Double.isNaN(phiInt)) {
-            System.out.format("HelixPlaneIntersect:rkIntersect: there is no intersection.\n");
+            //System.out.format("HelixPlaneIntersect:rkIntersect: there is no intersection.\n");
+            pInt.v[0] = P0.v[0];
+            pInt.v[1] = P0.v[1];
+            pInt.v[2] = P0.v[2];
             return X0;
         }
         //System.out.format("HelixPlaneIntersect:rkIntersect, delta-phi to the intersection is %12.5e\n", phiInt);
@@ -116,8 +119,7 @@ class HelixPlaneIntersect { // Calculates intersection of a helix with a nearly 
         // a: vector of 5 helix parameters
         // alpha: 10^12/c/B
 
-        // Take as a starting guess the solution for the case that the plane orientation
-        // is exactly y-hat.
+        // Take as a starting guess the solution for the case that the plane orientation is exactly y-hat.
         // System.out.format("HelixPlaneIntersection:planeIntersect, alpha=%f10.5\n", alpha);
         this.alpha = alpha;
         double arg = (a.v[2] / alpha) * ((a.v[0] + (alpha / a.v[2])) * Math.sin(a.v[1]) - (p.X().v[1] - pivot.v[1]));

--- a/tracking/src/main/java/org/hps/recon/tracking/kalman/HelixPlaneIntersect.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/kalman/HelixPlaneIntersect.java
@@ -83,6 +83,7 @@ class HelixPlaneIntersect { // Calculates intersection of a helix with a nearly 
         double phiInt = planeIntersect(helix, X1local, alpha, pLocal); // helix intersection
         if (Double.isNaN(phiInt)) {
             System.out.format("HelixPlaneIntersect:rkIntersect: there is no intersection.\n");
+            //X0.print("HelixPlaneInterstect:rkIntersect-no interstection error");
             return X0;
         }
         //System.out.format("HelixPlaneIntersect:rkIntersect, delta-phi to the intersection is %12.5e\n", phiInt);

--- a/tracking/src/main/java/org/hps/recon/tracking/kalman/HelixPlaneIntersect.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/kalman/HelixPlaneIntersect.java
@@ -82,8 +82,10 @@ class HelixPlaneIntersect { // Calculates intersection of a helix with a nearly 
         // Note: this call to planeIntersect fills in X0 and a
         double phiInt = planeIntersect(helix, X1local, alpha, pLocal); // helix intersection
         if (Double.isNaN(phiInt)) {
-            System.out.format("HelixPlaneIntersect:rkIntersect: there is no intersection.\n");
-            //X0.print("HelixPlaneInterstect:rkIntersect-no interstection error");
+            //System.out.format("HelixPlaneIntersect:rkIntersect: there is no intersection.\n");
+            pInt.v[0] = P0.v[0];
+            pInt.v[1] = P0.v[1];
+            pInt.v[2] = P0.v[2];
             return X0;
         }
         //System.out.format("HelixPlaneIntersect:rkIntersect, delta-phi to the intersection is %12.5e\n", phiInt);
@@ -117,8 +119,7 @@ class HelixPlaneIntersect { // Calculates intersection of a helix with a nearly 
         // a: vector of 5 helix parameters
         // alpha: 10^12/c/B
 
-        // Take as a starting guess the solution for the case that the plane orientation
-        // is exactly y-hat.
+        // Take as a starting guess the solution for the case that the plane orientation is exactly y-hat.
         // System.out.format("HelixPlaneIntersection:planeIntersect, alpha=%f10.5\n", alpha);
         this.alpha = alpha;
         double arg = (a.v[2] / alpha) * ((a.v[0] + (alpha / a.v[2])) * Math.sin(a.v[1]) - (p.X().v[1] - pivot.v[1]));

--- a/tracking/src/main/java/org/hps/recon/tracking/kalman/HelixTest3.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/kalman/HelixTest3.java
@@ -11,7 +11,7 @@ import java.util.ArrayList;
 import java.util.Random;
 
 //This is for testing only and is not part of the Kalman fitting code
-public class HelixTest3 { // Program for testing the Kalman fitting code
+class HelixTest3 { // Program for testing the Kalman fitting code
 
     // Coordinate system:
     // z is the B field direction, downward in lab coordinates
@@ -20,7 +20,7 @@ public class HelixTest3 { // Program for testing the Kalman fitting code
 
     Random rnd;
 
-    public HelixTest3(String path) {
+    HelixTest3(String path) {
 
         // Control parameters
         // Units are Tesla, GeV, mm

--- a/tracking/src/main/java/org/hps/recon/tracking/kalman/KalHit.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/kalman/KalHit.java
@@ -1,17 +1,18 @@
 package org.hps.recon.tracking.kalman;
 
-import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.HashSet;
+import java.util.Set;
 
 public class KalHit {
     SiModule module;
     Measurement hit;
-    ArrayList<TrackCandidate> tkrCandidates;
+    Set<TrackCandidate> tkrCandidates;
     
     KalHit(SiModule module, Measurement hit) {
         this.module = module;
         this.hit = hit;
-        tkrCandidates = new ArrayList<TrackCandidate>();
+        tkrCandidates = new HashSet<TrackCandidate>();
     }
     
     boolean isStereo() {

--- a/tracking/src/main/java/org/hps/recon/tracking/kalman/KalHit.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/kalman/KalHit.java
@@ -4,7 +4,7 @@ import java.util.Comparator;
 import java.util.HashSet;
 import java.util.Set;
 
-public class KalHit {
+class KalHit {
     SiModule module;
     Measurement hit;
     Set<TrackCandidate> tkrCandidates;

--- a/tracking/src/main/java/org/hps/recon/tracking/kalman/KalTrack.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/kalman/KalTrack.java
@@ -296,7 +296,7 @@ public class KalTrack {
         // be introduced, TBD
         double XL = 0.; // innerSite.XL / Math.abs(ct);
         helixAtOrigin = innerSite.aS.propagateRungeKutta(innerSite.m.Bfield, originCov, XL);
-
+        
         // Find the position and momentum of the particle near the origin, including
         // covariance
         Vec XonHelix = StateVector.atPhi(new Vec(0., 0., 0.), helixAtOrigin, 0., alpha);
@@ -350,6 +350,11 @@ public class KalTrack {
         return originCov.M.clone();
     }
 
+    public boolean covNaN() { 
+        if (!propagated) {originHelix();}
+        return originCov.isNaN();
+    }
+    
     public double[] originHelixParms() {
         if (propagated) return helixAtOrigin.v.clone();
         else return null;

--- a/tracking/src/main/java/org/hps/recon/tracking/kalman/KalTrack.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/kalman/KalTrack.java
@@ -29,7 +29,7 @@ public class KalTrack {
     public double alpha;
     private double[][] Cx;
     private double[][] Cp;
-    public double Bmag;
+    double Bmag;
     private Vec tB;
     private double time;
     private boolean verbose;
@@ -309,7 +309,23 @@ public class KalTrack {
         // be introduced, TBD
         double XL = 0.; // innerSite.XL / Math.abs(ct);
         helixAtOrigin = innerSite.aS.propagateRungeKutta(innerSite.m.Bfield, originCov, XL);
-        
+        if (Double.isNaN(originCov.M[0][0])) return false;
+        SquareMatrix Cinv = originCov.invert();
+        for (int i=0; i<5; ++i) {
+            if (Cinv.M[i][i] == 0.0) {  // The covariance matrix was singular
+                System.out.format("KalTrack.originHelix: the track %d covariance matrix is singular!\n", ID);
+                originCov.print("singular");
+                helixAtOrigin.print("singular");
+                for (int k=0; k<5; ++k) {
+                    for (int m=0; m<k; ++m) {
+                        originCov.M[k][m] = 0.;
+                        originCov.M[m][k] = 0.;
+                    }
+                }
+                break;
+            }
+        }
+
         // Find the position and momentum of the particle near the origin, including
         // covariance
         Vec XonHelix = StateVector.atPhi(new Vec(0., 0., 0.), helixAtOrigin, 0., alpha);
@@ -551,6 +567,7 @@ public class KalTrack {
             if (verbose) { System.out.format("KalTrack.fit: Iteration %d, Fit chi^2 after smoothing = %12.4e\n", iteration, chi2s); }
         }
         this.chi2 = chi2s;
+        propagated = false;
         return true;
     }
 

--- a/tracking/src/main/java/org/hps/recon/tracking/kalman/KalTrack.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/kalman/KalTrack.java
@@ -51,6 +51,16 @@ public class KalTrack {
                 continue;
             }
         }
+        if (verbose) {
+            if (this.SiteList.size() < 5) {
+                System.out.format("KalTrack error in event %d: not enough hits on track %d: ",evtNumb,tkID);
+                for (MeasurementSite site : SiteList) {
+                    System.out.format("(%d, %d, %d) ",site.m.Layer,site.m.detector,site.hitID);
+                }
+                System.out.format("\n");
+            }
+        }
+        
         Collections.sort(this.SiteList, MeasurementSite.SiteComparatorUp);
         this.nHits = nHits;
         this.chi2 = chi2;
@@ -181,7 +191,10 @@ public class KalTrack {
             int hitID = site.hitID;
             System.out.format("Layer %d, detector %d, stereo=%b, chi^2 inc.=%10.6f, Xscat=%10.8f Zscat=%10.8f, arc=%10.5f, hit=%d  ", m.Layer, m.detector, m.isStereo,
                     site.chi2inc, site.scatX(), site.scatZ(), site.arcLength, hitID);
-            if (hitID < 0) continue;
+            if (hitID < 0) {
+                System.out.format("\n");
+                continue;
+            }
             System.out.format(", t=%5.1f", site.m.hits.get(site.hitID).time);
             if (m.hits.get(hitID).tksMC != null) {
                 System.out.format("  MC tracks: ");
@@ -398,6 +411,14 @@ public class KalTrack {
         
         sortSites(true);
 
+        if (verbose) {
+            System.out.format("KalTrac.addHits: initial list of sites: ");
+            for (MeasurementSite site : SiteList) {
+                System.out.format("(%d, %d, %d) ",site.m.Layer, site.m.detector, site.hitID);
+            }
+            System.out.format("\n");
+        }
+        
         ArrayList<ArrayList<SiModule>> moduleList = new ArrayList<ArrayList<SiModule>>(numLayers);
         for (int lyr = 0; lyr < numLayers; lyr++) {
             ArrayList<SiModule> modules = new ArrayList<SiModule>();
@@ -453,6 +474,15 @@ public class KalTrack {
                 SiteList.add(site);
             }
             sortSites(true);
+            if (verbose) {
+                System.out.format("KalTrack.addHits: final list of sites: ");
+                for (MeasurementSite site : SiteList) {
+                    System.out.format("(%d, %d, %d) ",site.m.Layer, site.m.detector, site.hitID);
+                }
+                System.out.format("\n");
+            }
+        } else if (verbose) {
+            System.out.format("KalTrack.addHits: no hits added in event %d to track %d\n", eventNumber, ID);
         }
 
         return numAdded;

--- a/tracking/src/main/java/org/hps/recon/tracking/kalman/KalTrack.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/kalman/KalTrack.java
@@ -50,8 +50,11 @@ public class KalTrack {
             }
         }
         if (this.SiteList.size() < 5) {
-            System.out.format("KalTrack error: not enough hits on the candidate track\n");
-            for (MeasurementSite site : SiteList) site.print("in KalTrack input list");
+            System.out.format("KalTrack error in event %d: not enough hits on track %d: ",evtNumb,tkID);
+            for (MeasurementSite site : SiteList) {
+                System.out.format("(%d, %d, %d) ",site.m.Layer,site.m.detector,site.hitID);
+            }
+            System.out.format("\n");
         }
         Collections.sort(this.SiteList, MeasurementSite.SiteComparatorUp);
         this.nHits = nHits;
@@ -177,7 +180,10 @@ public class KalTrack {
             int hitID = site.hitID;
             System.out.format("Layer %d, detector %d, stereo=%b, chi^2 inc.=%10.6f, Xscat=%10.8f Zscat=%10.8f, arc=%10.5f, hit=%d  ", m.Layer, m.detector, m.isStereo,
                     site.chi2inc, site.scatX(), site.scatZ(), site.arcLength, hitID);
-            if (hitID < 0) continue;
+            if (hitID < 0) {
+                System.out.format("\n");
+                continue;
+            }
             System.out.format(", t=%5.1f", site.m.hits.get(site.hitID).time);
             if (m.hits.get(hitID).tksMC != null) {
                 System.out.format("  MC tracks: ");
@@ -389,6 +395,14 @@ public class KalTrack {
         
         sortSites(true);
 
+        if (verbose) {
+            System.out.format("KalTrac.addHits: initial list of sites: ");
+            for (MeasurementSite site : SiteList) {
+                System.out.format("(%d, %d, %d) ",site.m.Layer, site.m.detector, site.hitID);
+            }
+            System.out.format("\n");
+        }
+        
         ArrayList<ArrayList<SiModule>> moduleList = new ArrayList<ArrayList<SiModule>>(numLayers);
         for (int lyr = 0; lyr < numLayers; lyr++) {
             ArrayList<SiModule> modules = new ArrayList<SiModule>();
@@ -444,6 +458,15 @@ public class KalTrack {
                 SiteList.add(site);
             }
             sortSites(true);
+            if (verbose) {
+                System.out.format("KalTrack.addHits: final list of sites: ");
+                for (MeasurementSite site : SiteList) {
+                    System.out.format("(%d, %d, %d) ",site.m.Layer, site.m.detector, site.hitID);
+                }
+                System.out.format("\n");
+            }
+        } else if (verbose) {
+            System.out.format("KalTrack.addHits: no hits added in event %d to track %d\n", eventNumber, ID);
         }
 
         return numAdded;

--- a/tracking/src/main/java/org/hps/recon/tracking/kalman/KalTrack.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/kalman/KalTrack.java
@@ -32,11 +32,13 @@ public class KalTrack {
     public double Bmag;
     private Vec tB;
     private double time;
+    private boolean verbose;
     double tMin;
     double tMax;
 
     KalTrack(int evtNumb, int tkID, int nHits, ArrayList<MeasurementSite> SiteList, double chi2) {
         // System.out.format("KalTrack constructor chi2=%10.6f\n", chi2);
+        verbose = false;
         eventNumber = evtNumb;
         // Make a new list of sites in case somebody modifies the one referred to on input
         this.SiteList = new ArrayList<MeasurementSite>(SiteList.size());
@@ -49,14 +51,16 @@ public class KalTrack {
                 continue;
             }
         }
-        if (this.SiteList.size() < 5) {
-            System.out.format("KalTrack error: not enough hits on the candidate track\n");
-            for (MeasurementSite site : SiteList) site.print("in KalTrack input list");
-        }
         Collections.sort(this.SiteList, MeasurementSite.SiteComparatorUp);
         this.nHits = nHits;
         this.chi2 = chi2;
         ID = tkID;
+        if (this.SiteList.size() < 5) {
+            System.out.format("KalTrack error: not enough hits ("+SiteList.size()+") on the candidate track (ID::"+ID+") for event "+eventNumber+" \n" );
+            if (verbose) {
+                for (MeasurementSite site : SiteList) site.print("in KalTrack input list");
+            }
+        }
         helixAtOrigin = null;
         propagated = false;
         originCov = new SquareMatrix(5);

--- a/tracking/src/main/java/org/hps/recon/tracking/kalman/KalmanInterface.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/kalman/KalmanInterface.java
@@ -62,6 +62,7 @@ public class KalmanInterface {
     public int verboseLevel = 0;
     double svtAngle;
     private HelixPlaneIntersect hpi;
+    KalmanParams kPar;
     Random rnd;
     
     // Get the HPS tracker hit corresponding to a Kalman hit
@@ -166,8 +167,15 @@ public class KalmanInterface {
         long rndSeed = -3263009337738135404L;
         rnd = new Random();
         rnd.setSeed(rndSeed);
+        
+        kPar = new KalmanParams();
     }
 
+    // Return the reference to the parameter setting code for the driver to use
+    public KalmanParams getKalmanParams() {
+        return kPar;
+    }
+    
     // Transformation from HPS global coordinates to Kalman global coordinates
     public static Vec vectorGlbToKalman(double[] HPSvec) { 
         Vec kalVec = new Vec(HPSvec[0], HPSvec[2], -HPSvec[1]);
@@ -1069,7 +1077,7 @@ public class KalmanInterface {
                 }
                 System.out.format("KalmanInterface.KalmanPatRec event %d: calling KalmanPatRecHPS for topBottom=%d\n", event.getEventNumber(), topBottom);
             }
-            KalmanPatRecHPS kPat = new KalmanPatRecHPS(SiMoccupied, topBottom, evtNum, false);
+            KalmanPatRecHPS kPat = new KalmanPatRecHPS(SiMoccupied, topBottom, evtNum, kPar, false);
             outList.add(kPat);
         }
         return outList;

--- a/tracking/src/main/java/org/hps/recon/tracking/kalman/KalmanInterface.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/kalman/KalmanInterface.java
@@ -1045,9 +1045,9 @@ public class KalmanInterface {
                     SiModule SiM = SiMoccupied.get(i);
                     SiM.print(String.format("SiMoccupied Number %d for topBottom=%d", i, topBottom));
                 }
+                System.out.format("KalmanInterface.KalmanPatRec event %d: calling KalmanPatRecHPS for topBottom=%d\n", event.getEventNumber(), topBottom);
             }
-            System.out.format("KalmanInterface.KalmanPatRec event %d: calling KalmanPatRecHPS for topBottom=%d\n", event.getEventNumber(), topBottom);
-            KalmanPatRecHPS kPat = new KalmanPatRecHPS(SiMoccupied, topBottom, evtNum, event.getEventNumber()==17002);
+            KalmanPatRecHPS kPat = new KalmanPatRecHPS(SiMoccupied, topBottom, evtNum, (event.getEventNumber()==-99));
             outList.add(kPat);
         }
         return outList;

--- a/tracking/src/main/java/org/hps/recon/tracking/kalman/KalmanInterface.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/kalman/KalmanInterface.java
@@ -429,7 +429,10 @@ public class KalmanInterface {
         double[] globalParams = kT.originHelixParms();
         double c = 2.99793e8; // Speed of light in m/s
         double conFac = 1.0e12 / c;
-        Vec Bfield = KalmanInterface.getField(new Vec(0.,0.,0.), kT.SiteList.get(0).m.Bfield); // Field at the origin
+        // Field at the origin => For 2016 this is ~ 0.430612 T
+        //Vec Bfield = KalmanInterface.getField(new Vec(0.,0.,0.), kT.SiteList.get(0).m.Bfield); 
+        //In the center of SVT => For 2016 this is ~ 0.52340 T
+        Vec Bfield = KalmanInterface.getField(new Vec(0.,500.,0.), kT.SiteList.get(0).m.Bfield);
         double B = Bfield.mag();
         double alpha = conFac / B; // Convert from pt in GeV to curvature in mm
         double[] newParams = getLCSimParams(globalParams, alpha);

--- a/tracking/src/main/java/org/hps/recon/tracking/kalman/KalmanInterface.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/kalman/KalmanInterface.java
@@ -413,6 +413,10 @@ public class KalmanInterface {
             System.out.format("KalmanInterface.createTrack: Kalman track is incomplete.\n");
             return null;
         }
+        if (kT.covNaN()) {
+            System.out.format("KalmanInterface.createTrack: Kalman track has NaN cov matrix");
+            return null;
+        }
         kT.sortSites(true);
         int prevID = 0;
         int dummyCounter = -1;

--- a/tracking/src/main/java/org/hps/recon/tracking/kalman/KalmanInterface.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/kalman/KalmanInterface.java
@@ -58,7 +58,8 @@ public class KalmanInterface {
     private ArrayList<SiModule> SiMlist;
     private List<Integer> SeedTrackLayers = null;
     private static boolean uniformB;
-    public boolean verbose;
+    public boolean verbose = false;
+    public int verboseLevel = 0;
     double svtAngle;
     private HelixPlaneIntersect hpi;
     Random rnd;
@@ -109,13 +110,20 @@ public class KalmanInterface {
         SeedTrackLayers = input;
     }
 
+    public void setVerboseLevel(int input) {
+        verboseLevel = input;
+    }
+
     // Constructor with no argument defaults to verbose being turned off
     public KalmanInterface() {
         this(false, false);
     }
 
     public KalmanInterface(boolean verbose, boolean uniformB) {
-        System.out.format("Entering the KalmanInterface constructor with verbose=%b\n",verbose);
+        
+        if (verbose) {
+            System.out.format("Entering the KalmanInterface constructor\n");
+        }
         this.verbose = verbose;
         KalmanInterface.uniformB = uniformB;
         hpi = new HelixPlaneIntersect();
@@ -578,7 +586,9 @@ public class KalmanInterface {
 
     // Method to create one Kalman SiModule object for each silicon-strip detector
     public void createSiModules(List<SiStripPlane> inputPlanes, org.lcsim.geometry.FieldMap fm) {
-        System.out.format("Entering KalmanInterface.creasteSiModules\n");
+        if (verbose && verboseLevel > 1) {
+            System.out.format("Entering KalmanInterface.creasteSiModules\n");
+        }
         SiMlist.clear();
 
         for (SiStripPlane inputPlane : inputPlanes) {
@@ -1046,7 +1056,9 @@ public class KalmanInterface {
                     SiM.print(String.format("SiMoccupied Number %d for topBottom=%d", i, topBottom));
                 }
             }
-            System.out.format("KalmanInterface.KalmanPatRec event %d: calling KalmanPatRecHPS for topBottom=%d\n", event.getEventNumber(), topBottom);
+            if (verbose) {
+                System.out.format("KalmanInterface.KalmanPatRec event %d: calling KalmanPatRecHPS for topBottom=%d\n", event.getEventNumber(), topBottom);
+            }
             KalmanPatRecHPS kPat = new KalmanPatRecHPS(SiMoccupied, topBottom, evtNum, event.getEventNumber()==17002);
             outList.add(kPat);
         }

--- a/tracking/src/main/java/org/hps/recon/tracking/kalman/KalmanInterface.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/kalman/KalmanInterface.java
@@ -414,7 +414,7 @@ public class KalmanInterface {
             return null;
         }
         if (kT.covNaN()) {
-            System.out.format("KalmanInterface.createTrack: Kalman track has NaN cov matrix");
+            System.out.format("KalmanInterface.createTrack: Kalman track has NaN cov matrix. \n");
             return null;
         }
         kT.sortSites(true);

--- a/tracking/src/main/java/org/hps/recon/tracking/kalman/KalmanInterface.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/kalman/KalmanInterface.java
@@ -63,7 +63,7 @@ public class KalmanInterface {
     double svtAngle;
     private HelixPlaneIntersect hpi;
     Random rnd;
-
+    
     // Get the HPS tracker hit corresponding to a Kalman hit
     public TrackerHit getHpsHit(Measurement km) {
         return hitMap.get(km);
@@ -417,6 +417,7 @@ public class KalmanInterface {
             System.out.format("KalmanInterface.createTrack: Kalman track has NaN cov matrix. \n");
             return null;
         }
+        
         kT.sortSites(true);
         int prevID = 0;
         int dummyCounter = -1;
@@ -458,8 +459,11 @@ public class KalmanInterface {
 
             if (i == 0) {
                 loc = TrackState.AtFirstHit;
-            } else if (i == kT.SiteList.size() - 1) loc = TrackState.AtLastHit;
-
+            } else if (i == kT.SiteList.size() - 1) 
+                loc = TrackState.AtLastHit;
+            
+            //Do not add the missing layer track states yet. TODO!
+            /*
             if (storeTrackStates) {
                 for (int k = 1; k < lay - prevID; k++) {
                     // uses new lcsim constructor
@@ -469,15 +473,16 @@ public class KalmanInterface {
                 }
                 prevID = lay;
             }
-
+            */
+            
             if (loc == TrackState.AtFirstHit || loc == TrackState.AtLastHit || storeTrackStates) {
                 ts = createTrackState(site, loc, true);
                 if (ts != null) newTrack.getTrackStates().add(ts);
             }
         }
-
-        // TODO: get track params at ECal
-
+        
+        //TODO Ecal extrapolation should be done here [ Currently is done in the PatRecDriver ]
+        
         // other track properties
         newTrack.setChisq(kT.chi2);
         newTrack.setTrackType(BaseTrack.TrackType.Y_FIELD.ordinal());

--- a/tracking/src/main/java/org/hps/recon/tracking/kalman/KalmanInterface.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/kalman/KalmanInterface.java
@@ -1064,11 +1064,9 @@ public class KalmanInterface {
                     SiModule SiM = SiMoccupied.get(i);
                     SiM.print(String.format("SiMoccupied Number %d for topBottom=%d", i, topBottom));
                 }
-            }
-            if (verbose) {
                 System.out.format("KalmanInterface.KalmanPatRec event %d: calling KalmanPatRecHPS for topBottom=%d\n", event.getEventNumber(), topBottom);
             }
-            KalmanPatRecHPS kPat = new KalmanPatRecHPS(SiMoccupied, topBottom, evtNum, event.getEventNumber()==17002);
+            KalmanPatRecHPS kPat = new KalmanPatRecHPS(SiMoccupied, topBottom, evtNum, false);
             outList.add(kPat);
         }
         return outList;

--- a/tracking/src/main/java/org/hps/recon/tracking/kalman/KalmanInterface.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/kalman/KalmanInterface.java
@@ -61,6 +61,7 @@ public class KalmanInterface {
     public boolean verbose;
     double svtAngle;
     private HelixPlaneIntersect hpi;
+    KalmanParams kPar;
     Random rnd;
 
     // Get the HPS tracker hit corresponding to a Kalman hit
@@ -158,8 +159,15 @@ public class KalmanInterface {
         long rndSeed = -3263009337738135404L;
         rnd = new Random();
         rnd.setSeed(rndSeed);
+        
+        kPar = new KalmanParams();
     }
 
+    // Return the reference to the parameter setting code for the driver to use
+    public KalmanParams getKalmanParams() {
+        return kPar;
+    }
+    
     // Transformation from HPS global coordinates to Kalman global coordinates
     public static Vec vectorGlbToKalman(double[] HPSvec) { 
         Vec kalVec = new Vec(HPSvec[0], HPSvec[2], -HPSvec[1]);
@@ -1047,7 +1055,7 @@ public class KalmanInterface {
                 }
                 System.out.format("KalmanInterface.KalmanPatRec event %d: calling KalmanPatRecHPS for topBottom=%d\n", event.getEventNumber(), topBottom);
             }
-            KalmanPatRecHPS kPat = new KalmanPatRecHPS(SiMoccupied, topBottom, evtNum, (event.getEventNumber()==-99));
+            KalmanPatRecHPS kPat = new KalmanPatRecHPS(SiMoccupied, topBottom, evtNum, kPar, (event.getEventNumber()==-99));
             outList.add(kPat);
         }
         return outList;

--- a/tracking/src/main/java/org/hps/recon/tracking/kalman/KalmanParams.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/kalman/KalmanParams.java
@@ -1,0 +1,317 @@
+package org.hps.recon.tracking.kalman;
+
+import java.util.ArrayList;
+
+// Parameters used by the Kalman-Filter pattern recognition and fitting
+public class KalmanParams {
+    static final int nTries = 2;  // Number of iterations through the entire pattern recognition; not configurable
+    int nIterations;              // Number of Kalman-fit iterations in the final fit
+    double[] kMax; 
+    double[] tanlMax; 
+    double[] dRhoMax; 
+    double[] dzMax;
+    double[] chi2mx1; 
+    int minHits0;
+    int[] minHits1; 
+    double mxChi2Inc; 
+    double minChi2IncBad;
+    double[] mxResid; 
+    double mxResidShare; 
+    double mxChi2double;
+    int mxShared; 
+    int [] minStereo;
+    int minAxial;
+    double mxTdif;
+    ArrayList<int[]> [] lyrList;
+    private int[] Swap = {1,0, 3,2, 5,4, 7,6, 9,8, 11,10, 13,12};
+    
+    KalmanParams() {
+        
+        kMax = new double[nTries];
+        tanlMax = new double[nTries];
+        dRhoMax = new double[nTries];
+        dzMax = new double[nTries];
+        chi2mx1 = new double[nTries];
+        minHits1 = new int[nTries];
+        mxResid = new double[nTries];
+        minStereo = new int[nTries];  
+        
+        // Set all the default values
+        // Cut and parameter values (length units are mm, time is ns).
+        // The index is the iteration number.
+        // The second iteration generally will have looser cuts.
+        
+        nIterations = 1;    // Number of Kalman filter iterations per track in the final fit
+        kMax[0] = 3.0;      // Maximum curvature for seed
+        kMax[1] = 6.0;      
+        tanlMax[0] = 0.08;  // Maximum tan(lambda) for seed
+        tanlMax[1] = 0.12;
+        dRhoMax[0] = 15.;   // Maximum dRho at target plane for seed
+        dRhoMax[1] = 25.;
+        dzMax[0] = 3.;      // Maximum z at target plane for seed
+        dzMax[1] = 10.;
+        chi2mx1[0] = 8.0;   // Maximum chi**2/#hits for good track
+        chi2mx1[1] = 12.0;  
+        minHits0 = 6;       // Minimum number of hits in the initial outward filtering (including 5 from the seed)
+        minHits1[0] = 7;    // Minimum number of hits for a good track
+        minHits1[1] = 6;
+        mxChi2Inc = 2.;  // Maximum increment to the chi^2 to add a hit to a completed track 
+        minChi2IncBad = 10.; // Threshold for removing a bad hit from a track candidate
+        mxResid[0] = 150.;  // Maximum residual, in units of detector resolution, for picking up a hit
+        mxResid[1] = 200.;
+        mxResidShare = 10.; // Maximum residual, in units of detector resolution, for a hit to be shared
+        mxChi2double = 6.;  // Maximum chi^2 increment to keep a shared hit
+        minStereo[0] = 4;
+        minStereo[1] = 3;   // Minimum number of stereo hits
+        minAxial = 2;       // Minimum number of axial hits
+        mxShared = 2;       // Maximum number of shared hits
+        mxTdif = 30.;       // Maximum time difference of hits in a track
+        
+        // Load the default search strategies
+        // Index 0 is for the bottom tracker (+z), 1 for the top (-z)
+        lyrList = new ArrayList[2];
+        for (int i=0; i<2; ++i) {
+            lyrList[i] = new ArrayList<int[]>(15);
+        }
+        final int[] list0 = {6, 7, 8, 9, 10};
+        final int[] list1 = {4, 5, 6, 7, 8};
+        final int[] list2 = {5, 6, 8, 9, 10};
+        final int[] list3 = {5, 6, 7, 8, 10};
+        final int[] list4 = { 3, 6, 8, 9, 10 };
+        final int[] list5 = { 4, 5, 8, 9, 10 };
+        final int[] list6 = { 4, 6, 7, 8, 9 };
+        final int[] list7 = { 4, 6, 7, 9, 10 };
+        final int[] list8 = { 2, 5, 8, 9, 12};
+        final int[] list9 = { 8, 10, 11, 12, 13};
+        final int[] list10 = {6, 9, 10, 11, 12};
+        final int[] list11 = {6, 7, 9, 10, 12};
+        final int[] list12 = {2, 3, 4, 5, 6};
+        final int[] list13 = {2, 4, 5, 6, 7};
+        final int[] list14 = {6, 7, 8, 10, 11};
+        lyrList[0].add(list0);
+        lyrList[0].add(list1);
+        lyrList[0].add(list2);
+        lyrList[0].add(list3);
+        lyrList[0].add(list4);
+        lyrList[0].add(list5);
+        lyrList[0].add(list6);
+        lyrList[0].add(list7);
+        lyrList[0].add(list8);
+        lyrList[0].add(list9);
+        lyrList[0].add(list10);
+        lyrList[0].add(list11);
+        lyrList[0].add(list12);
+        lyrList[0].add(list13);
+        lyrList[0].add(list14);
+        
+        // Swap axial/stereo in list entries for the top tracker
+        for (int[] list: lyrList[0]) {
+            int [] listTop = new int[5];
+            for (int i=0; i<5; ++i) {
+                listTop[i] = Swap[list[i]];
+            }
+            for (int i=0; i<4; ++i) {
+                if (listTop[i] > listTop[i+1]) { // Sorting entries. No more than one swap should be necessary.
+                    int tmp = listTop[i];
+                    listTop[i] = listTop[i+1];
+                    listTop[i+1] = tmp;
+                }
+            }
+            lyrList[1].add(listTop);
+        }       
+    }
+    
+    public void setIterations(int N) {
+        if (N < 1) {
+            System.out.format("KalmanParams: %d iterations not allowed\n", N);
+            return;
+        }
+        System.out.format("KalmanParams: setting the number of Kalman Filter iterations to %d\n", N);
+        nIterations = N;
+    }
+    
+    public void setMxChi2Inc(double mxC) {
+        if (mxC <= 1.) {
+            System.out.format("KalmanParams: maximum chi^2 increment must be at least unity. %8.2f not valid\n", mxC);
+            return;
+        }
+        System.out.format("KalmanParams: setting the maximum chi^2 increment to add a hit to a track to %8.2f\n", mxC);
+        mxChi2Inc = mxC;
+    }
+    
+    public void setMxChi2double(double mxDb) {
+        if (mxDb <= 0.) {
+            System.out.format("KalmanParams: maximum chi^2 increment of shared hit of %8.2f not allowed\n", mxDb);
+            return;
+        }
+        System.out.format("KalmanParams: setting the maximum chi^2 increment of shared hit to %8.2f sigma\n", mxDb);
+        mxChi2double = mxDb;  
+    }
+    
+    public void setMinChi2IncBad(double mnB) {
+        if (mnB <= 3.0) {
+            System.out.format("KalmanParams: minimum chi^2 increment to remove a bad hit must be at least 3. %8.2f not valid\n", mnB);
+            return;
+        }
+        System.out.format("KalmanParams: setting the minimum chi^2 increment to remove a bad hit to %8.2f\n", mnB);
+        minChi2IncBad = mnB;        
+    }
+    
+    public void setMxResidShare(double mxSh) {
+        if (mxSh <= 0.) {
+            System.out.format("KalmanParams: maximum residual of shared hit of %8.2f not allowed\n", mxSh);
+            return;
+        }
+        System.out.format("KalmanParams: setting the maximum residual for a shared hit to %8.2f sigma\n", mxSh);
+        mxResidShare = mxSh;  
+    }
+    
+    public void setMaxK(double kMx) {
+        if (kMx <= 0.) {
+            System.out.format("KalmanParams: max 1/pt of %8.2f not allowed\n", kMx);
+            return;
+        }
+        System.out.format("KalmanParams: setting the maximum 1/pt to %8.2f\n", kMx);
+        kMax[1] = kMx;
+        kMax[0] = Math.min(kMax[0], 0.6*kMx);
+    }
+    
+    public void setMxResid(double mxR) {
+        if (mxR <= 1.) {
+            System.out.format("KalmanParams: max resid of %8.2f not allowed\n", mxR);
+            return;
+        }
+        System.out.format("KalmanParams: setting the maximum residual to pick up hits to %8.2f sigma\n", mxR);
+        mxResid[1] = mxR;
+        mxResid[0] = Math.min(mxResid[0], 0.5*mxR);
+    }
+    
+    public void setMaxTanL(double tlMx) {
+        if (tlMx <= 0.) {
+            System.out.format("KalmanParams: max seed tan(lambda) of %8.2f not allowed\n", tlMx);
+            return;
+        }
+        System.out.format("KalmanParams: setting the maximum seed tan(lambda) to %8.2f\n", tlMx);
+        tanlMax[1] = tlMx;
+        tanlMax[0] = Math.min(tanlMax[0], 0.8*tlMx);
+    }
+    
+    public void setMaxdRho(double dMx) {
+        if (dMx <= 0.0) {
+            System.out.format("KalmanParams: max dRho of %8.2f not allowed\n", dMx);
+            return;
+        }
+        System.out.format("KalmanParams: setting the maximum dRho to %8.2f mm\n", dMx);
+        dRhoMax[1] = dMx;
+        dRhoMax[0] = Math.min(dRhoMax[0], 0.6*dMx);
+    }
+    
+    public void setMaxdZ(double zMx) {
+        if (zMx <= 0.0) {
+            System.out.format("KalmanParams: max dZ of %8.2f not allowed\n", zMx);
+            return;
+        }
+        System.out.format("KalmanParams: setting the maximum dz to %8.2f mm\n", zMx);
+        dzMax[1] = zMx;
+        dzMax[0] = Math.min(dzMax[0], 0.6*zMx);
+    }
+    
+    public void setMaxChi2(double xMx) {
+        if (xMx <= 0.) {
+            System.out.format("KalmanParams: max chi2 of %8.2f not allowed\n", xMx);
+            return;
+        }
+        System.out.format("KalmanParams: setting the maximum chi^2/hit to %8.2f\n", xMx);
+        chi2mx1[1] = xMx;
+        chi2mx1[0] = Math.min(chi2mx1[0], 0.6*xMx);
+    }
+    
+    public void setMinHits(int minH) {
+        if (minH < 5) {
+            System.out.format("KalmanParams: minimum number of hits = %d not allowed\n", minH);
+            return;
+        }
+        System.out.format("KalmanParams: setting the minimum number of hits to %d\n", minH);
+        minHits1[1] = minH;
+        minHits1[0] = Math.max(minHits1[0], minH+1);
+    }
+    
+    public void setMinStereo(int minS) {
+        if (minS < 3) {
+            System.out.format("KalmanParams: minimum number of stereo hits = %d not allowed\n", minS);
+            return;
+        }
+        System.out.format("KalmanParams: setting the minimum number of stereo hits to %d\n", minS);
+        minStereo[1] = minS;
+        minStereo[0] = Math.max(minStereo[0], minS+1);
+    }
+    
+    public void setMaxShared(int mxSh) {
+        System.out.format("KalmanParams: setting the maximum number of shared hits to %d\n", mxSh);
+        mxShared = mxSh;
+    }
+    
+    public void setMaxTimeRange(double mxT) {
+        System.out.format("KalmanParams: setting the maximum time range for hits on a track to %8.2f ns\n", mxT);
+        mxTdif = mxT;
+    }
+    
+    public void clrStrategies() {
+        System.out.format("KalmanParams: clearing all lists of search strategies.\n");
+        lyrList[0].clear();
+        lyrList[1].clear();
+    }
+    
+    // Add a search strategy for the bottom and top trackers
+    public boolean addStrategy(int [] list) {
+        if (!addStrategy(list,0)) return false;
+        // Swap axial/stereo in list entries for the top tracker
+        int [] listTop = new int[5];
+        for (int i=0; i<5; ++i) {
+            listTop[i] = Swap[list[i]];
+        }
+        for (int i=0; i<4; ++i) {
+            if (listTop[i] > listTop[i+1]) { // Sorting entries. No more than one swap should be necessary.
+                int tmp = listTop[i];
+                listTop[i] = listTop[i+1];
+                listTop[i+1] = tmp;
+            }
+        } 
+        if (!addStrategy(listTop,1)) return false;
+        return true;
+    }
+    
+    // Add a search strategy for just the bottom or top tracker
+    public boolean addStrategy(int [] list, int topBottom) {
+        int nAxial = 0;
+        int nStereo = 0;
+        for (int i=0; i<5; ++i) {
+            if (list[i]%2 == 0) {
+                if (topBottom == 0) nStereo++;
+                else nAxial++;
+            } else {
+                if (topBottom == 0) nAxial++;
+                else nStereo++;
+            }
+        }
+        if (nAxial != 2 || nStereo != 3) {
+            System.out.format("KalmanParams.addStrategy: invalid search strategy for topBottom=%d: %d %d %d %d %d\n", 
+                    topBottom, list[0],list[1],list[2],list[3],list[4]);
+            return false;
+        }
+        for (int [] oldList : lyrList[topBottom]) {
+            int nMatch = 0;
+            for (int i=0; i<5; ++i) {
+                if (oldList[i] == list[i]) nMatch++;
+            }
+            if (nMatch == 5) {
+                System.out.format("KalmanParams.addStrategy: strategy %d %d %d %d %d is already in the list\n", list[0],list[1],list[2],list[3],list[4]);
+                return false;
+            }
+        }
+        System.out.format("KalmanParams.addStrategy: adding search strategy %d %d %d %d %d for topBottom=%d\n", 
+                list[0],list[1],list[2],list[3],list[4],topBottom);
+        lyrList[topBottom].add(list);
+        return true;
+    }
+}

--- a/tracking/src/main/java/org/hps/recon/tracking/kalman/KalmanParams.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/kalman/KalmanParams.java
@@ -57,8 +57,8 @@ public class KalmanParams {
         minHits1[1] = 6;
         mxChi2Inc = 2.;  // Maximum increment to the chi^2 to add a hit to a completed track 
         minChi2IncBad = 10.; // Threshold for removing a bad hit from a track candidate
-        mxResid[0] = 150.;  // Maximum residual, in units of detector resolution, for picking up a hit
-        mxResid[1] = 200.;
+        mxResid[0] = 50.;  // Maximum residual, in units of detector resolution, for picking up a hit
+        mxResid[1] = 100.;
         mxResidShare = 10.; // Maximum residual, in units of detector resolution, for a hit to be shared
         mxChi2double = 6.;  // Maximum chi^2 increment to keep a shared hit
         minStereo[0] = 4;

--- a/tracking/src/main/java/org/hps/recon/tracking/kalman/KalmanPatRecDriver.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/kalman/KalmanPatRecDriver.java
@@ -66,8 +66,22 @@ public class KalmanPatRecDriver extends Driver {
     private RelationalTable hitToRotated;
     private double executionTime;
 
+    //Path to store gnu plots
+    //Should be removed
+    private String outputGnuPlotDir = "./";
+    private boolean doGnuPlots = false;
+    
+
     public void setOutputPlotsFilename(String input) {
         outputPlots = input;
+    }
+
+    public void setOutputGnuPlotDir(String input) { 
+        outputGnuPlotDir = input;
+    }
+
+    public void setDoGnuPlots(boolean input) {
+        doGnuPlots = input;
     }
 
     public String getOutputFullTrackCollectionName() {
@@ -484,11 +498,10 @@ public class KalmanPatRecDriver extends Driver {
                 aida.histogram1D("GBL number of wrong hits on track").fill(nBad);
             }
         }
-        
-        String path = "C:\\Users\\Robert\\Desktop\\Kalman\\";
+       
         if (nPlotted < 40) {
-            KI.plotKalmanEvent(path, event, kPatList);
-            KI.plotGBLtracks(path, event);
+            KI.plotKalmanEvent(outputGnuPlotDir, event, kPatList);
+            KI.plotGBLtracks(outputGnuPlotDir, event);
             nPlotted++;
         }
         

--- a/tracking/src/main/java/org/hps/recon/tracking/kalman/KalmanPatRecDriver.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/kalman/KalmanPatRecDriver.java
@@ -367,12 +367,6 @@ public class KalmanPatRecDriver extends Driver {
                 double ptInv_check = hParams_check[2];
                 double pt = Math.abs(1./ptInv_check);
                 
-                if (pt < ptCut)
-                    continue;
-                
-                if (KalmanTrackHPS.getTrackerHits().size() < nMinHits)
-                    continue;
-                
                 outputFullTracks.add(KalmanTrackHPS);
                 List<GBLStripClusterData> clstrs = KI.createGBLStripClusterData(kTk);
                 if (verbose) {
@@ -561,8 +555,6 @@ public class KalmanPatRecDriver extends Driver {
                 double alpha = conFac / B; // Convert from pt in GeV to curvature in mm
                 for (Track tkrGBL : tracksGBL) {
                     aida.histogram1D("GBL track chi^2").fill(tkrGBL.getChi2());
-                    List<TrackState> stLst = tkrGBL.getTrackStates();
-                    
                     ArrayList<MCParticle> mcParts = new ArrayList<MCParticle>();
                     ArrayList<Integer> mcCnt= new ArrayList<Integer>();
                     List<TrackerHit> hitsOnTrack = TrackUtils.getStripHits(tkrGBL, hitToStrips, hitToRotated);

--- a/tracking/src/main/java/org/hps/recon/tracking/kalman/KalmanPatRecDriver.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/kalman/KalmanPatRecDriver.java
@@ -95,7 +95,7 @@ public class KalmanPatRecDriver extends Driver {
     public void setVerbose(boolean input) {
         verbose = input;
     }
-    
+
     public void setUniformB(boolean input) {
         uniformB = input;
         System.out.format("KalmanPatRecDriver: the B field will be assumed uniform.\n");
@@ -219,7 +219,7 @@ public class KalmanPatRecDriver extends Driver {
         double runTime = (double)(endTime - startTime)/1000000.;
         executionTime += runTime;
         nEvents++;
-        System.out.format("KalmanPatRecDriver.process: run time for pattern recognition at event %d is %12.7f milliseconds\n", evtNumb, runTime);
+        Logger.getLogger(KalmanPatRecDriver.class.getName()).log(Level.FINE,"KalmanPatRecDriver.process: run time for pattern recognition at event "+evtNumb+" is "+runTime+" milliseconds");
         aida.histogram1D("Kalman pattern recognition time").fill(runTime);
         if (kPatList == null) {
             System.out.println("KalmanPatRecDriver.process: null returned by KalmanPatRec.");
@@ -499,7 +499,7 @@ public class KalmanPatRecDriver extends Driver {
             }
         }
        
-        if (nPlotted < 40) {
+        if (doGnuPlots && nPlotted < 40) {
             KI.plotKalmanEvent(outputGnuPlotDir, event, kPatList);
             KI.plotGBLtracks(outputGnuPlotDir, event);
             nPlotted++;
@@ -725,10 +725,12 @@ public class KalmanPatRecDriver extends Driver {
     public void endOfData() {
         System.out.format("KalmanPatRecDrive.endOfData: total pattern recognition execution time=%12.4f ms for %d events and %d tracks.\n", 
                 executionTime, nEvents, nTracks);
-        System.out.println("Individual layer efficiencies:");
-        for (int lyr=0; lyr<14; lyr++) {
-            double effic = (double)nHitsOnTracks[lyr]/(double)nTracks;
-            System.out.format("   Layer %d, hit efficiency = %9.3f\n", lyr, effic);
+        if (verbose) {
+            System.out.println("Individual layer efficiencies:");
+            for (int lyr=0; lyr<14; lyr++) {
+                double effic = (double)nHitsOnTracks[lyr]/(double)nTracks;
+                System.out.format("   Layer %d, hit efficiency = %9.3f\n", lyr, effic);
+            }
         }
         if (outputPlots != null) {
             try {

--- a/tracking/src/main/java/org/hps/recon/tracking/kalman/KalmanPatRecDriver.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/kalman/KalmanPatRecDriver.java
@@ -276,7 +276,8 @@ public class KalmanPatRecDriver extends Driver {
                 
                 //Here is where the tracks to be persisted are formed
                 Track KalmanTrackHPS = KI.createTrack(kTk, true);
-                outputFullTracks.add(KalmanTrackHPS);
+                if (KalmanTrackHPS != null)
+                    outputFullTracks.add(KalmanTrackHPS);
                 List<GBLStripClusterData> clstrs = KI.createGBLStripClusterData(kTk);
                 if (verbose) {
                     for (GBLStripClusterData clstr : clstrs) {

--- a/tracking/src/main/java/org/hps/recon/tracking/kalman/KalmanPatRecDriver.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/kalman/KalmanPatRecDriver.java
@@ -67,8 +67,7 @@ public class KalmanPatRecDriver extends Driver {
     private RelationalTable hitToStrips;
     private RelationalTable hitToRotated;
     private double executionTime;
-    private double bfield;
-
+    
     //Path to store gnu plots
     //Should be removed
     private String outputGnuPlotDir = "./";
@@ -155,6 +154,7 @@ public class KalmanPatRecDriver extends Driver {
         aida.histogram1D("z0", 100, -2., 2.);
         aida.histogram1D("z0 error, sigmas", 100, -5., 5.);
         aida.histogram1D("pt inverse", 100, -2.5, 2.5);
+        aida.histogram1D("pt inverse True", 100, -2.5, 2.5);
         aida.histogram1D("pt inverse error, percent", 100, -50., 50.);
         aida.histogram1D("pt inverse error, sigmas", 100, -5., 5.);
         aida.histogram1D("tanLambda", 100, -0.3, 0.3);
@@ -208,10 +208,6 @@ public class KalmanPatRecDriver extends Driver {
         for (ScatteringDetectorVolume vol : materialVols) {
             detPlanes.add((SiStripPlane) (vol));
         }
-        
-        TrackUtils.getBField(det).magnitude();
-        Hep3Vector fieldInTracker = TrackUtils.getBField(det);
-        this.bfield = Math.abs(fieldInTracker.y());
         
         det.getSubdetector("Tracker").getDetectorElement().findDescendants(HpsSiSensor.class);
 
@@ -300,8 +296,9 @@ public class KalmanPatRecDriver extends Driver {
                     continue;
                 
                 //pT cut 
-                double momentum_param = 2.99792458e-04;
-                double pt = Math.abs((1 / KalmanTrackHPS.getTrackStates().get(0).getOmega()) * bfield * momentum_param);
+                double [] hParams_check = kTk.originHelixParms();
+                double ptInv_check = hParams_check[2];
+                double pt = Math.abs(1./ptInv_check);
                 
                 if (pt < ptCut)
                     continue;
@@ -471,6 +468,7 @@ public class KalmanPatRecDriver extends Driver {
                         aida.histogram1D("phi0").fill(phi0);
                         aida.histogram1D("phi0 error, sigmas").fill((phi0-phi0True)/phi0Err);
                         aida.histogram1D("pt inverse").fill(ptInv);
+                        aida.histogram1D("pt inverse True").fill(ptInvTrue);
                         aida.histogram1D("pt inverse error, percent").fill(100.*(ptInv-ptInvTrue)/ptInvTrue);
                         aida.histogram1D("pt inverse error, sigmas").fill((ptInv-ptInvTrue)/ptInvErr);
                         aida.histogram1D("tanLambda").fill(tanLambda);

--- a/tracking/src/main/java/org/hps/recon/tracking/kalman/KalmanPatRecDriver.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/kalman/KalmanPatRecDriver.java
@@ -75,9 +75,18 @@ public class KalmanPatRecDriver extends Driver {
     private boolean doDebugPlots = false;
 
     //Pattern Reco cuts 
-    private double ptCut = 0.3; //GeV
+    private double ptCut    = 0.3; //GeV
+    private double nMinHits = 8;  
     
 
+    public void setPtCut(double val) {
+        ptCut = val;
+    }
+    
+    public void setNMinHits(double val) {
+        nMinHits = val;
+    }
+    
     public void setOutputPlotsFilename(String input) {
         outputPlots = input;
     }
@@ -295,6 +304,9 @@ public class KalmanPatRecDriver extends Driver {
                 double pt = Math.abs((1 / KalmanTrackHPS.getTrackStates().get(0).getOmega()) * bfield * momentum_param);
                 
                 if (pt < ptCut)
+                    continue;
+                
+                if (KalmanTrackHPS.getTrackerHits().size() < nMinHits)
                     continue;
                 
                 outputFullTracks.add(KalmanTrackHPS);

--- a/tracking/src/main/java/org/hps/recon/tracking/kalman/KalmanPatRecDriver.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/kalman/KalmanPatRecDriver.java
@@ -67,25 +67,30 @@ public class KalmanPatRecDriver extends Driver {
     private RelationalTable hitToStrips;
     private RelationalTable hitToRotated;
     private double executionTime;
-    
     //Path to store gnu plots
     //Should be removed
     private String outputGnuPlotDir = "./";
     private boolean doDebugPlots = false;
 
-    //Pattern Reco cuts 
-    private double ptCut    = 0.3; //GeV
-    private double nMinHits = 8;  
+    private KalmanParams kPar;
     
+    // Parameters for the Kalman pattern recognition that can be set by the user in the steering file:
+    private int numKalmanIteration;    // Number of Kalman filter iterations per track in the final fit
+    private double maxPtInverse;       // Maximum value of 1/pt for the seed and the final track
+    private double maxD0;              // Maximum dRho (or D0) at the target plane for a seed and the final track
+    private double maxZ0;              // Maximum dz (or Z0) at the target plane for a seed and the final track
+    private double maxChi2;            // Maximum Kalman chi^2 per hit for a track candidate
+    private int minHits;               // Minimum number of hits on a track
+    private int minStereo;             // Minimum number of stereo hits on a track
+    private int maxSharedHits;         // Maximum number of hits on a track that are shared with another track
+    private double maxTimeRange;       // Maximum time range in ns spanned by all the hits on a track
+    private double maxTanLambda;       // Maximum tan(lambda) for a track seed
+    private double maxResidual;        // Maximum residual in units of SSD resolution to add a hit to a track candidate
+    private double maxChi2Inc;         // Maximum increment in chi^2 to add a hit to an already completed track
+    private double minChi2IncBad;      // Minimum increment in chi^2 to remove a hit from an already completed track
+    private double maxResidShare;      // Maximum residual in units of detector resolution for a shared hit
+    private double maxChi2IncShare;    // Maximum increment in chi^2 for a hit shared with another track
 
-    public void setPtCut(double val) {
-        ptCut = val;
-    }
-    
-    public void setNMinHits(double val) {
-        nMinHits = val;
-    }
-    
     public void setOutputPlotsFilename(String input) {
         outputPlots = input;
     }
@@ -211,10 +216,66 @@ public class KalmanPatRecDriver extends Driver {
         
         det.getSubdetector("Tracker").getDetectorElement().findDescendants(HpsSiSensor.class);
 
+        // Instantiate the interface to the Kalman-Filter code and set up the geometry
         KI = new KalmanInterface(verbose, uniformB);
         KI.createSiModules(detPlanes, fm);
         
         decoder = det.getSubdetector("Tracker").getIDDecoder();
+        
+        // Change Kalman parameters per settings supplied by the steering file
+        // We assume that if not set by the steering file, then the parameters will have the Java default values for the primitives
+        // Note that all of the parameters have defaults hard coded in KalmanParams.java
+        kPar = KI.getKalmanParams();
+        if (numKalmanIteration != 0) kPar.setIterations(numKalmanIteration);
+        if (maxPtInverse != 0.0) kPar.setMaxK(maxPtInverse);
+        if (maxD0 != 0.0) kPar.setMaxdRho(maxD0);
+        if (maxZ0 != 0.0) kPar.setMaxdZ(maxZ0);
+        if (maxChi2 != 0.0) kPar.setMaxChi2(maxChi2);
+        if (minHits != 0) kPar.setMinHits(minHits);
+        if (minStereo != 0) kPar.setMinStereo(minStereo);
+        if (maxSharedHits != 0) kPar.setMaxShared(maxSharedHits);
+        if (maxTimeRange != 0.0) kPar.setMaxTimeRange(maxTimeRange);
+        if (maxTanLambda != 0.0) kPar.setMaxTanL(maxTanLambda);
+        if (maxResidual != 0.0) kPar.setMxResid(maxResidual);
+        if (maxChi2Inc != 0.0) kPar.setMxChi2Inc(maxChi2Inc);
+        if (minChi2IncBad != 0.0) kPar.setMinChi2IncBad(minChi2IncBad);
+        if (maxResidShare != 0.0) kPar.setMxResidShare(maxResidShare);
+        if (maxChi2IncShare != 0.0) kPar.setMxChi2double(maxChi2IncShare);
+        
+        // Here we can replace or add search strategies to the pattern recognition (not, as yet, controlled by the steering file)
+        // Layers are numbered 0 through 13, and the numbering here corresponds to the bottom tracker. The top-tracker lists are
+        // appropriately translated from these. Each seed needs 3 stereo and 2 axial layers
+        kPar.clrStrategies();
+        int[] list0 = {6, 7, 8, 9, 10};
+        int[] list1 = {4, 5, 6, 7, 8};
+        int[] list2 = {5, 6, 8, 9, 10};
+        int[] list3 = {5, 6, 7, 8, 10};
+        int[] list4 = { 3, 6, 8, 9, 10 };
+        int[] list5 = { 4, 5, 8, 9, 10 };
+        int[] list6 = { 4, 6, 7, 8, 9 };
+        int[] list7 = { 4, 6, 7, 9, 10 };
+        int[] list8 = { 2, 5, 8, 9, 12};
+        int[] list9 = { 8, 10, 11, 12, 13};
+        int[] list10 = {6, 9, 10, 11, 12};
+        int[] list11 = {6, 7, 9, 10, 12};
+        int[] list12 = {2, 3, 4, 5, 6};
+        int[] list13 = {2, 4, 5, 6, 7};
+        int[] list14 = {6, 7, 8, 10, 11};
+        kPar.addStrategy(list0);
+        kPar.addStrategy(list1);
+        kPar.addStrategy(list2);
+        kPar.addStrategy(list3);
+        kPar.addStrategy(list4);
+        kPar.addStrategy(list5);
+        kPar.addStrategy(list6);
+        kPar.addStrategy(list7);
+        kPar.addStrategy(list8);
+        kPar.addStrategy(list9);
+        kPar.addStrategy(list10);
+        kPar.addStrategy(list11);
+        kPar.addStrategy(list12);
+        kPar.addStrategy(list13);
+        kPar.addStrategy(list14);
         
         System.out.format("KalmanPatRecDriver: the B field is assumed uniform? %b\n", uniformB);
     }
@@ -273,6 +334,13 @@ public class KalmanPatRecDriver extends Driver {
             }
             for (KalTrack kTk : kPat.TkrList) {
                 if (verbose) kTk.print(String.format(" PatRec for topBot=%d ",kPat.topBottom));
+                double [][] covar = kTk.originCovariance();
+                for (int ix=0; ix<5; ++ix) {
+                    for (int iy=0; iy<5; ++iy) {
+                        if (Double.isNaN(covar[ix][iy])) System.out.format("KalmanPatRecDriver.process event %d: NaN at %d %d in covariance for track %d\n",
+                                event.getEventNumber(), ix, iy, kTk.ID);
+                    }
+                }
                 
                 nKalTracks++;
                 if (doDebugPlots) {
@@ -576,7 +644,7 @@ public class KalmanPatRecDriver extends Driver {
             }
         }
         
-        if (doDebugPlots && nPlotted < 40) {
+        if (doDebugPlots && nPlotted < 20) {
             KI.plotKalmanEvent(outputGnuPlotDir, event, kPatList);
             KI.plotGBLtracks(outputGnuPlotDir, event);
             nPlotted++;
@@ -823,5 +891,52 @@ public class KalmanPatRecDriver extends Driver {
                 Logger.getLogger(TrackingReconstructionPlots.class.getName()).log(Level.SEVERE, null, ex);
             }
         }
+    }
+    
+    // Methods to set Kalman parameters from within the steering file
+    public void setNumKalmanIteration(int numKalmanIteration) {
+        this.numKalmanIteration = numKalmanIteration;
+    }
+    public void setMaxPtInverse(double maxPtInverse) {
+        this.maxPtInverse = maxPtInverse;
+    }
+    public void setMaxD0(double maxD0) {
+        this.maxD0 = maxD0;
+    }
+    public void setMaxZ0(double maxZ0) {
+        this.maxZ0 = maxZ0;
+    }
+    public void setMaxChi2(double maxChi2) {
+        this.maxChi2 = maxChi2;
+    }
+    public void setMinHits(int minHits) {
+        this.minHits = minHits;
+    }
+    public void setMinStereo(int minStereo) {
+        this.minStereo = minStereo;
+    }
+    public void setMaxSharedHits(int maxSharedHits) {
+        this.maxSharedHits = maxSharedHits;
+    }
+    public void setMaxTimeRange(double maxTimeRange) {
+        this.maxTimeRange = maxTimeRange;
+    }
+    public void setMaxTanLambda(double maxTanLambda) {
+        this.maxTanLambda = maxTanLambda;
+    }
+    public void setMaxResidual(double maxResidual) {
+        this.maxResidual = maxResidual;
+    }
+    public void setMaxChi2Inc(double maxChi2Inc) {
+        this.maxChi2Inc = maxChi2Inc;
+    }
+    public void setMinChi2IncBad(double minChi2IncBad) {
+        this.minChi2IncBad = minChi2IncBad;
+    }
+    public void setMaxResidShare(double maxResidShare) {
+        this.maxResidShare = maxResidShare;
+    }
+    public void setMaxChi2IncShare(double maxChi2IncShare) {
+        this.maxChi2IncShare = maxChi2IncShare;
     }
 }

--- a/tracking/src/main/java/org/hps/recon/tracking/kalman/KalmanPatRecDriver.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/kalman/KalmanPatRecDriver.java
@@ -342,22 +342,27 @@ public class KalmanPatRecDriver extends Driver {
                 }
                 int nBad = 0;
                 for (MeasurementSite site : kTk.SiteList) {
-                    SiModule mod = site.m;
-                    TrackerHit hpsHit = KI.getHpsHit(mod.hits.get(site.hitID));
-                    List<RawTrackerHit> rawHits = hpsHit.getRawHits();
-                    boolean goodHit = false;
-                    for (RawTrackerHit rawHit : rawHits) {
-                        Set<SimTrackerHit> simHits = rawtomc.allFrom(rawHit);
-                        for (SimTrackerHit simHit : simHits) {
-                            MCParticle mcp = simHit.getMCParticle();
-                            int id = mcParts.indexOf(mcp);
-                            if (id == idBest) {
-                                goodHit = true;
-                                break;
-                            }                          
+                    if (site.hitID < 0) {
+                        System.out.format("KalmanPatRecDriver:: Measurement Site has hitID < 0");
+                    }
+                    else {
+                        SiModule mod = site.m;
+                        TrackerHit hpsHit = KI.getHpsHit(mod.hits.get(site.hitID));
+                        List<RawTrackerHit> rawHits = hpsHit.getRawHits();
+                        boolean goodHit = false;
+                        for (RawTrackerHit rawHit : rawHits) {
+                            Set<SimTrackerHit> simHits = rawtomc.allFrom(rawHit);
+                            for (SimTrackerHit simHit : simHits) {
+                                MCParticle mcp = simHit.getMCParticle();
+                                int id = mcParts.indexOf(mcp);
+                                if (id == idBest) {
+                                    goodHit = true;
+                                    break;
+                                }
+                            }
                         }
-                    }    
-                    if (!goodHit) nBad++;
+                        if (!goodHit) nBad++;
+                    }
                 }
                 aida.histogram1D("Kalman number of wrong hits on track").fill(nBad);
                 if (kTk.nHits >= 10) aida.histogram1D("Kalman number of wrong hits on track, >= 10 hits").fill(nBad);

--- a/tracking/src/main/java/org/hps/recon/tracking/kalman/KalmanPatRecDriver.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/kalman/KalmanPatRecDriver.java
@@ -383,6 +383,8 @@ public class KalmanPatRecDriver extends Driver {
                     for (MeasurementSite site : kTk.SiteList) {
                         if (site.hitID < 0) {
                             System.out.format("KalmanPatRecDriver:: Measurement Site has hitID < 0");
+                            kTk.print("with bad site");
+                            site.print("bad one");
                         }
                         else {
                             SiModule mod = site.m;

--- a/tracking/src/main/java/org/hps/recon/tracking/kalman/KalmanPatRecDriver.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/kalman/KalmanPatRecDriver.java
@@ -205,7 +205,7 @@ public class KalmanPatRecDriver extends Driver {
         double runTime = (double)(endTime - startTime)/1000000.;
         executionTime += runTime;
         nEvents++;
-        System.out.format("KalmanPatRecDriver.process: run time for pattern recognition at event %d is %12.7f milliseconds\n", evtNumb, runTime);
+        if (verbose) System.out.format("KalmanPatRecDriver.process: run time for pattern recognition at event %d is %12.7f milliseconds\n", evtNumb, runTime);
         aida.histogram1D("Kalman pattern recognition time").fill(runTime);
         if (kPatList == null) {
             System.out.println("KalmanPatRecDriver.process: null returned by KalmanPatRec.");
@@ -329,6 +329,11 @@ public class KalmanPatRecDriver extends Driver {
                 int nBad = 0;
                 for (MeasurementSite site : kTk.SiteList) {
                     SiModule mod = site.m;
+                    if (site.hitID < 0) {
+                        System.out.format("KalmanPatRecDriver: site on layer %d is missing its hit.\n", site.m.Layer);
+                        kTk.print("with bad site");
+                        site.print("bad one");
+                    }
                     TrackerHit hpsHit = KI.getHpsHit(mod.hits.get(site.hitID));
                     List<RawTrackerHit> rawHits = hpsHit.getRawHits();
                     boolean goodHit = false;

--- a/tracking/src/main/java/org/hps/recon/tracking/kalman/KalmanPatRecDriver.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/kalman/KalmanPatRecDriver.java
@@ -1,22 +1,14 @@
 package org.hps.recon.tracking.kalman;
 
-//import java.io.File;
-//import java.io.FileNotFoundException;
-import java.io.IOException;
-//import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.hps.recon.tracking.MaterialSupervisor;
 import org.hps.recon.tracking.TrackUtils;
 import org.hps.recon.tracking.TrackData;
-import org.hps.recon.tracking.TrackingReconstructionPlots;
 import org.hps.recon.tracking.MaterialSupervisor.ScatteringDetectorVolume;
 import org.hps.recon.tracking.MaterialSupervisor.SiStripPlane;
 import org.hps.recon.tracking.gbl.GBLStripClusterData;
@@ -24,24 +16,17 @@ import org.hps.util.Pair;
 import org.lcsim.detector.tracker.silicon.HpsSiSensor;
 import org.lcsim.event.EventHeader;
 import org.lcsim.event.LCRelation;
-import org.lcsim.event.MCParticle;
 import org.lcsim.event.RawTrackerHit;
 import org.lcsim.event.RelationalTable;
-import org.lcsim.event.SimTrackerHit;
 import org.lcsim.event.Track;
-import org.lcsim.event.TrackState;
 import org.lcsim.event.TrackerHit;
 import org.lcsim.event.base.BaseTrackState;
 import org.lcsim.event.base.BaseLCRelation;
 import org.lcsim.event.base.BaseRelationalTable;
 import org.lcsim.geometry.Detector;
 import org.lcsim.lcio.LCIOConstants;
-import org.lcsim.recon.tracking.digitization.sisim.SiTrackerHitStrip1D;
-import org.lcsim.recon.tracking.digitization.sisim.TrackerHitType;
 import org.lcsim.util.Driver;
 import org.lcsim.util.aida.AIDA;
-
-import hep.physics.vec.Hep3Vector;
 
 import org.lcsim.geometry.IDDecoder;
 
@@ -56,22 +41,13 @@ public class KalmanPatRecDriver extends Driver {
     private KalmanInterface KI;
     private boolean verbose = false;
     private boolean uniformB = false;
-    private String trackCollectionName = "GBLTracks";
     private String outputFullTrackCollectionName = "KalmanFullTracks";
     public AIDA aida;
-    private String outputPlots = "KalmanTestPlots.root";
-    private int nPlotted;
     private int nTracks;
     private int nEvents;
-    private int[] nHitsOnTracks;
-    private RelationalTable hitToStrips;
-    private RelationalTable hitToRotated;
     private double executionTime;
-    //Path to store gnu plots
-    //Should be removed
-    private String outputGnuPlotDir = "./";
-    private boolean doDebugPlots = false;
     private KalmanParams kPar;
+    private KalmanPatRecPlots kPlot;
     
     // Parameters for the Kalman pattern recognition that can be set by the user in the steering file:
     private int numKalmanIteration;    // Number of Kalman filter iterations per track in the final fit
@@ -89,18 +65,8 @@ public class KalmanPatRecDriver extends Driver {
     private double minChi2IncBad;      // Minimum increment in chi^2 to remove a hit from an already completed track
     private double maxResidShare;      // Maximum residual in units of detector resolution for a shared hit
     private double maxChi2IncShare;    // Maximum increment in chi^2 for a hit shared with another track
-
-    public void setOutputPlotsFilename(String input) {
-        outputPlots = input;
-    }
-
-    public void setOutputGnuPlotDir(String input) { 
-        outputGnuPlotDir = input;
-    }
-
-    public void setDoDebugPlots(boolean input) {
-        doDebugPlots = input;
-    }
+    private int numEvtPlots;           // Number of event displays to plot (gnuplot files)
+    private boolean doDebugPlots;      // Whether to make all the debugging histograms 
 
     public String getOutputFullTrackCollectionName() {
         return outputFullTrackCollectionName;
@@ -126,76 +92,6 @@ public class KalmanPatRecDriver extends Driver {
     public void setTrackCollectionName(String input) {
     }
 
-    private void setupPlots() {
-        if (aida == null) aida = AIDA.defaultInstance();
-        aida.tree().cd("/");
-        nPlotted = 0;
-        nEvents = 0;
-
-        // arguments to histogram1D: name, nbins, min, max
-        aida.histogram1D("Kalman pattern recognition time", 100, 0., 500.);
-        aida.histogram1D("Kalman number of tracks", 10, 0., 10.);
-        aida.histogram1D("Kalman Track Chi2", 50, 0., 100.);
-        aida.histogram1D("Kalman Track Chi2, 12 hits", 50, 0., 100.);
-        aida.histogram1D("Kalman Track simple Chi2, 12 hits", 50, 0., 100.);
-        aida.histogram1D("Kalman Track Chi2 with 12 good hits", 50, 0., 100.);
-        aida.histogram2D("number tracks Kalman vs GBL", 20, 0., 5., 20, 0., 5.);
-        aida.histogram1D("helix chi-squared at origin", 100, 0., 25.);
-        aida.histogram1D("GBL track chi^2", 50, 0., 100.);
-        aida.histogram1D("GBL 12-hit track chi^2", 50, 0., 100.);
-        aida.histogram1D("Kalman Track Number Hits", 20, 0., 20.);
-        aida.histogram1D("GBL number tracks", 10, 0., 10.);
-        aida.histogram1D("Kalman missed hit residual", 100, -1.0, 1.0);
-        aida.histogram1D("Kalman track hit residual, sigmas", 100, -5., 5.);
-        aida.histogram1D("Kalman track hit residual >= 10 hits, sigmas", 100, -5., 5.);
-        aida.histogram1D("Kalman track hit residual", 100, -0.1, 0.1);
-        aida.histogram1D("Kalman hit true error", 100, -0.2, 0.2);
-        aida.histogram1D("Kalman hit true error over uncertainty", 100, -5., 5.);
-        aida.histogram1D("Kalman track Momentum", 100, 0., 5.);
-        aida.histogram1D("GBL momentum", 100, 0., 5.);
-        aida.histogram1D("dRho", 100, -5., 5.);
-        aida.histogram1D("dRho error, sigmas", 100, -5., 5.);
-        aida.histogram1D("z0", 100, -2., 2.);
-        aida.histogram1D("z0 error, sigmas", 100, -5., 5.);
-        aida.histogram1D("pt inverse", 100, -2.5, 2.5);
-        aida.histogram1D("pt inverse True", 100, -2.5, 2.5);
-        aida.histogram1D("pt inverse error, percent >= 10 hits", 100, -50., 50.);
-        aida.histogram1D("pt inverse error, sigmas >= 10 hits", 100, -5., 5.);
-        aida.histogram1D("tanLambda", 100, -0.3, 0.3);
-        aida.histogram1D("GBL tanLambda", 100, -0.3, 0.3);
-        aida.histogram1D("tanLambda true", 100, -0.3, 0.3);
-        aida.histogram1D("tanLambda error, sigmas", 100, -5., 5.);
-        aida.histogram1D("phi0 true", 100, -0.3, 0.3);
-        aida.histogram1D("phi0", 100, -0.3, 0.3);
-        aida.histogram1D("phi0 error, sigmas", 100, -5., 5.);
-        aida.histogram1D("Kalman track drho",100,-5.,5.);
-        aida.histogram1D("Kalman track dz",100,-2.,2.);
-        aida.histogram1D("Kalman track number MC particles",10,0.,10.);
-        aida.histogram1D("Kalman number of wrong hits on track",12,0.,12.);
-        aida.histogram1D("Kalman number of wrong hits on track, >= 10 hits", 12, 0., 12.);
-        aida.histogram1D("GBL track number MC particles",10,0.,10.);
-        aida.histogram1D("GBL number of wrong hits on track",12,0.,12.);
-        aida.histogram1D("MC hit z in local system (should be zero)", 50, -2., 2.);
-        aida.histogram1D("GBL d0", 100, -5., 5.);
-        aida.histogram1D("GBL z0", 100, -2., 2.);
-        aida.histogram1D("GBL pt inverse", 100, -2.5, 2.5);
-        aida.histogram1D("GBL pt inverse, sigmas", 100, -5., 5.);
-        aida.histogram1D("Kalman track time range (ns)", 100, 0., 100.);
-        aida.histogram1D("GBL number of hits",20,0.,20.);
-        for (int lyr=2; lyr<14; ++lyr) {
-            aida.histogram1D(String.format("Layers/Kalman track hit residual in layer %d",lyr), 100, -0.1, 0.1);
-            aida.histogram1D(String.format("Layers/Kalman track hit residual in layer %d, sigmas",lyr), 100, -5., 5.);
-            aida.histogram1D(String.format("Layers/Kalman true error in layer %d",lyr), 100, -0.2, 0.2);
-            aida.histogram1D(String.format("Layers/Kalman layer %d chi^2 contribution", lyr), 100, 0., 20.);
-            if (lyr<13) {
-                aida.histogram1D(String.format("Layers/Kalman kink in xy, layer %d", lyr),100, -0.001, .001);
-                aida.histogram1D(String.format("Layers/Kalman kink in zy, layer %d", lyr),100, -0.0025, .0025);
-            }
-        }
-        nTracks = 0;
-        nHitsOnTracks = new int[14];
-    }
-
     @Override
     public void detectorChanged(Detector det) {
         _materialManager = new MaterialSupervisor();
@@ -203,10 +99,6 @@ public class KalmanPatRecDriver extends Driver {
 
         fm = det.getFieldMap();
 
-        if (doDebugPlots) {
-            setupPlots();
-        }
-     
         detPlanes = new ArrayList<SiStripPlane>();
         List<ScatteringDetectorVolume> materialVols = ((MaterialSupervisor) (_materialManager)).getMaterialVolumes();
         for (ScatteringDetectorVolume vol : materialVols) {
@@ -220,6 +112,9 @@ public class KalmanPatRecDriver extends Driver {
         KI.createSiModules(detPlanes, fm);
         
         decoder = det.getSubdetector("Tracker").getIDDecoder();
+        if (doDebugPlots) {
+            kPlot = new KalmanPatRecPlots(verbose, KI, decoder, numEvtPlots, fm);
+        }
         
         // Change Kalman parameters per settings supplied by the steering file
         // We assume that if not set by the steering file, then the parameters will have the Java default values for the primitives
@@ -281,15 +176,15 @@ public class KalmanPatRecDriver extends Driver {
 
     @Override
     public void process(EventHeader event) {
+        int evtNumb = event.getEventNumber();
         List<Track> outputFullTracks = new ArrayList<Track>();
         List<TrackData> trackDataCollection = new ArrayList<TrackData>();
         List<LCRelation> trackDataRelations = new ArrayList<LCRelation>();
         String stripHitInputCollectionName = "StripClusterer_SiTrackerHitStrip1D";
         if (!event.hasCollection(TrackerHit.class, stripHitInputCollectionName)) {
-            System.out.println("KalmanPatRecDriver.process:" + stripHitInputCollectionName + " does not exist; skipping event");
+            System.out.format("KalmanPatRecDriver.process:" + stripHitInputCollectionName + " does not exist; skipping event %d\n", evtNumb);
             return;
         }
-        int evtNumb = event.getEventNumber();
 
         long startTime = System.nanoTime();
         ArrayList<KalmanPatRecHPS> kPatList = KI.KalmanPatRec(event, decoder);
@@ -297,24 +192,21 @@ public class KalmanPatRecDriver extends Driver {
         double runTime = (double)(endTime - startTime)/1000000.;
         executionTime += runTime;
         nEvents++;
-        Logger.getLogger(KalmanPatRecDriver.class.getName()).log(Level.FINE,"KalmanPatRecDriver.process: run time for pattern recognition at event "+evtNumb+" is "+runTime+" milliseconds");
-        if (doDebugPlots) {
-            aida.histogram1D("Kalman pattern recognition time").fill(runTime);
-        }
+        Logger.getLogger(KalmanPatRecDriver.class.getName()).log(Level.FINE,
+                "KalmanPatRecDriver.process: run time for pattern recognition at event "+evtNumb+" is "+runTime+" milliseconds");
+
         if (kPatList == null) {
-            System.out.println("KalmanPatRecDriver.process: null returned by KalmanPatRec.");
+            System.out.format("KalmanPatRecDriver.process: null returned by KalmanPatRec. Skipping event %d\n", evtNumb);
             return;
         }
-        
-        hitToStrips = TrackUtils.getHitToStripsTable(event);
-        hitToRotated = TrackUtils.getHitToRotatedTable(event);
         
         RelationalTable rawtomc = new BaseRelationalTable(RelationalTable.Mode.MANY_TO_MANY, RelationalTable.Weighting.UNWEIGHTED);
         if (event.hasCollection(LCRelation.class, "SVTTrueHitRelations")) {
             List<LCRelation> trueHitRelations = event.get(LCRelation.class, "SVTTrueHitRelations");
             for (LCRelation relation : trueHitRelations)
-                if (relation != null && relation.getFrom() != null && relation.getTo() != null)
+                if (relation != null && relation.getFrom() != null && relation.getTo() != null) {
                     rawtomc.add(relation.getFrom(), relation.getTo());
+                }
         }
 
         List<RawTrackerHit> rawhits = event.get(RawTrackerHit.class, "SVTRawTrackerHits");
@@ -328,7 +220,7 @@ public class KalmanPatRecDriver extends Driver {
         int nKalTracks = 0;
         for (KalmanPatRecHPS kPat : kPatList) {
             if (kPat == null) {
-                System.out.println("KalmanPatRecDriver.process: pattern recognition failed in the top or bottom tracker.\n");
+                System.out.format("KalmanPatRecDriver.process: pattern recognition failed in the top or bottom tracker for event %d.\n", evtNumb);
                 return;
             }
             for (KalTrack kTk : kPat.TkrList) {
@@ -336,31 +228,16 @@ public class KalmanPatRecDriver extends Driver {
                 double [][] covar = kTk.originCovariance();
                 for (int ix=0; ix<5; ++ix) {
                     for (int iy=0; iy<5; ++iy) {
-                        if (Double.isNaN(covar[ix][iy])) System.out.format("KalmanPatRecDriver.process event %d: NaN at %d %d in covariance for track %d\n",
-                                event.getEventNumber(), ix, iy, kTk.ID);
+                        if (Double.isNaN(covar[ix][iy])) {
+                            System.out.format("KalmanPatRecDriver.process event %d: NaN at %d %d in covariance for track %d\n",evtNumb,ix,iy,kTk.ID);
+                        }
                     }
-                }
-                
+                }                
                 nKalTracks++;
-                if (doDebugPlots) {
-                    aida.histogram1D("Kalman Track Number Hits").fill(kTk.nHits);
-                    if (kTk.nHits == 12) {
-                        aida.histogram1D("Kalman Track Chi2, 12 hits").fill(kTk.chi2);
-                        aida.histogram1D("Kalman Track simple Chi2, 12 hits").fill(kTk.chi2prime());
-                    }
-                    aida.histogram1D("Kalman Track Chi2").fill(kTk.chi2);
-                    double[] momentum = kTk.originP();
-                    double pMag = Math.sqrt(momentum[0]*momentum[0]+momentum[1]*momentum[1]+momentum[2]*momentum[2]);
-                    aida.histogram1D("Kalman track Momentum").fill(pMag);
-                    aida.histogram1D("Kalman track drho").fill(kTk.originHelixParms()[0]);
-                    aida.histogram1D("Kalman track dz").fill(kTk.originHelixParms()[3]);
-                    aida.histogram1D("Kalman track time range (ns)").fill(kTk.tMax - kTk.tMin);
-                }
                 
                 //Here is where the tracks to be persisted are formed
                 Track KalmanTrackHPS = KI.createTrack(kTk, true);
-                if (KalmanTrackHPS == null)
-                    continue;
+                if (KalmanTrackHPS == null) continue;
                 
                 //pT cut 
                 //double [] hParams_check = kTk.originHelixParms();
@@ -387,286 +264,22 @@ public class KalmanPatRecDriver extends Driver {
                 //Set top by default
                 int trackerVolume = 0;
                 //if tanLamda<0 set bottom
-                if (KalmanTrackHPS.getTrackStates().get(0).getTanLambda() < 0)
-                    trackerVolume = 1;
+                if (KalmanTrackHPS.getTrackStates().get(0).getTanLambda() < 0) trackerVolume = 1;
                 
                 //TODO: compute isolations
                 double qualityArray[] = new double[1];
                 qualityArray[0]= -1;
-                
-                
+                                
                 //Add the Track Data 
                 TrackData KFtrackData = new TrackData(trackerVolume, (float) kTk.getTime(), qualityArray);
                 trackDataCollection.add(KFtrackData);
                 trackDataRelations.add(new BaseLCRelation(KFtrackData, KalmanTrackHPS));
-                
+            } // end of loop on tracks
+        } // end of loop on trackers
 
-                
-                if (doDebugPlots) {
-                    // Histogram residuals of hits in layers with no hits on the track and with hits
-                    ArrayList<MCParticle> mcParts = new ArrayList<MCParticle>();
-                    ArrayList<Integer> mcCnt= new ArrayList<Integer>();
-                    for (MeasurementSite site : kTk.SiteList) {
-                        if (verbose) site.print(String.format("track %d", kTk.ID));
-                        StateVector aS = site.aS;
-                        SiModule mod = site.m;
-                        if (aS != null && mod != null) {
-                            double phiS = aS.planeIntersect(mod.p);
-                            if (!Double.isNaN(phiS)) {
-                                Vec rLocal = aS.atPhi(phiS);        // Position in the Bfield frame
-                                Vec rGlobal = aS.toGlobal(rLocal);  // Position in the global frame                 
-                                Vec rLoc = mod.toLocal(rGlobal);    // Position in the detector frame
-                                if (site.hitID < 0) {
-                                    for (Measurement m : mod.hits) {
-                                        double resid = m.v - rLoc.v[1];
-                                        aida.histogram1D("Kalman missed hit residual").fill(resid);
-                                    }                       
-                                } else {
-                                    nHitsOnTracks[mod.Layer]++;
-                                    double resid = mod.hits.get(site.hitID).v - rLoc.v[1];
-                                    if (kTk.nHits >= 10) aida.histogram1D("Kalman track hit residual >= 10 hits, sigmas").fill(resid/Math.sqrt(site.aS.R));
-                                    aida.histogram1D("Kalman track hit residual").fill(resid);
-                                    aida.histogram1D("Kalman track hit residual, sigmas").fill(resid/Math.sqrt(site.aS.R));
-                                    aida.histogram1D(String.format("Layers/Kalman track hit residual in layer %d",mod.Layer)).fill(resid);
-                                    aida.histogram1D(String.format("Layers/Kalman track hit residual in layer %d, sigmas",mod.Layer)).fill(resid/Math.sqrt(site.aS.R));
-                                    aida.histogram1D(String.format("Layers/Kalman layer %d chi^2 contribution", mod.Layer)).fill(site.chi2inc);
-                                    if (mod.Layer<13) {
-                                        aida.histogram1D(String.format("Layers/Kalman kink in xy, layer %d", mod.Layer)).fill(kTk.scatX(mod.Layer));
-                                        aida.histogram1D(String.format("Layers/Kalman kink in zy, layer %d", mod.Layer)).fill(kTk.scatZ(mod.Layer));
-                                    }                                  
-                                    TrackerHit hpsHit = KI.getHpsHit(mod.hits.get(site.hitID));
-                                    List<RawTrackerHit> rawHits = hpsHit.getRawHits();
-                                    for (RawTrackerHit rawHit : rawHits) {
-                                        Set<SimTrackerHit> simHits = rawtomc.allFrom(rawHit);
-                                        for (SimTrackerHit simHit : simHits) {
-                                            MCParticle mcp = simHit.getMCParticle();
-                                            if (mcParts.contains(mcp)) {
-                                                int id = mcParts.indexOf(mcp);
-                                                mcCnt.set(id, mcCnt.get(id)+1);
-                                            } else {
-                                                mcParts.add(mcp);
-                                                mcCnt.add(1);
-                                            }
-                                        }
-                                    }                               
-                                }
-                            }
-                        }
-                    }
-                    aida.histogram1D("Kalman track number MC particles").fill(mcParts.size());
-                    // Which MC particle is the best match?
-                    int idBest = -1;
-                    int nMatch = 0;
-                    for (int id=0; id<mcCnt.size(); ++id) {
-                        if (mcCnt.get(id) > nMatch) {
-                            nMatch = mcCnt.get(id);
-                            idBest = id;
-                        }
-                    }
-                    int nBad = 0;
-                    for (MeasurementSite site : kTk.SiteList) {
-                        if (site.hitID < 0) {
-                            System.out.format("KalmanPatRecDriver:: Measurement Site has hitID < 0");
-                            kTk.print("with bad site");
-                            site.print("bad one");
-                        }
-                        else {
-                            SiModule mod = site.m;
-                            TrackerHit hpsHit = KI.getHpsHit(mod.hits.get(site.hitID));
-                            List<RawTrackerHit> rawHits = hpsHit.getRawHits();
-                            boolean goodHit = false;
-                            for (RawTrackerHit rawHit : rawHits) {
-                                Set<SimTrackerHit> simHits = rawtomc.allFrom(rawHit);
-                                for (SimTrackerHit simHit : simHits) {
-                                    MCParticle mcp = simHit.getMCParticle();
-                                    int id = mcParts.indexOf(mcp);
-                                    if (id == idBest) {
-                                        goodHit = true;
-                                        break;
-                                    }
-                                }
-                            }
-                            if (!goodHit) nBad++;
-                        }
-                    }
-                    aida.histogram1D("Kalman number of wrong hits on track").fill(nBad);
-                    
-                    if (kTk.nHits >= 10) aida.histogram1D("Kalman number of wrong hits on track, >= 10 hits").fill(nBad);
-                    MCParticle mcBest = null;
-                    if (idBest > -1) {
-                        mcBest = mcParts.get(idBest); 
-                        Hep3Vector pVec = mcBest.getMomentum();
-                        Hep3Vector rVec = mcBest.getOrigin();
-                        double ptTrue = Math.sqrt(pVec.x()*pVec.x() + pVec.z()*pVec.z());
-                        double ptInvTrue = mcBest.getCharge()/ptTrue;
-                        //double [] pKal = kTk.originP();
-                        double [] hParams = kTk.originHelixParms();
-                        double ptInv = hParams[2];
-                        double tanLambda = -hParams[4];
-                        double tanLambdaTrue = pVec.y()/ptTrue;
-                        double phi0True = Math.atan2(pVec.x(), pVec.z());
-                        double phi0 = -hParams[1];
-                        double phi0Err = kTk.helixErr(1);
-                        double ptInvErr = kTk.helixErr(2);
-                        double tanLambdaErr = kTk.helixErr(4);
-                        double z0 = -hParams[3];
-                        double z0True = rVec.y();
-                        double z0Err = kTk.helixErr(3);
-                        double dRho = hParams[0];
-                        double dRhoErr = kTk.helixErr(0);
-                        Vec apTrue = new Vec(0.,-phi0True,ptInvTrue,-z0True,-tanLambdaTrue);
-                        Vec ap = new Vec(5,hParams);
-                        SquareMatrix Cov = new SquareMatrix(5,kTk.originCovariance());
-                        SquareMatrix CovInv = Cov.invert();
-                        Vec helixDiff = ap.dif(apTrue);
-                        double chi2Helix = helixDiff.dot(helixDiff.leftMultiply(CovInv));
-                        aida.histogram1D("helix chi-squared at origin").fill(chi2Helix);
-                        aida.histogram1D("dRho").fill(dRho);
-                        aida.histogram1D("dRho error, sigmas").fill(dRho/dRhoErr);
-                        aida.histogram1D("z0").fill(z0);
-                        aida.histogram1D("z0 error, sigmas").fill((z0-z0True)/z0Err);
-                        aida.histogram1D("phi0 true").fill(phi0True);
-                        aida.histogram1D("phi0").fill(phi0);
-                        aida.histogram1D("phi0 error, sigmas").fill((phi0-phi0True)/phi0Err);
-                        aida.histogram1D("pt inverse").fill(ptInv);
-                        aida.histogram1D("pt inverse True").fill(ptInvTrue);
-                        if (kTk.nHits >= 10) {
-                            aida.histogram1D("pt inverse error, percent >= 10 hits").fill(100.*(ptInv-ptInvTrue)/ptInvTrue);
-                            aida.histogram1D("pt inverse error, sigmas >= 10 hits").fill((ptInv-ptInvTrue)/ptInvErr);
-                        }
-                        aida.histogram1D("tanLambda").fill(tanLambda);
-                        aida.histogram1D("tanLambda true").fill(tanLambdaTrue);
-                        aida.histogram1D("tanLambda error, sigmas").fill((tanLambda - tanLambdaTrue)/tanLambdaErr);
-                    }
-                }
-            }
-        }
         nTracks += nKalTracks;
         
-        if (doDebugPlots) {
-            aida.histogram1D("Kalman number of tracks").fill(nKalTracks);
-            if (event.hasCollection(Track.class, trackCollectionName)) {
-                List<Track> tracksGBL = event.get(Track.class, trackCollectionName);
-                int nGBL = tracksGBL.size();
-                aida.histogram2D("number tracks Kalman vs GBL").fill(nKalTracks, nGBL);
-                aida.histogram1D("GBL number tracks").fill(nGBL);
-                double c = 2.99793e8; // Speed of light in m/s
-                double conFac = 1.0e12 / c;
-                Vec Bfield = KalmanInterface.getField(new Vec(0.,505.57,0.), fm); // Field at the instrument center
-                double B = Bfield.mag();
-                double alpha = conFac / B; // Convert from pt in GeV to curvature in mm
-                for (Track tkrGBL : tracksGBL) {
-                    aida.histogram1D("GBL track chi^2").fill(tkrGBL.getChi2());
-                    ArrayList<MCParticle> mcParts = new ArrayList<MCParticle>();
-                    ArrayList<Integer> mcCnt= new ArrayList<Integer>();
-                    List<TrackerHit> hitsOnTrack = TrackUtils.getStripHits(tkrGBL, hitToStrips, hitToRotated);
-                    int nGBLhits = hitsOnTrack.size();
-                    if (nGBLhits == 12) aida.histogram1D("GBL 12-hit track chi^2").fill(tkrGBL.getChi2());
-                    aida.histogram1D("GBL number of hits").fill(nGBLhits);
-                    for (TrackerHit hit1D : hitsOnTrack) {
-                        List<RawTrackerHit> rawHits = hit1D.getRawHits();
-                        for (RawTrackerHit rawHit : rawHits) {
-                            Set<SimTrackerHit> simHits = rawtomc.allFrom(rawHit);
-                            for (SimTrackerHit simHit : simHits) {
-                                MCParticle mcp = simHit.getMCParticle();
-                                if (mcParts.contains(mcp)) {
-                                    int id = mcParts.indexOf(mcp);
-                                    mcCnt.set(id, mcCnt.get(id)+1);
-                                } else {
-                                    mcParts.add(mcp);
-                                    mcCnt.add(1);
-                                }
-                            }//simHits
-                        }//rawHits               
-                    }//hitsOnTrack
-                    aida.histogram1D("GBL track number MC particles").fill(mcParts.size());
-                    // Which MC particle is the best match?
-                    int idBest = -1;
-                    int nMatch = 0;
-                    for (int id=0; id<mcCnt.size(); ++id) {
-                        if (mcCnt.get(id) > nMatch) {
-                            nMatch = mcCnt.get(id);
-                            idBest = id;
-                        }
-                    }
-                    int nBad = 0;
-                    for (TrackerHit hit1D : hitsOnTrack) {
-                        List<RawTrackerHit> rawHits = hit1D.getRawHits();
-                        boolean goodHit = false;
-                        for (RawTrackerHit rawHit : rawHits) {
-                            Set<SimTrackerHit> simHits = rawtomc.allFrom(rawHit);
-                            for (SimTrackerHit simHit : simHits) {
-                                MCParticle mcp = simHit.getMCParticle();
-                                int id = mcParts.indexOf(mcp);
-                                if (id == idBest) {
-                                    goodHit = true;
-                                    break;
-                                }                          
-                            }
-                        }  
-                        if (!goodHit) nBad++;
-                    }
-                    aida.histogram1D("GBL number of wrong hits on track").fill(nBad);
-                    MCParticle mcBest = null;
-                    double ptInvTrue = 1.;
-                    if (idBest > -1) {
-                        mcBest = mcParts.get(idBest); 
-                        Hep3Vector pVec = mcBest.getMomentum();
-                        //Hep3Vector rVec = mcBest.getOrigin();
-                        double ptTrue = Math.sqrt(pVec.x()*pVec.x() + pVec.z()*pVec.z());
-                        ptInvTrue = mcBest.getCharge()/ptTrue;
-                    }
-                    List<TrackState> stLst = tkrGBL.getTrackStates();
-                    for (TrackState st : stLst) {
-                        if (st.getLocation() == TrackState.AtIP) {
-                            double d0 = st.getParameter(0);
-                            aida.histogram1D("GBL d0").fill(d0);
-                            double z0 = st.getParameter(3);
-                            aida.histogram1D("GBL z0").fill(z0);
-                            double Omega = st.getOmega();
-                            double ptInvGBL = -alpha * Omega;
-                            aida.histogram1D("GBL pt inverse").fill(ptInvGBL);
-                            double [] covGBL = st.getCovMatrix();
-                            double ptInvErr = -alpha * Math.sqrt(covGBL[5]);
-                            double tanLambdaGBL = st.getTanLambda();
-                            aida.histogram1D("GBL tanLambda").fill(tanLambdaGBL);
-                            if (mcBest != null) {
-                                aida.histogram1D("GBL pt inverse, sigmas").fill((ptInvGBL-ptInvTrue)/ptInvErr);
-                            }
-                            double pMag = Math.sqrt(1.0+tanLambdaGBL*tanLambdaGBL)/Math.abs(ptInvGBL);
-                            aida.histogram1D("GBL momentum").fill(pMag);
-                            //System.out.format("d0=%10.5f +- %10.5f\n", d0, Math.sqrt(covGBL[0]));
-                            //System.out.format("phi0=%10.5f +- %10.5f\n", st.getParameter(1), Math.sqrt(covGBL[2]));
-                            //System.out.format("omega=%10.5f +- %10.5f\n", Omega, omegaErr);
-                            //System.out.format("z0=%10.5f +- %10.5f\n", z0, Math.sqrt(covGBL[9]));
-                            //System.out.format("tanL=%10.5f +- %10.5f\n", st.getParameter(4), Math.sqrt(covGBL[14]));
-                            break;
-                        } // Track State at IP
-                    }//loop on track states
-                } //loop on GBL Tracks
-            } //check if event has GBLTracks
-        }// do debug plots
-        
-        if (doDebugPlots && nPlotted < 20) {
-            KI.plotKalmanEvent(outputGnuPlotDir, event, kPatList);
-            KI.plotGBLtracks(outputGnuPlotDir, event);
-            nPlotted++;
-        }
-        
-        
-
-        //simScatters(event);
-        if (doDebugPlots) {
-            double maxTruErr = simHitRes(event);
-            if (maxTruErr < 0.02) {
-                for (KalmanPatRecHPS kPat : kPatList) {
-                    for (KalTrack kTk : kPat.TkrList) {
-                        if (kTk.nHits < 12) continue;                    
-                        aida.histogram1D("Kalman Track Chi2 with 12 good hits").fill(kTk.chi2);                    
-                    }
-                }
-            }
-        }
+        if (kPlot != null) kPlot.process(event, runTime, kPatList, rawtomc);
         
         KI.clearInterface();
         if (verbose) System.out.format("\n KalmanPatRecDriver.process: Done with event %d\n", evtNumb);
@@ -674,118 +287,9 @@ public class KalmanPatRecDriver extends Driver {
         int flag = 1 << LCIOConstants.TRBIT_HITS;
         event.put(outputFullTrackCollectionName, outputFullTracks, Track.class, flag);
         event.put("GBLStripClusterData", allClstrs, GBLStripClusterData.class, flag);
-        event.put("GBLStripClusterDataRelations", gblStripClusterDataRelations,  LCRelation.class, flag);
+        event.put("GBLStripClusterDataRelations", gblStripClusterDataRelations, LCRelation.class, flag);
         event.put("KFTrackData",trackDataCollection, TrackData.class,0);
         event.put("KFTrackDataRelations",trackDataRelations,LCRelation.class,0);
-    }
-
-    // Make histograms of the MC hit resolution
-    private double simHitRes(EventHeader event) {
-        // Get the collection of 1D hits
-        String stripHitInputCollectionName = "StripClusterer_SiTrackerHitStrip1D";
-        List<TrackerHit> stripHits = event.get(TrackerHit.class, stripHitInputCollectionName);
-        
-        if (stripHits == null) return 999.;
-
-        // Make a mapping from sensor to hits
-        Map<HpsSiSensor, ArrayList<TrackerHit>> hitSensorMap = new HashMap<HpsSiSensor, ArrayList<TrackerHit>>();
-        for (TrackerHit hit1D : stripHits) {
-            HpsSiSensor sensor = (HpsSiSensor) ((RawTrackerHit) hit1D.getRawHits().get(0)).getDetectorElement();
-
-            ArrayList<TrackerHit> hitsInSensor = null;
-            if (hitSensorMap.containsKey(sensor)) {
-                hitsInSensor = hitSensorMap.get(sensor);
-            } else {
-                hitsInSensor = new ArrayList<TrackerHit>();
-            }
-            hitsInSensor.add(hit1D);
-            hitSensorMap.put(sensor, hitsInSensor);
-        }
-        
-        String MCHitInputCollectionName = "TrackerHits";
-        List<SimTrackerHit> MChits = event.get(SimTrackerHit.class, MCHitInputCollectionName);
-        
-        if (MChits == null) return 999.;
-
-        // Make a map from MC particle to the hit in the layer
-        Map<Integer, ArrayList<SimTrackerHit>> hitMCparticleMap = new HashMap<Integer, ArrayList<SimTrackerHit>>();
-        for (SimTrackerHit hit1D : MChits) {
-            decoder.setID(hit1D.getCellID());
-            int Layer = decoder.getValue("layer") + 1;  // Kalman layers go from 0 to 13, with 0 and 1 for new 2019 modules
-            //int Module = decoder.getValue("module");
-            //MCParticle MCpart = hit1D.getMCParticle();
-            ArrayList<SimTrackerHit> partInLayer = null;
-            if (hitMCparticleMap.containsKey(Layer)) {
-                partInLayer = hitMCparticleMap.get(Layer);
-            } else {
-                partInLayer = new ArrayList<SimTrackerHit>();
-            }
-            partInLayer.add(hit1D);
-            hitMCparticleMap.put(Layer,partInLayer);
-        }
-        //System.out.format("KalmanPatRecDriver.simHitRes: found both hit collections in event %d\n", event.getEventNumber());
-        
-        double maxErr = 0.;
-        ArrayList<SiModule> SiMlist = KI.getSiModuleList();
-        Map<SiModule, SiStripPlane> moduleMap = KI.getModuleMap();
-        for (SiModule siMod : SiMlist) {
-            int layer = siMod.Layer;
-            if (hitMCparticleMap.get(layer) == null) continue;
-            SiStripPlane plane = moduleMap.get(siMod);
-            if (!hitSensorMap.containsKey(plane.getSensor())) continue;
-            ArrayList<TrackerHit> hitsInSensor = hitSensorMap.get(plane.getSensor());
-            if (hitsInSensor == null) continue;
-            for (TrackerHit hit : hitsInSensor) {
-                //System.out.format("simHitRes: Hit in sensor of layer %d, detector %d\n",layer,siMod.detector);
-                //Vec tkrHit = new Vec(3,hit.getPosition());
-                //tkrHit.print("Tracker hit position");
-                //SiTrackerHitStrip1D global = (new SiTrackerHitStrip1D(hit)).getTransformedHit(TrackerHitType.CoordinateSystem.GLOBAL);
-                SiTrackerHitStrip1D localHit = (new SiTrackerHitStrip1D(hit)).getTransformedHit(TrackerHitType.CoordinateSystem.SENSOR);
-                double du = Math.sqrt(localHit.getCovarianceAsMatrix().diagonal(0));
-                //Vec globalHPS = new Vec(3,global.getPosition());
-                //Vec localHPS = new Vec(3,localHit.getPosition());
-                //globalHPS.print("simulated hit in HPS global system");
-                //localHPS.print("simulated hit in HPS local system");
-                
-                //Vec hitGlobal = KalmanInterface.vectorGlbToKalman(global.getPosition());
-                Vec hitLocal = new Vec(-localHit.getPosition()[1], localHit.getPosition()[0], localHit.getPosition()[2]);
-                
-                //hitGlobal.print("simulated hit Kal global position");
-                //hitLocal.print("simulated hit Kal local position");
-                //Vec kalGlobal = siMod.toGlobal(hitLocal);
-                //kalGlobal.print("simulated hit global position from Kalman transformation");
-                for (SimTrackerHit hitMC : hitMCparticleMap.get(layer)) {
-                    Vec hitMCglobal = KalmanInterface.vectorGlbToKalman(hitMC.getPosition());
-                    //hitMCglobal.print("true hit Kal global position");
-                    Vec kalMClocal = siMod.toLocal(hitMCglobal);
-                    //kalMClocal.print("true hit Kal local position");
-                    //hitLocal.print("sim hit Kal local position");
-                    double hitError = hitLocal.v[1] - kalMClocal.v[1];
-                    if (Math.abs(hitError) > maxErr) maxErr = Math.abs(hitError);
-                    aida.histogram1D("Kalman hit true error").fill(hitError);
-                    aida.histogram1D("Kalman hit true error over uncertainty").fill(hitError/du);
-                    aida.histogram1D(String.format("Layers/Kalman true error in layer %d",layer)).fill(hitError);
-                    aida.histogram1D("MC hit z in local system (should be zero)").fill(kalMClocal.v[2]);
-                }
-            }
-        }
-        return maxErr;
-    }
-    
-    void printKalmanKinks(KalTrack tkr) {
-        //for (MeasurementSite site : tkr.SiteList) {
-        //    if (verbose) {
-        //        System.out.format("Layer %d Kalman filter lambda-kink= %10.8f  phi-kink=  %10.8f\n", site.m.Layer, site.scatZ(), site.scatX());
-        //    }
-        //}
-        for (int layer = 1; layer < 12; layer++) {
-            aida.histogram1D(String.format("Kalman lambda kinks for layer %d", layer)).fill(tkr.scatZ(layer));
-            aida.histogram1D(String.format("Kalman phi kinks for layer %d", layer)).fill(tkr.scatX(layer));
-            if (verbose) {
-                System.out.format("Layer %d Kalman smoother lambda-kink= %10.8f  phi-kink= %10.8f\n", layer, tkr.scatZ(layer),
-                        tkr.scatX(layer));
-            }
-        }
     }
     
     class SortByZ implements Comparator<Pair<double[], double[]>> {
@@ -808,21 +312,7 @@ public class KalmanPatRecDriver extends Driver {
     public void endOfData() {
         System.out.format("KalmanPatRecDrive.endOfData: total pattern recognition execution time=%12.4f ms for %d events and %d tracks.\n", 
                 executionTime, nEvents, nTracks);
-        if (verbose) {
-            System.out.println("Individual layer efficiencies:");
-            for (int lyr=0; lyr<14; lyr++) {
-                double effic = (double)nHitsOnTracks[lyr]/(double)nTracks;
-                System.out.format("   Layer %d, hit efficiency = %9.3f\n", lyr, effic);
-            }
-        }
-        if (outputPlots != null && doDebugPlots) {
-            try {
-                System.out.println("Outputting the aida histograms now.");
-                aida.saveAs(outputPlots);
-            } catch (IOException ex) {
-                Logger.getLogger(TrackingReconstructionPlots.class.getName()).log(Level.SEVERE, null, ex);
-            }
-        }
+        if (kPlot != null) kPlot.output();
     }
     
     // Methods to set Kalman parameters from within the steering file
@@ -870,5 +360,11 @@ public class KalmanPatRecDriver extends Driver {
     }
     public void setMaxChi2IncShare(double maxChi2IncShare) {
         this.maxChi2IncShare = maxChi2IncShare;
+    }
+    public void setNumEvtPlots(int numEvtPlots) {
+        this.numEvtPlots = numEvtPlots;
+    }
+    public void setDoDebugPlots(boolean doDebugPlots) {
+        this.doDebugPlots = doDebugPlots;
     }
 }

--- a/tracking/src/main/java/org/hps/recon/tracking/kalman/KalmanPatRecPlots.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/kalman/KalmanPatRecPlots.java
@@ -1,0 +1,515 @@
+package org.hps.recon.tracking.kalman;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.hps.recon.tracking.TrackUtils;
+import org.hps.recon.tracking.TrackingReconstructionPlots;
+import org.hps.recon.tracking.MaterialSupervisor.SiStripPlane;
+import org.lcsim.detector.tracker.silicon.HpsSiSensor;
+import org.lcsim.event.EventHeader;
+import org.lcsim.event.MCParticle;
+import org.lcsim.event.RawTrackerHit;
+import org.lcsim.event.RelationalTable;
+import org.lcsim.event.SimTrackerHit;
+import org.lcsim.event.Track;
+import org.lcsim.event.TrackState;
+import org.lcsim.event.TrackerHit;
+import org.lcsim.geometry.IDDecoder;
+import org.lcsim.recon.tracking.digitization.sisim.SiTrackerHitStrip1D;
+import org.lcsim.recon.tracking.digitization.sisim.TrackerHitType;
+import org.lcsim.util.aida.AIDA;
+
+import hep.physics.vec.Hep3Vector;
+
+// Histograms and plots for Kalman Filter pattern recognition development
+class KalmanPatRecPlots {
+    private KalmanInterface KI;
+    private AIDA aida;
+    private int nPlotted;
+    private int nEvents;
+    private boolean verbose;
+    private String trackCollectionName = "GBLTracks";
+    private org.lcsim.geometry.FieldMap fm;
+    private IDDecoder decoder;
+    private String outputFileName = "KalmanTestPlots.root";
+    private String outputGnuPlotDir = "./";
+    private RelationalTable hitToStrips;
+    private RelationalTable hitToRotated;
+    private int numEvtPlots;
+
+    KalmanPatRecPlots(boolean verbose, KalmanInterface KI, IDDecoder decoder, int numEvtPlots, org.lcsim.geometry.FieldMap fm) {
+        this.verbose = verbose;
+        this.KI = KI;
+        this.decoder = decoder;
+        this.fm = fm;
+        this.numEvtPlots = numEvtPlots;
+        
+        if (aida == null) aida = AIDA.defaultInstance();
+        aida.tree().cd("/");
+        nPlotted = 0;
+        nEvents = 0;
+        
+        // arguments to histogram1D: name, nbins, min, max
+        aida.histogram1D("Kalman pattern recognition time", 100, 0., 500.);
+        aida.histogram1D("Kalman number of tracks", 10, 0., 10.);
+        aida.histogram1D("Kalman Track Chi2", 50, 0., 100.);
+        aida.histogram1D("Kalman Track Chi2, 12 hits", 50, 0., 100.);
+        aida.histogram1D("Kalman Track simple Chi2, 12 hits", 50, 0., 100.);
+        aida.histogram1D("Kalman Track Chi2 with 12 good hits", 50, 0., 100.);
+        aida.histogram2D("number tracks Kalman vs GBL", 20, 0., 5., 20, 0., 5.);
+        aida.histogram1D("helix chi-squared at origin", 100, 0., 25.);
+        aida.histogram1D("GBL track chi^2", 50, 0., 100.);
+        aida.histogram1D("GBL 12-hit track chi^2", 50, 0., 100.);
+        aida.histogram1D("Kalman Track Number Hits", 20, 0., 20.);
+        aida.histogram1D("GBL number tracks", 10, 0., 10.);
+        aida.histogram1D("Kalman missed hit residual", 100, -1.0, 1.0);
+        aida.histogram1D("Kalman track hit residual, sigmas", 100, -5., 5.);
+        aida.histogram1D("Kalman track hit residual >= 10 hits, sigmas", 100, -5., 5.);
+        aida.histogram1D("Kalman track hit residual", 100, -0.1, 0.1);
+        aida.histogram1D("Kalman hit true error", 100, -0.2, 0.2);
+        aida.histogram1D("Kalman hit true error over uncertainty", 100, -5., 5.);
+        aida.histogram1D("Kalman track Momentum", 100, 0., 5.);
+        aida.histogram1D("GBL momentum", 100, 0., 5.);
+        aida.histogram1D("dRho", 100, -5., 5.);
+        aida.histogram1D("dRho error, sigmas", 100, -5., 5.);
+        aida.histogram1D("z0", 100, -2., 2.);
+        aida.histogram1D("z0 error, sigmas", 100, -5., 5.);
+        aida.histogram1D("pt inverse", 100, -2.5, 2.5);
+        aida.histogram1D("pt inverse True", 100, -2.5, 2.5);
+        aida.histogram1D("pt inverse error, percent >= 10 hits", 100, -50., 50.);
+        aida.histogram1D("pt inverse error, sigmas >= 10 hits", 100, -5., 5.);
+        aida.histogram1D("tanLambda", 100, -0.3, 0.3);
+        aida.histogram1D("GBL tanLambda", 100, -0.3, 0.3);
+        aida.histogram1D("tanLambda true", 100, -0.3, 0.3);
+        aida.histogram1D("tanLambda error, sigmas", 100, -5., 5.);
+        aida.histogram1D("phi0 true", 100, -0.3, 0.3);
+        aida.histogram1D("phi0", 100, -0.3, 0.3);
+        aida.histogram1D("phi0 error, sigmas", 100, -5., 5.);
+        aida.histogram1D("Kalman track drho",100,-5.,5.);
+        aida.histogram1D("Kalman track dz",100,-2.,2.);
+        aida.histogram1D("Kalman track number MC particles",10,0.,10.);
+        aida.histogram1D("Kalman number of wrong hits on track",12,0.,12.);
+        aida.histogram1D("Kalman number of wrong hits on track, >= 10 hits", 12, 0., 12.);
+        aida.histogram1D("GBL track number MC particles",10,0.,10.);
+        aida.histogram1D("GBL number of wrong hits on track",12,0.,12.);
+        aida.histogram1D("MC hit z in local system (should be zero)", 50, -2., 2.);
+        aida.histogram1D("GBL d0", 100, -5., 5.);
+        aida.histogram1D("GBL z0", 100, -2., 2.);
+        aida.histogram1D("GBL pt inverse", 100, -2.5, 2.5);
+        aida.histogram1D("GBL pt inverse, sigmas", 100, -5., 5.);
+        aida.histogram1D("Kalman track time range (ns)", 100, 0., 100.);
+        aida.histogram1D("GBL number of hits",20,0.,20.);
+        for (int lyr=2; lyr<14; ++lyr) {
+            aida.histogram1D(String.format("Layers/Kalman track hit residual in layer %d",lyr), 100, -0.1, 0.1);
+            aida.histogram1D(String.format("Layers/Kalman track hit residual in layer %d, sigmas",lyr), 100, -5., 5.);
+            aida.histogram1D(String.format("Layers/Kalman true error in layer %d",lyr), 100, -0.2, 0.2);
+            aida.histogram1D(String.format("Layers/Kalman layer %d chi^2 contribution", lyr), 100, 0., 20.);
+            if (lyr<13) {
+                aida.histogram1D(String.format("Layers/Kalman kink in xy, layer %d", lyr),100, -0.001, .001);
+                aida.histogram1D(String.format("Layers/Kalman kink in zy, layer %d", lyr),100, -0.0025, .0025);
+            }
+        }
+    }
+    
+    void process(EventHeader event, double runTime, ArrayList<KalmanPatRecHPS> kPatList, RelationalTable rawtomc) {
+        
+        aida.histogram1D("Kalman pattern recognition time").fill(runTime);
+        nEvents++;
+        
+        hitToStrips = TrackUtils.getHitToStripsTable(event);
+        hitToRotated = TrackUtils.getHitToRotatedTable(event);
+        
+        for (KalmanPatRecHPS kPat : kPatList) {
+            if (kPat == null) continue;
+            int nKalTracks = 0;
+            for (KalTrack kTk : kPat.TkrList) {
+                nKalTracks++;
+                aida.histogram1D("Kalman Track Number Hits").fill(kTk.nHits);
+                if (kTk.nHits == 12) {
+                    aida.histogram1D("Kalman Track Chi2, 12 hits").fill(kTk.chi2);
+                    aida.histogram1D("Kalman Track simple Chi2, 12 hits").fill(kTk.chi2prime());
+                }
+                aida.histogram1D("Kalman Track Chi2").fill(kTk.chi2);
+                double[] momentum = kTk.originP();
+                double pMag = Math.sqrt(momentum[0]*momentum[0]+momentum[1]*momentum[1]+momentum[2]*momentum[2]);
+                aida.histogram1D("Kalman track Momentum").fill(pMag);
+                aida.histogram1D("Kalman track drho").fill(kTk.originHelixParms()[0]);
+                aida.histogram1D("Kalman track dz").fill(kTk.originHelixParms()[3]);
+                aida.histogram1D("Kalman track time range (ns)").fill(kTk.tMax - kTk.tMin);
+
+                // Histogram residuals of hits in layers with no hits on the track and with hits
+                ArrayList<MCParticle> mcParts = new ArrayList<MCParticle>();
+                ArrayList<Integer> mcCnt= new ArrayList<Integer>();
+                for (MeasurementSite site : kTk.SiteList) {
+                    if (verbose) site.print(String.format("track %d", kTk.ID));
+                    StateVector aS = site.aS;
+                    SiModule mod = site.m;
+                    if (aS != null && mod != null) {
+                        double phiS = aS.planeIntersect(mod.p);
+                        if (!Double.isNaN(phiS)) {
+                            Vec rLocal = aS.atPhi(phiS);        // Position in the Bfield frame
+                            Vec rGlobal = aS.toGlobal(rLocal);  // Position in the global frame                 
+                            Vec rLoc = mod.toLocal(rGlobal);    // Position in the detector frame
+                            if (site.hitID < 0) {
+                                for (Measurement m : mod.hits) {
+                                    double resid = m.v - rLoc.v[1];
+                                    aida.histogram1D("Kalman missed hit residual").fill(resid);
+                                }                       
+                            } else {
+                                if (site.hitID > mod.hits.size()-1) { // This should never happen!!
+                                    System.out.format("KalmapPatRecPlots event %d, hit missing in layer %d detector %d\n",event.getEventNumber(),mod.Layer,mod.detector);
+                                    site.print("the bad site");
+                                    mod.print("the bad module");
+                                    continue;
+                                }
+                                double resid = mod.hits.get(site.hitID).v - rLoc.v[1];
+                                if (kTk.nHits >= 10) aida.histogram1D("Kalman track hit residual >= 10 hits, sigmas").fill(resid/Math.sqrt(site.aS.R));
+                                aida.histogram1D("Kalman track hit residual").fill(resid);
+                                aida.histogram1D("Kalman track hit residual, sigmas").fill(resid/Math.sqrt(site.aS.R));
+                                aida.histogram1D(String.format("Layers/Kalman track hit residual in layer %d",mod.Layer)).fill(resid);
+                                aida.histogram1D(String.format("Layers/Kalman track hit residual in layer %d, sigmas",mod.Layer)).fill(resid/Math.sqrt(site.aS.R));
+                                aida.histogram1D(String.format("Layers/Kalman layer %d chi^2 contribution", mod.Layer)).fill(site.chi2inc);
+                                if (mod.Layer<13) {
+                                    aida.histogram1D(String.format("Layers/Kalman kink in xy, layer %d", mod.Layer)).fill(kTk.scatX(mod.Layer));
+                                    aida.histogram1D(String.format("Layers/Kalman kink in zy, layer %d", mod.Layer)).fill(kTk.scatZ(mod.Layer));
+                                }                                  
+                                TrackerHit hpsHit = KI.getHpsHit(mod.hits.get(site.hitID));
+                                List<RawTrackerHit> rawHits = hpsHit.getRawHits();
+                                for (RawTrackerHit rawHit : rawHits) {
+                                    Set<SimTrackerHit> simHits = rawtomc.allFrom(rawHit);
+                                    for (SimTrackerHit simHit : simHits) {
+                                        MCParticle mcp = simHit.getMCParticle();
+                                        if (mcParts.contains(mcp)) {
+                                            int id = mcParts.indexOf(mcp);
+                                            mcCnt.set(id, mcCnt.get(id)+1);
+                                        } else {
+                                            mcParts.add(mcp);
+                                            mcCnt.add(1);
+                                        }
+                                    }
+                                }                               
+                            }
+                        }
+                    }
+                }
+                aida.histogram1D("Kalman track number MC particles").fill(mcParts.size());
+                // Which MC particle is the best match?
+                int idBest = -1;
+                int nMatch = 0;
+                for (int id=0; id<mcCnt.size(); ++id) {
+                    if (mcCnt.get(id) > nMatch) {
+                        nMatch = mcCnt.get(id);
+                        idBest = id;
+                    }
+                }
+                int nBad = 0;
+                for (MeasurementSite site : kTk.SiteList) {
+                    if (site.hitID < 0) {
+                        System.out.format("KalmanPatRecDriver:: Measurement Site has hitID < 0 in event %d\n",event.getEventNumber());
+                        kTk.print("with bad site");
+                        site.print("bad one");
+                    }
+                    else {
+                        SiModule mod = site.m;
+                        TrackerHit hpsHit = KI.getHpsHit(mod.hits.get(site.hitID));
+                        List<RawTrackerHit> rawHits = hpsHit.getRawHits();
+                        boolean goodHit = false;
+                        for (RawTrackerHit rawHit : rawHits) {
+                            Set<SimTrackerHit> simHits = rawtomc.allFrom(rawHit);
+                            for (SimTrackerHit simHit : simHits) {
+                                MCParticle mcp = simHit.getMCParticle();
+                                int id = mcParts.indexOf(mcp);
+                                if (id == idBest) {
+                                    goodHit = true;
+                                    break;
+                                }
+                            }
+                        }
+                        if (!goodHit) nBad++;
+                    }
+                }
+                aida.histogram1D("Kalman number of wrong hits on track").fill(nBad);
+            
+                if (kTk.nHits >= 10) aida.histogram1D("Kalman number of wrong hits on track, >= 10 hits").fill(nBad);
+                MCParticle mcBest = null;
+                if (idBest > -1) {
+                    mcBest = mcParts.get(idBest); 
+                    Hep3Vector pVec = mcBest.getMomentum();
+                    Hep3Vector rVec = mcBest.getOrigin();
+                    double ptTrue = Math.sqrt(pVec.x()*pVec.x() + pVec.z()*pVec.z());
+                    double ptInvTrue = mcBest.getCharge()/ptTrue;
+                    //double [] pKal = kTk.originP();
+                    double [] hParams = kTk.originHelixParms();
+                    double ptInv = hParams[2];
+                    double tanLambda = -hParams[4];
+                    double tanLambdaTrue = pVec.y()/ptTrue;
+                    double phi0True = Math.atan2(pVec.x(), pVec.z());
+                    double phi0 = -hParams[1];
+                    double phi0Err = kTk.helixErr(1);
+                    double ptInvErr = kTk.helixErr(2);
+                    double tanLambdaErr = kTk.helixErr(4);
+                    double z0 = -hParams[3];
+                    double z0True = rVec.y();
+                    double z0Err = kTk.helixErr(3);
+                    double dRho = hParams[0];
+                    double dRhoErr = kTk.helixErr(0);
+                    Vec apTrue = new Vec(0.,-phi0True,ptInvTrue,-z0True,-tanLambdaTrue);
+                    Vec ap = new Vec(5,hParams);
+                    SquareMatrix Cov = new SquareMatrix(5,kTk.originCovariance());
+                    SquareMatrix CovInv = Cov.invert();
+                    Vec helixDiff = ap.dif(apTrue);
+                    double chi2Helix = helixDiff.dot(helixDiff.leftMultiply(CovInv));
+                    aida.histogram1D("helix chi-squared at origin").fill(chi2Helix);
+                    aida.histogram1D("dRho").fill(dRho);
+                    aida.histogram1D("dRho error, sigmas").fill(dRho/dRhoErr);
+                    aida.histogram1D("z0").fill(z0);
+                    aida.histogram1D("z0 error, sigmas").fill((z0-z0True)/z0Err);
+                    aida.histogram1D("phi0 true").fill(phi0True);
+                    aida.histogram1D("phi0").fill(phi0);
+                    aida.histogram1D("phi0 error, sigmas").fill((phi0-phi0True)/phi0Err);
+                    aida.histogram1D("pt inverse").fill(ptInv);
+                    aida.histogram1D("pt inverse True").fill(ptInvTrue);
+                    if (kTk.nHits >= 10) {
+                        aida.histogram1D("pt inverse error, percent >= 10 hits").fill(100.*(ptInv-ptInvTrue)/ptInvTrue);
+                        aida.histogram1D("pt inverse error, sigmas >= 10 hits").fill((ptInv-ptInvTrue)/ptInvErr);
+                    }
+                    aida.histogram1D("tanLambda").fill(tanLambda);
+                    aida.histogram1D("tanLambda true").fill(tanLambdaTrue);
+                    aida.histogram1D("tanLambda error, sigmas").fill((tanLambda - tanLambdaTrue)/tanLambdaErr);
+                }
+            }
+        
+            aida.histogram1D("Kalman number of tracks").fill(nKalTracks);
+            if (event.hasCollection(Track.class, trackCollectionName)) {
+                List<Track> tracksGBL = event.get(Track.class, trackCollectionName);
+                int nGBL = tracksGBL.size();
+                aida.histogram2D("number tracks Kalman vs GBL").fill(nKalTracks, nGBL);
+                aida.histogram1D("GBL number tracks").fill(nGBL);
+                double c = 2.99793e8; // Speed of light in m/s
+                double conFac = 1.0e12 / c;
+                Vec Bfield = KalmanInterface.getField(new Vec(0.,505.57,0.), fm); // Field at the instrument center
+                double B = Bfield.mag();
+                double alpha = conFac / B; // Convert from pt in GeV to curvature in mm
+                for (Track tkrGBL : tracksGBL) {
+                    aida.histogram1D("GBL track chi^2").fill(tkrGBL.getChi2());
+                    ArrayList<MCParticle> mcParts = new ArrayList<MCParticle>();
+                    ArrayList<Integer> mcCnt= new ArrayList<Integer>();
+                    List<TrackerHit> hitsOnTrack = TrackUtils.getStripHits(tkrGBL, hitToStrips, hitToRotated);
+                    int nGBLhits = hitsOnTrack.size();
+                    if (nGBLhits == 12) aida.histogram1D("GBL 12-hit track chi^2").fill(tkrGBL.getChi2());
+                    aida.histogram1D("GBL number of hits").fill(nGBLhits);
+                    for (TrackerHit hit1D : hitsOnTrack) {
+                        List<RawTrackerHit> rawHits = hit1D.getRawHits();
+                        for (RawTrackerHit rawHit : rawHits) {
+                            Set<SimTrackerHit> simHits = rawtomc.allFrom(rawHit);
+                            for (SimTrackerHit simHit : simHits) {
+                                MCParticle mcp = simHit.getMCParticle();
+                                if (mcParts.contains(mcp)) {
+                                    int id = mcParts.indexOf(mcp);
+                                    mcCnt.set(id, mcCnt.get(id)+1);
+                                } else {
+                                    mcParts.add(mcp);
+                                    mcCnt.add(1);
+                                }
+                            }//simHits
+                        }//rawHits               
+                    }//hitsOnTrack
+                    aida.histogram1D("GBL track number MC particles").fill(mcParts.size());
+                    // Which MC particle is the best match?
+                    int idBest = -1;
+                    int nMatch = 0;
+                    for (int id=0; id<mcCnt.size(); ++id) {
+                        if (mcCnt.get(id) > nMatch) {
+                            nMatch = mcCnt.get(id);
+                            idBest = id;
+                        }
+                    }
+                    int nBad = 0;
+                    for (TrackerHit hit1D : hitsOnTrack) {
+                        List<RawTrackerHit> rawHits = hit1D.getRawHits();
+                        boolean goodHit = false;
+                        for (RawTrackerHit rawHit : rawHits) {
+                            Set<SimTrackerHit> simHits = rawtomc.allFrom(rawHit);
+                            for (SimTrackerHit simHit : simHits) {
+                                MCParticle mcp = simHit.getMCParticle();
+                                int id = mcParts.indexOf(mcp);
+                                if (id == idBest) {
+                                    goodHit = true;
+                                    break;
+                                }                          
+                            }
+                        }  
+                        if (!goodHit) nBad++;
+                    }
+                    aida.histogram1D("GBL number of wrong hits on track").fill(nBad);
+                    MCParticle mcBest = null;
+                    double ptInvTrue = 1.;
+                    if (idBest > -1) {
+                        mcBest = mcParts.get(idBest); 
+                        Hep3Vector pVec = mcBest.getMomentum();
+                        //Hep3Vector rVec = mcBest.getOrigin();
+                        double ptTrue = Math.sqrt(pVec.x()*pVec.x() + pVec.z()*pVec.z());
+                        ptInvTrue = mcBest.getCharge()/ptTrue;
+                    }
+                    List<TrackState> stLst = tkrGBL.getTrackStates();
+                    for (TrackState st : stLst) {
+                        if (st.getLocation() == TrackState.AtIP) {
+                            double d0 = st.getParameter(0);
+                            aida.histogram1D("GBL d0").fill(d0);
+                            double z0 = st.getParameter(3);
+                            aida.histogram1D("GBL z0").fill(z0);
+                            double Omega = st.getOmega();
+                            double ptInvGBL = -alpha * Omega;
+                            aida.histogram1D("GBL pt inverse").fill(ptInvGBL);
+                            double [] covGBL = st.getCovMatrix();
+                            double ptInvErr = -alpha * Math.sqrt(covGBL[5]);
+                            double tanLambdaGBL = st.getTanLambda();
+                            aida.histogram1D("GBL tanLambda").fill(tanLambdaGBL);
+                            if (mcBest != null) {
+                                aida.histogram1D("GBL pt inverse, sigmas").fill((ptInvGBL-ptInvTrue)/ptInvErr);
+                            }
+                            double pMag = Math.sqrt(1.0+tanLambdaGBL*tanLambdaGBL)/Math.abs(ptInvGBL);
+                            aida.histogram1D("GBL momentum").fill(pMag);
+                            //System.out.format("d0=%10.5f +- %10.5f\n", d0, Math.sqrt(covGBL[0]));
+                            //System.out.format("phi0=%10.5f +- %10.5f\n", st.getParameter(1), Math.sqrt(covGBL[2]));
+                            //System.out.format("omega=%10.5f +- %10.5f\n", Omega, omegaErr);
+                            //System.out.format("z0=%10.5f +- %10.5f\n", z0, Math.sqrt(covGBL[9]));
+                            //System.out.format("tanL=%10.5f +- %10.5f\n", st.getParameter(4), Math.sqrt(covGBL[14]));
+                            break;
+                        } // Track State at IP
+                    }//loop on track states
+                } //loop on GBL Tracks
+            } //check if event has GBLTracks
+        }// do debug plots
+        
+        if (nPlotted < numEvtPlots) {
+            KI.plotKalmanEvent(outputGnuPlotDir, event, kPatList);
+            KI.plotGBLtracks(outputGnuPlotDir, event);
+            nPlotted++;
+        }
+        
+        double maxTruErr = simHitRes(event);
+        if (maxTruErr < 0.02) {
+            for (KalmanPatRecHPS kPat : kPatList) {
+                for (KalTrack kTk : kPat.TkrList) {
+                    if (kTk.nHits < 12) continue;                    
+                    aida.histogram1D("Kalman Track Chi2 with 12 good hits").fill(kTk.chi2);                    
+                }
+            }
+        }
+    }
+    
+    // Make histograms of the MC hit resolution
+    private double simHitRes(EventHeader event) {
+        // Get the collection of 1D hits
+        String stripHitInputCollectionName = "StripClusterer_SiTrackerHitStrip1D";
+        List<TrackerHit> stripHits = event.get(TrackerHit.class, stripHitInputCollectionName);
+        
+        if (stripHits == null) return 999.;
+
+        // Make a mapping from sensor to hits
+        Map<HpsSiSensor, ArrayList<TrackerHit>> hitSensorMap = new HashMap<HpsSiSensor, ArrayList<TrackerHit>>();
+        for (TrackerHit hit1D : stripHits) {
+            HpsSiSensor sensor = (HpsSiSensor) ((RawTrackerHit) hit1D.getRawHits().get(0)).getDetectorElement();
+
+            ArrayList<TrackerHit> hitsInSensor = null;
+            if (hitSensorMap.containsKey(sensor)) {
+                hitsInSensor = hitSensorMap.get(sensor);
+            } else {
+                hitsInSensor = new ArrayList<TrackerHit>();
+            }
+            hitsInSensor.add(hit1D);
+            hitSensorMap.put(sensor, hitsInSensor);
+        }
+        
+        String MCHitInputCollectionName = "TrackerHits";
+        List<SimTrackerHit> MChits = event.get(SimTrackerHit.class, MCHitInputCollectionName);
+        
+        if (MChits == null) return 999.;
+
+        // Make a map from MC particle to the hit in the layer
+        Map<Integer, ArrayList<SimTrackerHit>> hitMCparticleMap = new HashMap<Integer, ArrayList<SimTrackerHit>>();
+        for (SimTrackerHit hit1D : MChits) {
+            decoder.setID(hit1D.getCellID());
+            int Layer = decoder.getValue("layer") + 1;  // Kalman layers go from 0 to 13, with 0 and 1 for new 2019 modules
+            //int Module = decoder.getValue("module");
+            //MCParticle MCpart = hit1D.getMCParticle();
+            ArrayList<SimTrackerHit> partInLayer = null;
+            if (hitMCparticleMap.containsKey(Layer)) {
+                partInLayer = hitMCparticleMap.get(Layer);
+            } else {
+                partInLayer = new ArrayList<SimTrackerHit>();
+            }
+            partInLayer.add(hit1D);
+            hitMCparticleMap.put(Layer,partInLayer);
+        }
+        //System.out.format("KalmanPatRecDriver.simHitRes: found both hit collections in event %d\n", event.getEventNumber());
+        
+        double maxErr = 0.;
+        ArrayList<SiModule> SiMlist = KI.getSiModuleList();
+        Map<SiModule, SiStripPlane> moduleMap = KI.getModuleMap();
+        for (SiModule siMod : SiMlist) {
+            int layer = siMod.Layer;
+            if (hitMCparticleMap.get(layer) == null) continue;
+            SiStripPlane plane = moduleMap.get(siMod);
+            if (!hitSensorMap.containsKey(plane.getSensor())) continue;
+            ArrayList<TrackerHit> hitsInSensor = hitSensorMap.get(plane.getSensor());
+            if (hitsInSensor == null) continue;
+            for (TrackerHit hit : hitsInSensor) {
+                //System.out.format("simHitRes: Hit in sensor of layer %d, detector %d\n",layer,siMod.detector);
+                //Vec tkrHit = new Vec(3,hit.getPosition());
+                //tkrHit.print("Tracker hit position");
+                //SiTrackerHitStrip1D global = (new SiTrackerHitStrip1D(hit)).getTransformedHit(TrackerHitType.CoordinateSystem.GLOBAL);
+                SiTrackerHitStrip1D localHit = (new SiTrackerHitStrip1D(hit)).getTransformedHit(TrackerHitType.CoordinateSystem.SENSOR);
+                double du = Math.sqrt(localHit.getCovarianceAsMatrix().diagonal(0));
+                //Vec globalHPS = new Vec(3,global.getPosition());
+                //Vec localHPS = new Vec(3,localHit.getPosition());
+                //globalHPS.print("simulated hit in HPS global system");
+                //localHPS.print("simulated hit in HPS local system");
+                
+                //Vec hitGlobal = KalmanInterface.vectorGlbToKalman(global.getPosition());
+                Vec hitLocal = new Vec(-localHit.getPosition()[1], localHit.getPosition()[0], localHit.getPosition()[2]);
+                
+                //hitGlobal.print("simulated hit Kal global position");
+                //hitLocal.print("simulated hit Kal local position");
+                //Vec kalGlobal = siMod.toGlobal(hitLocal);
+                //kalGlobal.print("simulated hit global position from Kalman transformation");
+                for (SimTrackerHit hitMC : hitMCparticleMap.get(layer)) {
+                    Vec hitMCglobal = KalmanInterface.vectorGlbToKalman(hitMC.getPosition());
+                    //hitMCglobal.print("true hit Kal global position");
+                    Vec kalMClocal = siMod.toLocal(hitMCglobal);
+                    //kalMClocal.print("true hit Kal local position");
+                    //hitLocal.print("sim hit Kal local position");
+                    double hitError = hitLocal.v[1] - kalMClocal.v[1];
+                    if (Math.abs(hitError) > maxErr) maxErr = Math.abs(hitError);
+                    aida.histogram1D("Kalman hit true error").fill(hitError);
+                    aida.histogram1D("Kalman hit true error over uncertainty").fill(hitError/du);
+                    aida.histogram1D(String.format("Layers/Kalman true error in layer %d",layer)).fill(hitError);
+                    aida.histogram1D("MC hit z in local system (should be zero)").fill(kalMClocal.v[2]);
+                }
+            }
+        }
+        return maxErr;
+    }
+    
+    void output() {
+        if (verbose) {
+            System.out.println("Individual layer efficiencies:");
+        }
+        try {
+            System.out.format("Outputting the aida histograms now for %d events to file %s\n", nEvents, outputFileName);
+            aida.saveAs(outputFileName);
+        } catch (IOException ex) {
+            Logger.getLogger(TrackingReconstructionPlots.class.getName()).log(Level.SEVERE, null, ex);
+        }
+    }
+    
+}
+

--- a/tracking/src/main/java/org/hps/recon/tracking/kalman/KalmanPatRecPlots.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/kalman/KalmanPatRecPlots.java
@@ -126,9 +126,9 @@ class KalmanPatRecPlots {
         hitToStrips = TrackUtils.getHitToStripsTable(event);
         hitToRotated = TrackUtils.getHitToRotatedTable(event);
         
+        int nKalTracks = 0;
         for (KalmanPatRecHPS kPat : kPatList) {
             if (kPat == null) continue;
-            int nKalTracks = 0;
             for (KalTrack kTk : kPat.TkrList) {
                 nKalTracks++;
                 aida.histogram1D("Kalman Track Number Hits").fill(kTk.nHits);
@@ -284,110 +284,110 @@ class KalmanPatRecPlots {
                     aida.histogram1D("tanLambda true").fill(tanLambdaTrue);
                     aida.histogram1D("tanLambda error, sigmas").fill((tanLambda - tanLambdaTrue)/tanLambdaErr);
                 }
-            }
+            }  // Loop over Kalman tracks
+        } // Loop over SVT trackers (top/bottom)
         
-            aida.histogram1D("Kalman number of tracks").fill(nKalTracks);
-            if (event.hasCollection(Track.class, trackCollectionName)) {
-                List<Track> tracksGBL = event.get(Track.class, trackCollectionName);
-                int nGBL = tracksGBL.size();
-                aida.histogram2D("number tracks Kalman vs GBL").fill(nKalTracks, nGBL);
-                aida.histogram1D("GBL number tracks").fill(nGBL);
-                double c = 2.99793e8; // Speed of light in m/s
-                double conFac = 1.0e12 / c;
-                Vec Bfield = KalmanInterface.getField(new Vec(0.,505.57,0.), fm); // Field at the instrument center
-                double B = Bfield.mag();
-                double alpha = conFac / B; // Convert from pt in GeV to curvature in mm
-                for (Track tkrGBL : tracksGBL) {
-                    aida.histogram1D("GBL track chi^2").fill(tkrGBL.getChi2());
-                    ArrayList<MCParticle> mcParts = new ArrayList<MCParticle>();
-                    ArrayList<Integer> mcCnt= new ArrayList<Integer>();
-                    List<TrackerHit> hitsOnTrack = TrackUtils.getStripHits(tkrGBL, hitToStrips, hitToRotated);
-                    int nGBLhits = hitsOnTrack.size();
-                    if (nGBLhits == 12) aida.histogram1D("GBL 12-hit track chi^2").fill(tkrGBL.getChi2());
-                    aida.histogram1D("GBL number of hits").fill(nGBLhits);
-                    for (TrackerHit hit1D : hitsOnTrack) {
-                        List<RawTrackerHit> rawHits = hit1D.getRawHits();
-                        for (RawTrackerHit rawHit : rawHits) {
-                            Set<SimTrackerHit> simHits = rawtomc.allFrom(rawHit);
-                            for (SimTrackerHit simHit : simHits) {
-                                MCParticle mcp = simHit.getMCParticle();
-                                if (mcParts.contains(mcp)) {
-                                    int id = mcParts.indexOf(mcp);
-                                    mcCnt.set(id, mcCnt.get(id)+1);
-                                } else {
-                                    mcParts.add(mcp);
-                                    mcCnt.add(1);
-                                }
-                            }//simHits
-                        }//rawHits               
-                    }//hitsOnTrack
-                    aida.histogram1D("GBL track number MC particles").fill(mcParts.size());
-                    // Which MC particle is the best match?
-                    int idBest = -1;
-                    int nMatch = 0;
-                    for (int id=0; id<mcCnt.size(); ++id) {
-                        if (mcCnt.get(id) > nMatch) {
-                            nMatch = mcCnt.get(id);
-                            idBest = id;
-                        }
-                    }
-                    int nBad = 0;
-                    for (TrackerHit hit1D : hitsOnTrack) {
-                        List<RawTrackerHit> rawHits = hit1D.getRawHits();
-                        boolean goodHit = false;
-                        for (RawTrackerHit rawHit : rawHits) {
-                            Set<SimTrackerHit> simHits = rawtomc.allFrom(rawHit);
-                            for (SimTrackerHit simHit : simHits) {
-                                MCParticle mcp = simHit.getMCParticle();
+        aida.histogram1D("Kalman number of tracks").fill(nKalTracks);
+        if (event.hasCollection(Track.class, trackCollectionName)) {
+            List<Track> tracksGBL = event.get(Track.class, trackCollectionName);
+            int nGBL = tracksGBL.size();
+            aida.histogram2D("number tracks Kalman vs GBL").fill(nKalTracks, nGBL);
+            aida.histogram1D("GBL number tracks").fill(nGBL);
+            double c = 2.99793e8; // Speed of light in m/s
+            double conFac = 1.0e12 / c;
+            Vec Bfield = KalmanInterface.getField(new Vec(0.,505.57,0.), fm); // Field at the instrument center
+            double B = Bfield.mag();
+            double alpha = conFac / B; // Convert from pt in GeV to curvature in mm
+            for (Track tkrGBL : tracksGBL) {
+                aida.histogram1D("GBL track chi^2").fill(tkrGBL.getChi2());
+                ArrayList<MCParticle> mcParts = new ArrayList<MCParticle>();
+                ArrayList<Integer> mcCnt= new ArrayList<Integer>();
+                List<TrackerHit> hitsOnTrack = TrackUtils.getStripHits(tkrGBL, hitToStrips, hitToRotated);
+                int nGBLhits = hitsOnTrack.size();
+                if (nGBLhits == 12) aida.histogram1D("GBL 12-hit track chi^2").fill(tkrGBL.getChi2());
+                aida.histogram1D("GBL number of hits").fill(nGBLhits);
+                for (TrackerHit hit1D : hitsOnTrack) {
+                    List<RawTrackerHit> rawHits = hit1D.getRawHits();
+                    for (RawTrackerHit rawHit : rawHits) {
+                        Set<SimTrackerHit> simHits = rawtomc.allFrom(rawHit);
+                        for (SimTrackerHit simHit : simHits) {
+                            MCParticle mcp = simHit.getMCParticle();
+                            if (mcParts.contains(mcp)) {
                                 int id = mcParts.indexOf(mcp);
-                                if (id == idBest) {
-                                    goodHit = true;
-                                    break;
-                                }                          
+                                mcCnt.set(id, mcCnt.get(id)+1);
+                            } else {
+                                mcParts.add(mcp);
+                                mcCnt.add(1);
                             }
-                        }  
-                        if (!goodHit) nBad++;
+                        }//simHits
+                    }//rawHits               
+                }//hitsOnTrack
+                aida.histogram1D("GBL track number MC particles").fill(mcParts.size());
+                // Which MC particle is the best match?
+                int idBest = -1;
+                int nMatch = 0;
+                for (int id=0; id<mcCnt.size(); ++id) {
+                    if (mcCnt.get(id) > nMatch) {
+                        nMatch = mcCnt.get(id);
+                        idBest = id;
                     }
-                    aida.histogram1D("GBL number of wrong hits on track").fill(nBad);
-                    MCParticle mcBest = null;
-                    double ptInvTrue = 1.;
-                    if (idBest > -1) {
-                        mcBest = mcParts.get(idBest); 
-                        Hep3Vector pVec = mcBest.getMomentum();
-                        //Hep3Vector rVec = mcBest.getOrigin();
-                        double ptTrue = Math.sqrt(pVec.x()*pVec.x() + pVec.z()*pVec.z());
-                        ptInvTrue = mcBest.getCharge()/ptTrue;
-                    }
-                    List<TrackState> stLst = tkrGBL.getTrackStates();
-                    for (TrackState st : stLst) {
-                        if (st.getLocation() == TrackState.AtIP) {
-                            double d0 = st.getParameter(0);
-                            aida.histogram1D("GBL d0").fill(d0);
-                            double z0 = st.getParameter(3);
-                            aida.histogram1D("GBL z0").fill(z0);
-                            double Omega = st.getOmega();
-                            double ptInvGBL = -alpha * Omega;
-                            aida.histogram1D("GBL pt inverse").fill(ptInvGBL);
-                            double [] covGBL = st.getCovMatrix();
-                            double ptInvErr = -alpha * Math.sqrt(covGBL[5]);
-                            double tanLambdaGBL = st.getTanLambda();
-                            aida.histogram1D("GBL tanLambda").fill(tanLambdaGBL);
-                            if (mcBest != null) {
-                                aida.histogram1D("GBL pt inverse, sigmas").fill((ptInvGBL-ptInvTrue)/ptInvErr);
-                            }
-                            double pMag = Math.sqrt(1.0+tanLambdaGBL*tanLambdaGBL)/Math.abs(ptInvGBL);
-                            aida.histogram1D("GBL momentum").fill(pMag);
-                            //System.out.format("d0=%10.5f +- %10.5f\n", d0, Math.sqrt(covGBL[0]));
-                            //System.out.format("phi0=%10.5f +- %10.5f\n", st.getParameter(1), Math.sqrt(covGBL[2]));
-                            //System.out.format("omega=%10.5f +- %10.5f\n", Omega, omegaErr);
-                            //System.out.format("z0=%10.5f +- %10.5f\n", z0, Math.sqrt(covGBL[9]));
-                            //System.out.format("tanL=%10.5f +- %10.5f\n", st.getParameter(4), Math.sqrt(covGBL[14]));
-                            break;
-                        } // Track State at IP
-                    }//loop on track states
-                } //loop on GBL Tracks
-            } //check if event has GBLTracks
-        }// do debug plots
+                }
+                int nBad = 0;
+                for (TrackerHit hit1D : hitsOnTrack) {
+                    List<RawTrackerHit> rawHits = hit1D.getRawHits();
+                    boolean goodHit = false;
+                    for (RawTrackerHit rawHit : rawHits) {
+                        Set<SimTrackerHit> simHits = rawtomc.allFrom(rawHit);
+                        for (SimTrackerHit simHit : simHits) {
+                            MCParticle mcp = simHit.getMCParticle();
+                            int id = mcParts.indexOf(mcp);
+                            if (id == idBest) {
+                                goodHit = true;
+                                break;
+                            }                          
+                        }
+                    }  
+                    if (!goodHit) nBad++;
+                }
+                aida.histogram1D("GBL number of wrong hits on track").fill(nBad);
+                MCParticle mcBest = null;
+                double ptInvTrue = 1.;
+                if (idBest > -1) {
+                    mcBest = mcParts.get(idBest); 
+                    Hep3Vector pVec = mcBest.getMomentum();
+                    //Hep3Vector rVec = mcBest.getOrigin();
+                    double ptTrue = Math.sqrt(pVec.x()*pVec.x() + pVec.z()*pVec.z());
+                    ptInvTrue = mcBest.getCharge()/ptTrue;
+                }
+                List<TrackState> stLst = tkrGBL.getTrackStates();
+                for (TrackState st : stLst) {
+                    if (st.getLocation() == TrackState.AtIP) {
+                        double d0 = st.getParameter(0);
+                        aida.histogram1D("GBL d0").fill(d0);
+                        double z0 = st.getParameter(3);
+                        aida.histogram1D("GBL z0").fill(z0);
+                        double Omega = st.getOmega();
+                        double ptInvGBL = -alpha * Omega;
+                        aida.histogram1D("GBL pt inverse").fill(ptInvGBL);
+                        double [] covGBL = st.getCovMatrix();
+                        double ptInvErr = -alpha * Math.sqrt(covGBL[5]);
+                        double tanLambdaGBL = st.getTanLambda();
+                        aida.histogram1D("GBL tanLambda").fill(tanLambdaGBL);
+                        if (mcBest != null) {
+                            aida.histogram1D("GBL pt inverse, sigmas").fill((ptInvGBL-ptInvTrue)/ptInvErr);
+                        }
+                        double pMag = Math.sqrt(1.0+tanLambdaGBL*tanLambdaGBL)/Math.abs(ptInvGBL);
+                        aida.histogram1D("GBL momentum").fill(pMag);
+                        //System.out.format("d0=%10.5f +- %10.5f\n", d0, Math.sqrt(covGBL[0]));
+                        //System.out.format("phi0=%10.5f +- %10.5f\n", st.getParameter(1), Math.sqrt(covGBL[2]));
+                        //System.out.format("omega=%10.5f +- %10.5f\n", Omega, omegaErr);
+                        //System.out.format("z0=%10.5f +- %10.5f\n", z0, Math.sqrt(covGBL[9]));
+                        //System.out.format("tanL=%10.5f +- %10.5f\n", st.getParameter(4), Math.sqrt(covGBL[14]));
+                        break;
+                    } // Track State at IP
+                }//loop on track states
+            } //loop on GBL Tracks
+        } //check if event has GBLTracks
         
         if (nPlotted < numEvtPlots) {
             KI.plotKalmanEvent(outputGnuPlotDir, event, kPatList);

--- a/tracking/src/main/java/org/hps/recon/tracking/kalman/KalmanTrackFit2.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/kalman/KalmanTrackFit2.java
@@ -7,7 +7,7 @@ import java.util.Iterator;
 //then starts over using the fit result to start filtering from layer 0 outward. Then it smooths
 //back to layer 0. The code assumes that the SiModules hold all the hits to be fit and only those hits.
 //No pattern recognition is done; no hits are dropped.
-public class KalmanTrackFit2 {
+class KalmanTrackFit2 {
 
     ArrayList<MeasurementSite> sites;
     int initialSite;
@@ -17,7 +17,7 @@ public class KalmanTrackFit2 {
     boolean success;
     KalTrack tkr;
 
-    public KalmanTrackFit2(int evtNumb, ArrayList<SiModule> data, // List of Si modules with data points to be included in the fit
+    KalmanTrackFit2(int evtNumb, ArrayList<SiModule> data, // List of Si modules with data points to be included in the fit
             int start, // Starting point in the list
             int nIterations, // Number of fit iterations requested
             Vec pivot, // Pivot point for the starting "guess" helix

--- a/tracking/src/main/java/org/hps/recon/tracking/kalman/LinearHelixFit.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/kalman/LinearHelixFit.java
@@ -2,7 +2,7 @@ package org.hps.recon.tracking.kalman;
 
 //package kalman;
 
-public class LinearHelixFit { // Simultaneous fit of axial and stereo measurements to a line in the non-bending plane
+class LinearHelixFit { // Simultaneous fit of axial and stereo measurements to a line in the non-bending plane
     // and a parabola in the bending plane
 
     private SquareMatrix C; // Covariance matrix of solution
@@ -10,7 +10,7 @@ public class LinearHelixFit { // Simultaneous fit of axial and stereo measuremen
     private double chi2;
     private double[] vpred;
 
-    public LinearHelixFit(int N, double[] y, double[] v, double[] s, double[][] delta, double[][] R2, boolean verbose) {
+    LinearHelixFit(int N, double[] y, double[] v, double[] s, double[][] delta, double[][] R2, boolean verbose) {
         // N = number of measurement points (detector layers) to fit. This must be no less than 5, with at least 2 axial and 2 stereo
         // y = nominal location of each measurement plane along the beam axis
         // v = measurement value in the detector coordinate system, perpendicular to the strips

--- a/tracking/src/main/java/org/hps/recon/tracking/kalman/MeasurementSite.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/kalman/MeasurementSite.java
@@ -23,12 +23,14 @@ class MeasurementSite {
     private double mxResid; // Maximum residual for adding a hit
     private double mxResidShare; // Maximum residual for a shared hit
     private boolean verbose;
+    private int verboseLevel;
     double B;
 
     // Note: I can remove the concept of a dummy layer and make all layers equivalent, except that the non-physical ones
     // will never have a hit and thus will be handled the same as physical layers that lack hits
-
+    
     void print(String s) {
+
         if (m.Layer < 0) {
             System.out.format("\n****Dump of dummy measurement site %d %s;  ", thisSite, s);
         } else {
@@ -79,6 +81,7 @@ class MeasurementSite {
         dEdx = -0.1 * sp * rho; // in GeV/mm
         chi2inc = 0.;
         verbose = false;
+        verboseLevel = 0 ;
     }
 
     double scatX() { // scattering angle in the x,y plane for the filtered state vector
@@ -459,7 +462,9 @@ class MeasurementSite {
                 continue; // don't add a hit that was just removed
             }
             Measurement hit = m.hits.get(hitidx);
-            hit.print("to try");
+            if (verbose) {
+                hit.print("to try");
+            }
             for (KalTrack tkOther: hit.tracks) {
                 if (tkOther != tkr) continue hitList; // ignore already used hits
             }
@@ -490,9 +495,11 @@ class MeasurementSite {
                 if (filter()) {
                     if (verbose) System.out.format("MeasurementSite.addHit: chi2inc from filter = %10.5f\n", chi2inc);
                     if (chi2inc < cut) {
-                        System.out.format("MeasurementSite.addHit: success! Adding hit %d on layer %d detector %d  hit=", hitID, m.Layer, m.detector);
-                        hit.print("short");
-                        System.out.format("\n");
+                        if (verbose) {
+                            System.out.format("MeasurementSite.addHit: success! Adding hit %d on layer %d detector %d  hit=", hitID, m.Layer, m.detector);
+                            hit.print("short");
+                            System.out.format("\n");
+                        }
                         return m.hits.get(hitID);
                     } else {
                         hitID = -1;

--- a/tracking/src/main/java/org/hps/recon/tracking/kalman/MeasurementSite.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/kalman/MeasurementSite.java
@@ -144,9 +144,10 @@ class MeasurementSite {
 
         // Check whether the intersection is within the bounds of the detector, with some margin
         // If not, then the pattern recognition may look in another detector in the layer
+        // Don't do the check if the hit number is already specified
         double tol = 1.0; // Tolerance on the check, in mm
         Vec rLocal = null;
-        if (checkBounds) {
+        if (checkBounds && hitNumber < 0) {
             Vec rGlobal = pS.toGlobal(X0); // Transform from field coordinates to global coordinates
             rLocal = m.toLocal(rGlobal); // Rotate into the detector coordinate system
             if (rLocal.v[0] < m.xExtent[0] - tol || rLocal.v[0] > m.xExtent[1] + tol) { return -2; }
@@ -258,7 +259,7 @@ class MeasurementSite {
                         //    continue;
                         //}
                         double residual = m.hits.get(i).v - aP.mPred;
-                        if (verbose2) {
+                        if (verbose) {
                             double ctv = residual/m.hits.get(i).sigma;
                             System.out.format("  MeasurementSite.makePrediction: Found unused hit, residual=%10.5f, sigmas=%10.5f, cut=%10.5f\n", residual, ctv, mxResid); 
                         }
@@ -271,7 +272,7 @@ class MeasurementSite {
                     if (theHit < 0 && sharingOK) {  // Look for good shared hits
                         for (int i = 0; i < nHits; i++) {
                             double residual = m.hits.get(i).v - aP.mPred;
-                            if (verbose2) {                         
+                            if (verbose) {                         
                                 double ctv = residual/m.hits.get(i).sigma;
                                 System.out.format("  MeasurementSite.makePrediction: Found used hit, residual=%10.5f, sigmas=%10.5f, cut=%10.5f\n", residual, ctv, mxResid); 
                             }
@@ -313,8 +314,8 @@ class MeasurementSite {
                 chi2inc = aP.r * aP.r / aP.R;
                 double cutVal = Math.abs(aP.r / m.hits.get(theHit).sigma);
                 if (verbose2) {
-                    System.out.format("  MeasurementSite.makePrediction: Lyr %d det %d: do we add hit with residual=%10.5f, err=%10.5f, chi2inc=%10.5f, %10.5f<%10.5f?\n",
-                            m.Layer, m.detector, aP.r, Math.sqrt(aP.R), chi2inc, cutVal, cut);
+                    System.out.format("  MeasurementSite.makePrediction: Lyr %d det %d: do we add hit with residual=%10.5f, err=%10.5f, chi2inc=%10.5f, %10.5f<%10.5f?, t=%8.2f\n",
+                            m.Layer, m.detector, aP.r, Math.sqrt(aP.R), chi2inc, cutVal, cut, m.hits.get(theHit).time);
                 }
 
                 if (hitNumber >= 0) { // Use the hit no matter what if it was handed to us
@@ -369,7 +370,7 @@ class MeasurementSite {
         // double phiCheck = aF.planeIntersect(m.p);
         // System.out.format("MeasurementSite.filter: phi = %10.7f, phi check = %10.7f\n",phiF, phiCheck);
         if (Double.isNaN(phiF)) { // There may be no intersection if the momentum is too low!
-            if (verbose) {
+            if (verbose2) {
                 System.out.format("MeasurementSite.filter: no intersection of helix with the plane exists at layer %d detector %d\n", m.Layer, m.detector);
                 aP.a.print("predicted helix parameters");
                 aF.a.print("Filtered helix parameters");
@@ -402,7 +403,7 @@ class MeasurementSite {
 
         //System.out.format("MeasurmentSite.filter: R=%10.8f\n", aF.R);
         if (aF.R < 0) {
-            if (verbose) { System.out.format("MeasurementSite.filter: covariance of residual %12.4e is negative\n", aF.R); }
+            if (verbose2) { System.out.format("MeasurementSite.filter: covariance of residual %12.4e is negative\n", aF.R); }
             aF.R = V;
         }
 
@@ -459,7 +460,7 @@ class MeasurementSite {
                 continue; // don't add a hit that was just removed
             }
             Measurement hit = m.hits.get(hitidx);
-            hit.print("to try");
+            if (verbose) hit.print("to try");
             for (KalTrack tkOther: hit.tracks) {
                 if (tkOther != tkr) continue hitList; // ignore already used hits
             }

--- a/tracking/src/main/java/org/hps/recon/tracking/kalman/PatRecTest.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/kalman/PatRecTest.java
@@ -11,11 +11,11 @@ import java.util.ArrayList;
 import java.util.Random;
 
 //This is for testing only and is not part of the Kalman fitting code
-public class PatRecTest {
+class PatRecTest {
 
     Random rnd;
 
-    public PatRecTest(String path) {
+    PatRecTest(String path) {
         // Units are Tesla, GeV, mm
 
         int nTrials = 100;              // The number of test eventNumbers to generate for pattern recognition and fitting
@@ -32,6 +32,9 @@ public class PatRecTest {
         rnd = new Random();
         rnd.setSeed(rndSeed);
 
+        // Set pattern recognition parameters
+        KalmanParams kPar = new KalmanParams();
+        
         // Definition of the magnetic field
         String mapType = "binary";
         //String mapFile = "C:\\Users\\Robert\\Documents\\GitHub\\hps-java\\fieldmap\\125acm2_3kg_corrected_unfolded_scaled_0.7992_v3.bin";
@@ -444,7 +447,7 @@ public class PatRecTest {
             }
 
             if (verbose) System.out.format("\n\n ******* PatRecTest: now making the call to KalmanPatRecHPS.\n");
-            KalmanPatRecHPS patRec = new KalmanPatRecHPS(SiModules, 0, eventNumber, verbose);
+            KalmanPatRecHPS patRec = new KalmanPatRecHPS(SiModules, 0, eventNumber, kPar, verbose);
             if (nPlot < mxPlot && verbose) {
                 nPlot++;
                 PrintWriter printWriter3 = null;

--- a/tracking/src/main/java/org/hps/recon/tracking/kalman/SeedTrack.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/kalman/SeedTrack.java
@@ -24,7 +24,7 @@ class SeedTrack {
     private Vec sol; // Fitted polynomial coefficients
     private SquareMatrix Csol; // Covariance matrix of the fitted polynomial coefficients
     private double Bavg; // Average B field
-    public double yOrigin;
+    double yOrigin;
     double chi2;
     private static Plane p0; // x,z plane at y=0
     private static double minDistXZ; // Minimum difference in distance to origin for it to be used in sorting

--- a/tracking/src/main/java/org/hps/recon/tracking/kalman/SiModule.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/kalman/SiModule.java
@@ -6,7 +6,7 @@ import java.util.Iterator;
 //import org.lcsim.geometry.FieldMap;
 
 // Description of a single silicon-strip module, and a container for its hits
-public class SiModule {
+class SiModule {
     int Layer; // Tracker layer number, or a negative integer for a dummy layer added just for stepping in a
                // non-uniform field
     int detector; // Detector number within the layer
@@ -32,18 +32,18 @@ public class SiModule {
         verbose = input;
     }
 
-    public SiModule(int Layer, Plane p, double stereo, double width, double height, double thickness, org.lcsim.geometry.FieldMap Bfield) {
+    SiModule(int Layer, Plane p, double stereo, double width, double height, double thickness, org.lcsim.geometry.FieldMap Bfield) {
         // for backwards-compatibility with old stand-alone development code: assume axial
         // layers have stereo angle=0
         this(Layer, p, stereo != 0.0, width, height, thickness, Bfield, 0);
     }
 
-    public SiModule(int Layer, Plane p, boolean isStereo, double width, double height, double thickness,
+    SiModule(int Layer, Plane p, boolean isStereo, double width, double height, double thickness,
             org.lcsim.geometry.FieldMap Bfield) {
         this(Layer, p, isStereo, width, height, thickness, Bfield, 0);
     }
 
-    public SiModule(int Layer, Plane p, boolean isStereo, double width, double height, double thickness,
+    SiModule(int Layer, Plane p, boolean isStereo, double width, double height, double thickness,
             org.lcsim.geometry.FieldMap Bfield, int detector) {
         
         if (verbose) { 
@@ -74,7 +74,7 @@ public class SiModule {
         hits = new ArrayList<Measurement>();
     }
 
-    public void print(String s) {
+    void print(String s) {
         System.out.format(
                 "Si module %s, Layer=%2d, Detector=%2d, stereo=%b, thickness=%8.4f mm, x extents=%10.6f %10.6f, y extents=%10.6f %10.6f\n",
                 s, Layer, detector, isStereo, thickness, xExtent[0], xExtent[1], yExtent[0], yExtent[1]);
@@ -97,11 +97,11 @@ public class SiModule {
     }
 
     // Delete all the existing hits
-    public void reset() {
+    void reset() {
         hits = new ArrayList<Measurement>();
     }
 
-    public void addMeasurement(Measurement m) {
+    void addMeasurement(Measurement m) {
         if (hits.size() == 0) hits.add(m);
         else {
             boolean added = false;

--- a/tracking/src/main/java/org/hps/recon/tracking/kalman/SiModule.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/kalman/SiModule.java
@@ -26,6 +26,12 @@ public class SiModule {
     org.lcsim.geometry.FieldMap Bfield;
     boolean isStereo;
 
+    boolean verbose = false;
+
+    void setVerbose(boolean input) { 
+        verbose = input;
+    }
+
     public SiModule(int Layer, Plane p, double stereo, double width, double height, double thickness, org.lcsim.geometry.FieldMap Bfield) {
         // for backwards-compatibility with old stand-alone development code: assume axial
         // layers have stereo angle=0
@@ -39,12 +45,17 @@ public class SiModule {
 
     public SiModule(int Layer, Plane p, boolean isStereo, double width, double height, double thickness,
             org.lcsim.geometry.FieldMap Bfield, int detector) {
-        System.out.format("SiModule constructor called with layer = %d, detector module = %d, y=%8.2f\n", Layer, detector, p.X().v[1]);
-        p.print("of SiModule");
+        
+        if (verbose) { 
+            System.out.format("SiModule constructor called with layer = %d, detector module = %d, y=%8.2f\n", Layer, detector, p.X().v[1]);
+            p.print("of SiModule");
+        }
         Vec BOnAxis = KalmanInterface.getField(new Vec(0.,p.X().v[1],0.), Bfield);
         Vec BatCenter = KalmanInterface.getField(p.X(), Bfield);
-        BOnAxis.print("B field on axis");
-        BatCenter.print("B at detector center");
+        if (verbose) {
+            BOnAxis.print("B field on axis");
+            BatCenter.print("B at detector center");
+        }
         this.Layer = Layer;
         this.detector = detector;
         this.Bfield = Bfield;

--- a/tracking/src/main/java/org/hps/recon/tracking/kalman/SiModule.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/kalman/SiModule.java
@@ -6,7 +6,7 @@ import java.util.Iterator;
 //import org.lcsim.geometry.FieldMap;
 
 // Description of a single silicon-strip module, and a container for its hits
-public class SiModule {
+class SiModule {
     int Layer; // Tracker layer number, or a negative integer for a dummy layer added just for stepping in a
                // non-uniform field
     int detector; // Detector number within the layer
@@ -26,18 +26,18 @@ public class SiModule {
     org.lcsim.geometry.FieldMap Bfield;
     boolean isStereo;
 
-    public SiModule(int Layer, Plane p, double stereo, double width, double height, double thickness, org.lcsim.geometry.FieldMap Bfield) {
+    SiModule(int Layer, Plane p, double stereo, double width, double height, double thickness, org.lcsim.geometry.FieldMap Bfield) {
         // for backwards-compatibility with old stand-alone development code: assume axial
         // layers have stereo angle=0
         this(Layer, p, stereo != 0.0, width, height, thickness, Bfield, 0);
     }
 
-    public SiModule(int Layer, Plane p, boolean isStereo, double width, double height, double thickness,
+    SiModule(int Layer, Plane p, boolean isStereo, double width, double height, double thickness,
             org.lcsim.geometry.FieldMap Bfield) {
         this(Layer, p, isStereo, width, height, thickness, Bfield, 0);
     }
 
-    public SiModule(int Layer, Plane p, boolean isStereo, double width, double height, double thickness,
+    SiModule(int Layer, Plane p, boolean isStereo, double width, double height, double thickness,
             org.lcsim.geometry.FieldMap Bfield, int detector) {
         System.out.format("SiModule constructor called with layer = %d, detector module = %d, y=%8.2f\n", Layer, detector, p.X().v[1]);
         p.print("of SiModule");
@@ -63,7 +63,7 @@ public class SiModule {
         hits = new ArrayList<Measurement>();
     }
 
-    public void print(String s) {
+    void print(String s) {
         System.out.format(
                 "Si module %s, Layer=%2d, Detector=%2d, stereo=%b, thickness=%8.4f mm, x extents=%10.6f %10.6f, y extents=%10.6f %10.6f\n",
                 s, Layer, detector, isStereo, thickness, xExtent[0], xExtent[1], yExtent[0], yExtent[1]);
@@ -86,11 +86,11 @@ public class SiModule {
     }
 
     // Delete all the existing hits
-    public void reset() {
+    void reset() {
         hits = new ArrayList<Measurement>();
     }
 
-    public void addMeasurement(Measurement m) {
+    void addMeasurement(Measurement m) {
         if (hits.size() == 0) hits.add(m);
         else {
             boolean added = false;

--- a/tracking/src/main/java/org/hps/recon/tracking/kalman/SquareMatrix.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/kalman/SquareMatrix.java
@@ -31,6 +31,16 @@ class SquareMatrix { // Simple matrix package strictly for N by N matrices neede
         }
     }
 
+    boolean isNaN() {
+        for (int i = 0; i < N; i++) {
+            for (int j = 0; j < N; j++) {
+                if (Double.isNaN(M[i][j]))
+                    return true;
+            }
+        }
+        return false;
+    }
+    
     SquareMatrix multiply(SquareMatrix M2) { // Standard matrix multiplication
         SquareMatrix Mp = new SquareMatrix(N);
         for (int i = 0; i < N; i++) {

--- a/tracking/src/main/java/org/hps/recon/tracking/kalman/StateVector.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/kalman/StateVector.java
@@ -338,7 +338,7 @@ class StateVector {
         // return new Vec(x, y, z);
     }
 
-    public static Vec atPhi(Vec X0, Vec a, double phi, double alpha) {
+    static Vec atPhi(Vec X0, Vec a, double phi, double alpha) {
         double x = X0.v[0] + (a.v[0] + (alpha / a.v[2])) * Math.cos(a.v[1]) - (alpha / a.v[2]) * Math.cos(a.v[1] + phi);
         double y = X0.v[1] + (a.v[0] + (alpha / a.v[2])) * Math.sin(a.v[1]) - (alpha / a.v[2]) * Math.sin(a.v[1] + phi);
         double z = X0.v[2] + a.v[3] - (alpha / a.v[2]) * phi * a.v[4];
@@ -351,7 +351,7 @@ class StateVector {
         return getMom(phi, a);
     }
 
-    public static Vec getMom(double phi, Vec a) {
+    static Vec getMom(double phi, Vec a) {
         double px = -Math.sin(a.v[1] + phi) / Math.abs(a.v[2]);
         double py = Math.cos(a.v[1] + phi) / Math.abs(a.v[2]);
         double pz = a.v[4] / Math.abs(a.v[2]);
@@ -450,7 +450,7 @@ class StateVector {
     }
 
     // Propagate a helix by Runge-Kutta itegration to an x,z plane containing the origin.
-    public Vec propagateRungeKutta(org.lcsim.geometry.FieldMap fM, SquareMatrix newCovariance, double XL) {
+    Vec propagateRungeKutta(org.lcsim.geometry.FieldMap fM, SquareMatrix newCovariance, double XL) {
 
         //boolean verbose = false; // !!!!!!!!!!
 
@@ -479,8 +479,7 @@ class StateVector {
         double Q = Math.signum(a.v[2]);
 
         Vec pInt = new Vec(3);
-        Vec Xplane = hpi.rkIntersect(originPlane, X0origin, P0origin, Q, fM, pInt); // RK propagation to the origin
-                                                                                    // plane
+        Vec Xplane = hpi.rkIntersect(originPlane, X0origin, P0origin, Q, fM, pInt); // RK propagation to the origin plane
 
         Vec helixAtIntersect = pTOa(pInt, 0., 0., Q);
         Vec helixAtOrigin = pivotTransform(new Vec(0., 0., 0.), helixAtIntersect, Xplane, alpha, 0.);

--- a/tracking/src/main/java/org/hps/recon/tracking/kalman/StateVector.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/kalman/StateVector.java
@@ -338,7 +338,7 @@ class StateVector {
         // return new Vec(x, y, z);
     }
 
-    public static Vec atPhi(Vec X0, Vec a, double phi, double alpha) {
+    static Vec atPhi(Vec X0, Vec a, double phi, double alpha) {
         double x = X0.v[0] + (a.v[0] + (alpha / a.v[2])) * Math.cos(a.v[1]) - (alpha / a.v[2]) * Math.cos(a.v[1] + phi);
         double y = X0.v[1] + (a.v[0] + (alpha / a.v[2])) * Math.sin(a.v[1]) - (alpha / a.v[2]) * Math.sin(a.v[1] + phi);
         double z = X0.v[2] + a.v[3] - (alpha / a.v[2]) * phi * a.v[4];
@@ -351,7 +351,7 @@ class StateVector {
         return getMom(phi, a);
     }
 
-    public static Vec getMom(double phi, Vec a) {
+    static Vec getMom(double phi, Vec a) {
         double px = -Math.sin(a.v[1] + phi) / Math.abs(a.v[2]);
         double py = Math.cos(a.v[1] + phi) / Math.abs(a.v[2]);
         double pz = a.v[4] / Math.abs(a.v[2]);
@@ -450,7 +450,7 @@ class StateVector {
     }
 
     // Propagate a helix by Runge-Kutta itegration to an x,z plane containing the origin.
-    public Vec propagateRungeKutta(org.lcsim.geometry.FieldMap fM, SquareMatrix newCovariance, double XL) {
+    Vec propagateRungeKutta(org.lcsim.geometry.FieldMap fM, SquareMatrix newCovariance, double XL) {
 
         //boolean verbose = false; // !!!!!!!!!!
 
@@ -479,9 +479,7 @@ class StateVector {
         double Q = Math.signum(a.v[2]);
 
         Vec pInt = new Vec(3);
-
-        Vec Xplane = hpi.rkIntersect(originPlane, X0origin, P0origin, Q, fM, pInt); // RK propagation to the origin
-                                                                                    // plane
+        Vec Xplane = hpi.rkIntersect(originPlane, X0origin, P0origin, Q, fM, pInt); // RK propagation to the origin plane
         Vec helixAtIntersect = pTOa(pInt, 0., 0., Q);
         Vec helixAtOrigin = pivotTransform(new Vec(0., 0., 0.), helixAtIntersect, Xplane, alpha, 0.);
         if (verbose) {

--- a/tracking/src/main/java/org/hps/recon/tracking/kalman/StateVector.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/kalman/StateVector.java
@@ -479,9 +479,9 @@ class StateVector {
         double Q = Math.signum(a.v[2]);
 
         Vec pInt = new Vec(3);
+
         Vec Xplane = hpi.rkIntersect(originPlane, X0origin, P0origin, Q, fM, pInt); // RK propagation to the origin
                                                                                     // plane
-
         Vec helixAtIntersect = pTOa(pInt, 0., 0., Q);
         Vec helixAtOrigin = pivotTransform(new Vec(0., 0., 0.), helixAtIntersect, Xplane, alpha, 0.);
         if (verbose) {
@@ -537,7 +537,6 @@ class StateVector {
             for (int i = 0; i < 5; ++i) { System.out.format(" %10.7f", Math.sqrt(newCovariance.M[i][i])); }
             System.out.println("\n");
         }
-
         return helixAtOrigin;
     }
 

--- a/tracking/src/main/java/org/hps/recon/tracking/kalman/TrackCandidate.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/kalman/TrackCandidate.java
@@ -6,6 +6,7 @@ import java.util.Comparator;
 import java.util.Map;
 
 public class TrackCandidate {
+    int ID;
     private Map<Measurement, KalHit> hitMap;
     ArrayList<MeasurementSite> sites;
     ArrayList<KalHit> hits;
@@ -19,8 +20,11 @@ public class TrackCandidate {
     boolean smoothed;
     boolean good;
     int kalTkrID;
+    int eventNumber;
 
-    TrackCandidate(ArrayList<KalHit> seedHits, int mxShared, double mxTdif, Map<Measurement, KalHit> hitMap) {
+    TrackCandidate(int IDset, ArrayList<KalHit> seedHits, int mxShared, double mxTdif, Map<Measurement, KalHit> hitMap, int event) {
+        ID = IDset;
+        eventNumber = event;
         this.mxShared = mxShared;
         this.mxTdif = mxTdif;
         filtered = false;
@@ -79,7 +83,7 @@ public class TrackCandidate {
             }
         }
         if (siteR == null) {
-            System.out.format("TrackCandidate.removeHit error: MeasurementSite is missing for layer %d\n", mod.Layer);
+            System.out.format("TrackCandidate.removeHit error in event %d: MeasurementSite is missing for layer %d\n", eventNumber, mod.Layer);
         } else {
             siteR.hitID = -1;
             sites.remove(siteR);
@@ -105,7 +109,7 @@ public class TrackCandidate {
     }
     
     boolean reFit(boolean verbose) {
-        if (verbose) System.out.format("TrackCandidate.reFit: starting filtering.\n");
+        if (verbose) System.out.format("TrackCandidate.reFit: starting filtering for event %d.\n",eventNumber);
 
         boolean failure = false;
         StateVector sHstart = sites.get(0).aS;
@@ -131,8 +135,12 @@ public class TrackCandidate {
                 currentSite.aF = null;
                 currentSite.aS = null;
                 boolean pickupHits = false;
-                if (!seedLyrs.contains(currentSite.m.Layer)) {
-                    currentSite.hitID = -1;  // Allow hit reselection only for non-seed layers
+                if (!seedLyrs.contains(currentSite.m.Layer)) {  // Allow hit reselection only for non-seed layers
+                    if (currentSite.hitID >= 0) {
+                        KalHit oldHit = hitMap.get(currentSite.m.hits.get(currentSite.hitID));
+                        oldHit.tkrCandidates.remove(this);
+                        currentSite.hitID = -1;  
+                    }
                     pickupHits = true;
                 } 
     
@@ -141,13 +149,13 @@ public class TrackCandidate {
                 double [] tRange = {tMax - mxTdif, tMin + mxTdif}; 
                 int rF = currentSite.makePrediction(sH, prevMod, currentSite.hitID, allowSharing, pickupHits, checkBounds, tRange, verbose);
                 if (rF < 0) {
-                    if (verbose) System.out.format("TrackCandidate.reFit: failed to make prediction at layer %d!!\n",currentSite.m.Layer);
+                    if (verbose) System.out.format("TrackCandidate.reFit: failed to make prediction at layer %d for event %d!\n",currentSite.m.Layer,eventNumber);
                     if (nStereo > 2 && hits.size() > 4) {
                         currentSite.hitID = 0;
                         failure = true;
                         break;
                     }
-                    if (verbose) System.out.format("TrackCandidate.reFit: aboart refit, nHits=%d, nStereo=%d\n", hits.size(), nStereo);
+                    if (verbose) System.out.format("TrackCandidate.reFit: abort refit for event %d, nHits=%d, nStereo=%d\n", eventNumber, hits.size(), nStereo);
                     return false;
                 } else if (rF == 1) {
                     if (currentSite.m.hits.get(currentSite.hitID).tracks.size() > 0) nTaken++;
@@ -155,13 +163,13 @@ public class TrackCandidate {
                     tMax = Math.max(tMax, currentSite.m.hits.get(currentSite.hitID).time);
                 }
                 if (!currentSite.filter(verbose)) {
-                    if (verbose) System.out.format("TrackCandidate.reFit: failed to filter at layer %d!!\n",currentSite.m.Layer);
+                    if (verbose) System.out.format("TrackCandidate.reFit: failed to filter at layer %d in event %d!\n",currentSite.m.Layer, eventNumber);
                     if (nStereo > 2 && hits.size() > 4) {
                         currentSite.hitID = 0;
                         failure = true;
                         break;
                     }
-                    if (verbose) System.out.format("TrackCandidate.reFit: abort refit, nHits=%d, nStereo=%d\n", hits.size(), nStereo);
+                    if (verbose) System.out.format("TrackCandidate.reFit: abort refit for event %d, nHits=%d, nStereo=%d\n", eventNumber, hits.size(), nStereo);
                     return false;
                 }
                 if (currentSite.chi2inc >= chi2s) {
@@ -178,6 +186,7 @@ public class TrackCandidate {
                 if (currentSite.hitID >= 0) {
                     KalHit hitNew = hitMap.get(currentSite.m.hits.get(currentSite.hitID));
                     hits.add(hitNew);
+                    //hitNew.tkrCandidates.add(this); don't do this; hits are marked later
                     chi2f += Math.max(currentSite.chi2inc,0.);
                     if (currentSite.m.isStereo) nStereo++;
                     if (currentSite.m.hits.get(currentSite.hitID).tracks.size() > 0) nTaken++;
@@ -190,7 +199,7 @@ public class TrackCandidate {
                 prevMod = currentSite.m;
             }
             if (nStereo < 3 || hits.size() < 5) {
-                if (verbose) System.out.format("TrackCandidate.reFit: not enough hits included in fit.  nHits=%d, nStereo=%d\n", hits.size(), nStereo);
+                if (verbose) System.out.format("TrackCandidate.reFit event %d: not enough hits included in fit.  nHits=%d, nStereo=%d\n", eventNumber, hits.size(), nStereo);
                 return false;
             }
             if (failure) {
@@ -203,6 +212,10 @@ public class TrackCandidate {
                 for (MeasurementSite site : sitesToRemove) {
                     if (verbose) System.out.format("TrackCandidate.refit: removing site at layer %d detector %d\n", site.m.Layer, site.m.detector);
                     sites.remove(site);
+                    if (site.hitID >= 0) {
+                        KalHit theHit = hitMap.get(site.m.hits.get(site.hitID));
+                        theHit.tkrCandidates.remove(this);
+                    }
                 }
             }
         } while (failure);
@@ -235,11 +248,11 @@ public class TrackCandidate {
     
     void print(String s, boolean shrt) {
         if (good) {
-            System.out.format("Good TrackCandidate %s, nHits=%d, nShared=%d, chi2f=%10.6f, chi2s=%10.6f, t=%5.1f to %5.1f\n", 
-                    s, hits.size(), nTaken, chi2f, chi2s, tMin, tMax);
+            System.out.format("%d Good TrackCandidate %s for event %d, nHits=%d, nShared=%d, chi2f=%10.6f, chi2s=%10.6f, t=%5.1f to %5.1f\n", 
+                    ID, s, eventNumber, hits.size(), nTaken, chi2f, chi2s, tMin, tMax);
         } else {
-            System.out.format(" Bad TrackCandidate %s, nHits=%d, nShared=%d, chi2f=%10.6f, chi2s=%10.6f, t=%5.1f to %5.1f\n", 
-                    s, hits.size(), nTaken, chi2f, chi2s, tMin, tMax);
+            System.out.format("%d Bad TrackCandidate %s for event %d, nHits=%d, nShared=%d, chi2f=%10.6f, chi2s=%10.6f, t=%5.1f to %5.1f\n", 
+                    ID, s, eventNumber, hits.size(), nTaken, chi2f, chi2s, tMin, tMax);
         }
         MeasurementSite site0 = null;
         for (MeasurementSite site : sites) {
@@ -267,6 +280,11 @@ public class TrackCandidate {
         for (KalHit ht : hits) ht.print("short");
         if (shrt) {
             System.out.format("\n");
+            System.out.format("   Site list: ");
+            for (MeasurementSite site : sites) {
+                System.out.format("(%d, %d, %d) ",site.m.Layer,site.m.detector,site.hitID);
+            }
+            System.out.format("\n");
         } else {
             System.out.format("   Site list:\n");
             for (MeasurementSite site : sites) {
@@ -290,8 +308,8 @@ public class TrackCandidate {
                 double resid;
                 if (site.hitID < 0) resid = 99.;
                 else resid = vPred - m.hits.get(site.hitID).v;
-                System.out.format("   %d Lyr %d %s stereo=%b Hit %d chi2inc=%10.6f, resid=%10.6f, vPred=%10.6f; Hits: ", cnt, m.Layer, S, m.isStereo,
-                        site.hitID, site.chi2inc, resid, vPred);
+                System.out.format("   %d Lyr=%d det=%d %s Hit=%d stereo=%b  chi2inc=%10.6f, resid=%10.6f, vPred=%10.6f; Hits: ", 
+                        cnt, m.Layer, m.detector, S, site.hitID, m.isStereo, site.chi2inc, resid, vPred);
                 for (Measurement hit : m.hits) {
                     if (hit.vTrue == 999.) System.out.format(" (v=%10.6f #tks=%d),", hit.v, hit.tracks.size());
                     else System.out.format(" v=%10.6f #tks=%d,", hit.v, hit.tracks.size());                   

--- a/tracking/src/main/java/org/hps/recon/tracking/kalman/TrackCandidate.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/kalman/TrackCandidate.java
@@ -5,7 +5,7 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.Map;
 
-public class TrackCandidate {
+class TrackCandidate {
     int ID;
     private Map<Measurement, KalHit> hitMap;
     ArrayList<MeasurementSite> sites;

--- a/tracking/src/main/java/org/hps/recon/tracking/kalman/Vec.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/kalman/Vec.java
@@ -141,4 +141,12 @@ class Vec { // N-vector for the Kalman filter
         return new Vec(N, R);
     }
 
+    boolean isNaN() {
+        for (int i = 0; i<N; i++) {
+            if (Double.isNaN(v[i])) {
+                return true;                
+            }
+        }
+        return false;
+    }
 }


### PR DESCRIPTION
This pull request brings the KF into the hps-java Reco chain
- KF pattern reco and vertexing can be called by steering file
- Doesn't change nominal processing
- Fixed issues with previous PR
- Code compiles: OK 
- Tests fail for 2019 reconstruction [unrelated to this branch] 

[INFO] Reactor Summary:
[INFO] 
[INFO] HPS Java .......................................... SUCCESS [4.274s]
[INFO] util .............................................. SUCCESS [5.524s]
[INFO] detector-data ..................................... SUCCESS [41.947s]
[INFO] logging ........................................... SUCCESS [1.931s]
[INFO] conditions ........................................ SUCCESS [12.376s]
[INFO] detector-model .................................... SUCCESS [28.066s]
[INFO] record-util ....................................... SUCCESS [10.082s]
[INFO] datacat ........................................... SUCCESS [2.014s]
[INFO] run-database ...................................... SUCCESS [2.820s]
[INFO] ecal-recon ........................................ SUCCESS [5.554s]
[INFO] ecal-readout-sim .................................. SUCCESS [3.930s]
[INFO] tracking .......................................... SUCCESS [18.966s]
[INFO] recon ............................................. SUCCESS [6.564s]
[INFO] analysis .......................................... SUCCESS [10.992s]
[INFO] crawler ........................................... SUCCESS [2.476s]
[INFO] job ............................................... SUCCESS [1.626s]
[INFO] evio .............................................. SUCCESS [4.572s]
[INFO] monitoring-util ................................... SUCCESS [4.609s]
[INFO] ecal-event-display ................................ SUCCESS [5.869s]
[INFO] monitoring-drivers ................................ SUCCESS [5.712s]
[INFO] steering-files .................................... SUCCESS [10.313s]
[INFO] monitoring-app .................................... SUCCESS [6.721s]
[INFO] online-recon ...................................... SUCCESS [4.473s]
[INFO] distribution ...................................... SUCCESS [33.228s]
[INFO] plugin ............................................ SUCCESS [7.778s]
[INFO] integration-tests ................................. SUCCESS [7.164s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 4:10.796s
[INFO] Finished at: Mon Mar 09 19:52:55 PDT 2020
[INFO] Final Memory: 76M/1253M
[INFO] ------------------------------------------------------------------------
