### PR TITLE
add 2019 v2 ECAL detector

### DIFF
--- a/detector-data/detectors/HPS-PhysicsRun2019-v2-4pt5/HPS-PhysicsRun2019-v2-4pt5.lcdd
+++ b/detector-data/detectors/HPS-PhysicsRun2019-v2-4pt5/HPS-PhysicsRun2019-v2-4pt5.lcdd
@@ -1,0 +1,10070 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lcdd xmlns:lcdd="http://www.lcsim.org/schemas/lcdd/1.0" xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/lcdd/1.0/lcdd.xsd">
+  <header>
+    <detector name="HPS-PhysicsRun2019-v2-4pt5" />
+    <generator name="lcsim" version="1.0" file="/Users/baltzell/hps-java/detector-data/detectors/HPS-PhysicsRun2019-v2-4pt5/compact.xml" checksum="2298344855" />
+    <author name="NONE" />
+    <comment>HPS detector for 2019 run with fieldmap, Tracker at nominal opening angle, no SVT survey, this detector uses the corrected fieldmap scaled to -1.022T for 4.5 GeV. Includes L0 and Hodoscope. ECAL with survey alignment for HPSEcal3 (global y/z translations).</comment>
+  </header>
+  <iddict>
+    <idspec name="HodoscopeForeHits" length="46">
+      <idfield signed="false" label="system" length="6" start="0" />
+      <idfield signed="false" label="barrel" length="3" start="6" />
+      <idfield signed="false" label="layer" length="4" start="9" />
+      <idfield signed="false" label="module" length="12" start="13" />
+      <idfield signed="false" label="sensor" length="1" start="25" />
+      <idfield signed="true" label="side" length="2" start="32" />
+      <idfield signed="false" label="strip" length="12" start="34" />
+    </idspec>
+    <idspec name="TrackerHitsFieldDef" length="46">
+      <idfield signed="false" label="system" length="6" start="0" />
+      <idfield signed="false" label="barrel" length="3" start="6" />
+      <idfield signed="false" label="layer" length="4" start="9" />
+      <idfield signed="false" label="module" length="12" start="13" />
+      <idfield signed="false" label="sensor" length="1" start="25" />
+      <idfield signed="true" label="side" length="2" start="32" />
+      <idfield signed="false" label="strip" length="12" start="34" />
+    </idspec>
+    <idspec name="TrackerHits" length="46">
+      <idfield signed="false" label="system" length="6" start="0" />
+      <idfield signed="false" label="barrel" length="3" start="6" />
+      <idfield signed="false" label="layer" length="4" start="9" />
+      <idfield signed="false" label="module" length="12" start="13" />
+      <idfield signed="false" label="sensor" length="1" start="25" />
+      <idfield signed="true" label="side" length="2" start="32" />
+      <idfield signed="false" label="strip" length="12" start="34" />
+    </idspec>
+    <idspec name="HodoscopeHits" length="23">
+      <idfield signed="false" label="system" length="6" start="0" />
+      <idfield signed="false" label="barrel" length="3" start="6" />
+      <idfield signed="false" label="layer" length="4" start="9" />
+      <idfield signed="false" label="ix" length="4" start="13" />
+      <idfield signed="true" label="iy" length="3" start="17" />
+      <idfield signed="true" label="hole" length="3" start="20" />
+    </idspec>
+    <idspec name="EcalHits" length="22">
+      <idfield signed="false" label="system" length="6" start="0" />
+      <idfield signed="false" label="layer" length="2" start="6" />
+      <idfield signed="true" label="ix" length="8" start="8" />
+      <idfield signed="true" label="iy" length="6" start="16" />
+    </idspec>
+    <idspec name="TrackerHitsECal" length="46">
+      <idfield signed="false" label="system" length="6" start="0" />
+      <idfield signed="false" label="barrel" length="3" start="6" />
+      <idfield signed="false" label="layer" length="4" start="9" />
+      <idfield signed="false" label="module" length="12" start="13" />
+      <idfield signed="false" label="sensor" length="1" start="25" />
+      <idfield signed="true" label="side" length="2" start="32" />
+      <idfield signed="false" label="strip" length="12" start="34" />
+    </idspec>
+  </iddict>
+  <sensitive_detectors>
+    <tracker name="Tracker" ecut="0.0" eunit="MeV" verbose="0" hits_collection="TrackerHits">
+      <idspecref ref="TrackerHits" />
+    </tracker>
+    <tracker name="ECalScoring" ecut="0.0" eunit="MeV" verbose="0" hits_collection="TrackerHitsECal">
+      <idspecref ref="TrackerHitsECal" />
+      <hit_processor type="ScoringTrackerHitProcessor" />
+    </tracker>
+    <calorimeter name="Ecal" ecut="0.0" eunit="MeV" verbose="0" hits_collection="EcalHits">
+      <idspecref ref="EcalHits" />
+      <grid_xyz grid_size_x="0.0" grid_size_y="0.0" grid_size_z="0.0" />
+    </calorimeter>
+    <tracker name="Hodoscope" ecut="0.0" eunit="MeV" verbose="0" hits_collection="HodoscopeHits">
+      <idspecref ref="HodoscopeHits" />
+    </tracker>
+  </sensitive_detectors>
+  <limits />
+  <regions>
+    <region name="TrackingRegion" store_secondaries="true" kill_tracks="false" cut="10.0" lunit="mm" threshold="1.0" eunit="MeV" />
+  </regions>
+  <display>
+    <vis name="InvisibleWithDaughters" line_style="unbroken" drawing_style="wireframe" show_daughters="true" visible="false">
+      <color R="0.0" G="0.0" B="0.0" alpha="0.0" />
+    </vis>
+    <vis name="SensorVis" line_style="unbroken" drawing_style="wireframe" show_daughters="true" visible="true">
+      <color R="1.0" G="0.0" B="0.0" alpha="1.0" />
+    </vis>
+    <vis name="SvtBoxVis" line_style="unbroken" drawing_style="wireframe" show_daughters="true" visible="true">
+      <color R="1.0" G="1.0" B="0.0" alpha="1.0" />
+    </vis>
+    <vis name="ComponentVis" line_style="unbroken" drawing_style="solid" show_daughters="false" visible="false">
+      <color R="0.0" G="0.2" B="0.4" alpha="0.0" />
+    </vis>
+    <vis name="HybridVis" line_style="unbroken" drawing_style="solid" show_daughters="true" visible="true">
+      <color R="0.0" G="1.0" B="0.0" alpha="1.0" />
+    </vis>
+    <vis name="ColdBlockVis" line_style="dashed" drawing_style="solid" show_daughters="true" visible="true">
+      <color R="0.75" G="0.73" B="0.75" alpha="1.0" />
+    </vis>
+    <vis name="ECALVis" line_style="unbroken" drawing_style="wireframe" show_daughters="true" visible="true">
+      <color R="0.8" G="0.5" B="0.1" alpha="1.0" />
+    </vis>
+    <vis name="HodoscopeVis" line_style="unbroken" drawing_style="solid" show_daughters="true" visible="true">
+      <color R="0.0" G="0.3372549" B="0.50980395" alpha="1.0" />
+    </vis>
+    <vis name="BasePlateVis" line_style="dashed" drawing_style="solid" show_daughters="true" visible="true">
+      <color R="0.35" G="0.35" B="0.35" alpha="1.0" />
+    </vis>
+    <vis name="BeamPlaneVis" line_style="unbroken" drawing_style="solid" show_daughters="false" visible="true">
+      <color R="1.0" G="1.0" B="1.0" alpha="1.0" />
+    </vis>
+    <vis name="HalfModuleVis" line_style="dashed" drawing_style="wireframe" show_daughters="true" visible="true">
+      <color R="1.0" G="1.0" B="1.0" alpha="1.0" />
+    </vis>
+    <vis name="CarbonFiberVis" line_style="unbroken" drawing_style="solid" show_daughters="true" visible="true">
+      <color R="0.88" G="0.88" B="0.88" alpha="1.0" />
+    </vis>
+    <vis name="ModuleVis" line_style="dotted" drawing_style="wireframe" show_daughters="true" visible="true">
+      <color R="1.0" G="1.0" B="1.0" alpha="1.0" />
+    </vis>
+    <vis name="SupportPlateVis" line_style="dashed" drawing_style="solid" show_daughters="true" visible="true">
+      <color R="0.45" G="0.45" B="0.45" alpha="1.0" />
+    </vis>
+    <vis name="LayerVis" line_style="unbroken" drawing_style="wireframe" show_daughters="true" visible="false">
+      <color R="0.0" G="0.0" B="1.0" alpha="0.0" />
+    </vis>
+    <vis name="ChamberVis" line_style="unbroken" drawing_style="wireframe" show_daughters="true" visible="true">
+      <color R="1.0" G="0.0" B="1.0" alpha="1.0" />
+    </vis>
+    <vis name="InvisibleNoDaughters" line_style="unbroken" drawing_style="wireframe" show_daughters="false" visible="false">
+      <color R="0.0" G="0.0" B="0.0" alpha="0.0" />
+    </vis>
+    <vis name="ActiveSensorVis" line_style="unbroken" drawing_style="solid" show_daughters="true" visible="true">
+      <color R="1.0" G="0.0" B="0.0" alpha="1.0" />
+    </vis>
+    <vis name="KaptonVis" line_style="unbroken" drawing_style="solid" show_daughters="true" visible="true">
+      <color R="0.91" G="0.77" B="0.06" alpha="1.0" />
+    </vis>
+    <vis name="SupportVolumeVis" line_style="dashed" drawing_style="wireframe" show_daughters="true" visible="true">
+      <color R="0.75" G="0.73" B="0.75" alpha="1.0" />
+    </vis>
+    <vis name="WorldVis" line_style="unbroken" drawing_style="wireframe" show_daughters="true" visible="false">
+      <color R="1.0" G="1.0" B="1.0" alpha="1.0" />
+    </vis>
+    <vis name="TrackingVis" line_style="unbroken" drawing_style="wireframe" show_daughters="true" visible="false">
+      <color R="1.0" G="1.0" B="1.0" alpha="1.0" />
+    </vis>
+  </display>
+  <gdml>
+    <define>
+      <rotation name="identity_rot" x="0.0" y="0.0" z="0.0" unit="radian" />
+      <rotation name="reflect_rot" x="3.141592653589793" y="0.0" z="0.0" unit="radian" />
+      <position name="identity_pos" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <constant name="bot_tr_x" value="-0.405" />
+      <constant name="x_rot_top" value="0.0" />
+      <constant name="hodoscopeXMin2" value="48.0" />
+      <constant name="hodoscopeXMin1" value="43.548" />
+      <constant name="scoringThickness" value="0.001" />
+      <constant name="ecal_back" value="8.0" />
+      <constant name="pivot" value="791.0" />
+      <constant name="bot_tr_y" value="-0.9125" />
+      <constant name="hodoscopeThickness" value="10.0" />
+      <constant name="bot_tr_z" value="2.6225" />
+      <constant name="bot_rot_beta" value="0.0" />
+      <constant name="dipoleMagnetWidth" value="1000.0" />
+      <constant name="top_rot_beta" value="0.0" />
+      <constant name="SA1" value="0.1" />
+      <constant name="x_rot_top_add" value="0.0" />
+      <constant name="SA2" value="0.05" />
+      <constant name="tracking_region_min" value="50.0" />
+      <constant name="y02t" value="21.419865625949214" />
+      <constant name="world_side" value="5000.0" />
+      <constant name="sensorLength" value="98.33" />
+      <constant name="sensorWidth" value="38.3399" />
+      <constant name="y02b" value="-21.419865625949214" />
+      <constant name="bot_rot_gamma" value="0.0013469727279283583" />
+      <constant name="x_rot_bot" value="0.0" />
+      <constant name="dipoleMagnetHeight" value="1000.0" />
+      <constant name="z02t" value="146.185" />
+      <constant name="top_rot_alpha" value="6.4964212772E-4" />
+      <constant name="y_rot" value="0.03052" />
+      <constant name="tracking_region_zmax" value="1368.0" />
+      <constant name="constBFieldY" value="-1.08" />
+      <constant name="top_tr_z" value="4.9375" />
+      <constant name="top_tr_y" value="2.725" />
+      <constant name="top_tr_x" value="-0.71" />
+      <constant name="dipoleMagnetLength" value="1080.0" />
+      <constant name="top_rot_gamma" value="-4.6882347412E-4" />
+      <constant name="y01t" value="21.419865625949214" />
+      <constant name="x_rot_bot_add" value="0.0" />
+      <constant name="zst" value="1.0" />
+      <constant name="bot_rot_alpha" value="5.150274940439E-4" />
+      <constant name="hodoscopePixelHeight" value="59.225" />
+      <constant name="beam_angle" value="0.03052" />
+      <constant name="z02b" value="161.185" />
+      <constant name="y01b" value="-21.419865625949214" />
+      <constant name="electronGapLeftEdge" value="382.492" />
+      <constant name="ecal_front" value="6.65" />
+      <constant name="z01t" value="138.815" />
+      <constant name="world_x" value="5000.0" />
+      <constant name="hodoscopeScoreDisplacement" value="1.0" />
+      <constant name="world_y" value="5000.0" />
+      <constant name="dipoleMagnetPositionX" value="21.17" />
+      <constant name="world_z" value="5000.0" />
+      <constant name="dipoleMagnetPositionZ" value="457.2" />
+      <constant name="tracking_region_radius" value="2000.0" />
+      <constant name="moduleWidth" value="40.34" />
+      <constant name="x_off" value="0.0" />
+      <constant name="electronGapRightEdge" value="474.962" />
+      <constant name="hodoscopeZ" value="1098.5" />
+      <constant name="moduleLength" value="100.0" />
+      <constant name="PI" value="3.14159265359" />
+      <constant name="ecal_dface" value="1448.0" />
+      <constant name="ecal_z" value="80.0" />
+      <constant name="z01b" value="153.815" />
+      <position name="tracking_region_pos" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <position name="base_position" x="21.336" y="0.0" z="349.9358" unit="mm" />
+      <rotation name="base_rotation" x="1.5707963267948963" y="-0.0" z="0.0" unit="radian" />
+      <position name="base_plate_position" x="0.0" y="0.0" z="-82.423" unit="mm" />
+      <rotation name="base_plate_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="support_plate_bottom_L14_position" x="-43.91306765955236" y="158.27227920870018" z="-63.962887251951265" unit="mm" />
+      <rotation name="support_plate_bottom_L14_rotation" x="-1.0000000000000003E-4" y="-6.352747104407253E-22" z="3.111052254139705" unit="radian" />
+      <position name="support_plate_top_L14_position" x="-43.92289273297251" y="158.27347335985155" z="63.96288718823114" unit="mm" />
+      <rotation name="support_plate_top_L14_rotation" x="-3.1414926535897933" y="-8.470329472543003E-22" z="0.030433306424175563" unit="radian" />
+      <position name="support_plate_bottom_L46_position" x="0.14270823091617224" y="-354.5345474665431" z="-65.573" unit="mm" />
+      <rotation name="support_plate_bottom_L46_rotation" x="0.0" y="-0.0" z="3.1111093540316292" unit="radian" />
+      <position name="support_plate_top_L46_position" x="0.14255566889328364" y="-354.53517226223204" z="65.573" unit="mm" />
+      <rotation name="support_plate_top_L46_rotation" x="3.141592653589793" y="-0.0" z="0.030483299558163937" unit="radian" />
+      <position name="module_L1b_halfmodule_axial_position" x="-19.4763620296784" y="288.3405232637967" z="-7.926880147387408" unit="mm" />
+      <rotation name="module_L1b_halfmodule_axial_rotation" x="-1.5708963267948963" y="-0.030540399450088233" z="1.5707963267948966" unit="radian" />
+      <position name="module_L1b_halfmodule_axial_sensor_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L1b_halfmodule_axial_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L1b_halfmodule_axial_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L1b_halfmodule_axial_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L1b_halfmodule_stereo_position" x="-18.93367257553973" y="295.9552314347069" z="-7.785338508834556" unit="mm" />
+      <rotation name="module_L1b_halfmodule_stereo_rotation" x="1.5706963267948966" y="0.030540399450088455" z="-1.4707963267948967" unit="radian" />
+      <position name="module_L1b_halfmodule_stereo_sensor_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L1b_halfmodule_stereo_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L1b_halfmodule_stereo_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L1b_halfmodule_stereo_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L1t_halfmodule_axial_position" x="-20.179448539066072" y="311.56932623679046" z="7.810557322207359" unit="mm" />
+      <rotation name="module_L1t_halfmodule_axial_rotation" x="1.5708963267948965" y="0.030433306424175535" z="1.5707963267948966" unit="radian" />
+      <position name="module_L1t_halfmodule_axial_sensor_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L1t_halfmodule_axial_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L1t_halfmodule_axial_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L1t_halfmodule_axial_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L1t_halfmodule_stereo_position" x="-19.173757379240968" y="304.00182269206425" z="7.799533905476132" unit="mm" />
+      <rotation name="module_L1t_halfmodule_stereo_rotation" x="-1.5706963267948966" y="-0.030433306424175258" z="-1.470796326794897" unit="radian" />
+      <position name="module_L1t_halfmodule_stereo_sensor_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L1t_halfmodule_stereo_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L1t_halfmodule_stereo_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L1t_halfmodule_stereo_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L2b_halfmodule_axial_position" x="-18.19946284499224" y="238.35624418830275" z="-8.316878577236608" unit="mm" />
+      <rotation name="module_L2b_halfmodule_axial_rotation" x="-1.5708963267948963" y="-0.030540399450088233" z="1.5707963267948966" unit="radian" />
+      <position name="module_L2b_halfmodule_axial_sensor_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L2b_halfmodule_axial_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L2b_halfmodule_axial_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L2b_halfmodule_axial_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L2b_halfmodule_stereo_position" x="-17.656773390853573" y="245.97095715921293" z="-8.223336938443758" unit="mm" />
+      <rotation name="module_L2b_halfmodule_stereo_rotation" x="1.5706963267948966" y="0.030540399450088455" z="-1.4707963267948967" unit="radian" />
+      <position name="module_L2b_halfmodule_stereo_sensor_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L2b_halfmodule_stereo_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L2b_halfmodule_stereo_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L2b_halfmodule_stereo_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L2t_halfmodule_axial_position" x="-18.90790233353613" y="261.58490570093295" z="8.150555765952603" unit="mm" />
+      <rotation name="module_L2t_halfmodule_axial_rotation" x="1.5708963267948965" y="0.030433306424175535" z="1.5707963267948966" unit="radian" />
+      <position name="module_L2t_halfmodule_axial_sensor_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L2t_halfmodule_axial_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L2t_halfmodule_axial_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L2t_halfmodule_axial_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L2t_halfmodule_stereo_position" x="-17.902211173711024" y="254.01741265620672" z="8.244532348696374" unit="mm" />
+      <rotation name="module_L2t_halfmodule_stereo_rotation" x="-1.5706963267948966" y="-0.030433306424175258" z="-1.470796326794897" unit="radian" />
+      <position name="module_L2t_halfmodule_stereo_sensor_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L2t_halfmodule_stereo_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L2t_halfmodule_stereo_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L2t_halfmodule_stereo_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3b_halfmodule_axial_position" x="-44.86653535485047" y="136.9890822925367" z="-24.872315376186474" unit="mm" />
+      <rotation name="module_L3b_halfmodule_axial_rotation" x="-1.5708963267948963" y="-0.030540399450088233" z="1.5707963267948966" unit="radian" />
+      <position name="module_L3b_halfmodule_axial_sensor_position" x="-3.414999999999999" y="30.0" z="-0.50725" unit="mm" />
+      <rotation name="module_L3b_halfmodule_axial_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3b_halfmodule_axial_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L3b_halfmodule_axial_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3b_halfmodule_axial_lamination_position" x="-3.414999999999999" y="30.0" z="-0.69225" unit="mm" />
+      <rotation name="module_L3b_halfmodule_axial_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3b_halfmodule_axial_cf_position" x="-3.414999999999999" y="30.0" z="-0.81875" unit="mm" />
+      <rotation name="module_L3b_halfmodule_axial_cf_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3b_halfmodule_axial_hybrid_position" x="-3.414999999999999" y="-55.0" z="0.12649999999999995" unit="mm" />
+      <rotation name="module_L3b_halfmodule_axial_hybrid_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3b_halfmodule_stereo_position" x="-45.31340636973398" y="145.3594584256962" z="-21.05354159446107" unit="mm" />
+      <rotation name="module_L3b_halfmodule_stereo_rotation" x="1.570696326794897" y="0.03054039945008829" z="1.6707963267948964" unit="radian" />
+      <position name="module_L3b_halfmodule_stereo_sensor_position" x="-3.414999999999999" y="30.0" z="-0.50725" unit="mm" />
+      <rotation name="module_L3b_halfmodule_stereo_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3b_halfmodule_stereo_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L3b_halfmodule_stereo_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3b_halfmodule_stereo_lamination_position" x="-3.414999999999999" y="30.0" z="-0.69225" unit="mm" />
+      <rotation name="module_L3b_halfmodule_stereo_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3b_halfmodule_stereo_cf_position" x="-3.414999999999999" y="30.0" z="-0.81875" unit="mm" />
+      <rotation name="module_L3b_halfmodule_stereo_cf_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3b_halfmodule_stereo_hybrid_position" x="-3.414999999999999" y="-55.0" z="0.12649999999999995" unit="mm" />
+      <rotation name="module_L3b_halfmodule_stereo_hybrid_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3t_halfmodule_axial_position" x="-45.616700407442764" y="161.23464016719979" z="24.80289087575093" unit="mm" />
+      <rotation name="module_L3t_halfmodule_axial_rotation" x="1.5708963267948965" y="0.030433306424175535" z="1.5707963267948966" unit="radian" />
+      <position name="module_L3t_halfmodule_axial_sensor_position" x="-3.414999999999999" y="30.0" z="-0.50725" unit="mm" />
+      <rotation name="module_L3t_halfmodule_axial_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3t_halfmodule_axial_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L3t_halfmodule_axial_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3t_halfmodule_axial_lamination_position" x="-3.414999999999999" y="30.0" z="-0.69225" unit="mm" />
+      <rotation name="module_L3t_halfmodule_axial_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3t_halfmodule_axial_cf_position" x="-3.414999999999999" y="30.0" z="-0.81875" unit="mm" />
+      <rotation name="module_L3t_halfmodule_axial_cf_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3t_halfmodule_axial_hybrid_position" x="-3.414999999999999" y="-55.0" z="0.12649999999999995" unit="mm" />
+      <rotation name="module_L3t_halfmodule_axial_hybrid_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3t_halfmodule_stereo_position" x="-45.552661057467056" y="152.85182549677594" z="20.985792413111472" unit="mm" />
+      <rotation name="module_L3t_halfmodule_stereo_rotation" x="-1.5706963267948966" y="-0.030433306424175702" z="1.6707963267948966" unit="radian" />
+      <position name="module_L3t_halfmodule_stereo_sensor_position" x="-3.414999999999999" y="30.0" z="-0.50725" unit="mm" />
+      <rotation name="module_L3t_halfmodule_stereo_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3t_halfmodule_stereo_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L3t_halfmodule_stereo_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3t_halfmodule_stereo_lamination_position" x="-3.414999999999999" y="30.0" z="-0.69225" unit="mm" />
+      <rotation name="module_L3t_halfmodule_stereo_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3t_halfmodule_stereo_cf_position" x="-3.414999999999999" y="30.0" z="-0.81875" unit="mm" />
+      <rotation name="module_L3t_halfmodule_stereo_cf_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3t_halfmodule_stereo_hybrid_position" x="-3.414999999999999" y="-55.0" z="0.12649999999999995" unit="mm" />
+      <rotation name="module_L3t_halfmodule_stereo_hybrid_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4b_halfmodule_axial_position" x="-41.81297014635422" y="37.03586020751486" z="-26.334710705690302" unit="mm" />
+      <rotation name="module_L4b_halfmodule_axial_rotation" x="-1.5708963267948963" y="-0.030540399450088233" z="1.5707963267948966" unit="radian" />
+      <position name="module_L4b_halfmodule_axial_sensor_position" x="-3.414999999999999" y="30.0" z="-0.50725" unit="mm" />
+      <rotation name="module_L4b_halfmodule_axial_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4b_halfmodule_axial_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L4b_halfmodule_axial_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4b_halfmodule_axial_lamination_position" x="-3.414999999999999" y="30.0" z="-0.69225" unit="mm" />
+      <rotation name="module_L4b_halfmodule_axial_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4b_halfmodule_axial_cf_position" x="-3.414999999999999" y="30.0" z="-0.81875" unit="mm" />
+      <rotation name="module_L4b_halfmodule_axial_cf_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4b_halfmodule_axial_hybrid_position" x="-3.414999999999999" y="-55.0" z="0.12649999999999995" unit="mm" />
+      <rotation name="module_L4b_halfmodule_axial_hybrid_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4b_halfmodule_stereo_position" x="-42.25984116123773" y="45.406236340674354" z="-22.515936923964897" unit="mm" />
+      <rotation name="module_L4b_halfmodule_stereo_rotation" x="1.570696326794897" y="0.03054039945008829" z="1.6707963267948964" unit="radian" />
+      <position name="module_L4b_halfmodule_stereo_sensor_position" x="-3.414999999999999" y="30.0" z="-0.50725" unit="mm" />
+      <rotation name="module_L4b_halfmodule_stereo_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4b_halfmodule_stereo_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L4b_halfmodule_stereo_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4b_halfmodule_stereo_lamination_position" x="-3.414999999999999" y="30.0" z="-0.69225" unit="mm" />
+      <rotation name="module_L4b_halfmodule_stereo_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4b_halfmodule_stereo_cf_position" x="-3.414999999999999" y="30.0" z="-0.81875" unit="mm" />
+      <rotation name="module_L4b_halfmodule_stereo_cf_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4b_halfmodule_stereo_hybrid_position" x="-3.414999999999999" y="-55.0" z="0.12649999999999995" unit="mm" />
+      <rotation name="module_L4b_halfmodule_stereo_hybrid_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4t_halfmodule_axial_position" x="-42.57383952504712" y="61.281095699820554" z="26.305886237695976" unit="mm" />
+      <rotation name="module_L4t_halfmodule_axial_rotation" x="1.5708963267948965" y="0.030433306424175535" z="1.5707963267948966" unit="radian" />
+      <position name="module_L4t_halfmodule_axial_sensor_position" x="-3.414999999999999" y="30.0" z="-0.50725" unit="mm" />
+      <rotation name="module_L4t_halfmodule_axial_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4t_halfmodule_axial_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L4t_halfmodule_axial_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4t_halfmodule_axial_lamination_position" x="-3.414999999999999" y="30.0" z="-0.69225" unit="mm" />
+      <rotation name="module_L4t_halfmodule_axial_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4t_halfmodule_axial_cf_position" x="-3.414999999999999" y="30.0" z="-0.81875" unit="mm" />
+      <rotation name="module_L4t_halfmodule_axial_cf_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4t_halfmodule_axial_hybrid_position" x="-3.414999999999999" y="-55.0" z="0.12649999999999995" unit="mm" />
+      <rotation name="module_L4t_halfmodule_axial_hybrid_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4t_halfmodule_stereo_position" x="-42.50980017507141" y="52.89828102939675" z="22.48878777505652" unit="mm" />
+      <rotation name="module_L4t_halfmodule_stereo_rotation" x="-1.5706963267948966" y="-0.030433306424175702" z="1.6707963267948966" unit="radian" />
+      <position name="module_L4t_halfmodule_stereo_sensor_position" x="-3.414999999999999" y="30.0" z="-0.50725" unit="mm" />
+      <rotation name="module_L4t_halfmodule_stereo_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4t_halfmodule_stereo_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L4t_halfmodule_stereo_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4t_halfmodule_stereo_lamination_position" x="-3.414999999999999" y="30.0" z="-0.69225" unit="mm" />
+      <rotation name="module_L4t_halfmodule_stereo_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4t_halfmodule_stereo_cf_position" x="-3.414999999999999" y="30.0" z="-0.81875" unit="mm" />
+      <rotation name="module_L4t_halfmodule_stereo_cf_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4t_halfmodule_stereo_hybrid_position" x="-3.414999999999999" y="-55.0" z="0.12649999999999995" unit="mm" />
+      <rotation name="module_L4t_halfmodule_stereo_hybrid_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5b_halfmodule_axial_hole_position" x="-56.217250308986" y="-162.97132249781242" z="-26.66020000000001" unit="mm" />
+      <rotation name="module_L5b_halfmodule_axial_hole_rotation" x="-1.5707963267948966" y="-0.030483299558163958" z="1.5707963267948963" unit="radian" />
+      <position name="module_L5b_halfmodule_axial_hole_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L5b_halfmodule_axial_hole_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5b_halfmodule_axial_hole_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L5b_halfmodule_axial_hole_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5b_halfmodule_axial_hole_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L5b_halfmodule_axial_hole_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5b_halfmodule_axial_slot_position" x="44.72623159126889" y="-159.89327863637723" z="-26.66020000000001" unit="mm" />
+      <rotation name="module_L5b_halfmodule_axial_slot_rotation" x="-1.5707963267948968" y="-0.030483299558164013" z="-1.5707963267948963" unit="radian" />
+      <position name="module_L5b_halfmodule_axial_slot_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L5b_halfmodule_axial_slot_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5b_halfmodule_axial_slot_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L5b_halfmodule_axial_slot_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5b_halfmodule_axial_slot_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L5b_halfmodule_axial_slot_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5b_halfmodule_stereo_hole_position" x="-56.38945519192267" y="-155.65717305182127" z="-29.20020000000001" unit="mm" />
+      <rotation name="module_L5b_halfmodule_stereo_hole_rotation" x="1.5707963267948963" y="0.030483299558163958" z="1.6207963267948968" unit="radian" />
+      <position name="module_L5b_halfmodule_stereo_hole_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L5b_halfmodule_stereo_hole_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5b_halfmodule_stereo_hole_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L5b_halfmodule_stereo_hole_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5b_halfmodule_stereo_hole_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L5b_halfmodule_stereo_hole_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5b_halfmodule_stereo_slot_position" x="44.452473909639814" y="-152.58222581398914" z="-24.1456" unit="mm" />
+      <rotation name="module_L5b_halfmodule_stereo_slot_rotation" x="1.5707963267948963" y="0.030483299558163958" z="-1.520796326794897" unit="radian" />
+      <position name="module_L5b_halfmodule_stereo_slot_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L5b_halfmodule_stereo_slot_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5b_halfmodule_stereo_slot_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L5b_halfmodule_stereo_slot_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5b_halfmodule_stereo_slot_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L5b_halfmodule_stereo_slot_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5t_halfmodule_axial_hole_position" x="-56.924231591268885" y="-139.79172136362277" z="26.66020000000001" unit="mm" />
+      <rotation name="module_L5t_halfmodule_axial_hole_rotation" x="1.5707963267948966" y="0.030483299558163958" z="1.5707963267948963" unit="radian" />
+      <position name="module_L5t_halfmodule_axial_hole_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L5t_halfmodule_axial_hole_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5t_halfmodule_axial_hole_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L5t_halfmodule_axial_hole_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5t_halfmodule_axial_hole_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L5t_halfmodule_axial_hole_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5t_halfmodule_axial_slot_position" x="44.01925030898598" y="-136.71367750218758" z="26.66020000000001" unit="mm" />
+      <rotation name="module_L5t_halfmodule_axial_slot_rotation" x="1.5707963267948968" y="0.030483299558164013" z="-1.5707963267948963" unit="radian" />
+      <position name="module_L5t_halfmodule_axial_slot_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L5t_halfmodule_axial_slot_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5t_halfmodule_axial_slot_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L5t_halfmodule_axial_slot_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5t_halfmodule_axial_slot_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L5t_halfmodule_axial_slot_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5t_halfmodule_stereo_hole_position" x="-56.65047390963981" y="-147.10277418601086" z="29.20020000000001" unit="mm" />
+      <rotation name="module_L5t_halfmodule_stereo_hole_rotation" x="-1.5707963267948963" y="-0.030483299558163958" z="1.6207963267948968" unit="radian" />
+      <position name="module_L5t_halfmodule_stereo_hole_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L5t_halfmodule_stereo_hole_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5t_halfmodule_stereo_hole_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L5t_halfmodule_stereo_hole_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5t_halfmodule_stereo_hole_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L5t_halfmodule_stereo_hole_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5t_halfmodule_stereo_slot_position" x="44.19145519192265" y="-144.02782694817873" z="24.1456" unit="mm" />
+      <rotation name="module_L5t_halfmodule_stereo_slot_rotation" x="-1.5707963267948966" y="-0.030483299558163847" z="-1.520796326794897" unit="radian" />
+      <position name="module_L5t_halfmodule_stereo_slot_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L5t_halfmodule_stereo_slot_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5t_halfmodule_stereo_slot_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L5t_halfmodule_stereo_slot_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5t_halfmodule_stereo_slot_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L5t_halfmodule_stereo_slot_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6b_halfmodule_axial_hole_position" x="-50.12153455494366" y="-362.8784065379883" z="-29.66020000000001" unit="mm" />
+      <rotation name="module_L6b_halfmodule_axial_hole_rotation" x="-1.5707963267948966" y="-0.030483299558163958" z="1.5707963267948963" unit="radian" />
+      <position name="module_L6b_halfmodule_axial_hole_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L6b_halfmodule_axial_hole_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6b_halfmodule_axial_hole_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L6b_halfmodule_axial_hole_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6b_halfmodule_axial_hole_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L6b_halfmodule_axial_hole_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6b_halfmodule_axial_slot_position" x="50.82194734531124" y="-359.8003626765531" z="-29.66020000000001" unit="mm" />
+      <rotation name="module_L6b_halfmodule_axial_slot_rotation" x="-1.5707963267948968" y="-0.030483299558164013" z="-1.5707963267948963" unit="radian" />
+      <position name="module_L6b_halfmodule_axial_slot_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L6b_halfmodule_axial_slot_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6b_halfmodule_axial_slot_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L6b_halfmodule_axial_slot_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6b_halfmodule_axial_slot_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L6b_halfmodule_axial_slot_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6b_halfmodule_stereo_hole_position" x="-50.293739437880326" y="-355.56425709199715" z="-32.20020000000001" unit="mm" />
+      <rotation name="module_L6b_halfmodule_stereo_hole_rotation" x="1.5707963267948963" y="0.030483299558163958" z="1.6207963267948968" unit="radian" />
+      <position name="module_L6b_halfmodule_stereo_hole_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L6b_halfmodule_stereo_hole_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6b_halfmodule_stereo_hole_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L6b_halfmodule_stereo_hole_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6b_halfmodule_stereo_hole_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L6b_halfmodule_stereo_hole_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6b_halfmodule_stereo_slot_position" x="50.54818966368216" y="-352.489309854165" z="-27.1456" unit="mm" />
+      <rotation name="module_L6b_halfmodule_stereo_slot_rotation" x="1.5707963267948963" y="0.030483299558163958" z="-1.520796326794897" unit="radian" />
+      <position name="module_L6b_halfmodule_stereo_slot_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L6b_halfmodule_stereo_slot_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6b_halfmodule_stereo_slot_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L6b_halfmodule_stereo_slot_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6b_halfmodule_stereo_slot_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L6b_halfmodule_stereo_slot_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6t_halfmodule_axial_hole_position" x="-50.82851583722654" y="-339.6988054037986" z="29.66020000000001" unit="mm" />
+      <rotation name="module_L6t_halfmodule_axial_hole_rotation" x="1.5707963267948966" y="0.030483299558163958" z="1.5707963267948963" unit="radian" />
+      <position name="module_L6t_halfmodule_axial_hole_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L6t_halfmodule_axial_hole_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6t_halfmodule_axial_hole_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L6t_halfmodule_axial_hole_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6t_halfmodule_axial_hole_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L6t_halfmodule_axial_hole_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6t_halfmodule_axial_slot_position" x="50.11496606302833" y="-336.6207615423634" z="29.66020000000001" unit="mm" />
+      <rotation name="module_L6t_halfmodule_axial_slot_rotation" x="1.5707963267948968" y="0.030483299558164013" z="-1.5707963267948963" unit="radian" />
+      <position name="module_L6t_halfmodule_axial_slot_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L6t_halfmodule_axial_slot_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6t_halfmodule_axial_slot_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L6t_halfmodule_axial_slot_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6t_halfmodule_axial_slot_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L6t_halfmodule_axial_slot_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6t_halfmodule_stereo_hole_position" x="-50.55475815559746" y="-347.00985822618674" z="32.20020000000001" unit="mm" />
+      <rotation name="module_L6t_halfmodule_stereo_hole_rotation" x="-1.5707963267948963" y="-0.030483299558163958" z="1.6207963267948968" unit="radian" />
+      <position name="module_L6t_halfmodule_stereo_hole_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L6t_halfmodule_stereo_hole_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6t_halfmodule_stereo_hole_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L6t_halfmodule_stereo_hole_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6t_halfmodule_stereo_hole_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L6t_halfmodule_stereo_hole_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6t_halfmodule_stereo_slot_position" x="50.287170945964995" y="-343.9349109883546" z="27.1456" unit="mm" />
+      <rotation name="module_L6t_halfmodule_stereo_slot_rotation" x="-1.5707963267948966" y="-0.030483299558163847" z="-1.520796326794897" unit="radian" />
+      <position name="module_L6t_halfmodule_stereo_slot_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L6t_halfmodule_stereo_slot_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6t_halfmodule_stereo_slot_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L6t_halfmodule_stereo_slot_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6t_halfmodule_stereo_slot_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L6t_halfmodule_stereo_slot_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7b_halfmodule_axial_hole_position" x="-44.02581880090134" y="-562.7854905781641" z="-32.66020000000001" unit="mm" />
+      <rotation name="module_L7b_halfmodule_axial_hole_rotation" x="-1.5707963267948966" y="-0.030483299558163958" z="1.5707963267948963" unit="radian" />
+      <position name="module_L7b_halfmodule_axial_hole_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L7b_halfmodule_axial_hole_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7b_halfmodule_axial_hole_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L7b_halfmodule_axial_hole_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7b_halfmodule_axial_hole_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L7b_halfmodule_axial_hole_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7b_halfmodule_axial_slot_position" x="56.917663099353554" y="-559.7074467167289" z="-32.66020000000001" unit="mm" />
+      <rotation name="module_L7b_halfmodule_axial_slot_rotation" x="-1.5707963267948968" y="-0.030483299558164013" z="-1.5707963267948963" unit="radian" />
+      <position name="module_L7b_halfmodule_axial_slot_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L7b_halfmodule_axial_slot_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7b_halfmodule_axial_slot_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L7b_halfmodule_axial_slot_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7b_halfmodule_axial_slot_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L7b_halfmodule_axial_slot_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7b_halfmodule_stereo_hole_position" x="-44.19802368383801" y="-555.4713411321728" z="-35.20020000000001" unit="mm" />
+      <rotation name="module_L7b_halfmodule_stereo_hole_rotation" x="1.5707963267948963" y="0.030483299558163958" z="1.6207963267948968" unit="radian" />
+      <position name="module_L7b_halfmodule_stereo_hole_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L7b_halfmodule_stereo_hole_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7b_halfmodule_stereo_hole_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L7b_halfmodule_stereo_hole_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7b_halfmodule_stereo_hole_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L7b_halfmodule_stereo_hole_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7b_halfmodule_stereo_slot_position" x="56.643905417724476" y="-552.3963938943408" z="-30.1456" unit="mm" />
+      <rotation name="module_L7b_halfmodule_stereo_slot_rotation" x="1.5707963267948963" y="0.030483299558163958" z="-1.520796326794897" unit="radian" />
+      <position name="module_L7b_halfmodule_stereo_slot_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L7b_halfmodule_stereo_slot_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7b_halfmodule_stereo_slot_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L7b_halfmodule_stereo_slot_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7b_halfmodule_stereo_slot_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L7b_halfmodule_stereo_slot_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7t_halfmodule_axial_hole_position" x="-44.732800083184195" y="-539.6058894439745" z="32.66020000000001" unit="mm" />
+      <rotation name="module_L7t_halfmodule_axial_hole_rotation" x="1.5707963267948966" y="0.030483299558163958" z="1.5707963267948963" unit="radian" />
+      <position name="module_L7t_halfmodule_axial_hole_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L7t_halfmodule_axial_hole_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7t_halfmodule_axial_hole_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L7t_halfmodule_axial_hole_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7t_halfmodule_axial_hole_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L7t_halfmodule_axial_hole_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7t_halfmodule_axial_slot_position" x="56.21068181707067" y="-536.5278455825394" z="32.66020000000001" unit="mm" />
+      <rotation name="module_L7t_halfmodule_axial_slot_rotation" x="1.5707963267948968" y="0.030483299558164013" z="-1.5707963267948963" unit="radian" />
+      <position name="module_L7t_halfmodule_axial_slot_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L7t_halfmodule_axial_slot_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7t_halfmodule_axial_slot_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L7t_halfmodule_axial_slot_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7t_halfmodule_axial_slot_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L7t_halfmodule_axial_slot_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7t_halfmodule_stereo_hole_position" x="-44.459042401555116" y="-546.9169422663626" z="35.20020000000001" unit="mm" />
+      <rotation name="module_L7t_halfmodule_stereo_hole_rotation" x="-1.5707963267948963" y="-0.030483299558163958" z="1.6207963267948968" unit="radian" />
+      <position name="module_L7t_halfmodule_stereo_hole_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L7t_halfmodule_stereo_hole_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7t_halfmodule_stereo_hole_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L7t_halfmodule_stereo_hole_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7t_halfmodule_stereo_hole_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L7t_halfmodule_stereo_hole_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7t_halfmodule_stereo_slot_position" x="56.38288670000734" y="-543.8419950285305" z="30.1456" unit="mm" />
+      <rotation name="module_L7t_halfmodule_stereo_slot_rotation" x="-1.5707963267948966" y="-0.030483299558163847" z="-1.520796326794897" unit="radian" />
+      <position name="module_L7t_halfmodule_stereo_slot_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L7t_halfmodule_stereo_slot_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7t_halfmodule_stereo_slot_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L7t_halfmodule_stereo_slot_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7t_halfmodule_stereo_slot_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L7t_halfmodule_stereo_slot_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="BeamLeftVolume_component0_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="BeamLeftVolume_component0_rotation" x="0.0" y="0.0" z="0.0" unit="radian" />
+      <position name="BeamLeftVolume_component0Sensor0Position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="BeamLeftVolume_component0Sensor0Rotation" x="0.0" y="0.0" z="0.0" unit="radian" />
+      <position name="ElectronGapVolume_component0_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="ElectronGapVolume_component0_rotation" x="0.0" y="0.0" z="0.0" unit="radian" />
+      <position name="ElectronGapVolume_component0Sensor0Position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="ElectronGapVolume_component0Sensor0Rotation" x="0.0" y="0.0" z="0.0" unit="radian" />
+      <position name="BeamRightVolume_component0_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="BeamRightVolume_component0_rotation" x="0.0" y="0.0" z="0.0" unit="radian" />
+      <position name="BeamRightVolume_component0Sensor0Position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="BeamRightVolume_component0Sensor0Rotation" x="0.0" y="0.0" z="0.0" unit="radian" />
+      <position name="ECalScoring_BeamLeft_layer1_module0_position" x="214.099" y="122.8" z="1443.001" unit="mm" />
+      <rotation name="ECalScoring_BeamLeft_layer1_module0_rotation" x="0.0" y="0.0" z="-1.570796326795" unit="radian" />
+      <position name="ECalScoring_ElectronGap_layer1_module0_position" x="-23.38199999999999" y="130.465" z="1443.001" unit="mm" />
+      <rotation name="ECalScoring_ElectronGap_layer1_module0_rotation" x="0.0" y="0.0" z="-1.570796326795" unit="radian" />
+      <position name="ECalScoring_BeamRight_layer1_module0_position" x="-216.31099999999998" y="121.3" z="1443.001" unit="mm" />
+      <rotation name="ECalScoring_BeamRight_layer1_module0_rotation" x="0.0" y="0.0" z="-1.570796326795" unit="radian" />
+      <position name="ECalScoring_BeamLeft_layer2_module0_position" x="214.099" y="-122.8" z="1443.001" unit="mm" />
+      <rotation name="ECalScoring_BeamLeft_layer2_module0_rotation" x="0.0" y="0.0" z="-4.7123889803850005" unit="radian" />
+      <position name="ECalScoring_ElectronGap_layer2_module0_position" x="-23.38199999999999" y="-130.465" z="1443.001" unit="mm" />
+      <rotation name="ECalScoring_ElectronGap_layer2_module0_rotation" x="0.0" y="0.0" z="-4.7123889803850005" unit="radian" />
+      <position name="ECalScoring_BeamRight_layer2_module0_position" x="-216.31099999999998" y="-121.3" z="1443.001" unit="mm" />
+      <rotation name="ECalScoring_BeamRight_layer2_module0_rotation" x="0.0" y="0.0" z="-4.7123889803850005" unit="radian" />
+      <position name="crystal1-1_pos_pos_bot" x="50.20495188328156" y="-29.07473927539554" z="1528.1626281236922" unit="mm" />
+      <rotation name="crystal1-1_rot_pos_bot" x="-0.0084372997827221" y="-0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal1-1_pos_neg_bot" x="35.15547333249048" y="-29.07473927539554" z="1528.1626281236922" unit="mm" />
+      <rotation name="crystal1-1_rot_neg_bot" x="-0.0084372997827221" y="0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal1-1_pos_pos_top" x="50.20495188328156" y="29.974739275395542" z="1528.1626281236922" unit="mm" />
+      <rotation name="crystal1-1_rot_pos_top" x="0.0084372997827221" y="-0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal1-1_pos_neg_top" x="35.15547333249048" y="29.974739275395542" z="1528.1626281236922" unit="mm" />
+      <rotation name="crystal1-1_rot_neg_top" x="0.0084372997827221" y="0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal2-1_pos_pos_bot" x="65.05802548582456" y="-29.07473927539554" z="1528.2520480856124" unit="mm" />
+      <rotation name="crystal2-1_rot_pos_bot" x="-0.0084372997827221" y="-0.0253118993481663" z="0.0" unit="radian" />
+      <position name="crystal2-1_pos_pos_top" x="65.05802548582456" y="29.974739275395542" z="1528.2520480856124" unit="mm" />
+      <rotation name="crystal2-1_rot_pos_top" x="0.0084372997827221" y="-0.0253118993481663" z="0.0" unit="radian" />
+      <position name="crystal3-1_pos_pos_bot" x="79.9180994782841" y="-29.07473927539554" z="1528.3186477918262" unit="mm" />
+      <rotation name="crystal3-1_rot_pos_bot" x="-0.0084372997827221" y="-0.042186498913610496" z="0.0" unit="radian" />
+      <position name="crystal3-1_pos_pos_top" x="79.9180994782841" y="29.974739275395542" z="1528.3186477918262" unit="mm" />
+      <rotation name="crystal3-1_rot_pos_top" x="0.0084372997827221" y="-0.042186498913610496" z="0.0" unit="radian" />
+      <position name="crystal4-1_pos_pos_bot" x="94.78858692586502" y="-29.07473927539554" z="1528.3624082783765" unit="mm" />
+      <rotation name="crystal4-1_rot_pos_bot" x="-0.0084372997827221" y="-0.0590610984790547" z="0.0" unit="radian" />
+      <position name="crystal4-1_pos_pos_top" x="94.78858692586502" y="29.974739275395542" z="1528.3624082783765" unit="mm" />
+      <rotation name="crystal4-1_rot_pos_top" x="0.0084372997827221" y="-0.0590610984790547" z="0.0" unit="radian" />
+      <position name="crystal5-1_pos_pos_bot" x="109.67291416309662" y="-29.07473927539554" z="1528.3833170846683" unit="mm" />
+      <rotation name="crystal5-1_rot_pos_bot" x="-0.0084372997827221" y="-0.0759356980444989" z="0.0" unit="radian" />
+      <position name="crystal5-1_pos_pos_top" x="109.67291416309662" y="29.974739275395542" z="1528.3833170846683" unit="mm" />
+      <rotation name="crystal5-1_rot_pos_top" x="0.0084372997827221" y="-0.0759356980444989" z="0.0" unit="radian" />
+      <position name="crystal6-1_pos_pos_bot" x="124.57452638340096" y="-29.07473927539554" z="1528.381368257016" unit="mm" />
+      <rotation name="crystal6-1_rot_pos_bot" x="-0.0084372997827221" y="-0.0928102976099431" z="0.0" unit="radian" />
+      <position name="crystal6-1_pos_pos_top" x="124.57452638340096" y="29.974739275395542" z="1528.381368257016" unit="mm" />
+      <rotation name="crystal6-1_rot_pos_top" x="0.0084372997827221" y="-0.0928102976099431" z="0.0" unit="radian" />
+      <position name="crystal7-1_pos_pos_bot" x="139.4968932952259" y="-29.07473927539554" z="1528.3565623503396" unit="mm" />
+      <rotation name="crystal7-1_rot_pos_bot" x="-0.0084372997827221" y="-0.10968489717538729" z="0.0" unit="radian" />
+      <position name="crystal7-1_pos_pos_top" x="139.4968932952259" y="29.974739275395542" z="1528.3565623503396" unit="mm" />
+      <rotation name="crystal7-1_rot_pos_top" x="0.0084372997827221" y="-0.10968489717538729" z="0.0" unit="radian" />
+      <position name="crystal8-1_pos_pos_bot" x="154.44351486445828" y="-29.07473927539554" z="1528.3089064280052" unit="mm" />
+      <rotation name="crystal8-1_rot_pos_bot" x="-0.0084372997827221" y="-0.1265594967408315" z="0.0" unit="radian" />
+      <position name="crystal8-1_pos_pos_top" x="154.44351486445828" y="29.974739275395542" z="1528.3089064280052" unit="mm" />
+      <rotation name="crystal8-1_rot_pos_top" x="0.0084372997827221" y="-0.1265594967408315" z="0.0" unit="radian" />
+      <position name="crystal9-1_pos_pos_bot" x="169.41792716339802" y="-29.07473927539554" z="1528.2384140598156" unit="mm" />
+      <rotation name="crystal9-1_rot_pos_bot" x="-0.0084372997827221" y="-0.14343409630627568" z="0.0" unit="radian" />
+      <position name="crystal9-1_pos_pos_top" x="169.41792716339802" y="29.974739275395542" z="1528.2384140598156" unit="mm" />
+      <rotation name="crystal9-1_rot_pos_top" x="0.0084372997827221" y="-0.14343409630627568" z="0.0" unit="radian" />
+      <position name="crystal10-1_pos_pos_bot" x="184.42370834727978" y="-29.07473927539554" z="1528.1451053181452" unit="mm" />
+      <rotation name="crystal10-1_rot_pos_bot" x="-0.0084372997827221" y="-0.1603086958717199" z="0.0" unit="radian" />
+      <position name="crystal10-1_pos_pos_top" x="184.42370834727978" y="29.974739275395542" z="1528.1451053181452" unit="mm" />
+      <rotation name="crystal10-1_rot_pos_top" x="0.0084372997827221" y="-0.1603086958717199" z="0.0" unit="radian" />
+      <position name="crystal11-1_pos_pos_bot" x="199.46448478017476" y="-29.07473927539554" z="1528.0290067722244" unit="mm" />
+      <rotation name="crystal11-1_rot_pos_bot" x="-0.0084372997827221" y="-0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal11-1_pos_neg_bot" x="-114.1040595644027" y="-29.07473927539554" z="1528.0290067722244" unit="mm" />
+      <rotation name="crystal11-1_rot_neg_bot" x="-0.0084372997827221" y="0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal11-1_pos_pos_top" x="199.46448478017476" y="29.974739275395542" z="1528.0290067722244" unit="mm" />
+      <rotation name="crystal11-1_rot_pos_top" x="0.0084372997827221" y="-0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal11-1_pos_neg_top" x="-114.1040595644027" y="29.974739275395542" z="1528.0290067722244" unit="mm" />
+      <rotation name="crystal11-1_rot_neg_top" x="0.0084372997827221" y="0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal12-1_pos_pos_bot" x="214.5439373331128" y="-29.07473927539554" z="1527.8901514805746" unit="mm" />
+      <rotation name="crystal12-1_rot_pos_bot" x="-0.0084372997827221" y="-0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal12-1_pos_neg_bot" x="-129.1835121173408" y="-29.07473927539554" z="1527.8901514805746" unit="mm" />
+      <rotation name="crystal12-1_rot_neg_bot" x="-0.0084372997827221" y="0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal12-1_pos_pos_top" x="214.5439373331128" y="29.974739275395542" z="1527.8901514805746" unit="mm" />
+      <rotation name="crystal12-1_rot_pos_top" x="0.0084372997827221" y="-0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal12-1_pos_neg_top" x="-129.1835121173408" y="29.974739275395542" z="1527.8901514805746" unit="mm" />
+      <rotation name="crystal12-1_rot_neg_top" x="0.0084372997827221" y="0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal13-1_pos_pos_bot" x="229.66580787843168" y="-29.07473927539554" z="1527.7285789815953" unit="mm" />
+      <rotation name="crystal13-1_rot_pos_bot" x="-0.0084372997827221" y="-0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal13-1_pos_neg_bot" x="-144.30538266265967" y="-29.07473927539554" z="1527.7285789815953" unit="mm" />
+      <rotation name="crystal13-1_rot_neg_bot" x="-0.0084372997827221" y="0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal13-1_pos_pos_top" x="229.66580787843168" y="29.974739275395542" z="1527.7285789815953" unit="mm" />
+      <rotation name="crystal13-1_rot_pos_top" x="0.0084372997827221" y="-0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal13-1_pos_neg_top" x="-144.30538266265967" y="29.974739275395542" z="1527.7285789815953" unit="mm" />
+      <rotation name="crystal13-1_rot_neg_top" x="0.0084372997827221" y="0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal14-1_pos_pos_bot" x="244.83390600570817" y="-29.07473927539554" z="1527.5443352823047" unit="mm" />
+      <rotation name="crystal14-1_rot_pos_bot" x="-0.0084372997827221" y="-0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal14-1_pos_neg_bot" x="-159.47348078993616" y="-29.07473927539554" z="1527.5443352823047" unit="mm" />
+      <rotation name="crystal14-1_rot_neg_bot" x="-0.0084372997827221" y="0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal14-1_pos_pos_top" x="244.83390600570817" y="29.974739275395542" z="1527.5443352823047" unit="mm" />
+      <rotation name="crystal14-1_rot_pos_top" x="0.0084372997827221" y="-0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal14-1_pos_neg_top" x="-159.47348078993616" y="29.974739275395542" z="1527.5443352823047" unit="mm" />
+      <rotation name="crystal14-1_rot_neg_top" x="0.0084372997827221" y="0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal15-1_pos_pos_bot" x="260.0521159861688" y="-29.07473927539554" z="1527.3374728452397" unit="mm" />
+      <rotation name="crystal15-1_rot_pos_bot" x="-0.0084372997827221" y="-0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal15-1_pos_neg_bot" x="-174.6916907703968" y="-29.07473927539554" z="1527.3374728452397" unit="mm" />
+      <rotation name="crystal15-1_rot_neg_bot" x="-0.0084372997827221" y="0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal15-1_pos_pos_top" x="260.0521159861688" y="29.974739275395542" z="1527.3374728452397" unit="mm" />
+      <rotation name="crystal15-1_rot_pos_top" x="0.0084372997827221" y="-0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal15-1_pos_neg_top" x="-174.6916907703968" y="29.974739275395542" z="1527.3374728452397" unit="mm" />
+      <rotation name="crystal15-1_rot_neg_top" x="0.0084372997827221" y="0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal16-1_pos_pos_bot" x="275.32440401422616" y="-29.07473927539554" z="1527.108050573519" unit="mm" />
+      <rotation name="crystal16-1_rot_pos_bot" x="-0.0084372997827221" y="-0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal16-1_pos_neg_bot" x="-189.96397879845415" y="-29.07473927539554" z="1527.108050573519" unit="mm" />
+      <rotation name="crystal16-1_rot_neg_bot" x="-0.0084372997827221" y="0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal16-1_pos_pos_top" x="275.32440401422616" y="29.974739275395542" z="1527.108050573519" unit="mm" />
+      <rotation name="crystal16-1_rot_pos_top" x="0.0084372997827221" y="-0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal16-1_pos_neg_top" x="-189.96397879845415" y="29.974739275395542" z="1527.108050573519" unit="mm" />
+      <rotation name="crystal16-1_rot_neg_top" x="0.0084372997827221" y="0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal17-1_pos_pos_bot" x="290.6548257567732" y="-29.07473927539554" z="1526.8561337940675" unit="mm" />
+      <rotation name="crystal17-1_rot_pos_bot" x="-0.0084372997827221" y="-0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal17-1_pos_neg_bot" x="-205.2944005410012" y="-29.07473927539554" z="1526.8561337940675" unit="mm" />
+      <rotation name="crystal17-1_rot_neg_bot" x="-0.0084372997827221" y="0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal17-1_pos_pos_top" x="290.6548257567732" y="29.974739275395542" z="1526.8561337940675" unit="mm" />
+      <rotation name="crystal17-1_rot_pos_top" x="0.0084372997827221" y="-0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal17-1_pos_neg_top" x="-205.2944005410012" y="29.974739275395542" z="1526.8561337940675" unit="mm" />
+      <rotation name="crystal17-1_rot_neg_top" x="0.0084372997827221" y="0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal18-1_pos_pos_bot" x="306.0475342431027" y="-29.07473927539554" z="1526.581794239018" unit="mm" />
+      <rotation name="crystal18-1_rot_pos_bot" x="-0.0084372997827221" y="-0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal18-1_pos_neg_bot" x="-220.68710902733068" y="-29.07473927539554" z="1526.581794239018" unit="mm" />
+      <rotation name="crystal18-1_rot_neg_bot" x="-0.0084372997827221" y="0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal18-1_pos_pos_top" x="306.0475342431027" y="29.974739275395542" z="1526.581794239018" unit="mm" />
+      <rotation name="crystal18-1_rot_pos_top" x="0.0084372997827221" y="-0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal18-1_pos_neg_top" x="-220.68710902733068" y="29.974739275395542" z="1526.581794239018" unit="mm" />
+      <rotation name="crystal18-1_rot_neg_top" x="0.0084372997827221" y="0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal19-1_pos_pos_bot" x="321.5067881308382" y="-29.07473927539554" z="1526.2851100252847" unit="mm" />
+      <rotation name="crystal19-1_rot_pos_bot" x="-0.0084372997827221" y="-0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal19-1_pos_neg_bot" x="-236.14636291506616" y="-29.07473927539554" z="1526.2851100252847" unit="mm" />
+      <rotation name="crystal19-1_rot_neg_bot" x="-0.0084372997827221" y="0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal19-1_pos_pos_top" x="321.5067881308382" y="29.974739275395542" z="1526.2851100252847" unit="mm" />
+      <rotation name="crystal19-1_rot_pos_top" x="0.0084372997827221" y="-0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal19-1_pos_neg_top" x="-236.14636291506616" y="29.974739275395542" z="1526.2851100252847" unit="mm" />
+      <rotation name="crystal19-1_rot_neg_top" x="0.0084372997827221" y="0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal20-1_pos_pos_bot" x="337.03696038609246" y="-29.07473927539554" z="1525.9661656323178" unit="mm" />
+      <rotation name="crystal20-1_rot_pos_bot" x="-0.0084372997827221" y="-0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal20-1_pos_neg_bot" x="-251.67653517032045" y="-29.07473927539554" z="1525.9661656323178" unit="mm" />
+      <rotation name="crystal20-1_rot_neg_bot" x="-0.0084372997827221" y="0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal20-1_pos_pos_top" x="337.03696038609246" y="29.974739275395542" z="1525.9661656323178" unit="mm" />
+      <rotation name="crystal20-1_rot_pos_top" x="0.0084372997827221" y="-0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal20-1_pos_neg_top" x="-251.67653517032045" y="29.974739275395542" z="1525.9661656323178" unit="mm" />
+      <rotation name="crystal20-1_rot_neg_top" x="0.0084372997827221" y="0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal21-1_pos_pos_bot" x="352.64254741924634" y="-29.07473927539554" z="1525.625051878052" unit="mm" />
+      <rotation name="crystal21-1_rot_pos_bot" x="-0.0084372997827221" y="-0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal21-1_pos_neg_bot" x="-267.28212220347433" y="-29.07473927539554" z="1525.625051878052" unit="mm" />
+      <rotation name="crystal21-1_rot_neg_bot" x="-0.0084372997827221" y="0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal21-1_pos_pos_top" x="352.64254741924634" y="29.974739275395542" z="1525.625051878052" unit="mm" />
+      <rotation name="crystal21-1_rot_pos_top" x="0.0084372997827221" y="-0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal21-1_pos_neg_top" x="-267.28212220347433" y="29.974739275395542" z="1525.625051878052" unit="mm" />
+      <rotation name="crystal21-1_rot_neg_top" x="0.0084372997827221" y="0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal22-1_pos_pos_bot" x="368.32817872130425" y="-29.07473927539554" z="1525.2618658930442" unit="mm" />
+      <rotation name="crystal22-1_rot_pos_bot" x="-0.0084372997827221" y="-0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal22-1_pos_neg_bot" x="-282.96775350553224" y="-29.07473927539554" z="1525.2618658930442" unit="mm" />
+      <rotation name="crystal22-1_rot_neg_bot" x="-0.0084372997827221" y="0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal22-1_pos_pos_top" x="368.32817872130425" y="29.974739275395542" z="1525.2618658930442" unit="mm" />
+      <rotation name="crystal22-1_rot_pos_top" x="0.0084372997827221" y="-0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal22-1_pos_neg_top" x="-282.96775350553224" y="29.974739275395542" z="1525.2618658930442" unit="mm" />
+      <rotation name="crystal22-1_rot_neg_top" x="0.0084372997827221" y="0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal23-1_pos_pos_bot" x="384.09862704978" y="-29.07473927539554" z="1524.8767110928152" unit="mm" />
+      <rotation name="crystal23-1_rot_pos_bot" x="-0.0084372997827221" y="-0.3796784902224945" z="0.0" unit="radian" />
+      <position name="crystal23-1_pos_neg_bot" x="-298.738201834008" y="-29.07473927539554" z="1524.8767110928152" unit="mm" />
+      <rotation name="crystal23-1_rot_neg_bot" x="-0.0084372997827221" y="0.3796784902224945" z="0.0" unit="radian" />
+      <position name="crystal23-1_pos_pos_top" x="384.09862704978" y="29.974739275395542" z="1524.8767110928152" unit="mm" />
+      <rotation name="crystal23-1_rot_pos_top" x="0.0084372997827221" y="-0.3796784902224945" z="0.0" unit="radian" />
+      <position name="crystal23-1_pos_neg_top" x="-298.738201834008" y="29.974739275395542" z="1524.8767110928152" unit="mm" />
+      <rotation name="crystal23-1_rot_neg_top" x="0.0084372997827221" y="0.3796784902224945" z="0.0" unit="radian" />
+      <position name="crystal1-2_pos_pos_bot" x="50.20495188328156" y="-44.077812877938534" z="1528.2520480856124" unit="mm" />
+      <rotation name="crystal1-2_rot_pos_bot" x="-0.0253118993481663" y="-0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal1-2_pos_neg_bot" x="35.15547333249048" y="-44.077812877938534" z="1528.2520480856124" unit="mm" />
+      <rotation name="crystal1-2_rot_neg_bot" x="-0.0253118993481663" y="0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal1-2_pos_pos_top" x="50.20495188328156" y="44.97781287793853" z="1528.2520480856124" unit="mm" />
+      <rotation name="crystal1-2_rot_pos_top" x="0.0253118993481663" y="-0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal1-2_pos_neg_top" x="35.15547333249048" y="44.97781287793853" z="1528.2520480856124" unit="mm" />
+      <rotation name="crystal1-2_rot_neg_top" x="0.0253118993481663" y="0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal2-2_pos_pos_bot" x="65.05802548582456" y="-44.077812877938534" z="1528.3414680475323" unit="mm" />
+      <rotation name="crystal2-2_rot_pos_bot" x="-0.0253118993481663" y="-0.0253118993481663" z="0.0" unit="radian" />
+      <position name="crystal2-2_pos_neg_bot" x="20.302399729947485" y="-44.077812877938534" z="1528.3414680475323" unit="mm" />
+      <rotation name="crystal2-2_rot_neg_bot" x="-0.0253118993481663" y="0.0253118993481663" z="0.0" unit="radian" />
+      <position name="crystal2-2_pos_pos_top" x="65.05802548582456" y="44.97781287793853" z="1528.3414680475323" unit="mm" />
+      <rotation name="crystal2-2_rot_pos_top" x="0.0253118993481663" y="-0.0253118993481663" z="0.0" unit="radian" />
+      <position name="crystal2-2_pos_neg_top" x="20.302399729947485" y="44.97781287793853" z="1528.3414680475323" unit="mm" />
+      <rotation name="crystal2-2_rot_neg_top" x="0.0253118993481663" y="0.0253118993481663" z="0.0" unit="radian" />
+      <position name="crystal3-2_pos_pos_bot" x="79.9180994782841" y="-44.077812877938534" z="1528.4080677537463" unit="mm" />
+      <rotation name="crystal3-2_rot_pos_bot" x="-0.0253118993481663" y="-0.042186498913610496" z="0.0" unit="radian" />
+      <position name="crystal3-2_pos_neg_bot" x="5.442325737487934" y="-44.077812877938534" z="1528.4080677537463" unit="mm" />
+      <rotation name="crystal3-2_rot_neg_bot" x="-0.0253118993481663" y="0.042186498913610496" z="0.0" unit="radian" />
+      <position name="crystal3-2_pos_pos_top" x="79.9180994782841" y="44.97781287793853" z="1528.4080677537463" unit="mm" />
+      <rotation name="crystal3-2_rot_pos_top" x="0.0253118993481663" y="-0.042186498913610496" z="0.0" unit="radian" />
+      <position name="crystal3-2_pos_neg_top" x="5.442325737487934" y="44.97781287793853" z="1528.4080677537463" unit="mm" />
+      <rotation name="crystal3-2_rot_neg_top" x="0.0253118993481663" y="0.042186498913610496" z="0.0" unit="radian" />
+      <position name="crystal4-2_pos_pos_bot" x="94.78858692586502" y="-44.077812877938534" z="1528.4518282402964" unit="mm" />
+      <rotation name="crystal4-2_rot_pos_bot" x="-0.0253118993481663" y="-0.0590610984790547" z="0.0" unit="radian" />
+      <position name="crystal4-2_pos_neg_bot" x="-9.42816171009298" y="-44.077812877938534" z="1528.4518282402964" unit="mm" />
+      <rotation name="crystal4-2_rot_neg_bot" x="-0.0253118993481663" y="0.0590610984790547" z="0.0" unit="radian" />
+      <position name="crystal4-2_pos_pos_top" x="94.78858692586502" y="44.97781287793853" z="1528.4518282402964" unit="mm" />
+      <rotation name="crystal4-2_rot_pos_top" x="0.0253118993481663" y="-0.0590610984790547" z="0.0" unit="radian" />
+      <position name="crystal4-2_pos_neg_top" x="-9.42816171009298" y="44.97781287793853" z="1528.4518282402964" unit="mm" />
+      <rotation name="crystal4-2_rot_neg_top" x="0.0253118993481663" y="0.0590610984790547" z="0.0" unit="radian" />
+      <position name="crystal5-2_pos_pos_bot" x="109.67291416309662" y="-44.077812877938534" z="1528.4727370465882" unit="mm" />
+      <rotation name="crystal5-2_rot_pos_bot" x="-0.0253118993481663" y="-0.0759356980444989" z="0.0" unit="radian" />
+      <position name="crystal5-2_pos_neg_bot" x="-24.31248894732458" y="-44.077812877938534" z="1528.4727370465882" unit="mm" />
+      <rotation name="crystal5-2_rot_neg_bot" x="-0.0253118993481663" y="0.0759356980444989" z="0.0" unit="radian" />
+      <position name="crystal5-2_pos_pos_top" x="109.67291416309662" y="44.97781287793853" z="1528.4727370465882" unit="mm" />
+      <rotation name="crystal5-2_rot_pos_top" x="0.0253118993481663" y="-0.0759356980444989" z="0.0" unit="radian" />
+      <position name="crystal5-2_pos_neg_top" x="-24.31248894732458" y="44.97781287793853" z="1528.4727370465882" unit="mm" />
+      <rotation name="crystal5-2_rot_neg_top" x="0.0253118993481663" y="0.0759356980444989" z="0.0" unit="radian" />
+      <position name="crystal6-2_pos_pos_bot" x="124.57452638340096" y="-44.077812877938534" z="1528.4707882189361" unit="mm" />
+      <rotation name="crystal6-2_rot_pos_bot" x="-0.0253118993481663" y="-0.0928102976099431" z="0.0" unit="radian" />
+      <position name="crystal6-2_pos_neg_bot" x="-39.214101167628925" y="-44.077812877938534" z="1528.4707882189361" unit="mm" />
+      <rotation name="crystal6-2_rot_neg_bot" x="-0.0253118993481663" y="0.0928102976099431" z="0.0" unit="radian" />
+      <position name="crystal6-2_pos_pos_top" x="124.57452638340096" y="44.97781287793853" z="1528.4707882189361" unit="mm" />
+      <rotation name="crystal6-2_rot_pos_top" x="0.0253118993481663" y="-0.0928102976099431" z="0.0" unit="radian" />
+      <position name="crystal6-2_pos_neg_top" x="-39.214101167628925" y="44.97781287793853" z="1528.4707882189361" unit="mm" />
+      <rotation name="crystal6-2_rot_neg_top" x="0.0253118993481663" y="0.0928102976099431" z="0.0" unit="radian" />
+      <position name="crystal7-2_pos_pos_bot" x="139.4968932952259" y="-44.077812877938534" z="1528.4459823122595" unit="mm" />
+      <rotation name="crystal7-2_rot_pos_bot" x="-0.0253118993481663" y="-0.10968489717538729" z="0.0" unit="radian" />
+      <position name="crystal7-2_pos_neg_bot" x="-54.13646807945388" y="-44.077812877938534" z="1528.4459823122595" unit="mm" />
+      <rotation name="crystal7-2_rot_neg_bot" x="-0.0253118993481663" y="0.10968489717538729" z="0.0" unit="radian" />
+      <position name="crystal7-2_pos_pos_top" x="139.4968932952259" y="44.97781287793853" z="1528.4459823122595" unit="mm" />
+      <rotation name="crystal7-2_rot_pos_top" x="0.0253118993481663" y="-0.10968489717538729" z="0.0" unit="radian" />
+      <position name="crystal7-2_pos_neg_top" x="-54.13646807945388" y="44.97781287793853" z="1528.4459823122595" unit="mm" />
+      <rotation name="crystal7-2_rot_neg_top" x="0.0253118993481663" y="0.10968489717538729" z="0.0" unit="radian" />
+      <position name="crystal8-2_pos_pos_bot" x="154.44351486445828" y="-44.077812877938534" z="1528.3983263899254" unit="mm" />
+      <rotation name="crystal8-2_rot_pos_bot" x="-0.0253118993481663" y="-0.1265594967408315" z="0.0" unit="radian" />
+      <position name="crystal8-2_pos_neg_bot" x="-69.08308964868624" y="-44.077812877938534" z="1528.3983263899254" unit="mm" />
+      <rotation name="crystal8-2_rot_neg_bot" x="-0.0253118993481663" y="0.1265594967408315" z="0.0" unit="radian" />
+      <position name="crystal8-2_pos_pos_top" x="154.44351486445828" y="44.97781287793853" z="1528.3983263899254" unit="mm" />
+      <rotation name="crystal8-2_rot_pos_top" x="0.0253118993481663" y="-0.1265594967408315" z="0.0" unit="radian" />
+      <position name="crystal8-2_pos_neg_top" x="-69.08308964868624" y="44.97781287793853" z="1528.3983263899254" unit="mm" />
+      <rotation name="crystal8-2_rot_neg_top" x="0.0253118993481663" y="0.1265594967408315" z="0.0" unit="radian" />
+      <position name="crystal9-2_pos_pos_bot" x="169.41792716339802" y="-44.077812877938534" z="1528.3278340217357" unit="mm" />
+      <rotation name="crystal9-2_rot_pos_bot" x="-0.0253118993481663" y="-0.14343409630627568" z="0.0" unit="radian" />
+      <position name="crystal9-2_pos_neg_bot" x="-84.057501947626" y="-44.077812877938534" z="1528.3278340217357" unit="mm" />
+      <rotation name="crystal9-2_rot_neg_bot" x="-0.0253118993481663" y="0.14343409630627568" z="0.0" unit="radian" />
+      <position name="crystal9-2_pos_pos_top" x="169.41792716339802" y="44.97781287793853" z="1528.3278340217357" unit="mm" />
+      <rotation name="crystal9-2_rot_pos_top" x="0.0253118993481663" y="-0.14343409630627568" z="0.0" unit="radian" />
+      <position name="crystal9-2_pos_neg_top" x="-84.057501947626" y="44.97781287793853" z="1528.3278340217357" unit="mm" />
+      <rotation name="crystal9-2_rot_neg_top" x="0.0253118993481663" y="0.14343409630627568" z="0.0" unit="radian" />
+      <position name="crystal10-2_pos_pos_bot" x="184.42370834727978" y="-44.077812877938534" z="1528.2345252800653" unit="mm" />
+      <rotation name="crystal10-2_rot_pos_bot" x="-0.0253118993481663" y="-0.1603086958717199" z="0.0" unit="radian" />
+      <position name="crystal10-2_pos_neg_bot" x="-99.06328313150773" y="-44.077812877938534" z="1528.2345252800653" unit="mm" />
+      <rotation name="crystal10-2_rot_neg_bot" x="-0.0253118993481663" y="0.1603086958717199" z="0.0" unit="radian" />
+      <position name="crystal10-2_pos_pos_top" x="184.42370834727978" y="44.97781287793853" z="1528.2345252800653" unit="mm" />
+      <rotation name="crystal10-2_rot_pos_top" x="0.0253118993481663" y="-0.1603086958717199" z="0.0" unit="radian" />
+      <position name="crystal10-2_pos_neg_top" x="-99.06328313150773" y="44.97781287793853" z="1528.2345252800653" unit="mm" />
+      <rotation name="crystal10-2_rot_neg_top" x="0.0253118993481663" y="0.1603086958717199" z="0.0" unit="radian" />
+      <position name="crystal11-2_pos_pos_bot" x="199.46448478017476" y="-44.077812877938534" z="1528.1184267341444" unit="mm" />
+      <rotation name="crystal11-2_rot_pos_bot" x="-0.0253118993481663" y="-0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal11-2_pos_neg_bot" x="-114.1040595644027" y="-44.077812877938534" z="1528.1184267341444" unit="mm" />
+      <rotation name="crystal11-2_rot_neg_bot" x="-0.0253118993481663" y="0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal11-2_pos_pos_top" x="199.46448478017476" y="44.97781287793853" z="1528.1184267341444" unit="mm" />
+      <rotation name="crystal11-2_rot_pos_top" x="0.0253118993481663" y="-0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal11-2_pos_neg_top" x="-114.1040595644027" y="44.97781287793853" z="1528.1184267341444" unit="mm" />
+      <rotation name="crystal11-2_rot_neg_top" x="0.0253118993481663" y="0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal12-2_pos_pos_bot" x="214.5439373331128" y="-44.077812877938534" z="1527.9795714424947" unit="mm" />
+      <rotation name="crystal12-2_rot_pos_bot" x="-0.0253118993481663" y="-0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal12-2_pos_neg_bot" x="-129.1835121173408" y="-44.077812877938534" z="1527.9795714424947" unit="mm" />
+      <rotation name="crystal12-2_rot_neg_bot" x="-0.0253118993481663" y="0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal12-2_pos_pos_top" x="214.5439373331128" y="44.97781287793853" z="1527.9795714424947" unit="mm" />
+      <rotation name="crystal12-2_rot_pos_top" x="0.0253118993481663" y="-0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal12-2_pos_neg_top" x="-129.1835121173408" y="44.97781287793853" z="1527.9795714424947" unit="mm" />
+      <rotation name="crystal12-2_rot_neg_top" x="0.0253118993481663" y="0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal13-2_pos_pos_bot" x="229.66580787843168" y="-44.077812877938534" z="1527.8179989435152" unit="mm" />
+      <rotation name="crystal13-2_rot_pos_bot" x="-0.0253118993481663" y="-0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal13-2_pos_neg_bot" x="-144.30538266265967" y="-44.077812877938534" z="1527.8179989435152" unit="mm" />
+      <rotation name="crystal13-2_rot_neg_bot" x="-0.0253118993481663" y="0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal13-2_pos_pos_top" x="229.66580787843168" y="44.97781287793853" z="1527.8179989435152" unit="mm" />
+      <rotation name="crystal13-2_rot_pos_top" x="0.0253118993481663" y="-0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal13-2_pos_neg_top" x="-144.30538266265967" y="44.97781287793853" z="1527.8179989435152" unit="mm" />
+      <rotation name="crystal13-2_rot_neg_top" x="0.0253118993481663" y="0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal14-2_pos_pos_bot" x="244.83390600570817" y="-44.077812877938534" z="1527.6337552442246" unit="mm" />
+      <rotation name="crystal14-2_rot_pos_bot" x="-0.0253118993481663" y="-0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal14-2_pos_neg_bot" x="-159.47348078993616" y="-44.077812877938534" z="1527.6337552442246" unit="mm" />
+      <rotation name="crystal14-2_rot_neg_bot" x="-0.0253118993481663" y="0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal14-2_pos_pos_top" x="244.83390600570817" y="44.97781287793853" z="1527.6337552442246" unit="mm" />
+      <rotation name="crystal14-2_rot_pos_top" x="0.0253118993481663" y="-0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal14-2_pos_neg_top" x="-159.47348078993616" y="44.97781287793853" z="1527.6337552442246" unit="mm" />
+      <rotation name="crystal14-2_rot_neg_top" x="0.0253118993481663" y="0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal15-2_pos_pos_bot" x="260.0521159861688" y="-44.077812877938534" z="1527.42689280716" unit="mm" />
+      <rotation name="crystal15-2_rot_pos_bot" x="-0.0253118993481663" y="-0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal15-2_pos_neg_bot" x="-174.6916907703968" y="-44.077812877938534" z="1527.42689280716" unit="mm" />
+      <rotation name="crystal15-2_rot_neg_bot" x="-0.0253118993481663" y="0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal15-2_pos_pos_top" x="260.0521159861688" y="44.97781287793853" z="1527.42689280716" unit="mm" />
+      <rotation name="crystal15-2_rot_pos_top" x="0.0253118993481663" y="-0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal15-2_pos_neg_top" x="-174.6916907703968" y="44.97781287793853" z="1527.42689280716" unit="mm" />
+      <rotation name="crystal15-2_rot_neg_top" x="0.0253118993481663" y="0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal16-2_pos_pos_bot" x="275.32440401422616" y="-44.077812877938534" z="1527.1974705354392" unit="mm" />
+      <rotation name="crystal16-2_rot_pos_bot" x="-0.0253118993481663" y="-0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal16-2_pos_neg_bot" x="-189.96397879845415" y="-44.077812877938534" z="1527.1974705354392" unit="mm" />
+      <rotation name="crystal16-2_rot_neg_bot" x="-0.0253118993481663" y="0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal16-2_pos_pos_top" x="275.32440401422616" y="44.97781287793853" z="1527.1974705354392" unit="mm" />
+      <rotation name="crystal16-2_rot_pos_top" x="0.0253118993481663" y="-0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal16-2_pos_neg_top" x="-189.96397879845415" y="44.97781287793853" z="1527.1974705354392" unit="mm" />
+      <rotation name="crystal16-2_rot_neg_top" x="0.0253118993481663" y="0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal17-2_pos_pos_bot" x="290.6548257567732" y="-44.077812877938534" z="1526.9455537559877" unit="mm" />
+      <rotation name="crystal17-2_rot_pos_bot" x="-0.0253118993481663" y="-0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal17-2_pos_neg_bot" x="-205.2944005410012" y="-44.077812877938534" z="1526.9455537559877" unit="mm" />
+      <rotation name="crystal17-2_rot_neg_bot" x="-0.0253118993481663" y="0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal17-2_pos_pos_top" x="290.6548257567732" y="44.97781287793853" z="1526.9455537559877" unit="mm" />
+      <rotation name="crystal17-2_rot_pos_top" x="0.0253118993481663" y="-0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal17-2_pos_neg_top" x="-205.2944005410012" y="44.97781287793853" z="1526.9455537559877" unit="mm" />
+      <rotation name="crystal17-2_rot_neg_top" x="0.0253118993481663" y="0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal18-2_pos_pos_bot" x="306.0475342431027" y="-44.077812877938534" z="1526.6712142009383" unit="mm" />
+      <rotation name="crystal18-2_rot_pos_bot" x="-0.0253118993481663" y="-0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal18-2_pos_neg_bot" x="-220.68710902733068" y="-44.077812877938534" z="1526.6712142009383" unit="mm" />
+      <rotation name="crystal18-2_rot_neg_bot" x="-0.0253118993481663" y="0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal18-2_pos_pos_top" x="306.0475342431027" y="44.97781287793853" z="1526.6712142009383" unit="mm" />
+      <rotation name="crystal18-2_rot_pos_top" x="0.0253118993481663" y="-0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal18-2_pos_neg_top" x="-220.68710902733068" y="44.97781287793853" z="1526.6712142009383" unit="mm" />
+      <rotation name="crystal18-2_rot_neg_top" x="0.0253118993481663" y="0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal19-2_pos_pos_bot" x="321.5067881308382" y="-44.077812877938534" z="1526.3745299872046" unit="mm" />
+      <rotation name="crystal19-2_rot_pos_bot" x="-0.0253118993481663" y="-0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal19-2_pos_neg_bot" x="-236.14636291506616" y="-44.077812877938534" z="1526.3745299872046" unit="mm" />
+      <rotation name="crystal19-2_rot_neg_bot" x="-0.0253118993481663" y="0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal19-2_pos_pos_top" x="321.5067881308382" y="44.97781287793853" z="1526.3745299872046" unit="mm" />
+      <rotation name="crystal19-2_rot_pos_top" x="0.0253118993481663" y="-0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal19-2_pos_neg_top" x="-236.14636291506616" y="44.97781287793853" z="1526.3745299872046" unit="mm" />
+      <rotation name="crystal19-2_rot_neg_top" x="0.0253118993481663" y="0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal20-2_pos_pos_bot" x="337.03696038609246" y="-44.077812877938534" z="1526.055585594238" unit="mm" />
+      <rotation name="crystal20-2_rot_pos_bot" x="-0.0253118993481663" y="-0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal20-2_pos_neg_bot" x="-251.67653517032045" y="-44.077812877938534" z="1526.055585594238" unit="mm" />
+      <rotation name="crystal20-2_rot_neg_bot" x="-0.0253118993481663" y="0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal20-2_pos_pos_top" x="337.03696038609246" y="44.97781287793853" z="1526.055585594238" unit="mm" />
+      <rotation name="crystal20-2_rot_pos_top" x="0.0253118993481663" y="-0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal20-2_pos_neg_top" x="-251.67653517032045" y="44.97781287793853" z="1526.055585594238" unit="mm" />
+      <rotation name="crystal20-2_rot_neg_top" x="0.0253118993481663" y="0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal21-2_pos_pos_bot" x="352.64254741924634" y="-44.077812877938534" z="1525.7144718399722" unit="mm" />
+      <rotation name="crystal21-2_rot_pos_bot" x="-0.0253118993481663" y="-0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal21-2_pos_neg_bot" x="-267.28212220347433" y="-44.077812877938534" z="1525.7144718399722" unit="mm" />
+      <rotation name="crystal21-2_rot_neg_bot" x="-0.0253118993481663" y="0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal21-2_pos_pos_top" x="352.64254741924634" y="44.97781287793853" z="1525.7144718399722" unit="mm" />
+      <rotation name="crystal21-2_rot_pos_top" x="0.0253118993481663" y="-0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal21-2_pos_neg_top" x="-267.28212220347433" y="44.97781287793853" z="1525.7144718399722" unit="mm" />
+      <rotation name="crystal21-2_rot_neg_top" x="0.0253118993481663" y="0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal22-2_pos_pos_bot" x="368.32817872130425" y="-44.077812877938534" z="1525.351285854964" unit="mm" />
+      <rotation name="crystal22-2_rot_pos_bot" x="-0.0253118993481663" y="-0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal22-2_pos_neg_bot" x="-282.96775350553224" y="-44.077812877938534" z="1525.351285854964" unit="mm" />
+      <rotation name="crystal22-2_rot_neg_bot" x="-0.0253118993481663" y="0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal22-2_pos_pos_top" x="368.32817872130425" y="44.97781287793853" z="1525.351285854964" unit="mm" />
+      <rotation name="crystal22-2_rot_pos_top" x="0.0253118993481663" y="-0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal22-2_pos_neg_top" x="-282.96775350553224" y="44.97781287793853" z="1525.351285854964" unit="mm" />
+      <rotation name="crystal22-2_rot_neg_top" x="0.0253118993481663" y="0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal23-2_pos_pos_bot" x="384.09862704978" y="-44.077812877938534" z="1524.9661310547353" unit="mm" />
+      <rotation name="crystal23-2_rot_pos_bot" x="-0.0253118993481663" y="-0.3796784902224945" z="0.0" unit="radian" />
+      <position name="crystal23-2_pos_neg_bot" x="-298.738201834008" y="-44.077812877938534" z="1524.9661310547353" unit="mm" />
+      <rotation name="crystal23-2_rot_neg_bot" x="-0.0253118993481663" y="0.3796784902224945" z="0.0" unit="radian" />
+      <position name="crystal23-2_pos_pos_top" x="384.09862704978" y="44.97781287793853" z="1524.9661310547353" unit="mm" />
+      <rotation name="crystal23-2_rot_pos_top" x="0.0253118993481663" y="-0.3796784902224945" z="0.0" unit="radian" />
+      <position name="crystal23-2_pos_neg_top" x="-298.738201834008" y="44.97781287793853" z="1524.9661310547353" unit="mm" />
+      <rotation name="crystal23-2_rot_neg_top" x="0.0253118993481663" y="0.3796784902224945" z="0.0" unit="radian" />
+      <position name="crystal1-3_pos_pos_bot" x="50.20495188328156" y="-59.08788687039808" z="1528.3186477918262" unit="mm" />
+      <rotation name="crystal1-3_rot_pos_bot" x="-0.042186498913610496" y="-0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal1-3_pos_neg_bot" x="35.15547333249048" y="-59.08788687039808" z="1528.3186477918262" unit="mm" />
+      <rotation name="crystal1-3_rot_neg_bot" x="-0.042186498913610496" y="0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal1-3_pos_pos_top" x="50.20495188328156" y="59.987886870398086" z="1528.3186477918262" unit="mm" />
+      <rotation name="crystal1-3_rot_pos_top" x="0.042186498913610496" y="-0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal1-3_pos_neg_top" x="35.15547333249048" y="59.987886870398086" z="1528.3186477918262" unit="mm" />
+      <rotation name="crystal1-3_rot_neg_top" x="0.042186498913610496" y="0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal2-3_pos_pos_bot" x="65.05802548582456" y="-59.08788687039808" z="1528.4080677537463" unit="mm" />
+      <rotation name="crystal2-3_rot_pos_bot" x="-0.042186498913610496" y="-0.0253118993481663" z="0.0" unit="radian" />
+      <position name="crystal2-3_pos_neg_bot" x="20.302399729947485" y="-59.08788687039808" z="1528.4080677537463" unit="mm" />
+      <rotation name="crystal2-3_rot_neg_bot" x="-0.042186498913610496" y="0.0253118993481663" z="0.0" unit="radian" />
+      <position name="crystal2-3_pos_pos_top" x="65.05802548582456" y="59.987886870398086" z="1528.4080677537463" unit="mm" />
+      <rotation name="crystal2-3_rot_pos_top" x="0.042186498913610496" y="-0.0253118993481663" z="0.0" unit="radian" />
+      <position name="crystal2-3_pos_neg_top" x="20.302399729947485" y="59.987886870398086" z="1528.4080677537463" unit="mm" />
+      <rotation name="crystal2-3_rot_neg_top" x="0.042186498913610496" y="0.0253118993481663" z="0.0" unit="radian" />
+      <position name="crystal3-3_pos_pos_bot" x="79.9180994782841" y="-59.08788687039808" z="1528.47466745996" unit="mm" />
+      <rotation name="crystal3-3_rot_pos_bot" x="-0.042186498913610496" y="-0.042186498913610496" z="0.0" unit="radian" />
+      <position name="crystal3-3_pos_neg_bot" x="5.442325737487934" y="-59.08788687039808" z="1528.47466745996" unit="mm" />
+      <rotation name="crystal3-3_rot_neg_bot" x="-0.042186498913610496" y="0.042186498913610496" z="0.0" unit="radian" />
+      <position name="crystal3-3_pos_pos_top" x="79.9180994782841" y="59.987886870398086" z="1528.47466745996" unit="mm" />
+      <rotation name="crystal3-3_rot_pos_top" x="0.042186498913610496" y="-0.042186498913610496" z="0.0" unit="radian" />
+      <position name="crystal3-3_pos_neg_top" x="5.442325737487934" y="59.987886870398086" z="1528.47466745996" unit="mm" />
+      <rotation name="crystal3-3_rot_neg_top" x="0.042186498913610496" y="0.042186498913610496" z="0.0" unit="radian" />
+      <position name="crystal4-3_pos_pos_bot" x="94.78858692586502" y="-59.08788687039808" z="1528.5184279465104" unit="mm" />
+      <rotation name="crystal4-3_rot_pos_bot" x="-0.042186498913610496" y="-0.0590610984790547" z="0.0" unit="radian" />
+      <position name="crystal4-3_pos_neg_bot" x="-9.42816171009298" y="-59.08788687039808" z="1528.5184279465104" unit="mm" />
+      <rotation name="crystal4-3_rot_neg_bot" x="-0.042186498913610496" y="0.0590610984790547" z="0.0" unit="radian" />
+      <position name="crystal4-3_pos_pos_top" x="94.78858692586502" y="59.987886870398086" z="1528.5184279465104" unit="mm" />
+      <rotation name="crystal4-3_rot_pos_top" x="0.042186498913610496" y="-0.0590610984790547" z="0.0" unit="radian" />
+      <position name="crystal4-3_pos_neg_top" x="-9.42816171009298" y="59.987886870398086" z="1528.5184279465104" unit="mm" />
+      <rotation name="crystal4-3_rot_neg_top" x="0.042186498913610496" y="0.0590610984790547" z="0.0" unit="radian" />
+      <position name="crystal5-3_pos_pos_bot" x="109.67291416309662" y="-59.08788687039808" z="1528.5393367528022" unit="mm" />
+      <rotation name="crystal5-3_rot_pos_bot" x="-0.042186498913610496" y="-0.0759356980444989" z="0.0" unit="radian" />
+      <position name="crystal5-3_pos_neg_bot" x="-24.31248894732458" y="-59.08788687039808" z="1528.5393367528022" unit="mm" />
+      <rotation name="crystal5-3_rot_neg_bot" x="-0.042186498913610496" y="0.0759356980444989" z="0.0" unit="radian" />
+      <position name="crystal5-3_pos_pos_top" x="109.67291416309662" y="59.987886870398086" z="1528.5393367528022" unit="mm" />
+      <rotation name="crystal5-3_rot_pos_top" x="0.042186498913610496" y="-0.0759356980444989" z="0.0" unit="radian" />
+      <position name="crystal5-3_pos_neg_top" x="-24.31248894732458" y="59.987886870398086" z="1528.5393367528022" unit="mm" />
+      <rotation name="crystal5-3_rot_neg_top" x="0.042186498913610496" y="0.0759356980444989" z="0.0" unit="radian" />
+      <position name="crystal6-3_pos_pos_bot" x="124.57452638340096" y="-59.08788687039808" z="1528.53738792515" unit="mm" />
+      <rotation name="crystal6-3_rot_pos_bot" x="-0.042186498913610496" y="-0.0928102976099431" z="0.0" unit="radian" />
+      <position name="crystal6-3_pos_neg_bot" x="-39.214101167628925" y="-59.08788687039808" z="1528.53738792515" unit="mm" />
+      <rotation name="crystal6-3_rot_neg_bot" x="-0.042186498913610496" y="0.0928102976099431" z="0.0" unit="radian" />
+      <position name="crystal6-3_pos_pos_top" x="124.57452638340096" y="59.987886870398086" z="1528.53738792515" unit="mm" />
+      <rotation name="crystal6-3_rot_pos_top" x="0.042186498913610496" y="-0.0928102976099431" z="0.0" unit="radian" />
+      <position name="crystal6-3_pos_neg_top" x="-39.214101167628925" y="59.987886870398086" z="1528.53738792515" unit="mm" />
+      <rotation name="crystal6-3_rot_neg_top" x="0.042186498913610496" y="0.0928102976099431" z="0.0" unit="radian" />
+      <position name="crystal7-3_pos_pos_bot" x="139.4968932952259" y="-59.08788687039808" z="1528.5125820184735" unit="mm" />
+      <rotation name="crystal7-3_rot_pos_bot" x="-0.042186498913610496" y="-0.10968489717538729" z="0.0" unit="radian" />
+      <position name="crystal7-3_pos_neg_bot" x="-54.13646807945388" y="-59.08788687039808" z="1528.5125820184735" unit="mm" />
+      <rotation name="crystal7-3_rot_neg_bot" x="-0.042186498913610496" y="0.10968489717538729" z="0.0" unit="radian" />
+      <position name="crystal7-3_pos_pos_top" x="139.4968932952259" y="59.987886870398086" z="1528.5125820184735" unit="mm" />
+      <rotation name="crystal7-3_rot_pos_top" x="0.042186498913610496" y="-0.10968489717538729" z="0.0" unit="radian" />
+      <position name="crystal7-3_pos_neg_top" x="-54.13646807945388" y="59.987886870398086" z="1528.5125820184735" unit="mm" />
+      <rotation name="crystal7-3_rot_neg_top" x="0.042186498913610496" y="0.10968489717538729" z="0.0" unit="radian" />
+      <position name="crystal8-3_pos_pos_bot" x="154.44351486445828" y="-59.08788687039808" z="1528.4649260961392" unit="mm" />
+      <rotation name="crystal8-3_rot_pos_bot" x="-0.042186498913610496" y="-0.1265594967408315" z="0.0" unit="radian" />
+      <position name="crystal8-3_pos_neg_bot" x="-69.08308964868624" y="-59.08788687039808" z="1528.4649260961392" unit="mm" />
+      <rotation name="crystal8-3_rot_neg_bot" x="-0.042186498913610496" y="0.1265594967408315" z="0.0" unit="radian" />
+      <position name="crystal8-3_pos_pos_top" x="154.44351486445828" y="59.987886870398086" z="1528.4649260961392" unit="mm" />
+      <rotation name="crystal8-3_rot_pos_top" x="0.042186498913610496" y="-0.1265594967408315" z="0.0" unit="radian" />
+      <position name="crystal8-3_pos_neg_top" x="-69.08308964868624" y="59.987886870398086" z="1528.4649260961392" unit="mm" />
+      <rotation name="crystal8-3_rot_neg_top" x="0.042186498913610496" y="0.1265594967408315" z="0.0" unit="radian" />
+      <position name="crystal9-3_pos_pos_bot" x="169.41792716339802" y="-59.08788687039808" z="1528.3944337279495" unit="mm" />
+      <rotation name="crystal9-3_rot_pos_bot" x="-0.042186498913610496" y="-0.14343409630627568" z="0.0" unit="radian" />
+      <position name="crystal9-3_pos_neg_bot" x="-84.057501947626" y="-59.08788687039808" z="1528.3944337279495" unit="mm" />
+      <rotation name="crystal9-3_rot_neg_bot" x="-0.042186498913610496" y="0.14343409630627568" z="0.0" unit="radian" />
+      <position name="crystal9-3_pos_pos_top" x="169.41792716339802" y="59.987886870398086" z="1528.3944337279495" unit="mm" />
+      <rotation name="crystal9-3_rot_pos_top" x="0.042186498913610496" y="-0.14343409630627568" z="0.0" unit="radian" />
+      <position name="crystal9-3_pos_neg_top" x="-84.057501947626" y="59.987886870398086" z="1528.3944337279495" unit="mm" />
+      <rotation name="crystal9-3_rot_neg_top" x="0.042186498913610496" y="0.14343409630627568" z="0.0" unit="radian" />
+      <position name="crystal10-3_pos_pos_bot" x="184.42370834727978" y="-59.08788687039808" z="1528.301124986279" unit="mm" />
+      <rotation name="crystal10-3_rot_pos_bot" x="-0.042186498913610496" y="-0.1603086958717199" z="0.0" unit="radian" />
+      <position name="crystal10-3_pos_neg_bot" x="-99.06328313150773" y="-59.08788687039808" z="1528.301124986279" unit="mm" />
+      <rotation name="crystal10-3_rot_neg_bot" x="-0.042186498913610496" y="0.1603086958717199" z="0.0" unit="radian" />
+      <position name="crystal10-3_pos_pos_top" x="184.42370834727978" y="59.987886870398086" z="1528.301124986279" unit="mm" />
+      <rotation name="crystal10-3_rot_pos_top" x="0.042186498913610496" y="-0.1603086958717199" z="0.0" unit="radian" />
+      <position name="crystal10-3_pos_neg_top" x="-99.06328313150773" y="59.987886870398086" z="1528.301124986279" unit="mm" />
+      <rotation name="crystal10-3_rot_neg_top" x="0.042186498913610496" y="0.1603086958717199" z="0.0" unit="radian" />
+      <position name="crystal11-3_pos_pos_bot" x="199.46448478017476" y="-59.08788687039808" z="1528.1850264403583" unit="mm" />
+      <rotation name="crystal11-3_rot_pos_bot" x="-0.042186498913610496" y="-0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal11-3_pos_neg_bot" x="-114.1040595644027" y="-59.08788687039808" z="1528.1850264403583" unit="mm" />
+      <rotation name="crystal11-3_rot_neg_bot" x="-0.042186498913610496" y="0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal11-3_pos_pos_top" x="199.46448478017476" y="59.987886870398086" z="1528.1850264403583" unit="mm" />
+      <rotation name="crystal11-3_rot_pos_top" x="0.042186498913610496" y="-0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal11-3_pos_neg_top" x="-114.1040595644027" y="59.987886870398086" z="1528.1850264403583" unit="mm" />
+      <rotation name="crystal11-3_rot_neg_top" x="0.042186498913610496" y="0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal12-3_pos_pos_bot" x="214.5439373331128" y="-59.08788687039808" z="1528.0461711487085" unit="mm" />
+      <rotation name="crystal12-3_rot_pos_bot" x="-0.042186498913610496" y="-0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal12-3_pos_neg_bot" x="-129.1835121173408" y="-59.08788687039808" z="1528.0461711487085" unit="mm" />
+      <rotation name="crystal12-3_rot_neg_bot" x="-0.042186498913610496" y="0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal12-3_pos_pos_top" x="214.5439373331128" y="59.987886870398086" z="1528.0461711487085" unit="mm" />
+      <rotation name="crystal12-3_rot_pos_top" x="0.042186498913610496" y="-0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal12-3_pos_neg_top" x="-129.1835121173408" y="59.987886870398086" z="1528.0461711487085" unit="mm" />
+      <rotation name="crystal12-3_rot_neg_top" x="0.042186498913610496" y="0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal13-3_pos_pos_bot" x="229.66580787843168" y="-59.08788687039808" z="1527.8845986497292" unit="mm" />
+      <rotation name="crystal13-3_rot_pos_bot" x="-0.042186498913610496" y="-0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal13-3_pos_neg_bot" x="-144.30538266265967" y="-59.08788687039808" z="1527.8845986497292" unit="mm" />
+      <rotation name="crystal13-3_rot_neg_bot" x="-0.042186498913610496" y="0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal13-3_pos_pos_top" x="229.66580787843168" y="59.987886870398086" z="1527.8845986497292" unit="mm" />
+      <rotation name="crystal13-3_rot_pos_top" x="0.042186498913610496" y="-0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal13-3_pos_neg_top" x="-144.30538266265967" y="59.987886870398086" z="1527.8845986497292" unit="mm" />
+      <rotation name="crystal13-3_rot_neg_top" x="0.042186498913610496" y="0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal14-3_pos_pos_bot" x="244.83390600570817" y="-59.08788687039808" z="1527.7003549504386" unit="mm" />
+      <rotation name="crystal14-3_rot_pos_bot" x="-0.042186498913610496" y="-0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal14-3_pos_neg_bot" x="-159.47348078993616" y="-59.08788687039808" z="1527.7003549504386" unit="mm" />
+      <rotation name="crystal14-3_rot_neg_bot" x="-0.042186498913610496" y="0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal14-3_pos_pos_top" x="244.83390600570817" y="59.987886870398086" z="1527.7003549504386" unit="mm" />
+      <rotation name="crystal14-3_rot_pos_top" x="0.042186498913610496" y="-0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal14-3_pos_neg_top" x="-159.47348078993616" y="59.987886870398086" z="1527.7003549504386" unit="mm" />
+      <rotation name="crystal14-3_rot_neg_top" x="0.042186498913610496" y="0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal15-3_pos_pos_bot" x="260.0521159861688" y="-59.08788687039808" z="1527.4934925133737" unit="mm" />
+      <rotation name="crystal15-3_rot_pos_bot" x="-0.042186498913610496" y="-0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal15-3_pos_neg_bot" x="-174.6916907703968" y="-59.08788687039808" z="1527.4934925133737" unit="mm" />
+      <rotation name="crystal15-3_rot_neg_bot" x="-0.042186498913610496" y="0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal15-3_pos_pos_top" x="260.0521159861688" y="59.987886870398086" z="1527.4934925133737" unit="mm" />
+      <rotation name="crystal15-3_rot_pos_top" x="0.042186498913610496" y="-0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal15-3_pos_neg_top" x="-174.6916907703968" y="59.987886870398086" z="1527.4934925133737" unit="mm" />
+      <rotation name="crystal15-3_rot_neg_top" x="0.042186498913610496" y="0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal16-3_pos_pos_bot" x="275.32440401422616" y="-59.08788687039808" z="1527.264070241653" unit="mm" />
+      <rotation name="crystal16-3_rot_pos_bot" x="-0.042186498913610496" y="-0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal16-3_pos_neg_bot" x="-189.96397879845415" y="-59.08788687039808" z="1527.264070241653" unit="mm" />
+      <rotation name="crystal16-3_rot_neg_bot" x="-0.042186498913610496" y="0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal16-3_pos_pos_top" x="275.32440401422616" y="59.987886870398086" z="1527.264070241653" unit="mm" />
+      <rotation name="crystal16-3_rot_pos_top" x="0.042186498913610496" y="-0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal16-3_pos_neg_top" x="-189.96397879845415" y="59.987886870398086" z="1527.264070241653" unit="mm" />
+      <rotation name="crystal16-3_rot_neg_top" x="0.042186498913610496" y="0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal17-3_pos_pos_bot" x="290.6548257567732" y="-59.08788687039808" z="1527.0121534622015" unit="mm" />
+      <rotation name="crystal17-3_rot_pos_bot" x="-0.042186498913610496" y="-0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal17-3_pos_neg_bot" x="-205.2944005410012" y="-59.08788687039808" z="1527.0121534622015" unit="mm" />
+      <rotation name="crystal17-3_rot_neg_bot" x="-0.042186498913610496" y="0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal17-3_pos_pos_top" x="290.6548257567732" y="59.987886870398086" z="1527.0121534622015" unit="mm" />
+      <rotation name="crystal17-3_rot_pos_top" x="0.042186498913610496" y="-0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal17-3_pos_neg_top" x="-205.2944005410012" y="59.987886870398086" z="1527.0121534622015" unit="mm" />
+      <rotation name="crystal17-3_rot_neg_top" x="0.042186498913610496" y="0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal18-3_pos_pos_bot" x="306.0475342431027" y="-59.08788687039808" z="1526.737813907152" unit="mm" />
+      <rotation name="crystal18-3_rot_pos_bot" x="-0.042186498913610496" y="-0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal18-3_pos_neg_bot" x="-220.68710902733068" y="-59.08788687039808" z="1526.737813907152" unit="mm" />
+      <rotation name="crystal18-3_rot_neg_bot" x="-0.042186498913610496" y="0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal18-3_pos_pos_top" x="306.0475342431027" y="59.987886870398086" z="1526.737813907152" unit="mm" />
+      <rotation name="crystal18-3_rot_pos_top" x="0.042186498913610496" y="-0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal18-3_pos_neg_top" x="-220.68710902733068" y="59.987886870398086" z="1526.737813907152" unit="mm" />
+      <rotation name="crystal18-3_rot_neg_top" x="0.042186498913610496" y="0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal19-3_pos_pos_bot" x="321.5067881308382" y="-59.08788687039808" z="1526.4411296934186" unit="mm" />
+      <rotation name="crystal19-3_rot_pos_bot" x="-0.042186498913610496" y="-0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal19-3_pos_neg_bot" x="-236.14636291506616" y="-59.08788687039808" z="1526.4411296934186" unit="mm" />
+      <rotation name="crystal19-3_rot_neg_bot" x="-0.042186498913610496" y="0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal19-3_pos_pos_top" x="321.5067881308382" y="59.987886870398086" z="1526.4411296934186" unit="mm" />
+      <rotation name="crystal19-3_rot_pos_top" x="0.042186498913610496" y="-0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal19-3_pos_neg_top" x="-236.14636291506616" y="59.987886870398086" z="1526.4411296934186" unit="mm" />
+      <rotation name="crystal19-3_rot_neg_top" x="0.042186498913610496" y="0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal20-3_pos_pos_bot" x="337.03696038609246" y="-59.08788687039808" z="1526.1221853004517" unit="mm" />
+      <rotation name="crystal20-3_rot_pos_bot" x="-0.042186498913610496" y="-0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal20-3_pos_neg_bot" x="-251.67653517032045" y="-59.08788687039808" z="1526.1221853004517" unit="mm" />
+      <rotation name="crystal20-3_rot_neg_bot" x="-0.042186498913610496" y="0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal20-3_pos_pos_top" x="337.03696038609246" y="59.987886870398086" z="1526.1221853004517" unit="mm" />
+      <rotation name="crystal20-3_rot_pos_top" x="0.042186498913610496" y="-0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal20-3_pos_neg_top" x="-251.67653517032045" y="59.987886870398086" z="1526.1221853004517" unit="mm" />
+      <rotation name="crystal20-3_rot_neg_top" x="0.042186498913610496" y="0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal21-3_pos_pos_bot" x="352.64254741924634" y="-59.08788687039808" z="1525.781071546186" unit="mm" />
+      <rotation name="crystal21-3_rot_pos_bot" x="-0.042186498913610496" y="-0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal21-3_pos_neg_bot" x="-267.28212220347433" y="-59.08788687039808" z="1525.781071546186" unit="mm" />
+      <rotation name="crystal21-3_rot_neg_bot" x="-0.042186498913610496" y="0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal21-3_pos_pos_top" x="352.64254741924634" y="59.987886870398086" z="1525.781071546186" unit="mm" />
+      <rotation name="crystal21-3_rot_pos_top" x="0.042186498913610496" y="-0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal21-3_pos_neg_top" x="-267.28212220347433" y="59.987886870398086" z="1525.781071546186" unit="mm" />
+      <rotation name="crystal21-3_rot_neg_top" x="0.042186498913610496" y="0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal22-3_pos_pos_bot" x="368.32817872130425" y="-59.08788687039808" z="1525.417885561178" unit="mm" />
+      <rotation name="crystal22-3_rot_pos_bot" x="-0.042186498913610496" y="-0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal22-3_pos_neg_bot" x="-282.96775350553224" y="-59.08788687039808" z="1525.417885561178" unit="mm" />
+      <rotation name="crystal22-3_rot_neg_bot" x="-0.042186498913610496" y="0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal22-3_pos_pos_top" x="368.32817872130425" y="59.987886870398086" z="1525.417885561178" unit="mm" />
+      <rotation name="crystal22-3_rot_pos_top" x="0.042186498913610496" y="-0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal22-3_pos_neg_top" x="-282.96775350553224" y="59.987886870398086" z="1525.417885561178" unit="mm" />
+      <rotation name="crystal22-3_rot_neg_top" x="0.042186498913610496" y="0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal23-3_pos_pos_bot" x="384.09862704978" y="-59.08788687039808" z="1525.032730760949" unit="mm" />
+      <rotation name="crystal23-3_rot_pos_bot" x="-0.042186498913610496" y="-0.3796784902224945" z="0.0" unit="radian" />
+      <position name="crystal23-3_pos_neg_bot" x="-298.738201834008" y="-59.08788687039808" z="1525.032730760949" unit="mm" />
+      <rotation name="crystal23-3_rot_neg_bot" x="-0.042186498913610496" y="0.3796784902224945" z="0.0" unit="radian" />
+      <position name="crystal23-3_pos_pos_top" x="384.09862704978" y="59.987886870398086" z="1525.032730760949" unit="mm" />
+      <rotation name="crystal23-3_rot_pos_top" x="0.042186498913610496" y="-0.3796784902224945" z="0.0" unit="radian" />
+      <position name="crystal23-3_pos_neg_top" x="-298.738201834008" y="59.987886870398086" z="1525.032730760949" unit="mm" />
+      <rotation name="crystal23-3_rot_neg_top" x="0.042186498913610496" y="0.3796784902224945" z="0.0" unit="radian" />
+      <position name="crystal1-4_pos_pos_bot" x="50.20495188328156" y="-74.108374317979" z="1528.3624082783765" unit="mm" />
+      <rotation name="crystal1-4_rot_pos_bot" x="-0.0590610984790547" y="-0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal1-4_pos_neg_bot" x="35.15547333249048" y="-74.108374317979" z="1528.3624082783765" unit="mm" />
+      <rotation name="crystal1-4_rot_neg_bot" x="-0.0590610984790547" y="0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal1-4_pos_pos_top" x="50.20495188328156" y="75.008374317979" z="1528.3624082783765" unit="mm" />
+      <rotation name="crystal1-4_rot_pos_top" x="0.0590610984790547" y="-0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal1-4_pos_neg_top" x="35.15547333249048" y="75.008374317979" z="1528.3624082783765" unit="mm" />
+      <rotation name="crystal1-4_rot_neg_top" x="0.0590610984790547" y="0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal2-4_pos_pos_bot" x="65.05802548582456" y="-74.108374317979" z="1528.4518282402964" unit="mm" />
+      <rotation name="crystal2-4_rot_pos_bot" x="-0.0590610984790547" y="-0.0253118993481663" z="0.0" unit="radian" />
+      <position name="crystal2-4_pos_neg_bot" x="20.302399729947485" y="-74.108374317979" z="1528.4518282402964" unit="mm" />
+      <rotation name="crystal2-4_rot_neg_bot" x="-0.0590610984790547" y="0.0253118993481663" z="0.0" unit="radian" />
+      <position name="crystal2-4_pos_pos_top" x="65.05802548582456" y="75.008374317979" z="1528.4518282402964" unit="mm" />
+      <rotation name="crystal2-4_rot_pos_top" x="0.0590610984790547" y="-0.0253118993481663" z="0.0" unit="radian" />
+      <position name="crystal2-4_pos_neg_top" x="20.302399729947485" y="75.008374317979" z="1528.4518282402964" unit="mm" />
+      <rotation name="crystal2-4_rot_neg_top" x="0.0590610984790547" y="0.0253118993481663" z="0.0" unit="radian" />
+      <position name="crystal3-4_pos_pos_bot" x="79.9180994782841" y="-74.108374317979" z="1528.5184279465104" unit="mm" />
+      <rotation name="crystal3-4_rot_pos_bot" x="-0.0590610984790547" y="-0.042186498913610496" z="0.0" unit="radian" />
+      <position name="crystal3-4_pos_neg_bot" x="5.442325737487934" y="-74.108374317979" z="1528.5184279465104" unit="mm" />
+      <rotation name="crystal3-4_rot_neg_bot" x="-0.0590610984790547" y="0.042186498913610496" z="0.0" unit="radian" />
+      <position name="crystal3-4_pos_pos_top" x="79.9180994782841" y="75.008374317979" z="1528.5184279465104" unit="mm" />
+      <rotation name="crystal3-4_rot_pos_top" x="0.0590610984790547" y="-0.042186498913610496" z="0.0" unit="radian" />
+      <position name="crystal3-4_pos_neg_top" x="5.442325737487934" y="75.008374317979" z="1528.5184279465104" unit="mm" />
+      <rotation name="crystal3-4_rot_neg_top" x="0.0590610984790547" y="0.042186498913610496" z="0.0" unit="radian" />
+      <position name="crystal4-4_pos_pos_bot" x="94.78858692586502" y="-74.108374317979" z="1528.5621884330608" unit="mm" />
+      <rotation name="crystal4-4_rot_pos_bot" x="-0.0590610984790547" y="-0.0590610984790547" z="0.0" unit="radian" />
+      <position name="crystal4-4_pos_neg_bot" x="-9.42816171009298" y="-74.108374317979" z="1528.5621884330608" unit="mm" />
+      <rotation name="crystal4-4_rot_neg_bot" x="-0.0590610984790547" y="0.0590610984790547" z="0.0" unit="radian" />
+      <position name="crystal4-4_pos_pos_top" x="94.78858692586502" y="75.008374317979" z="1528.5621884330608" unit="mm" />
+      <rotation name="crystal4-4_rot_pos_top" x="0.0590610984790547" y="-0.0590610984790547" z="0.0" unit="radian" />
+      <position name="crystal4-4_pos_neg_top" x="-9.42816171009298" y="75.008374317979" z="1528.5621884330608" unit="mm" />
+      <rotation name="crystal4-4_rot_neg_top" x="0.0590610984790547" y="0.0590610984790547" z="0.0" unit="radian" />
+      <position name="crystal5-4_pos_pos_bot" x="109.67291416309662" y="-74.108374317979" z="1528.5830972393524" unit="mm" />
+      <rotation name="crystal5-4_rot_pos_bot" x="-0.0590610984790547" y="-0.0759356980444989" z="0.0" unit="radian" />
+      <position name="crystal5-4_pos_neg_bot" x="-24.31248894732458" y="-74.108374317979" z="1528.5830972393524" unit="mm" />
+      <rotation name="crystal5-4_rot_neg_bot" x="-0.0590610984790547" y="0.0759356980444989" z="0.0" unit="radian" />
+      <position name="crystal5-4_pos_pos_top" x="109.67291416309662" y="75.008374317979" z="1528.5830972393524" unit="mm" />
+      <rotation name="crystal5-4_rot_pos_top" x="0.0590610984790547" y="-0.0759356980444989" z="0.0" unit="radian" />
+      <position name="crystal5-4_pos_neg_top" x="-24.31248894732458" y="75.008374317979" z="1528.5830972393524" unit="mm" />
+      <rotation name="crystal5-4_rot_neg_top" x="0.0590610984790547" y="0.0759356980444989" z="0.0" unit="radian" />
+      <position name="crystal6-4_pos_pos_bot" x="124.57452638340096" y="-74.108374317979" z="1528.5811484117003" unit="mm" />
+      <rotation name="crystal6-4_rot_pos_bot" x="-0.0590610984790547" y="-0.0928102976099431" z="0.0" unit="radian" />
+      <position name="crystal6-4_pos_neg_bot" x="-39.214101167628925" y="-74.108374317979" z="1528.5811484117003" unit="mm" />
+      <rotation name="crystal6-4_rot_neg_bot" x="-0.0590610984790547" y="0.0928102976099431" z="0.0" unit="radian" />
+      <position name="crystal6-4_pos_pos_top" x="124.57452638340096" y="75.008374317979" z="1528.5811484117003" unit="mm" />
+      <rotation name="crystal6-4_rot_pos_top" x="0.0590610984790547" y="-0.0928102976099431" z="0.0" unit="radian" />
+      <position name="crystal6-4_pos_neg_top" x="-39.214101167628925" y="75.008374317979" z="1528.5811484117003" unit="mm" />
+      <rotation name="crystal6-4_rot_neg_top" x="0.0590610984790547" y="0.0928102976099431" z="0.0" unit="radian" />
+      <position name="crystal7-4_pos_pos_bot" x="139.4968932952259" y="-74.108374317979" z="1528.5563425050236" unit="mm" />
+      <rotation name="crystal7-4_rot_pos_bot" x="-0.0590610984790547" y="-0.10968489717538729" z="0.0" unit="radian" />
+      <position name="crystal7-4_pos_neg_bot" x="-54.13646807945388" y="-74.108374317979" z="1528.5563425050236" unit="mm" />
+      <rotation name="crystal7-4_rot_neg_bot" x="-0.0590610984790547" y="0.10968489717538729" z="0.0" unit="radian" />
+      <position name="crystal7-4_pos_pos_top" x="139.4968932952259" y="75.008374317979" z="1528.5563425050236" unit="mm" />
+      <rotation name="crystal7-4_rot_pos_top" x="0.0590610984790547" y="-0.10968489717538729" z="0.0" unit="radian" />
+      <position name="crystal7-4_pos_neg_top" x="-54.13646807945388" y="75.008374317979" z="1528.5563425050236" unit="mm" />
+      <rotation name="crystal7-4_rot_neg_top" x="0.0590610984790547" y="0.10968489717538729" z="0.0" unit="radian" />
+      <position name="crystal8-4_pos_pos_bot" x="154.44351486445828" y="-74.108374317979" z="1528.5086865826895" unit="mm" />
+      <rotation name="crystal8-4_rot_pos_bot" x="-0.0590610984790547" y="-0.1265594967408315" z="0.0" unit="radian" />
+      <position name="crystal8-4_pos_neg_bot" x="-69.08308964868624" y="-74.108374317979" z="1528.5086865826895" unit="mm" />
+      <rotation name="crystal8-4_rot_neg_bot" x="-0.0590610984790547" y="0.1265594967408315" z="0.0" unit="radian" />
+      <position name="crystal8-4_pos_pos_top" x="154.44351486445828" y="75.008374317979" z="1528.5086865826895" unit="mm" />
+      <rotation name="crystal8-4_rot_pos_top" x="0.0590610984790547" y="-0.1265594967408315" z="0.0" unit="radian" />
+      <position name="crystal8-4_pos_neg_top" x="-69.08308964868624" y="75.008374317979" z="1528.5086865826895" unit="mm" />
+      <rotation name="crystal8-4_rot_neg_top" x="0.0590610984790547" y="0.1265594967408315" z="0.0" unit="radian" />
+      <position name="crystal9-4_pos_pos_bot" x="169.41792716339802" y="-74.108374317979" z="1528.4381942144998" unit="mm" />
+      <rotation name="crystal9-4_rot_pos_bot" x="-0.0590610984790547" y="-0.14343409630627568" z="0.0" unit="radian" />
+      <position name="crystal9-4_pos_neg_bot" x="-84.057501947626" y="-74.108374317979" z="1528.4381942144998" unit="mm" />
+      <rotation name="crystal9-4_rot_neg_bot" x="-0.0590610984790547" y="0.14343409630627568" z="0.0" unit="radian" />
+      <position name="crystal9-4_pos_pos_top" x="169.41792716339802" y="75.008374317979" z="1528.4381942144998" unit="mm" />
+      <rotation name="crystal9-4_rot_pos_top" x="0.0590610984790547" y="-0.14343409630627568" z="0.0" unit="radian" />
+      <position name="crystal9-4_pos_neg_top" x="-84.057501947626" y="75.008374317979" z="1528.4381942144998" unit="mm" />
+      <rotation name="crystal9-4_rot_neg_top" x="0.0590610984790547" y="0.14343409630627568" z="0.0" unit="radian" />
+      <position name="crystal10-4_pos_pos_bot" x="184.42370834727978" y="-74.108374317979" z="1528.3448854728294" unit="mm" />
+      <rotation name="crystal10-4_rot_pos_bot" x="-0.0590610984790547" y="-0.1603086958717199" z="0.0" unit="radian" />
+      <position name="crystal10-4_pos_neg_bot" x="-99.06328313150773" y="-74.108374317979" z="1528.3448854728294" unit="mm" />
+      <rotation name="crystal10-4_rot_neg_bot" x="-0.0590610984790547" y="0.1603086958717199" z="0.0" unit="radian" />
+      <position name="crystal10-4_pos_pos_top" x="184.42370834727978" y="75.008374317979" z="1528.3448854728294" unit="mm" />
+      <rotation name="crystal10-4_rot_pos_top" x="0.0590610984790547" y="-0.1603086958717199" z="0.0" unit="radian" />
+      <position name="crystal10-4_pos_neg_top" x="-99.06328313150773" y="75.008374317979" z="1528.3448854728294" unit="mm" />
+      <rotation name="crystal10-4_rot_neg_top" x="0.0590610984790547" y="0.1603086958717199" z="0.0" unit="radian" />
+      <position name="crystal11-4_pos_pos_bot" x="199.46448478017476" y="-74.108374317979" z="1528.2287869269085" unit="mm" />
+      <rotation name="crystal11-4_rot_pos_bot" x="-0.0590610984790547" y="-0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal11-4_pos_neg_bot" x="-114.1040595644027" y="-74.108374317979" z="1528.2287869269085" unit="mm" />
+      <rotation name="crystal11-4_rot_neg_bot" x="-0.0590610984790547" y="0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal11-4_pos_pos_top" x="199.46448478017476" y="75.008374317979" z="1528.2287869269085" unit="mm" />
+      <rotation name="crystal11-4_rot_pos_top" x="0.0590610984790547" y="-0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal11-4_pos_neg_top" x="-114.1040595644027" y="75.008374317979" z="1528.2287869269085" unit="mm" />
+      <rotation name="crystal11-4_rot_neg_top" x="0.0590610984790547" y="0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal12-4_pos_pos_bot" x="214.5439373331128" y="-74.108374317979" z="1528.0899316352588" unit="mm" />
+      <rotation name="crystal12-4_rot_pos_bot" x="-0.0590610984790547" y="-0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal12-4_pos_neg_bot" x="-129.1835121173408" y="-74.108374317979" z="1528.0899316352588" unit="mm" />
+      <rotation name="crystal12-4_rot_neg_bot" x="-0.0590610984790547" y="0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal12-4_pos_pos_top" x="214.5439373331128" y="75.008374317979" z="1528.0899316352588" unit="mm" />
+      <rotation name="crystal12-4_rot_pos_top" x="0.0590610984790547" y="-0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal12-4_pos_neg_top" x="-129.1835121173408" y="75.008374317979" z="1528.0899316352588" unit="mm" />
+      <rotation name="crystal12-4_rot_neg_top" x="0.0590610984790547" y="0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal13-4_pos_pos_bot" x="229.66580787843168" y="-74.108374317979" z="1527.9283591362796" unit="mm" />
+      <rotation name="crystal13-4_rot_pos_bot" x="-0.0590610984790547" y="-0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal13-4_pos_neg_bot" x="-144.30538266265967" y="-74.108374317979" z="1527.9283591362796" unit="mm" />
+      <rotation name="crystal13-4_rot_neg_bot" x="-0.0590610984790547" y="0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal13-4_pos_pos_top" x="229.66580787843168" y="75.008374317979" z="1527.9283591362796" unit="mm" />
+      <rotation name="crystal13-4_rot_pos_top" x="0.0590610984790547" y="-0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal13-4_pos_neg_top" x="-144.30538266265967" y="75.008374317979" z="1527.9283591362796" unit="mm" />
+      <rotation name="crystal13-4_rot_neg_top" x="0.0590610984790547" y="0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal14-4_pos_pos_bot" x="244.83390600570817" y="-74.108374317979" z="1527.744115436989" unit="mm" />
+      <rotation name="crystal14-4_rot_pos_bot" x="-0.0590610984790547" y="-0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal14-4_pos_neg_bot" x="-159.47348078993616" y="-74.108374317979" z="1527.744115436989" unit="mm" />
+      <rotation name="crystal14-4_rot_neg_bot" x="-0.0590610984790547" y="0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal14-4_pos_pos_top" x="244.83390600570817" y="75.008374317979" z="1527.744115436989" unit="mm" />
+      <rotation name="crystal14-4_rot_pos_top" x="0.0590610984790547" y="-0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal14-4_pos_neg_top" x="-159.47348078993616" y="75.008374317979" z="1527.744115436989" unit="mm" />
+      <rotation name="crystal14-4_rot_neg_top" x="0.0590610984790547" y="0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal15-4_pos_pos_bot" x="260.0521159861688" y="-74.108374317979" z="1527.537252999924" unit="mm" />
+      <rotation name="crystal15-4_rot_pos_bot" x="-0.0590610984790547" y="-0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal15-4_pos_neg_bot" x="-174.6916907703968" y="-74.108374317979" z="1527.537252999924" unit="mm" />
+      <rotation name="crystal15-4_rot_neg_bot" x="-0.0590610984790547" y="0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal15-4_pos_pos_top" x="260.0521159861688" y="75.008374317979" z="1527.537252999924" unit="mm" />
+      <rotation name="crystal15-4_rot_pos_top" x="0.0590610984790547" y="-0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal15-4_pos_neg_top" x="-174.6916907703968" y="75.008374317979" z="1527.537252999924" unit="mm" />
+      <rotation name="crystal15-4_rot_neg_top" x="0.0590610984790547" y="0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal16-4_pos_pos_bot" x="275.32440401422616" y="-74.108374317979" z="1527.3078307282033" unit="mm" />
+      <rotation name="crystal16-4_rot_pos_bot" x="-0.0590610984790547" y="-0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal16-4_pos_neg_bot" x="-189.96397879845415" y="-74.108374317979" z="1527.3078307282033" unit="mm" />
+      <rotation name="crystal16-4_rot_neg_bot" x="-0.0590610984790547" y="0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal16-4_pos_pos_top" x="275.32440401422616" y="75.008374317979" z="1527.3078307282033" unit="mm" />
+      <rotation name="crystal16-4_rot_pos_top" x="0.0590610984790547" y="-0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal16-4_pos_neg_top" x="-189.96397879845415" y="75.008374317979" z="1527.3078307282033" unit="mm" />
+      <rotation name="crystal16-4_rot_neg_top" x="0.0590610984790547" y="0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal17-4_pos_pos_bot" x="290.6548257567732" y="-74.108374317979" z="1527.0559139487518" unit="mm" />
+      <rotation name="crystal17-4_rot_pos_bot" x="-0.0590610984790547" y="-0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal17-4_pos_neg_bot" x="-205.2944005410012" y="-74.108374317979" z="1527.0559139487518" unit="mm" />
+      <rotation name="crystal17-4_rot_neg_bot" x="-0.0590610984790547" y="0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal17-4_pos_pos_top" x="290.6548257567732" y="75.008374317979" z="1527.0559139487518" unit="mm" />
+      <rotation name="crystal17-4_rot_pos_top" x="0.0590610984790547" y="-0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal17-4_pos_neg_top" x="-205.2944005410012" y="75.008374317979" z="1527.0559139487518" unit="mm" />
+      <rotation name="crystal17-4_rot_neg_top" x="0.0590610984790547" y="0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal18-4_pos_pos_bot" x="306.0475342431027" y="-74.108374317979" z="1526.7815743937024" unit="mm" />
+      <rotation name="crystal18-4_rot_pos_bot" x="-0.0590610984790547" y="-0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal18-4_pos_neg_bot" x="-220.68710902733068" y="-74.108374317979" z="1526.7815743937024" unit="mm" />
+      <rotation name="crystal18-4_rot_neg_bot" x="-0.0590610984790547" y="0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal18-4_pos_pos_top" x="306.0475342431027" y="75.008374317979" z="1526.7815743937024" unit="mm" />
+      <rotation name="crystal18-4_rot_pos_top" x="0.0590610984790547" y="-0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal18-4_pos_neg_top" x="-220.68710902733068" y="75.008374317979" z="1526.7815743937024" unit="mm" />
+      <rotation name="crystal18-4_rot_neg_top" x="0.0590610984790547" y="0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal19-4_pos_pos_bot" x="321.5067881308382" y="-74.108374317979" z="1526.4848901799687" unit="mm" />
+      <rotation name="crystal19-4_rot_pos_bot" x="-0.0590610984790547" y="-0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal19-4_pos_neg_bot" x="-236.14636291506616" y="-74.108374317979" z="1526.4848901799687" unit="mm" />
+      <rotation name="crystal19-4_rot_neg_bot" x="-0.0590610984790547" y="0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal19-4_pos_pos_top" x="321.5067881308382" y="75.008374317979" z="1526.4848901799687" unit="mm" />
+      <rotation name="crystal19-4_rot_pos_top" x="0.0590610984790547" y="-0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal19-4_pos_neg_top" x="-236.14636291506616" y="75.008374317979" z="1526.4848901799687" unit="mm" />
+      <rotation name="crystal19-4_rot_neg_top" x="0.0590610984790547" y="0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal20-4_pos_pos_bot" x="337.03696038609246" y="-74.108374317979" z="1526.165945787002" unit="mm" />
+      <rotation name="crystal20-4_rot_pos_bot" x="-0.0590610984790547" y="-0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal20-4_pos_neg_bot" x="-251.67653517032045" y="-74.108374317979" z="1526.165945787002" unit="mm" />
+      <rotation name="crystal20-4_rot_neg_bot" x="-0.0590610984790547" y="0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal20-4_pos_pos_top" x="337.03696038609246" y="75.008374317979" z="1526.165945787002" unit="mm" />
+      <rotation name="crystal20-4_rot_pos_top" x="0.0590610984790547" y="-0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal20-4_pos_neg_top" x="-251.67653517032045" y="75.008374317979" z="1526.165945787002" unit="mm" />
+      <rotation name="crystal20-4_rot_neg_top" x="0.0590610984790547" y="0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal21-4_pos_pos_bot" x="352.64254741924634" y="-74.108374317979" z="1525.8248320327364" unit="mm" />
+      <rotation name="crystal21-4_rot_pos_bot" x="-0.0590610984790547" y="-0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal21-4_pos_neg_bot" x="-267.28212220347433" y="-74.108374317979" z="1525.8248320327364" unit="mm" />
+      <rotation name="crystal21-4_rot_neg_bot" x="-0.0590610984790547" y="0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal21-4_pos_pos_top" x="352.64254741924634" y="75.008374317979" z="1525.8248320327364" unit="mm" />
+      <rotation name="crystal21-4_rot_pos_top" x="0.0590610984790547" y="-0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal21-4_pos_neg_top" x="-267.28212220347433" y="75.008374317979" z="1525.8248320327364" unit="mm" />
+      <rotation name="crystal21-4_rot_neg_top" x="0.0590610984790547" y="0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal22-4_pos_pos_bot" x="368.32817872130425" y="-74.108374317979" z="1525.4616460477282" unit="mm" />
+      <rotation name="crystal22-4_rot_pos_bot" x="-0.0590610984790547" y="-0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal22-4_pos_neg_bot" x="-282.96775350553224" y="-74.108374317979" z="1525.4616460477282" unit="mm" />
+      <rotation name="crystal22-4_rot_neg_bot" x="-0.0590610984790547" y="0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal22-4_pos_pos_top" x="368.32817872130425" y="75.008374317979" z="1525.4616460477282" unit="mm" />
+      <rotation name="crystal22-4_rot_pos_top" x="0.0590610984790547" y="-0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal22-4_pos_neg_top" x="-282.96775350553224" y="75.008374317979" z="1525.4616460477282" unit="mm" />
+      <rotation name="crystal22-4_rot_neg_top" x="0.0590610984790547" y="0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal23-4_pos_pos_bot" x="384.09862704978" y="-74.108374317979" z="1525.0764912474995" unit="mm" />
+      <rotation name="crystal23-4_rot_pos_bot" x="-0.0590610984790547" y="-0.3796784902224945" z="0.0" unit="radian" />
+      <position name="crystal23-4_pos_neg_bot" x="-298.738201834008" y="-74.108374317979" z="1525.0764912474995" unit="mm" />
+      <rotation name="crystal23-4_rot_neg_bot" x="-0.0590610984790547" y="0.3796784902224945" z="0.0" unit="radian" />
+      <position name="crystal23-4_pos_pos_top" x="384.09862704978" y="75.008374317979" z="1525.0764912474995" unit="mm" />
+      <rotation name="crystal23-4_rot_pos_top" x="0.0590610984790547" y="-0.3796784902224945" z="0.0" unit="radian" />
+      <position name="crystal23-4_pos_neg_top" x="-298.738201834008" y="75.008374317979" z="1525.0764912474995" unit="mm" />
+      <rotation name="crystal23-4_rot_neg_top" x="0.0590610984790547" y="0.3796784902224945" z="0.0" unit="radian" />
+      <position name="crystal1-5_pos_pos_bot" x="50.20495188328156" y="-89.1427015552106" z="1528.3833170846683" unit="mm" />
+      <rotation name="crystal1-5_rot_pos_bot" x="-0.0759356980444989" y="-0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal1-5_pos_neg_bot" x="35.15547333249048" y="-89.1427015552106" z="1528.3833170846683" unit="mm" />
+      <rotation name="crystal1-5_rot_neg_bot" x="-0.0759356980444989" y="0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal1-5_pos_pos_top" x="50.20495188328156" y="90.0427015552106" z="1528.3833170846683" unit="mm" />
+      <rotation name="crystal1-5_rot_pos_top" x="0.0759356980444989" y="-0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal1-5_pos_neg_top" x="35.15547333249048" y="90.0427015552106" z="1528.3833170846683" unit="mm" />
+      <rotation name="crystal1-5_rot_neg_top" x="0.0759356980444989" y="0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal2-5_pos_pos_bot" x="65.05802548582456" y="-89.1427015552106" z="1528.4727370465882" unit="mm" />
+      <rotation name="crystal2-5_rot_pos_bot" x="-0.0759356980444989" y="-0.0253118993481663" z="0.0" unit="radian" />
+      <position name="crystal2-5_pos_neg_bot" x="20.302399729947485" y="-89.1427015552106" z="1528.4727370465882" unit="mm" />
+      <rotation name="crystal2-5_rot_neg_bot" x="-0.0759356980444989" y="0.0253118993481663" z="0.0" unit="radian" />
+      <position name="crystal2-5_pos_pos_top" x="65.05802548582456" y="90.0427015552106" z="1528.4727370465882" unit="mm" />
+      <rotation name="crystal2-5_rot_pos_top" x="0.0759356980444989" y="-0.0253118993481663" z="0.0" unit="radian" />
+      <position name="crystal2-5_pos_neg_top" x="20.302399729947485" y="90.0427015552106" z="1528.4727370465882" unit="mm" />
+      <rotation name="crystal2-5_rot_neg_top" x="0.0759356980444989" y="0.0253118993481663" z="0.0" unit="radian" />
+      <position name="crystal3-5_pos_pos_bot" x="79.9180994782841" y="-89.1427015552106" z="1528.5393367528022" unit="mm" />
+      <rotation name="crystal3-5_rot_pos_bot" x="-0.0759356980444989" y="-0.042186498913610496" z="0.0" unit="radian" />
+      <position name="crystal3-5_pos_neg_bot" x="5.442325737487934" y="-89.1427015552106" z="1528.5393367528022" unit="mm" />
+      <rotation name="crystal3-5_rot_neg_bot" x="-0.0759356980444989" y="0.042186498913610496" z="0.0" unit="radian" />
+      <position name="crystal3-5_pos_pos_top" x="79.9180994782841" y="90.0427015552106" z="1528.5393367528022" unit="mm" />
+      <rotation name="crystal3-5_rot_pos_top" x="0.0759356980444989" y="-0.042186498913610496" z="0.0" unit="radian" />
+      <position name="crystal3-5_pos_neg_top" x="5.442325737487934" y="90.0427015552106" z="1528.5393367528022" unit="mm" />
+      <rotation name="crystal3-5_rot_neg_top" x="0.0759356980444989" y="0.042186498913610496" z="0.0" unit="radian" />
+      <position name="crystal4-5_pos_pos_bot" x="94.78858692586502" y="-89.1427015552106" z="1528.5830972393524" unit="mm" />
+      <rotation name="crystal4-5_rot_pos_bot" x="-0.0759356980444989" y="-0.0590610984790547" z="0.0" unit="radian" />
+      <position name="crystal4-5_pos_neg_bot" x="-9.42816171009298" y="-89.1427015552106" z="1528.5830972393524" unit="mm" />
+      <rotation name="crystal4-5_rot_neg_bot" x="-0.0759356980444989" y="0.0590610984790547" z="0.0" unit="radian" />
+      <position name="crystal4-5_pos_pos_top" x="94.78858692586502" y="90.0427015552106" z="1528.5830972393524" unit="mm" />
+      <rotation name="crystal4-5_rot_pos_top" x="0.0759356980444989" y="-0.0590610984790547" z="0.0" unit="radian" />
+      <position name="crystal4-5_pos_neg_top" x="-9.42816171009298" y="90.0427015552106" z="1528.5830972393524" unit="mm" />
+      <rotation name="crystal4-5_rot_neg_top" x="0.0759356980444989" y="0.0590610984790547" z="0.0" unit="radian" />
+      <position name="crystal5-5_pos_pos_bot" x="109.67291416309662" y="-89.1427015552106" z="1528.6040060456442" unit="mm" />
+      <rotation name="crystal5-5_rot_pos_bot" x="-0.0759356980444989" y="-0.0759356980444989" z="0.0" unit="radian" />
+      <position name="crystal5-5_pos_neg_bot" x="-24.31248894732458" y="-89.1427015552106" z="1528.6040060456442" unit="mm" />
+      <rotation name="crystal5-5_rot_neg_bot" x="-0.0759356980444989" y="0.0759356980444989" z="0.0" unit="radian" />
+      <position name="crystal5-5_pos_pos_top" x="109.67291416309662" y="90.0427015552106" z="1528.6040060456442" unit="mm" />
+      <rotation name="crystal5-5_rot_pos_top" x="0.0759356980444989" y="-0.0759356980444989" z="0.0" unit="radian" />
+      <position name="crystal5-5_pos_neg_top" x="-24.31248894732458" y="90.0427015552106" z="1528.6040060456442" unit="mm" />
+      <rotation name="crystal5-5_rot_neg_top" x="0.0759356980444989" y="0.0759356980444989" z="0.0" unit="radian" />
+      <position name="crystal6-5_pos_pos_bot" x="124.57452638340096" y="-89.1427015552106" z="1528.602057217992" unit="mm" />
+      <rotation name="crystal6-5_rot_pos_bot" x="-0.0759356980444989" y="-0.0928102976099431" z="0.0" unit="radian" />
+      <position name="crystal6-5_pos_neg_bot" x="-39.214101167628925" y="-89.1427015552106" z="1528.602057217992" unit="mm" />
+      <rotation name="crystal6-5_rot_neg_bot" x="-0.0759356980444989" y="0.0928102976099431" z="0.0" unit="radian" />
+      <position name="crystal6-5_pos_pos_top" x="124.57452638340096" y="90.0427015552106" z="1528.602057217992" unit="mm" />
+      <rotation name="crystal6-5_rot_pos_top" x="0.0759356980444989" y="-0.0928102976099431" z="0.0" unit="radian" />
+      <position name="crystal6-5_pos_neg_top" x="-39.214101167628925" y="90.0427015552106" z="1528.602057217992" unit="mm" />
+      <rotation name="crystal6-5_rot_neg_top" x="0.0759356980444989" y="0.0928102976099431" z="0.0" unit="radian" />
+      <position name="crystal7-5_pos_pos_bot" x="139.4968932952259" y="-89.1427015552106" z="1528.5772513113154" unit="mm" />
+      <rotation name="crystal7-5_rot_pos_bot" x="-0.0759356980444989" y="-0.10968489717538729" z="0.0" unit="radian" />
+      <position name="crystal7-5_pos_neg_bot" x="-54.13646807945388" y="-89.1427015552106" z="1528.5772513113154" unit="mm" />
+      <rotation name="crystal7-5_rot_neg_bot" x="-0.0759356980444989" y="0.10968489717538729" z="0.0" unit="radian" />
+      <position name="crystal7-5_pos_pos_top" x="139.4968932952259" y="90.0427015552106" z="1528.5772513113154" unit="mm" />
+      <rotation name="crystal7-5_rot_pos_top" x="0.0759356980444989" y="-0.10968489717538729" z="0.0" unit="radian" />
+      <position name="crystal7-5_pos_neg_top" x="-54.13646807945388" y="90.0427015552106" z="1528.5772513113154" unit="mm" />
+      <rotation name="crystal7-5_rot_neg_top" x="0.0759356980444989" y="0.10968489717538729" z="0.0" unit="radian" />
+      <position name="crystal8-5_pos_pos_bot" x="154.44351486445828" y="-89.1427015552106" z="1528.5295953889813" unit="mm" />
+      <rotation name="crystal8-5_rot_pos_bot" x="-0.0759356980444989" y="-0.1265594967408315" z="0.0" unit="radian" />
+      <position name="crystal8-5_pos_neg_bot" x="-69.08308964868624" y="-89.1427015552106" z="1528.5295953889813" unit="mm" />
+      <rotation name="crystal8-5_rot_neg_bot" x="-0.0759356980444989" y="0.1265594967408315" z="0.0" unit="radian" />
+      <position name="crystal8-5_pos_pos_top" x="154.44351486445828" y="90.0427015552106" z="1528.5295953889813" unit="mm" />
+      <rotation name="crystal8-5_rot_pos_top" x="0.0759356980444989" y="-0.1265594967408315" z="0.0" unit="radian" />
+      <position name="crystal8-5_pos_neg_top" x="-69.08308964868624" y="90.0427015552106" z="1528.5295953889813" unit="mm" />
+      <rotation name="crystal8-5_rot_neg_top" x="0.0759356980444989" y="0.1265594967408315" z="0.0" unit="radian" />
+      <position name="crystal9-5_pos_pos_bot" x="169.41792716339802" y="-89.1427015552106" z="1528.4591030207916" unit="mm" />
+      <rotation name="crystal9-5_rot_pos_bot" x="-0.0759356980444989" y="-0.14343409630627568" z="0.0" unit="radian" />
+      <position name="crystal9-5_pos_neg_bot" x="-84.057501947626" y="-89.1427015552106" z="1528.4591030207916" unit="mm" />
+      <rotation name="crystal9-5_rot_neg_bot" x="-0.0759356980444989" y="0.14343409630627568" z="0.0" unit="radian" />
+      <position name="crystal9-5_pos_pos_top" x="169.41792716339802" y="90.0427015552106" z="1528.4591030207916" unit="mm" />
+      <rotation name="crystal9-5_rot_pos_top" x="0.0759356980444989" y="-0.14343409630627568" z="0.0" unit="radian" />
+      <position name="crystal9-5_pos_neg_top" x="-84.057501947626" y="90.0427015552106" z="1528.4591030207916" unit="mm" />
+      <rotation name="crystal9-5_rot_neg_top" x="0.0759356980444989" y="0.14343409630627568" z="0.0" unit="radian" />
+      <position name="crystal10-5_pos_pos_bot" x="184.42370834727978" y="-89.1427015552106" z="1528.3657942791212" unit="mm" />
+      <rotation name="crystal10-5_rot_pos_bot" x="-0.0759356980444989" y="-0.1603086958717199" z="0.0" unit="radian" />
+      <position name="crystal10-5_pos_neg_bot" x="-99.06328313150773" y="-89.1427015552106" z="1528.3657942791212" unit="mm" />
+      <rotation name="crystal10-5_rot_neg_bot" x="-0.0759356980444989" y="0.1603086958717199" z="0.0" unit="radian" />
+      <position name="crystal10-5_pos_pos_top" x="184.42370834727978" y="90.0427015552106" z="1528.3657942791212" unit="mm" />
+      <rotation name="crystal10-5_rot_pos_top" x="0.0759356980444989" y="-0.1603086958717199" z="0.0" unit="radian" />
+      <position name="crystal10-5_pos_neg_top" x="-99.06328313150773" y="90.0427015552106" z="1528.3657942791212" unit="mm" />
+      <rotation name="crystal10-5_rot_neg_top" x="0.0759356980444989" y="0.1603086958717199" z="0.0" unit="radian" />
+      <position name="crystal11-5_pos_pos_bot" x="199.46448478017476" y="-89.1427015552106" z="1528.2496957332003" unit="mm" />
+      <rotation name="crystal11-5_rot_pos_bot" x="-0.0759356980444989" y="-0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal11-5_pos_neg_bot" x="-114.1040595644027" y="-89.1427015552106" z="1528.2496957332003" unit="mm" />
+      <rotation name="crystal11-5_rot_neg_bot" x="-0.0759356980444989" y="0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal11-5_pos_pos_top" x="199.46448478017476" y="90.0427015552106" z="1528.2496957332003" unit="mm" />
+      <rotation name="crystal11-5_rot_pos_top" x="0.0759356980444989" y="-0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal11-5_pos_neg_top" x="-114.1040595644027" y="90.0427015552106" z="1528.2496957332003" unit="mm" />
+      <rotation name="crystal11-5_rot_neg_top" x="0.0759356980444989" y="0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal12-5_pos_pos_bot" x="214.5439373331128" y="-89.1427015552106" z="1528.1108404415506" unit="mm" />
+      <rotation name="crystal12-5_rot_pos_bot" x="-0.0759356980444989" y="-0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal12-5_pos_neg_bot" x="-129.1835121173408" y="-89.1427015552106" z="1528.1108404415506" unit="mm" />
+      <rotation name="crystal12-5_rot_neg_bot" x="-0.0759356980444989" y="0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal12-5_pos_pos_top" x="214.5439373331128" y="90.0427015552106" z="1528.1108404415506" unit="mm" />
+      <rotation name="crystal12-5_rot_pos_top" x="0.0759356980444989" y="-0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal12-5_pos_neg_top" x="-129.1835121173408" y="90.0427015552106" z="1528.1108404415506" unit="mm" />
+      <rotation name="crystal12-5_rot_neg_top" x="0.0759356980444989" y="0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal13-5_pos_pos_bot" x="229.66580787843168" y="-89.1427015552106" z="1527.9492679425712" unit="mm" />
+      <rotation name="crystal13-5_rot_pos_bot" x="-0.0759356980444989" y="-0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal13-5_pos_neg_bot" x="-144.30538266265967" y="-89.1427015552106" z="1527.9492679425712" unit="mm" />
+      <rotation name="crystal13-5_rot_neg_bot" x="-0.0759356980444989" y="0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal13-5_pos_pos_top" x="229.66580787843168" y="90.0427015552106" z="1527.9492679425712" unit="mm" />
+      <rotation name="crystal13-5_rot_pos_top" x="0.0759356980444989" y="-0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal13-5_pos_neg_top" x="-144.30538266265967" y="90.0427015552106" z="1527.9492679425712" unit="mm" />
+      <rotation name="crystal13-5_rot_neg_top" x="0.0759356980444989" y="0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal14-5_pos_pos_bot" x="244.83390600570817" y="-89.1427015552106" z="1527.7650242432805" unit="mm" />
+      <rotation name="crystal14-5_rot_pos_bot" x="-0.0759356980444989" y="-0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal14-5_pos_neg_bot" x="-159.47348078993616" y="-89.1427015552106" z="1527.7650242432805" unit="mm" />
+      <rotation name="crystal14-5_rot_neg_bot" x="-0.0759356980444989" y="0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal14-5_pos_pos_top" x="244.83390600570817" y="90.0427015552106" z="1527.7650242432805" unit="mm" />
+      <rotation name="crystal14-5_rot_pos_top" x="0.0759356980444989" y="-0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal14-5_pos_neg_top" x="-159.47348078993616" y="90.0427015552106" z="1527.7650242432805" unit="mm" />
+      <rotation name="crystal14-5_rot_neg_top" x="0.0759356980444989" y="0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal15-5_pos_pos_bot" x="260.0521159861688" y="-89.1427015552106" z="1527.5581618062158" unit="mm" />
+      <rotation name="crystal15-5_rot_pos_bot" x="-0.0759356980444989" y="-0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal15-5_pos_neg_bot" x="-174.6916907703968" y="-89.1427015552106" z="1527.5581618062158" unit="mm" />
+      <rotation name="crystal15-5_rot_neg_bot" x="-0.0759356980444989" y="0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal15-5_pos_pos_top" x="260.0521159861688" y="90.0427015552106" z="1527.5581618062158" unit="mm" />
+      <rotation name="crystal15-5_rot_pos_top" x="0.0759356980444989" y="-0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal15-5_pos_neg_top" x="-174.6916907703968" y="90.0427015552106" z="1527.5581618062158" unit="mm" />
+      <rotation name="crystal15-5_rot_neg_top" x="0.0759356980444989" y="0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal16-5_pos_pos_bot" x="275.32440401422616" y="-89.1427015552106" z="1527.328739534495" unit="mm" />
+      <rotation name="crystal16-5_rot_pos_bot" x="-0.0759356980444989" y="-0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal16-5_pos_neg_bot" x="-189.96397879845415" y="-89.1427015552106" z="1527.328739534495" unit="mm" />
+      <rotation name="crystal16-5_rot_neg_bot" x="-0.0759356980444989" y="0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal16-5_pos_pos_top" x="275.32440401422616" y="90.0427015552106" z="1527.328739534495" unit="mm" />
+      <rotation name="crystal16-5_rot_pos_top" x="0.0759356980444989" y="-0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal16-5_pos_neg_top" x="-189.96397879845415" y="90.0427015552106" z="1527.328739534495" unit="mm" />
+      <rotation name="crystal16-5_rot_neg_top" x="0.0759356980444989" y="0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal17-5_pos_pos_bot" x="290.6548257567732" y="-89.1427015552106" z="1527.0768227550436" unit="mm" />
+      <rotation name="crystal17-5_rot_pos_bot" x="-0.0759356980444989" y="-0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal17-5_pos_neg_bot" x="-205.2944005410012" y="-89.1427015552106" z="1527.0768227550436" unit="mm" />
+      <rotation name="crystal17-5_rot_neg_bot" x="-0.0759356980444989" y="0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal17-5_pos_pos_top" x="290.6548257567732" y="90.0427015552106" z="1527.0768227550436" unit="mm" />
+      <rotation name="crystal17-5_rot_pos_top" x="0.0759356980444989" y="-0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal17-5_pos_neg_top" x="-205.2944005410012" y="90.0427015552106" z="1527.0768227550436" unit="mm" />
+      <rotation name="crystal17-5_rot_neg_top" x="0.0759356980444989" y="0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal18-5_pos_pos_bot" x="306.0475342431027" y="-89.1427015552106" z="1526.8024831999942" unit="mm" />
+      <rotation name="crystal18-5_rot_pos_bot" x="-0.0759356980444989" y="-0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal18-5_pos_neg_bot" x="-220.68710902733068" y="-89.1427015552106" z="1526.8024831999942" unit="mm" />
+      <rotation name="crystal18-5_rot_neg_bot" x="-0.0759356980444989" y="0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal18-5_pos_pos_top" x="306.0475342431027" y="90.0427015552106" z="1526.8024831999942" unit="mm" />
+      <rotation name="crystal18-5_rot_pos_top" x="0.0759356980444989" y="-0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal18-5_pos_neg_top" x="-220.68710902733068" y="90.0427015552106" z="1526.8024831999942" unit="mm" />
+      <rotation name="crystal18-5_rot_neg_top" x="0.0759356980444989" y="0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal19-5_pos_pos_bot" x="321.5067881308382" y="-89.1427015552106" z="1526.5057989862605" unit="mm" />
+      <rotation name="crystal19-5_rot_pos_bot" x="-0.0759356980444989" y="-0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal19-5_pos_neg_bot" x="-236.14636291506616" y="-89.1427015552106" z="1526.5057989862605" unit="mm" />
+      <rotation name="crystal19-5_rot_neg_bot" x="-0.0759356980444989" y="0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal19-5_pos_pos_top" x="321.5067881308382" y="90.0427015552106" z="1526.5057989862605" unit="mm" />
+      <rotation name="crystal19-5_rot_pos_top" x="0.0759356980444989" y="-0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal19-5_pos_neg_top" x="-236.14636291506616" y="90.0427015552106" z="1526.5057989862605" unit="mm" />
+      <rotation name="crystal19-5_rot_neg_top" x="0.0759356980444989" y="0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal20-5_pos_pos_bot" x="337.03696038609246" y="-89.1427015552106" z="1526.186854593294" unit="mm" />
+      <rotation name="crystal20-5_rot_pos_bot" x="-0.0759356980444989" y="-0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal20-5_pos_neg_bot" x="-251.67653517032045" y="-89.1427015552106" z="1526.186854593294" unit="mm" />
+      <rotation name="crystal20-5_rot_neg_bot" x="-0.0759356980444989" y="0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal20-5_pos_pos_top" x="337.03696038609246" y="90.0427015552106" z="1526.186854593294" unit="mm" />
+      <rotation name="crystal20-5_rot_pos_top" x="0.0759356980444989" y="-0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal20-5_pos_neg_top" x="-251.67653517032045" y="90.0427015552106" z="1526.186854593294" unit="mm" />
+      <rotation name="crystal20-5_rot_neg_top" x="0.0759356980444989" y="0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal21-5_pos_pos_bot" x="352.64254741924634" y="-89.1427015552106" z="1525.8457408390282" unit="mm" />
+      <rotation name="crystal21-5_rot_pos_bot" x="-0.0759356980444989" y="-0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal21-5_pos_neg_bot" x="-267.28212220347433" y="-89.1427015552106" z="1525.8457408390282" unit="mm" />
+      <rotation name="crystal21-5_rot_neg_bot" x="-0.0759356980444989" y="0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal21-5_pos_pos_top" x="352.64254741924634" y="90.0427015552106" z="1525.8457408390282" unit="mm" />
+      <rotation name="crystal21-5_rot_pos_top" x="0.0759356980444989" y="-0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal21-5_pos_neg_top" x="-267.28212220347433" y="90.0427015552106" z="1525.8457408390282" unit="mm" />
+      <rotation name="crystal21-5_rot_neg_top" x="0.0759356980444989" y="0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal22-5_pos_pos_bot" x="368.32817872130425" y="-89.1427015552106" z="1525.48255485402" unit="mm" />
+      <rotation name="crystal22-5_rot_pos_bot" x="-0.0759356980444989" y="-0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal22-5_pos_neg_bot" x="-282.96775350553224" y="-89.1427015552106" z="1525.48255485402" unit="mm" />
+      <rotation name="crystal22-5_rot_neg_bot" x="-0.0759356980444989" y="0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal22-5_pos_pos_top" x="368.32817872130425" y="90.0427015552106" z="1525.48255485402" unit="mm" />
+      <rotation name="crystal22-5_rot_pos_top" x="0.0759356980444989" y="-0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal22-5_pos_neg_top" x="-282.96775350553224" y="90.0427015552106" z="1525.48255485402" unit="mm" />
+      <rotation name="crystal22-5_rot_neg_top" x="0.0759356980444989" y="0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal23-5_pos_pos_bot" x="384.09862704978" y="-89.1427015552106" z="1525.0974000537913" unit="mm" />
+      <rotation name="crystal23-5_rot_pos_bot" x="-0.0759356980444989" y="-0.3796784902224945" z="0.0" unit="radian" />
+      <position name="crystal23-5_pos_neg_bot" x="-298.738201834008" y="-89.1427015552106" z="1525.0974000537913" unit="mm" />
+      <rotation name="crystal23-5_rot_neg_bot" x="-0.0759356980444989" y="0.3796784902224945" z="0.0" unit="radian" />
+      <position name="crystal23-5_pos_pos_top" x="384.09862704978" y="90.0427015552106" z="1525.0974000537913" unit="mm" />
+      <rotation name="crystal23-5_rot_pos_top" x="0.0759356980444989" y="-0.3796784902224945" z="0.0" unit="radian" />
+      <position name="crystal23-5_pos_neg_top" x="-298.738201834008" y="90.0427015552106" z="1525.0974000537913" unit="mm" />
+      <rotation name="crystal23-5_rot_neg_top" x="0.0759356980444989" y="0.3796784902224945" z="0.0" unit="radian" />
+      <rotation name="hodo_rot" x="0.0" y="0.0" z="0.0" unit="radian" />
+      <position name="hodo_pos_L1TP0" x="73.63" y="44.2" z="1103.5" unit="mm" />
+      <position name="hodo_forecover_pos_L1TP0" x="73.63" y="44.2" z="1098.625" unit="mm" />
+      <position name="hodo_postcover_pos_L1TP0" x="73.63" y="44.2" z="1108.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L1TP0" x="65.75500000000001" y="44.2" z="1103.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L1TP0" x="81.50500000000001" y="44.2" z="1103.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L1TP0" x="73.63" y="74.17500000000001" z="1103.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L1TP0" x="73.63" y="14.225000000000003" z="1103.5" unit="mm" />
+      <position name="hodo_pos_L1BP0" x="73.63" y="-44.2" z="1103.5" unit="mm" />
+      <position name="hodo_forecover_pos_L1BP0" x="73.63" y="-44.2" z="1098.625" unit="mm" />
+      <position name="hodo_postcover_pos_L1BP0" x="73.63" y="-44.2" z="1108.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L1BP0" x="65.75500000000001" y="-44.2" z="1103.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L1BP0" x="81.50500000000001" y="-44.2" z="1103.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L1BP0" x="73.63" y="-14.225000000000003" z="1103.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L1BP0" x="73.63" y="-74.17500000000001" z="1103.5" unit="mm" />
+      <position name="hodo_pos_L1TP1" x="98.63" y="44.2" z="1103.5" unit="mm" />
+      <position name="hodo_forecover_pos_L1TP1" x="98.63" y="44.2" z="1098.625" unit="mm" />
+      <position name="hodo_postcover_pos_L1TP1" x="98.63" y="44.2" z="1108.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L1TP1" x="81.555" y="44.2" z="1103.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L1TP1" x="115.70500000000001" y="44.2" z="1103.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L1TP1" x="98.63" y="74.17500000000001" z="1103.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L1TP1" x="98.63" y="14.225000000000003" z="1103.5" unit="mm" />
+      <position name="hodo_pos_L1BP1" x="98.63" y="-44.2" z="1103.5" unit="mm" />
+      <position name="hodo_forecover_pos_L1BP1" x="98.63" y="-44.2" z="1098.625" unit="mm" />
+      <position name="hodo_postcover_pos_L1BP1" x="98.63" y="-44.2" z="1108.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L1BP1" x="81.555" y="-44.2" z="1103.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L1BP1" x="115.70500000000001" y="-44.2" z="1103.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L1BP1" x="98.63" y="-14.225000000000003" z="1103.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L1BP1" x="98.63" y="-74.17500000000001" z="1103.5" unit="mm" />
+      <position name="hodo_pos_L1TP2" x="137.78" y="44.2" z="1103.5" unit="mm" />
+      <position name="hodo_forecover_pos_L1TP2" x="137.78" y="44.2" z="1098.625" unit="mm" />
+      <position name="hodo_postcover_pos_L1TP2" x="137.78" y="44.2" z="1108.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L1TP2" x="115.75500000000001" y="44.2" z="1103.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L1TP2" x="159.805" y="44.2" z="1103.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L1TP2" x="137.78" y="74.17500000000001" z="1103.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L1TP2" x="137.78" y="14.225000000000003" z="1103.5" unit="mm" />
+      <position name="hodo_pos_L1BP2" x="137.78" y="-44.2" z="1103.5" unit="mm" />
+      <position name="hodo_forecover_pos_L1BP2" x="137.78" y="-44.2" z="1098.625" unit="mm" />
+      <position name="hodo_postcover_pos_L1BP2" x="137.78" y="-44.2" z="1108.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L1BP2" x="115.75500000000001" y="-44.2" z="1103.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L1BP2" x="159.805" y="-44.2" z="1103.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L1BP2" x="137.78" y="-14.225000000000003" z="1103.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L1BP2" x="137.78" y="-74.17500000000001" z="1103.5" unit="mm" />
+      <position name="hodo_pos_L1TP3" x="181.88" y="44.2" z="1103.5" unit="mm" />
+      <position name="hodo_forecover_pos_L1TP3" x="181.88" y="44.2" z="1098.625" unit="mm" />
+      <position name="hodo_postcover_pos_L1TP3" x="181.88" y="44.2" z="1108.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L1TP3" x="159.855" y="44.2" z="1103.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L1TP3" x="203.905" y="44.2" z="1103.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L1TP3" x="181.88" y="74.17500000000001" z="1103.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L1TP3" x="181.88" y="14.225000000000003" z="1103.5" unit="mm" />
+      <position name="hodo_pos_L1BP3" x="181.88" y="-44.2" z="1103.5" unit="mm" />
+      <position name="hodo_forecover_pos_L1BP3" x="181.88" y="-44.2" z="1098.625" unit="mm" />
+      <position name="hodo_postcover_pos_L1BP3" x="181.88" y="-44.2" z="1108.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L1BP3" x="159.855" y="-44.2" z="1103.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L1BP3" x="203.905" y="-44.2" z="1103.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L1BP3" x="181.88" y="-14.225000000000003" z="1103.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L1BP3" x="181.88" y="-74.17500000000001" z="1103.5" unit="mm" />
+      <position name="hodo_pos_L1TP4" x="225.98000000000002" y="44.2" z="1103.5" unit="mm" />
+      <position name="hodo_forecover_pos_L1TP4" x="225.98000000000002" y="44.2" z="1098.625" unit="mm" />
+      <position name="hodo_postcover_pos_L1TP4" x="225.98000000000002" y="44.2" z="1108.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L1TP4" x="203.955" y="44.2" z="1103.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L1TP4" x="248.00500000000002" y="44.2" z="1103.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L1TP4" x="225.98000000000002" y="74.17500000000001" z="1103.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L1TP4" x="225.98000000000002" y="14.225000000000003" z="1103.5" unit="mm" />
+      <position name="hodo_pos_L1BP4" x="225.98000000000002" y="-44.2" z="1103.5" unit="mm" />
+      <position name="hodo_forecover_pos_L1BP4" x="225.98000000000002" y="-44.2" z="1098.625" unit="mm" />
+      <position name="hodo_postcover_pos_L1BP4" x="225.98000000000002" y="-44.2" z="1108.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L1BP4" x="203.955" y="-44.2" z="1103.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L1BP4" x="248.00500000000002" y="-44.2" z="1103.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L1BP4" x="225.98000000000002" y="-14.225000000000003" z="1103.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L1BP4" x="225.98000000000002" y="-74.17500000000001" z="1103.5" unit="mm" />
+      <position name="hodo_pos_L2TP0" x="78.61999999999999" y="44.2" z="1115.5" unit="mm" />
+      <position name="hodo_forecover_pos_L2TP0" x="78.61999999999999" y="44.2" z="1110.625" unit="mm" />
+      <position name="hodo_postcover_pos_L2TP0" x="78.61999999999999" y="44.2" z="1120.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L2TP0" x="69.095" y="44.2" z="1115.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L2TP0" x="88.145" y="44.2" z="1115.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L2TP0" x="78.61999999999999" y="74.17500000000001" z="1115.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L2TP0" x="78.61999999999999" y="14.225000000000003" z="1115.5" unit="mm" />
+      <position name="hodo_pos_L2BP0" x="78.61999999999999" y="-44.2" z="1115.5" unit="mm" />
+      <position name="hodo_forecover_pos_L2BP0" x="78.61999999999999" y="-44.2" z="1110.625" unit="mm" />
+      <position name="hodo_postcover_pos_L2BP0" x="78.61999999999999" y="-44.2" z="1120.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L2BP0" x="69.095" y="-44.2" z="1115.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L2BP0" x="88.145" y="-44.2" z="1115.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L2BP0" x="78.61999999999999" y="-14.225000000000003" z="1115.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L2BP0" x="78.61999999999999" y="-74.17500000000001" z="1115.5" unit="mm" />
+      <position name="hodo_pos_L2TP1" x="110.22" y="44.2" z="1115.5" unit="mm" />
+      <position name="hodo_forecover_pos_L2TP1" x="110.22" y="44.2" z="1110.625" unit="mm" />
+      <position name="hodo_postcover_pos_L2TP1" x="110.22" y="44.2" z="1120.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L2TP1" x="88.19500000000001" y="44.2" z="1115.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L2TP1" x="132.245" y="44.2" z="1115.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L2TP1" x="110.22" y="74.17500000000001" z="1115.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L2TP1" x="110.22" y="14.225000000000003" z="1115.5" unit="mm" />
+      <position name="hodo_pos_L2BP1" x="110.22" y="-44.2" z="1115.5" unit="mm" />
+      <position name="hodo_forecover_pos_L2BP1" x="110.22" y="-44.2" z="1110.625" unit="mm" />
+      <position name="hodo_postcover_pos_L2BP1" x="110.22" y="-44.2" z="1120.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L2BP1" x="88.19500000000001" y="-44.2" z="1115.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L2BP1" x="132.245" y="-44.2" z="1115.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L2BP1" x="110.22" y="-14.225000000000003" z="1115.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L2BP1" x="110.22" y="-74.17500000000001" z="1115.5" unit="mm" />
+      <position name="hodo_pos_L2TP2" x="154.32000000000002" y="44.2" z="1115.5" unit="mm" />
+      <position name="hodo_forecover_pos_L2TP2" x="154.32000000000002" y="44.2" z="1110.625" unit="mm" />
+      <position name="hodo_postcover_pos_L2TP2" x="154.32000000000002" y="44.2" z="1120.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L2TP2" x="132.29500000000002" y="44.2" z="1115.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L2TP2" x="176.34500000000003" y="44.2" z="1115.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L2TP2" x="154.32000000000002" y="74.17500000000001" z="1115.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L2TP2" x="154.32000000000002" y="14.225000000000003" z="1115.5" unit="mm" />
+      <position name="hodo_pos_L2BP2" x="154.32000000000002" y="-44.2" z="1115.5" unit="mm" />
+      <position name="hodo_forecover_pos_L2BP2" x="154.32000000000002" y="-44.2" z="1110.625" unit="mm" />
+      <position name="hodo_postcover_pos_L2BP2" x="154.32000000000002" y="-44.2" z="1120.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L2BP2" x="132.29500000000002" y="-44.2" z="1115.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L2BP2" x="176.34500000000003" y="-44.2" z="1115.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L2BP2" x="154.32000000000002" y="-14.225000000000003" z="1115.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L2BP2" x="154.32000000000002" y="-74.17500000000001" z="1115.5" unit="mm" />
+      <position name="hodo_pos_L2TP3" x="198.42000000000004" y="44.2" z="1115.5" unit="mm" />
+      <position name="hodo_forecover_pos_L2TP3" x="198.42000000000004" y="44.2" z="1110.625" unit="mm" />
+      <position name="hodo_postcover_pos_L2TP3" x="198.42000000000004" y="44.2" z="1120.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L2TP3" x="176.39500000000004" y="44.2" z="1115.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L2TP3" x="220.44500000000005" y="44.2" z="1115.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L2TP3" x="198.42000000000004" y="74.17500000000001" z="1115.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L2TP3" x="198.42000000000004" y="14.225000000000003" z="1115.5" unit="mm" />
+      <position name="hodo_pos_L2BP3" x="198.42000000000004" y="-44.2" z="1115.5" unit="mm" />
+      <position name="hodo_forecover_pos_L2BP3" x="198.42000000000004" y="-44.2" z="1110.625" unit="mm" />
+      <position name="hodo_postcover_pos_L2BP3" x="198.42000000000004" y="-44.2" z="1120.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L2BP3" x="176.39500000000004" y="-44.2" z="1115.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L2BP3" x="220.44500000000005" y="-44.2" z="1115.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L2BP3" x="198.42000000000004" y="-14.225000000000003" z="1115.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L2BP3" x="198.42000000000004" y="-74.17500000000001" z="1115.5" unit="mm" />
+      <position name="hodo_pos_L2TP4" x="235.92000000000002" y="44.2" z="1115.5" unit="mm" />
+      <position name="hodo_forecover_pos_L2TP4" x="235.92000000000002" y="44.2" z="1110.625" unit="mm" />
+      <position name="hodo_postcover_pos_L2TP4" x="235.92000000000002" y="44.2" z="1120.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L2TP4" x="220.495" y="44.2" z="1115.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L2TP4" x="251.34500000000003" y="44.2" z="1115.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L2TP4" x="235.92000000000002" y="74.17500000000001" z="1115.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L2TP4" x="235.92000000000002" y="14.225000000000003" z="1115.5" unit="mm" />
+      <position name="hodo_pos_L2BP4" x="235.92000000000002" y="-44.2" z="1115.5" unit="mm" />
+      <position name="hodo_forecover_pos_L2BP4" x="235.92000000000002" y="-44.2" z="1110.625" unit="mm" />
+      <position name="hodo_postcover_pos_L2BP4" x="235.92000000000002" y="-44.2" z="1120.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L2BP4" x="220.495" y="-44.2" z="1115.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L2BP4" x="251.34500000000003" y="-44.2" z="1115.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L2BP4" x="235.92000000000002" y="-14.225000000000003" z="1115.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L2BP4" x="235.92000000000002" y="-74.17500000000001" z="1115.5" unit="mm" />
+      <position name="hodo_bufferT_pos" x="153.99" y="54.2" z="1109.5" unit="mm" />
+      <position name="hodo_bufferB_pos" x="153.99" y="-54.2" z="1109.5" unit="mm" />
+      <position name="front_flange_1inworld_volumepos" x="2.1420000000000003" y="0" z="137.80000000000001" unit="cm" />
+      <position name="back_flange_1inworld_volumepos" x="-12.608499999999999" y="0" z="180.80000000000001" unit="cm" />
+      <position name="ECAL_chamber_1inworld_volumepos" x="-11.940800000000001" y="0" z="159.30000000000001" unit="cm" />
+      <position name="al_honeycomb_1inworld_volumepos" x="-18.858000000000001" y="0" z="155.80000000000001" unit="cm" />
+      <position name="layer_1_top_1inworld_volumepos" x="4.1920000000000002" y="8.0999999999999996" z="152.80000000000001" unit="cm" />
+      <position name="layer_2_top_1inworld_volumepos" x="4.1920000000000002" y="6.6899999999999995" z="152.80000000000001" unit="cm" />
+      <position name="layer_3_top_1inworld_volumepos" x="4.1920000000000002" y="5.2799999999999994" z="152.80000000000001" unit="cm" />
+      <position name="layer_4_top_1inworld_volumepos" x="4.1920000000000002" y="3.8699999999999992" z="152.80000000000001" unit="cm" />
+      <position name="layer_1_bottom_1inworld_volumepos" x="4.1920000000000002" y="-4.0999999999999996" z="152.80000000000001" unit="cm" />
+      <position name="layer_2_bottom_1inworld_volumepos" x="4.1920000000000002" y="-5.5099999999999998" z="152.80000000000001" unit="cm" />
+      <position name="layer_3_bottom_1inworld_volumepos" x="4.1920000000000002" y="-6.9199999999999999" z="152.80000000000001" unit="cm" />
+      <position name="layer_4_bottom_1inworld_volumepos" x="4.1920000000000002" y="-8.3300000000000001" z="152.80000000000001" unit="cm" />
+      <position name="layer_5T_left_1inworld_volumepos" x="4.1920000000000002" y="2.46" z="152.80000000000001" unit="cm" />
+      <position name="layer_5B_left_1inworld_volumepos" x="4.1920000000000002" y="-2.6899999999999995" z="152.80000000000001" unit="cm" />
+      <position name="steel_bar_1inworld_volumepos" x="-35.357999999999997" y="0.90000000000000002" z="152.80000000000001" unit="cm" />
+      <position name="cu_Tpipe_inner_left_1inworld_volumepos" x="1.6420000000000003" y="2.7000000000000002" z="152.80000000000001" unit="cm" />
+      <rotation name="cu_Tpipe_inner_left_1inworld_volumerot" x="0" y="-0.95599999999999996" z="0" unit="deg" />
+      <position name="cu_Tpipe_inner_right_1inworld_volumepos" x="-9.1580000000000013" y="2.7000000000000002" z="152.80000000000001" unit="cm" />
+      <rotation name="cu_Tpipe_inner_right_1inworld_volumerot" x="0" y="9.6799999999999997" z="0" unit="deg" />
+      <position name="cu_Bpipe_inner_left_1inworld_volumepos" x="1.6420000000000003" y="-2.7000000000000002" z="152.80000000000001" unit="cm" />
+      <rotation name="cu_Bpipe_inner_left_1inworld_volumerot" x="0" y="-0.95599999999999996" z="0" unit="deg" />
+      <position name="cu_Bpipe_inner_right_1inworld_volumepos" x="-9.1580000000000013" y="-2.7000000000000002" z="152.80000000000001" unit="cm" />
+      <rotation name="cu_Bpipe_inner_right_1inworld_volumerot" x="0" y="9.6799999999999997" z="0" unit="deg" />
+      <position name="cu_Tpipe_outer_right1_1inworld_volumepos" x="-10.858000000000001" y="1.3999999999999999" z="154.30000000000001" unit="cm" />
+      <rotation name="cu_Tpipe_outer_right1_1inworld_volumerot" x="0" y="10" z="0" unit="deg" />
+      <position name="cu_Tpipe_outer_right2_1inworld_volumepos" x="-27.858000000000001" y="1.3999999999999999" z="154.30000000000001" unit="cm" />
+      <position name="cu_Tpipe_outer_right3_1inworld_volumepos" x="-34.857999999999997" y="1.5" z="142.10000000000002" unit="cm" />
+      <rotation name="cu_Tpipe_outer_right3_1inworld_volumerot" x="-0" y="90" z="0" unit="deg" />
+      <position name="cu_Bpipe_outer_right_1inworld_volumepos" x="-34.857999999999997" y="-1.5" z="142.10000000000002" unit="cm" />
+      <rotation name="cu_Bpipe_outer_right_1inworld_volumerot" x="-0" y="90" z="0" unit="deg" />
+      <position name="cu_Bpipe_outer_right1_1inworld_volumepos" x="-10.858000000000001" y="-1.3999999999999999" z="154.30000000000001" unit="cm" />
+      <rotation name="cu_Bpipe_outer_right1_1inworld_volumerot" x="0" y="10" z="0" unit="deg" />
+      <position name="cu_Bpipe_outer_right2_1inworld_volumepos" x="-27.858000000000001" y="-1.3999999999999999" z="154.30000000000001" unit="cm" />
+      <position name="al_pipe_across_top1_1inworld_volumepos" x="2.1420000000000003" y="9" z="142.10000000000002" unit="cm" />
+      <rotation name="al_pipe_across_top1_1inworld_volumerot" x="-90" y="86.999999999999957" z="180" unit="deg" />
+      <position name="al_pipe_across_top2_1inworld_volumepos" x="2.1420000000000003" y="4" z="142.10000000000002" unit="cm" />
+      <rotation name="al_pipe_across_top2_1inworld_volumerot" x="-90" y="89.000000000000099" z="180" unit="deg" />
+      <position name="al_pipe_across_bottom1_1inworld_volumepos" x="2.1420000000000003" y="-9" z="142.10000000000002" unit="cm" />
+      <rotation name="al_pipe_across_bottom1_1inworld_volumerot" x="90" y="86.999999999999957" z="0" unit="deg" />
+      <position name="al_pipe_across_bottom2_1inworld_volumepos" x="2.1420000000000003" y="-4" z="142.10000000000002" unit="cm" />
+      <rotation name="al_pipe_across_bottom2_1inworld_volumerot" x="90" y="89.000000000000099" z="0" unit="deg" />
+      <position name="cu_plate_top_left_1inworld_volumepos" x="22.141999999999999" y="1.6000000000000001" z="152.80000000000001" unit="cm" />
+      <position name="cu_plate_bottom_left_1inworld_volumepos" x="22.141999999999999" y="-1.6000000000000001" z="152.80000000000001" unit="cm" />
+      <position name="cu_plate_top_right_1inworld_volumepos" x="-20.858000000000001" y="1.6000000000000001" z="152.80000000000001" unit="cm" />
+      <position name="cu_plate_bottom_right_1inworld_volumepos" x="-20.858000000000001" y="-1.6000000000000001" z="152.80000000000001" unit="cm" />
+      <position name="cu_plate_top_middle_1inworld_volumepos" x="-3.3579999999999997" y="3.1000000000000001" z="152.80000000000001" unit="cm" />
+      <position name="cu_plate_bottom_middle_1inworld_volumepos" x="-3.3579999999999997" y="-3.1000000000000001" z="152.80000000000001" unit="cm" />
+      <position name="hodo_flange_1intracking_volumepos" x="2.1170000000000004" y="0" z="134.30000000000001" unit="cm" />
+      <position name="arms1_block1_1intracking_volumepos" x="21.517000000000003" y="14.938225000000001" z="132.70000000000002" unit="cm" />
+      <position name="arms1_block2_1intracking_volumepos" x="9.5170000000000012" y="14.938225000000001" z="132.70000000000002" unit="cm" />
+      <position name="arms1_block3_1intracking_volumepos" x="21.517000000000003" y="-14.938225000000001" z="132.70000000000002" unit="cm" />
+      <position name="arms1_block4_1intracking_volumepos" x="9.5170000000000012" y="-14.938225000000001" z="132.70000000000002" unit="cm" />
+      <position name="cross_bar_top_1intracking_volumepos" x="15.517000000000003" y="16.34" z="132.70000000000002" unit="cm" />
+      <position name="cross_bar_bottom_1intracking_volumepos" x="15.517000000000003" y="-16.34" z="132.70000000000002" unit="cm" />
+      <position name="support_arm_bottom_left_plus_block_1intracking_volumepos" x="21.517000000000003" y="-12.771562277258594" z="121.10000000000001" unit="cm" />
+      <position name="support_arm_bottom_right_1intracking_volumepos" x="9.5170000000000012" y="-12.771562277258594" z="121.10000000000001" unit="cm" />
+      <position name="support_arm_top_left_1intracking_volumepos" x="21.517000000000003" y="12.771562277258594" z="121.10000000000001" unit="cm" />
+      <rotation name="support_arm_top_left_1intracking_volumerot" x="0" y="-0" z="180" unit="deg" />
+      <position name="support_arm_top_right_1intracking_volumepos" x="9.5170000000000012" y="12.771562277258594" z="121.10000000000001" unit="cm" />
+      <rotation name="support_arm_top_right_1intracking_volumerot" x="0" y="-0" z="180" unit="deg" />
+      <position name="u_support_bar_bottom_1intracking_volumepos" x="15.517000000000003" y="-9.8400000000000034" z="110.899" unit="cm" />
+      <position name="u_support_bar_upper1_1intracking_volumepos" x="15.517000000000003" y="-8.5400000000000027" z="110.65000000000001" unit="cm" />
+      <position name="u_support_bar_upper2_1intracking_volumepos" x="15.517000000000003" y="-8.5400000000000027" z="111.2" unit="cm" />
+      <position name="u_support_bar_top_1intracking_volumepos" x="15.517000000000003" y="9.8400000000000034" z="110.899" unit="cm" />
+      <position name="u_support_bar_upper3_1intracking_volumepos" x="15.517000000000003" y="8.5400000000000027" z="110.65000000000001" unit="cm" />
+      <position name="u_support_bar_upper4_1intracking_volumepos" x="15.517000000000003" y="8.5400000000000027" z="111.2" unit="cm" />
+      <constant name="svt_chamber_box_z" value="609.6" />
+      <constant name="svt_chamber_flare1_z" value="1285.621" />
+      <constant name="svt_chamber_flare2_z" value="1478.407" />
+      <constant name="svt_chamber_flange_z" value="1614.297" />
+      <constant name="svt_chamber_x" value="21.17" />
+      <constant name="svt_chamber_z" value="1318-1623.822" />
+    </define>
+    <materials>
+      <element Z="1" formula="H" name="H">
+        <atom type="A" unit="g/mol" value="1.00794" />
+      </element>
+      <element Z="82" formula="Pb" name="Pb">
+        <atom type="A" unit="g/mol" value="207.217" />
+      </element>
+      <element Z="74" formula="W" name="W">
+        <atom type="A" unit="g/mol" value="183.842" />
+      </element>
+      <element Z="8" formula="O" name="O">
+        <atom type="A" unit="g/mol" value="15.9994" />
+      </element>
+      <element Z="6" formula="C" name="C">
+        <atom type="A" unit="g/mol" value="12.0107" />
+      </element>
+      <element Z="22" formula="Ti" name="Ti">
+        <atom type="A" unit="g/mol" value="47.8667" />
+      </element>
+      <material name="Vacuum">
+        <D type="density" unit="g/cm3" value="0.00000001" />
+        <fraction n="1" ref="H" />
+      </material>
+      <material name="WorldMaterial">
+        <D type="density" unit="g/cm3" value="0.0000000000000001" />
+        <fraction n="1.0" ref="Vacuum" />
+      </material>
+      <material name="TrackingMaterial">
+        <D type="density" unit="g/cm3" value="0.0000000000000001" />
+        <fraction n="1.0" ref="Vacuum" />
+      </material>
+      <material name="LeadTungstate">
+        <D value="8.28" unit="g/cm3" type="density" />
+        <composite n="1" ref="Pb" />
+        <composite n="1" ref="W" />
+        <composite n="4" ref="O" />
+      </material>
+      <material name="EJ204_PlasticScintillator">
+        <D value="1.032" unit="g/cm3" type="density" />
+        <fraction n="0.523618" ref="H" />
+        <fraction n="0.476382" ref="C" />
+      </material>
+      <material name="TitaniumDioxide">
+        <D value="4.23" unit="g/cm3" type="density" />
+        <composite n="1" ref="Ti" />
+        <composite n="2" ref="O" />
+      </material>
+      <material name="Mylar">
+        <D value="1.4" unit="g/cm3" type="density" />
+        <fraction n="0.041958" ref="H" />
+        <fraction n="0.625017" ref="C" />
+        <fraction n="0.333025" ref="O" />
+      </material>
+      <material name="GenericFoam">
+        <D value="0.052" unit="g/cm3" type="density" />
+        <fraction n="0.5" ref="H" />
+        <fraction n="0.5" ref="C" />
+      </material>
+      <element name="Al" formula="Al" Z="13">
+        <atom type="A" unit="g/mol" value="26.9815" />
+      </element>
+      <material name="Aluminum">
+        <RL type="X0" unit="cm" value="8.89632" />
+        <NIL type="lambda" unit="cm" value="38.8766" />
+        <D type="density" unit="g/cm3" value="2.699" />
+        <composite n="1" ref="Al" />
+      </material>
+      <element name="Si" formula="Si" Z="14">
+        <atom type="A" unit="g/mol" value="28.0854" />
+      </element>
+      <material name="Silicon">
+        <RL type="X0" unit="cm" value="9.36607" />
+        <NIL type="lambda" unit="cm" value="45.7531" />
+        <D type="density" unit="g/cm3" value="2.33" />
+        <composite n="1" ref="Si" />
+      </material>
+      <element name="N" formula="N" Z="7">
+        <atom type="A" unit="g/mol" value="14.0068" />
+      </element>
+      <material name="Kapton">
+        <D value="1.43" unit="g/cm3" />
+        <composite n="22" ref="C" />
+        <composite n="10" ref="H" />
+        <composite n="2" ref="N" />
+        <composite n="5" ref="O" />
+      </material>
+      <material name="Epoxy">
+        <D type="density" value="1.3" unit="g/cm3" />
+        <composite n="44" ref="H" />
+        <composite n="15" ref="C" />
+        <composite n="7" ref="O" />
+      </material>
+      <material name="CarbonFiber">
+        <D type="density" value="1.5" unit="g/cm3" />
+        <fraction n="0.65" ref="C" />
+        <fraction n="0.35" ref="Epoxy" />
+      </material>
+      <element name="Cl" formula="Cl" Z="17">
+        <atom type="A" unit="g/mol" value="35.4526" />
+      </element>
+      <material name="Quartz">
+        <D type="density" value="2.2" unit="g/cm3" />
+        <composite n="1" ref="Si" />
+        <composite n="2" ref="O" />
+      </material>
+      <material name="G10">
+        <D type="density" value="1.7" unit="g/cm3" />
+        <fraction n="0.08" ref="Cl" />
+        <fraction n="0.773" ref="Quartz" />
+        <fraction n="0.147" ref="Epoxy" />
+      </material>
+      <material name="Polystyrene">
+        <D value="1.032" unit="g/cm3" />
+        <composite n="19" ref="C" />
+        <composite n="21" ref="H" />
+      </material>
+      <material name="Carbon">
+        <RL type="X0" unit="cm" value="21.3485" />
+        <NIL type="lambda" unit="cm" value="40.1008" />
+        <D type="density" unit="g/cm3" value="2" />
+        <composite n="1" ref="C" />
+      </material>
+      <material name="G4_Al" Z="13">
+        <D unit="g/cm3" value="2.6989999999999998" />
+        <atom unit="g/mole" value="26.981538" />
+      </material>
+      <material name="AlHoneycomb" Z="13">
+        <D unit="g/cm3" value="0.13" />
+        <atom unit="g/mole" value="26.981538" />
+      </material>
+      <element name="MANGANESE_elm" formula="MN" Z="25">
+        <atom unit="g/mole" value="54.938048999999999" />
+      </element>
+      <element name="SILICON_elm" formula="SI" Z="14">
+        <atom unit="g/mole" value="28.0855" />
+      </element>
+      <element name="CHROMIUM_elm" formula="CR" Z="24">
+        <atom unit="g/mole" value="51.996099999999998" />
+      </element>
+      <element name="NICKEL_elm" formula="NI" Z="28">
+        <atom unit="g/mole" value="58.693399999999997" />
+      </element>
+      <element name="IRON_elm" formula="FE" Z="26">
+        <atom unit="g/mole" value="55.844999999999999" />
+      </element>
+      <material name="StainlessSteel">
+        <D unit="g/cm3" value="8.0199999999999996" />
+        <fraction n="0.18999999761581421" ref="CHROMIUM_elm" />
+        <fraction n="0.68000000715255737" ref="IRON_elm" />
+        <fraction n="0.019999999552965164" ref="MANGANESE_elm" />
+        <fraction n="0.10000000149011612" ref="NICKEL_elm" />
+        <fraction n="0.0099999997764825821" ref="SILICON_elm" />
+      </material>
+      <material name="G4_Cu" Z="29">
+        <D unit="g/cm3" value="8.9600000000000009" />
+        <atom unit="g/mole" value="63.545645059999998" />
+      </material>
+      <element name="OXYGEN_elm" formula="O" Z="8">
+        <atom unit="g/mole" value="15.9994" />
+      </element>
+      <element name="CARBON_elm" formula="C" Z="6">
+        <atom unit="g/mole" value="12.0107" />
+      </element>
+      <element name="HYDROGEN_elm" formula="H" Z="1">
+        <atom unit="g/mole" value="1.0079400000000001" />
+      </element>
+      <material name="G10_FR4">
+        <D unit="g/cm3" value="1.8500000000000001" />
+        <fraction n="0.40416482090950012" ref="CARBON_elm" />
+        <fraction n="0.067835167050361633" ref="HYDROGEN_elm" />
+        <fraction n="0.28119435906410217" ref="OXYGEN_elm" />
+        <fraction n="0.24680563807487488" ref="SILICON_elm" />
+      </material>
+      <material name="SiO2">
+        <D unit="g/cm3" value="2.2000000000000002" />
+        <fraction n="0.53256505727767944" ref="OXYGEN_elm" />
+        <fraction n="0.46743491291999817" ref="SILICON_elm" />
+      </material>
+      <element Z="26" formula="Fe" name="Iron">
+        <atom value="55.845" />
+      </element>
+      <element Z="24" formula="Cr" name="Chromium">
+        <atom value="51.9961" />
+      </element>
+      <element Z="28" formula="Ni" name="Nickel">
+        <atom value="58.6934" />
+      </element>
+      <material formula=" " name="Stainless_304">
+        <D value="8.00" />
+        <fraction n="0.733078" ref="Iron" />
+        <fraction n="0.191516" ref="Chromium" />
+        <fraction n="0.075406" ref="Nickel" />
+      </material>
+      <material Z="1" name="G4_Galactic" state="gas">
+        <T unit="K" value="2.73" />
+        <P unit="pascal" value="3e-18" />
+        <!-- <MEE unit="eV" value="21.8"/> -->
+        <D unit="g/cm3" value="2e-25" />
+        <atom unit="g/mole" value="1.01" />
+      </material>
+    </materials>
+    <solids>
+      <box name="world_box" x="world_x" y="world_y" z="world_z" />
+      <tube name="tracking_cylinder" deltaphi="6.283185307179586" rmin="0.0" rmax="tracking_region_radius" z="2*tracking_region_zmax" />
+      <box name="baseBox" x="406.4" y="1282.6999999999998" z="171.196" />
+      <box name="base_plateBox" x="406.4" y="1282.6999999999998" z="6.35" />
+      <box name="support_plate_bottom_L14Box" x="234.95" y="456.4" z="9.524999999999999" />
+      <box name="support_plate_top_L14Box" x="234.95" y="456.4" z="9.524999999999999" />
+      <box name="support_plate_bottom_L46Box" x="342.9" y="533.4" z="12.7" />
+      <box name="support_plate_top_L46Box" x="342.9" y="533.4" z="12.7" />
+      <box name="module_L1b_halfmodule_axialBox" x="14.525" y="30.0" z="0.2" />
+      <box name="module_L1b_halfmodule_axial_sensorBox" x="14.525" y="30.0" z="0.2" />
+      <box name="module_L1b_halfmodule_axial_sensor_activeBox" x="14.025" y="30.0" z="0.2" />
+      <box name="module_L1b_halfmodule_stereoBox" x="14.525" y="30.0" z="0.2" />
+      <box name="module_L1b_halfmodule_stereo_sensorBox" x="14.525" y="30.0" z="0.2" />
+      <box name="module_L1b_halfmodule_stereo_sensor_activeBox" x="14.025" y="30.0" z="0.2" />
+      <box name="module_L1t_halfmodule_axialBox" x="14.525" y="30.0" z="0.2" />
+      <box name="module_L1t_halfmodule_axial_sensorBox" x="14.525" y="30.0" z="0.2" />
+      <box name="module_L1t_halfmodule_axial_sensor_activeBox" x="14.025" y="30.0" z="0.2" />
+      <box name="module_L1t_halfmodule_stereoBox" x="14.525" y="30.0" z="0.2" />
+      <box name="module_L1t_halfmodule_stereo_sensorBox" x="14.525" y="30.0" z="0.2" />
+      <box name="module_L1t_halfmodule_stereo_sensor_activeBox" x="14.025" y="30.0" z="0.2" />
+      <box name="module_L2b_halfmodule_axialBox" x="14.525" y="30.0" z="0.2" />
+      <box name="module_L2b_halfmodule_axial_sensorBox" x="14.525" y="30.0" z="0.2" />
+      <box name="module_L2b_halfmodule_axial_sensor_activeBox" x="14.025" y="30.0" z="0.2" />
+      <box name="module_L2b_halfmodule_stereoBox" x="14.525" y="30.0" z="0.2" />
+      <box name="module_L2b_halfmodule_stereo_sensorBox" x="14.525" y="30.0" z="0.2" />
+      <box name="module_L2b_halfmodule_stereo_sensor_activeBox" x="14.025" y="30.0" z="0.2" />
+      <box name="module_L2t_halfmodule_axialBox" x="14.525" y="30.0" z="0.2" />
+      <box name="module_L2t_halfmodule_axial_sensorBox" x="14.525" y="30.0" z="0.2" />
+      <box name="module_L2t_halfmodule_axial_sensor_activeBox" x="14.025" y="30.0" z="0.2" />
+      <box name="module_L2t_halfmodule_stereoBox" x="14.525" y="30.0" z="0.2" />
+      <box name="module_L2t_halfmodule_stereo_sensorBox" x="14.525" y="30.0" z="0.2" />
+      <box name="module_L2t_halfmodule_stereo_sensor_activeBox" x="14.025" y="30.0" z="0.2" />
+      <box name="module_L3b_halfmodule_axialBox" x="47.17" y="200.0" z="1.8405" />
+      <box name="module_L3b_halfmodule_axial_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L3b_halfmodule_axial_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L3b_halfmodule_axial_laminationBox" x="38.0" y="100.0" z="0.05" />
+      <box name="module_L3b_halfmodule_axial_cfBox" x="36.02" y="100.0" z="0.203" />
+      <box name="module_L3b_halfmodule_axial_hybridBox" x="40.34" y="70.0" z="1.5875" />
+      <box name="module_L3b_halfmodule_stereoBox" x="47.17" y="200.0" z="1.8405" />
+      <box name="module_L3b_halfmodule_stereo_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L3b_halfmodule_stereo_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L3b_halfmodule_stereo_laminationBox" x="38.0" y="100.0" z="0.05" />
+      <box name="module_L3b_halfmodule_stereo_cfBox" x="36.02" y="100.0" z="0.203" />
+      <box name="module_L3b_halfmodule_stereo_hybridBox" x="40.34" y="70.0" z="1.5875" />
+      <box name="module_L3t_halfmodule_axialBox" x="47.17" y="200.0" z="1.8405" />
+      <box name="module_L3t_halfmodule_axial_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L3t_halfmodule_axial_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L3t_halfmodule_axial_laminationBox" x="38.0" y="100.0" z="0.05" />
+      <box name="module_L3t_halfmodule_axial_cfBox" x="36.02" y="100.0" z="0.203" />
+      <box name="module_L3t_halfmodule_axial_hybridBox" x="40.34" y="70.0" z="1.5875" />
+      <box name="module_L3t_halfmodule_stereoBox" x="47.17" y="200.0" z="1.8405" />
+      <box name="module_L3t_halfmodule_stereo_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L3t_halfmodule_stereo_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L3t_halfmodule_stereo_laminationBox" x="38.0" y="100.0" z="0.05" />
+      <box name="module_L3t_halfmodule_stereo_cfBox" x="36.02" y="100.0" z="0.203" />
+      <box name="module_L3t_halfmodule_stereo_hybridBox" x="40.34" y="70.0" z="1.5875" />
+      <box name="module_L4b_halfmodule_axialBox" x="47.17" y="200.0" z="1.8405" />
+      <box name="module_L4b_halfmodule_axial_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L4b_halfmodule_axial_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L4b_halfmodule_axial_laminationBox" x="38.0" y="100.0" z="0.05" />
+      <box name="module_L4b_halfmodule_axial_cfBox" x="36.02" y="100.0" z="0.203" />
+      <box name="module_L4b_halfmodule_axial_hybridBox" x="40.34" y="70.0" z="1.5875" />
+      <box name="module_L4b_halfmodule_stereoBox" x="47.17" y="200.0" z="1.8405" />
+      <box name="module_L4b_halfmodule_stereo_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L4b_halfmodule_stereo_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L4b_halfmodule_stereo_laminationBox" x="38.0" y="100.0" z="0.05" />
+      <box name="module_L4b_halfmodule_stereo_cfBox" x="36.02" y="100.0" z="0.203" />
+      <box name="module_L4b_halfmodule_stereo_hybridBox" x="40.34" y="70.0" z="1.5875" />
+      <box name="module_L4t_halfmodule_axialBox" x="47.17" y="200.0" z="1.8405" />
+      <box name="module_L4t_halfmodule_axial_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L4t_halfmodule_axial_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L4t_halfmodule_axial_laminationBox" x="38.0" y="100.0" z="0.05" />
+      <box name="module_L4t_halfmodule_axial_cfBox" x="36.02" y="100.0" z="0.203" />
+      <box name="module_L4t_halfmodule_axial_hybridBox" x="40.34" y="70.0" z="1.5875" />
+      <box name="module_L4t_halfmodule_stereoBox" x="47.17" y="200.0" z="1.8405" />
+      <box name="module_L4t_halfmodule_stereo_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L4t_halfmodule_stereo_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L4t_halfmodule_stereo_laminationBox" x="38.0" y="100.0" z="0.05" />
+      <box name="module_L4t_halfmodule_stereo_cfBox" x="36.02" y="100.0" z="0.203" />
+      <box name="module_L4t_halfmodule_stereo_hybridBox" x="40.34" y="70.0" z="1.5875" />
+      <box name="module_L5b_halfmodule_axial_holeBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L5b_halfmodule_axial_hole_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L5b_halfmodule_axial_hole_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L5b_halfmodule_axial_hole_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L5b_halfmodule_axial_slotBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L5b_halfmodule_axial_slot_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L5b_halfmodule_axial_slot_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L5b_halfmodule_axial_slot_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L5b_halfmodule_stereo_holeBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L5b_halfmodule_stereo_hole_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L5b_halfmodule_stereo_hole_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L5b_halfmodule_stereo_hole_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L5b_halfmodule_stereo_slotBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L5b_halfmodule_stereo_slot_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L5b_halfmodule_stereo_slot_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L5b_halfmodule_stereo_slot_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L5t_halfmodule_axial_holeBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L5t_halfmodule_axial_hole_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L5t_halfmodule_axial_hole_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L5t_halfmodule_axial_hole_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L5t_halfmodule_axial_slotBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L5t_halfmodule_axial_slot_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L5t_halfmodule_axial_slot_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L5t_halfmodule_axial_slot_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L5t_halfmodule_stereo_holeBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L5t_halfmodule_stereo_hole_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L5t_halfmodule_stereo_hole_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L5t_halfmodule_stereo_hole_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L5t_halfmodule_stereo_slotBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L5t_halfmodule_stereo_slot_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L5t_halfmodule_stereo_slot_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L5t_halfmodule_stereo_slot_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L6b_halfmodule_axial_holeBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L6b_halfmodule_axial_hole_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L6b_halfmodule_axial_hole_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L6b_halfmodule_axial_hole_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L6b_halfmodule_axial_slotBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L6b_halfmodule_axial_slot_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L6b_halfmodule_axial_slot_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L6b_halfmodule_axial_slot_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L6b_halfmodule_stereo_holeBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L6b_halfmodule_stereo_hole_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L6b_halfmodule_stereo_hole_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L6b_halfmodule_stereo_hole_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L6b_halfmodule_stereo_slotBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L6b_halfmodule_stereo_slot_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L6b_halfmodule_stereo_slot_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L6b_halfmodule_stereo_slot_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L6t_halfmodule_axial_holeBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L6t_halfmodule_axial_hole_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L6t_halfmodule_axial_hole_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L6t_halfmodule_axial_hole_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L6t_halfmodule_axial_slotBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L6t_halfmodule_axial_slot_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L6t_halfmodule_axial_slot_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L6t_halfmodule_axial_slot_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L6t_halfmodule_stereo_holeBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L6t_halfmodule_stereo_hole_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L6t_halfmodule_stereo_hole_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L6t_halfmodule_stereo_hole_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L6t_halfmodule_stereo_slotBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L6t_halfmodule_stereo_slot_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L6t_halfmodule_stereo_slot_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L6t_halfmodule_stereo_slot_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L7b_halfmodule_axial_holeBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L7b_halfmodule_axial_hole_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L7b_halfmodule_axial_hole_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L7b_halfmodule_axial_hole_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L7b_halfmodule_axial_slotBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L7b_halfmodule_axial_slot_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L7b_halfmodule_axial_slot_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L7b_halfmodule_axial_slot_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L7b_halfmodule_stereo_holeBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L7b_halfmodule_stereo_hole_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L7b_halfmodule_stereo_hole_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L7b_halfmodule_stereo_hole_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L7b_halfmodule_stereo_slotBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L7b_halfmodule_stereo_slot_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L7b_halfmodule_stereo_slot_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L7b_halfmodule_stereo_slot_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L7t_halfmodule_axial_holeBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L7t_halfmodule_axial_hole_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L7t_halfmodule_axial_hole_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L7t_halfmodule_axial_hole_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L7t_halfmodule_axial_slotBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L7t_halfmodule_axial_slot_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L7t_halfmodule_axial_slot_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L7t_halfmodule_axial_slot_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L7t_halfmodule_stereo_holeBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L7t_halfmodule_stereo_hole_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L7t_halfmodule_stereo_hole_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L7t_halfmodule_stereo_hole_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L7t_halfmodule_stereo_slotBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L7t_halfmodule_stereo_slot_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L7t_halfmodule_stereo_slot_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L7t_halfmodule_stereo_slot_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="BeamLeftBox" x="211.6" y="382.492" z="0.001" />
+      <box name="BeamLeftVolume_component0Box" x="211.6" y="382.492" z="0.001" />
+      <box name="BeamLeftVolume_component0Sensor0Box" x="211.6" y="382.492" z="0.001" />
+      <box name="ElectronGapBox" x="196.26999999999998" y="92.46999999999997" z="0.001" />
+      <box name="ElectronGapVolume_component0Box" x="196.26999999999998" y="92.46999999999997" z="0.001" />
+      <box name="ElectronGapVolume_component0Sensor0Box" x="196.26999999999998" y="92.46999999999997" z="0.001" />
+      <box name="BeamRightBox" x="214.6" y="293.38800000000003" z="0.001" />
+      <box name="BeamRightVolume_component0Box" x="214.6" y="293.38800000000003" z="0.001" />
+      <box name="BeamRightVolume_component0Sensor0Box" x="214.6" y="293.38800000000003" z="0.001" />
+      <trd name="crystal_trap" x1="13.3" x2="16.0" y1="13.3" y2="16.0" z="160.0" />
+      <box name="hodo_pixel_L1TP0" x="15.7" y="59.9" z="9.5" />
+      <box name="hodo_cover_L1TP0" x="15.7" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L1TP0" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L1TP0" x="15.799999999999999" y="0.05" z="10.0" />
+      <box name="hodo_pixel_L1BP0" x="15.7" y="59.9" z="9.5" />
+      <box name="hodo_cover_L1BP0" x="15.7" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L1BP0" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L1BP0" x="15.799999999999999" y="0.05" z="10.0" />
+      <box name="hodo_pixel_L1TP1" x="34.1" y="59.9" z="9.5" />
+      <box name="hodo_cover_L1TP1" x="34.1" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L1TP1" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L1TP1" x="34.2" y="0.05" z="10.0" />
+      <box name="hodo_pixel_L1BP1" x="34.1" y="59.9" z="9.5" />
+      <box name="hodo_cover_L1BP1" x="34.1" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L1BP1" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L1BP1" x="34.2" y="0.05" z="10.0" />
+      <box name="hodo_pixel_L1TP2" x="44.0" y="59.9" z="9.5" />
+      <box name="hodo_cover_L1TP2" x="44.0" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L1TP2" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L1TP2" x="44.1" y="0.05" z="10.0" />
+      <box name="hodo_pixel_L1BP2" x="44.0" y="59.9" z="9.5" />
+      <box name="hodo_cover_L1BP2" x="44.0" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L1BP2" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L1BP2" x="44.1" y="0.05" z="10.0" />
+      <box name="hodo_pixel_L1TP3" x="44.0" y="59.9" z="9.5" />
+      <box name="hodo_cover_L1TP3" x="44.0" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L1TP3" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L1TP3" x="44.1" y="0.05" z="10.0" />
+      <box name="hodo_pixel_L1BP3" x="44.0" y="59.9" z="9.5" />
+      <box name="hodo_cover_L1BP3" x="44.0" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L1BP3" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L1BP3" x="44.1" y="0.05" z="10.0" />
+      <box name="hodo_pixel_L1TP4" x="44.0" y="59.9" z="9.5" />
+      <box name="hodo_cover_L1TP4" x="44.0" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L1TP4" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L1TP4" x="44.1" y="0.05" z="10.0" />
+      <box name="hodo_pixel_L1BP4" x="44.0" y="59.9" z="9.5" />
+      <box name="hodo_cover_L1BP4" x="44.0" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L1BP4" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L1BP4" x="44.1" y="0.05" z="10.0" />
+      <box name="hodo_pixel_L2TP0" x="19.0" y="59.9" z="9.5" />
+      <box name="hodo_cover_L2TP0" x="19.0" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L2TP0" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L2TP0" x="19.1" y="0.05" z="10.0" />
+      <box name="hodo_pixel_L2BP0" x="19.0" y="59.9" z="9.5" />
+      <box name="hodo_cover_L2BP0" x="19.0" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L2BP0" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L2BP0" x="19.1" y="0.05" z="10.0" />
+      <box name="hodo_pixel_L2TP1" x="44.0" y="59.9" z="9.5" />
+      <box name="hodo_cover_L2TP1" x="44.0" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L2TP1" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L2TP1" x="44.1" y="0.05" z="10.0" />
+      <box name="hodo_pixel_L2BP1" x="44.0" y="59.9" z="9.5" />
+      <box name="hodo_cover_L2BP1" x="44.0" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L2BP1" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L2BP1" x="44.1" y="0.05" z="10.0" />
+      <box name="hodo_pixel_L2TP2" x="44.0" y="59.9" z="9.5" />
+      <box name="hodo_cover_L2TP2" x="44.0" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L2TP2" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L2TP2" x="44.1" y="0.05" z="10.0" />
+      <box name="hodo_pixel_L2BP2" x="44.0" y="59.9" z="9.5" />
+      <box name="hodo_cover_L2BP2" x="44.0" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L2BP2" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L2BP2" x="44.1" y="0.05" z="10.0" />
+      <box name="hodo_pixel_L2TP3" x="44.0" y="59.9" z="9.5" />
+      <box name="hodo_cover_L2TP3" x="44.0" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L2TP3" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L2TP3" x="44.1" y="0.05" z="10.0" />
+      <box name="hodo_pixel_L2BP3" x="44.0" y="59.9" z="9.5" />
+      <box name="hodo_cover_L2BP3" x="44.0" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L2BP3" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L2BP3" x="44.1" y="0.05" z="10.0" />
+      <box name="hodo_pixel_L2TP4" x="30.8" y="59.9" z="9.5" />
+      <box name="hodo_cover_L2TP4" x="30.8" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L2TP4" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L2TP4" x="30.900000000000002" y="0.05" z="10.0" />
+      <box name="hodo_pixel_L2BP4" x="30.8" y="59.9" z="9.5" />
+      <box name="hodo_cover_L2BP4" x="30.8" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L2BP4" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L2BP4" x="30.900000000000002" y="0.05" z="10.0" />
+      <box name="hodo_buffer" x="187.64" y="80.0" z="2.0" />
+      <box name="world_volume_solid" x="2000" y="2000" z="2000" lunit="cm" />
+      <box name="front_flange_box_shape" x="76.835000000000008" y="45.719999999999999" z="2" lunit="cm" />
+      <trap name="front_chamber_trap_shape" z="3" theta="-0.98799999999999999" phi="0" x1="33.119799999999998" x2="33.119799999999998" x3="33.406400000000005" x4="33.406400000000005" y1="1.6000000000000001" y2="1.6000000000000001" alpha1="0" alpha2="0" aunit="deg" lunit="cm" />
+      <subtraction name="front_minus_chamber_shape">
+        <first ref="front_flange_box_shape" />
+        <second ref="front_chamber_trap_shape" />
+        <position name="front_minus_chamber_shapefront_chamber_trap_shapepos" x="-14.6309" y="0" z="0" unit="cm" />
+      </subtraction>
+      <eltube name="flange_photontube_inside_shape" dx="1.1000000000000001" dy="1.1000000000000001" dz="3" lunit="cm" />
+      <subtraction name="front_minus_photontube_shape">
+        <first ref="front_minus_chamber_shape" />
+        <second ref="flange_photontube_inside_shape" />
+        <position name="front_minus_photontube_shapeflange_photontube_inside_shapepos" x="2.0007000000000001" y="0" z="0" unit="cm" />
+        <rotation name="front_minus_photontube_shapeflange_photontube_inside_shaperot" x="0" y="1.7480000000000002" z="0" unit="deg" />
+      </subtraction>
+      <trap name="front_egap_trap_shape" z="3" theta="-4.7960000000000003" phi="0" x1="2.5683000000000002" x2="2.5683000000000002" x3="2.9716000000000005" x4="2.9716000000000005" y1="5.266" y2="5.266" alpha1="0" alpha2="0" aunit="deg" lunit="cm" />
+      <subtraction name="front_minus_egap_shape">
+        <first ref="front_minus_photontube_shape" />
+        <second ref="front_egap_trap_shape" />
+        <position name="front_minus_egap_shapefront_egap_trap_shapepos" x="-4.4683000000000002" y="0" z="0" unit="cm" />
+      </subtraction>
+      <eltube name="flange_egap_inside_tube_shape" dx="2.633" dy="2.633" dz="3" lunit="cm" />
+      <subtraction name="front_minus_egapleft_shape">
+        <first ref="front_minus_egap_shape" />
+        <second ref="flange_egap_inside_tube_shape" />
+        <position name="front_minus_egapleft_shapeflange_egap_inside_tube_shapepos" x="-3.0832999999999999" y="0" z="0" unit="cm" />
+        <rotation name="front_minus_egapleft_shapeflange_egap_inside_tube_shaperot" x="0" y="-0.95599999999999996" z="0" unit="deg" />
+      </subtraction>
+      <eltube name="flange_egap_inside_tube2_shape" dx="2.633" dy="2.633" dz="3" lunit="cm" />
+      <subtraction name="front_flange_shape">
+        <first ref="front_minus_egapleft_shape" />
+        <second ref="flange_egap_inside_tube2_shape" />
+        <position name="front_flange_shapeflange_egap_inside_tube2_shapepos" x="-5.8532000000000002" y="0" z="0" unit="cm" />
+        <rotation name="front_flange_shapeflange_egap_inside_tube2_shaperot" x="0" y="-8.5939999999999994" z="0" unit="deg" />
+      </subtraction>
+      <box name="back_flange_box_shape" x="50.5" y="16" z="2" lunit="cm" />
+      <trap name="back_chamber_trap_shape" z="3" theta="-0.98799999999999999" phi="0" x1="37.227899999999998" x2="37.227899999999998" x3="37.514499999999998" x4="37.514499999999998" y1="1.6000000000000001" y2="1.6000000000000001" alpha1="0" alpha2="0" aunit="deg" lunit="cm" />
+      <subtraction name="back_minus_chamber_shape">
+        <first ref="back_flange_box_shape" />
+        <second ref="back_chamber_trap_shape" />
+        <position name="back_minus_chamber_shapeback_chamber_trap_shapepos" x="-0.62210000000000043" y="0" z="0" unit="cm" />
+      </subtraction>
+      <eltube name="flange_photontube_inside2_shape" dx="1.1000000000000001" dy="1.1000000000000001" dz="3" lunit="cm" />
+      <subtraction name="back_minus_photontube_shape">
+        <first ref="back_minus_chamber_shape" />
+        <second ref="flange_photontube_inside2_shape" />
+        <position name="back_minus_photontube_shapeflange_photontube_inside2_shapepos" x="18.063500000000001" y="0" z="0" unit="cm" />
+        <rotation name="back_minus_photontube_shapeflange_photontube_inside2_shaperot" x="0" y="1.7480000000000002" z="0" unit="deg" />
+      </subtraction>
+      <trap name="back_egap_trap_shape" z="3" theta="-4.7960000000000003" phi="0" x1="8.3492999999999995" x2="8.3492999999999995" x3="8.7525999999999993" x4="8.7525999999999993" y1="5.266" y2="5.266" alpha1="0" alpha2="0" aunit="deg" lunit="cm" />
+      <subtraction name="back_minus_egap_shape">
+        <first ref="back_minus_photontube_shape" />
+        <second ref="back_egap_trap_shape" />
+        <position name="back_minus_egap_shapeback_egap_trap_shapepos" x="6.674199999999999" y="0" z="0" unit="cm" />
+      </subtraction>
+      <eltube name="flange_egap_inside_tube3_shape" dx="2.633" dy="2.633" dz="3" lunit="cm" />
+      <subtraction name="back_minus_egapleft_shape">
+        <first ref="back_minus_egap_shape" />
+        <second ref="flange_egap_inside_tube3_shape" />
+        <position name="back_minus_egapleft_shapeflange_egap_inside_tube3_shapepos" x="10.9497" y="0" z="0" unit="cm" />
+        <rotation name="back_minus_egapleft_shapeflange_egap_inside_tube3_shaperot" x="0" y="-0.95599999999999996" z="0" unit="deg" />
+      </subtraction>
+      <eltube name="flange_egap_inside_tube4_shape" dx="2.633" dy="2.633" dz="3" lunit="cm" />
+      <subtraction name="back_flange_shape">
+        <first ref="back_minus_egapleft_shape" />
+        <second ref="flange_egap_inside_tube4_shape" />
+        <position name="back_flange_shapeflange_egap_inside_tube4_shapepos" x="2.3986999999999994" y="0" z="0" unit="cm" />
+        <rotation name="back_flange_shapeflange_egap_inside_tube4_shaperot" x="0" y="-8.5939999999999994" z="0" unit="deg" />
+      </subtraction>
+      <trap name="chamber_trap_shape" z="45" theta="-1.8640000000000001" phi="0" x1="37.700000000000003" x2="37.700000000000003" x3="40.629000000000005" x4="40.629000000000005" y1="2.8000000000000003" y2="2.8000000000000003" alpha1="0" alpha2="0" aunit="deg" lunit="cm" />
+      <box name="chamber_cutaway_box_shape" x="50" y="1" z="30" lunit="cm" />
+      <subtraction name="chamber_trim1_shape">
+        <first ref="chamber_trap_shape" />
+        <second ref="chamber_cutaway_box_shape" />
+        <position name="chamber_trim1_shapechamber_cutaway_box_shapepos" x="0" y="1.6000000000000001" z="-9" unit="cm" />
+      </subtraction>
+      <box name="chamber_cutaway_box2_shape" x="50" y="1" z="30" lunit="cm" />
+      <subtraction name="chamber_trim2_shape">
+        <first ref="chamber_trim1_shape" />
+        <second ref="chamber_cutaway_box2_shape" />
+        <position name="chamber_trim2_shapechamber_cutaway_box2_shapepos" x="0" y="-1.6000000000000001" z="-9" unit="cm" />
+      </subtraction>
+      <eltube name="photontube_outside_shape" dx="1.3" dy="1.3" dz="23.5" lunit="cm" />
+      <union name="chamber_with_photontube_shape">
+        <first ref="chamber_trim2_shape" />
+        <second ref="photontube_outside_shape" />
+        <position name="chamber_with_photontube_shapephotontube_outside_shapepos" x="16.739699999999999" y="0" z="0" unit="cm" />
+        <rotation name="chamber_with_photontube_shapephotontube_outside_shaperot" x="0" y="1.7480000000000002" z="0" unit="deg" />
+      </union>
+      <trap name="egap_outside_trap_upper_shape" z="45" theta="-4.7960000000000003" phi="0" x1="10.691200000000002" x2="5.2344000000000008" x3="16.741099999999999" x4="11.284300000000002" y1="3.2330000000000001" y2="3.2330000000000001" alpha1="0.26900000000000002" alpha2="0.26900000000000002" aunit="deg" lunit="cm" />
+      <union name="chamber_with_egap_upper_shape">
+        <first ref="chamber_with_photontube_shape" />
+        <second ref="egap_outside_trap_upper_shape" />
+        <position name="chamber_with_egap_upper_shapeegap_outside_trap_upper_shapepos" x="7.7018000000000004" y="1.6165" z="0" unit="cm" />
+      </union>
+      <trap name="egap_outside_trap_lower_shape" z="45" theta="-4.7960000000000003" phi="0" x1="5.2344000000000008" x2="10.691200000000002" x3="11.284300000000002" x4="16.741099999999999" y1="3.2330000000000001" y2="3.2330000000000001" alpha1="-0.26900000000000002" alpha2="-0.26900000000000002" aunit="deg" lunit="cm" />
+      <union name="chamber_with_egap_lower_shape">
+        <first ref="chamber_with_egap_upper_shape" />
+        <second ref="egap_outside_trap_lower_shape" />
+        <position name="chamber_with_egap_lower_shapeegap_outside_trap_lower_shapepos" x="7.7018000000000004" y="-1.6165" z="0" unit="cm" />
+      </union>
+      <box name="chamber_cutaway_box3_shape" x="50" y="1" z="30" lunit="cm" />
+      <subtraction name="chamber_with_egap_trimtop_shape">
+        <first ref="chamber_with_egap_lower_shape" />
+        <second ref="chamber_cutaway_box3_shape" />
+        <position name="chamber_with_egap_trimtop_shapechamber_cutaway_box3_shapepos" x="0" y="3.4329999999999998" z="-9" unit="cm" />
+      </subtraction>
+      <box name="chamber_cutaway_box4_shape" x="50" y="1" z="30" lunit="cm" />
+      <subtraction name="chamber_with_egap_trimbot_shape">
+        <first ref="chamber_with_egap_trimtop_shape" />
+        <second ref="chamber_cutaway_box4_shape" />
+        <position name="chamber_with_egap_trimbot_shapechamber_cutaway_box4_shapepos" x="0" y="-3.4329999999999998" z="-9" unit="cm" />
+      </subtraction>
+      <box name="back_end_box_shape" x="76.835000000000008" y="45.719999999999999" z="5" lunit="cm" />
+      <subtraction name="chamber_outside_trim1_shape">
+        <first ref="chamber_with_egap_trimbot_shape" />
+        <second ref="back_end_box_shape" />
+        <position name="chamber_outside_trim1_shapeback_end_box_shapepos" x="0" y="0" z="-23" unit="cm" />
+      </subtraction>
+      <box name="back_end_box2_shape" x="76.835000000000008" y="45.719999999999999" z="5" lunit="cm" />
+      <subtraction name="chamber_outside_trim2_shape">
+        <first ref="chamber_outside_trim1_shape" />
+        <second ref="back_end_box2_shape" />
+        <position name="chamber_outside_trim2_shapeback_end_box2_shapepos" x="0" y="0" z="23" unit="cm" />
+      </subtraction>
+      <eltube name="photontube_inside_shape" dx="1.1000000000000001" dy="1.1000000000000001" dz="23.5" lunit="cm" />
+      <subtraction name="chamber_minus_photontube_shape">
+        <first ref="chamber_outside_trim2_shape" />
+        <second ref="photontube_inside_shape" />
+        <position name="chamber_minus_photontube_shapephotontube_inside_shapepos" x="16.739699999999999" y="0" z="0" unit="cm" />
+        <rotation name="chamber_minus_photontube_shapephotontube_inside_shaperot" x="0" y="1.7480000000000002" z="0" unit="deg" />
+      </subtraction>
+      <trap name="chamber_inside_trap_shape" z="45.000100000000003" theta="-0.98799999999999999" phi="0" x1="33.1676" x2="33.1676" x3="37.466699999999996" x4="37.466699999999996" y1="1.6000000000000001" y2="1.6000000000000001" alpha1="0" alpha2="0" aunit="deg" lunit="cm" />
+      <subtraction name="chamber_minus_inside_shape">
+        <first ref="chamber_minus_photontube_shape" />
+        <second ref="chamber_inside_trap_shape" />
+        <position name="chamber_minus_inside_shapechamber_inside_trap_shapepos" x="-0.91889999999999938" y="0" z="0" unit="cm" />
+      </subtraction>
+      <trap name="egap_inside_trap_shape" z="45.000100000000003" theta="-4.7960000000000003" phi="0" x1="2.6355000000000004" x2="2.6355000000000004" x3="8.6853999999999996" x4="8.6853999999999996" y1="5.266" y2="5.266" alpha1="0" alpha2="0" aunit="deg" lunit="cm" />
+      <subtraction name="chamber_minus_egapinside_shape">
+        <first ref="chamber_minus_inside_shape" />
+        <second ref="egap_inside_trap_shape" />
+        <position name="chamber_minus_egapinside_shapeegap_inside_trap_shapepos" x="7.8105000000000011" y="0" z="0" unit="cm" />
+      </subtraction>
+      <eltube name="egap_inside_tube_shape" dx="2.633" dy="2.633" dz="24" lunit="cm" />
+      <subtraction name="chamber_minus_egap_left_shape">
+        <first ref="chamber_minus_egapinside_shape" />
+        <second ref="egap_inside_tube_shape" />
+        <position name="chamber_minus_egap_left_shapeegap_inside_tube_shapepos" x="10.640750000000001" y="0" z="0" unit="cm" />
+        <rotation name="chamber_minus_egap_left_shapeegap_inside_tube_shaperot" x="0" y="-0.95599999999999996" z="0" unit="deg" />
+      </subtraction>
+      <tube name="egap_inside_tube2_shape" rmin="0" rmax="2.633" z="48" startphi="0" deltaphi="360" aunit="deg" lunit="cm" />
+      <subtraction name="ECAL_chamber_shape">
+        <first ref="chamber_minus_egap_left_shape" />
+        <second ref="egap_inside_tube2_shape" />
+        <position name="ECAL_chamber_shapeegap_inside_tube2_shapepos" x="4.9802999999999997" y="0" z="0" unit="cm" />
+        <rotation name="ECAL_chamber_shapeegap_inside_tube2_shaperot" x="0" y="-8.5939999999999994" z="0" unit="deg" />
+      </subtraction>
+      <box name="al_honeycomb_shape" x="6" y="1.6000000000000001" z="6" lunit="cm" />
+      <box name="ecal_box_outer1_shape" x="80" y="1.3999999999999999" z="20.100000000000001" lunit="cm" />
+      <box name="ecal_box_inner1_shape" x="78" y="2" z="21" lunit="cm" />
+      <subtraction name="ecal_box_minus_inner1_shape">
+        <first ref="ecal_box_outer1_shape" />
+        <second ref="ecal_box_inner1_shape" />
+        <position name="ecal_box_minus_inner1_shapeecal_box_inner1_shapepos" x="0" y="0.16" z="1.8500000000000001" unit="cm" />
+      </subtraction>
+      <box name="ecal_box_inner2_shape" x="68" y="1.2" z="7.4199999999999999" lunit="cm" />
+      <subtraction name="ecal_box_minus_inner2_shape">
+        <first ref="ecal_box_minus_inner1_shape" />
+        <second ref="ecal_box_inner2_shape" />
+        <position name="ecal_box_minus_inner2_shapeecal_box_inner2_shapepos" x="0" y="0.16" z="-10.050000000000001" unit="cm" />
+      </subtraction>
+      <para name="ppd_0_shape" x="0.59999999999999998" y="1.3999999999999999" z="1.5" alpha="0" theta="0" phi="0" aunit="deg" lunit="cm" />
+      <union name="box_with_ppd_shape">
+        <first ref="ecal_box_minus_inner2_shape" />
+        <second ref="ppd_0_shape" />
+        <position name="box_with_ppd_shapeppd_0_shapepos" x="0" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <para name="ppd_1_shape" x="0.59999999999999998" y="1.3999999999999999" z="1.5" alpha="0" theta="-3.8700000000000001" phi="0" aunit="deg" lunit="cm" />
+      <union name="box_with_ppd1_shape">
+        <first ref="box_with_ppd_shape" />
+        <second ref="ppd_1_shape" />
+        <position name="box_with_ppd1_shapeppd_1_shapepos" x="-5.2400000000000002" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <para name="ppd_2_shape" x="0.59999999999999998" y="1.3999999999999999" z="1.5" alpha="0" theta="-7.7400000000000002" phi="0" aunit="deg" lunit="cm" />
+      <union name="box_with_ppd2_shape">
+        <first ref="box_with_ppd1_shape" />
+        <second ref="ppd_2_shape" />
+        <position name="box_with_ppd2_shapeppd_2_shapepos" x="-10.5" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <para name="ppd_3_shape" x="0.59999999999999998" y="1.3999999999999999" z="1.5" alpha="0" theta="-11.619999999999999" phi="0" aunit="deg" lunit="cm" />
+      <union name="box_with_ppd3_shape">
+        <first ref="box_with_ppd2_shape" />
+        <second ref="ppd_3_shape" />
+        <position name="box_with_ppd3_shapeppd_3_shapepos" x="-15.800000000000001" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <para name="ppd_4_shape" x="0.59999999999999998" y="1.3999999999999999" z="1.5" alpha="0" theta="-15.49" phi="0" aunit="deg" lunit="cm" />
+      <union name="box_with_ppd4_shape">
+        <first ref="box_with_ppd3_shape" />
+        <second ref="ppd_4_shape" />
+        <position name="box_with_ppd4_shapeppd_4_shapepos" x="-21.170000000000002" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <para name="ppd_5_shape" x="0.59999999999999998" y="1.3999999999999999" z="1.5" alpha="0" theta="-19.359999999999999" phi="0" aunit="deg" lunit="cm" />
+      <union name="box_with_ppd5_shape">
+        <first ref="box_with_ppd4_shape" />
+        <second ref="ppd_5_shape" />
+        <position name="box_with_ppd5_shapeppd_5_shapepos" x="-26.640000000000001" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <para name="ppd_6_shape" x="0.59999999999999998" y="1.3999999999999999" z="1.5" alpha="0" theta="3.8700000000000001" phi="0" aunit="deg" lunit="cm" />
+      <union name="box_with_ppd6_shape">
+        <first ref="box_with_ppd5_shape" />
+        <second ref="ppd_6_shape" />
+        <position name="box_with_ppd6_shapeppd_6_shapepos" x="5.2400000000000002" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <para name="ppd_7_shape" x="0.59999999999999998" y="1.3999999999999999" z="1.5" alpha="0" theta="7.7400000000000002" phi="0" aunit="deg" lunit="cm" />
+      <union name="box_with_ppd7_shape">
+        <first ref="box_with_ppd6_shape" />
+        <second ref="ppd_7_shape" />
+        <position name="box_with_ppd7_shapeppd_7_shapepos" x="10.5" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <para name="ppd_8_shape" x="0.59999999999999998" y="1.3999999999999999" z="1.5" alpha="0" theta="11.619999999999999" phi="0" aunit="deg" lunit="cm" />
+      <union name="box_with_ppd8_shape">
+        <first ref="box_with_ppd7_shape" />
+        <second ref="ppd_8_shape" />
+        <position name="box_with_ppd8_shapeppd_8_shapepos" x="15.800000000000001" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <para name="ppd_9_shape" x="0.59999999999999998" y="1.3999999999999999" z="1.5" alpha="0" theta="15.49" phi="0" aunit="deg" lunit="cm" />
+      <union name="box_with_ppd9_shape">
+        <first ref="box_with_ppd8_shape" />
+        <second ref="ppd_9_shape" />
+        <position name="box_with_ppd9_shapeppd_9_shapepos" x="21.170000000000002" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <para name="ppd_10_shape" x="0.59999999999999998" y="1.3999999999999999" z="1.5" alpha="0" theta="19.359999999999999" phi="0" aunit="deg" lunit="cm" />
+      <union name="layer_1_top_shape">
+        <first ref="box_with_ppd9_shape" />
+        <second ref="ppd_10_shape" />
+        <position name="layer_1_top_shapeppd_10_shapepos" x="26.640000000000001" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <union name="layer_2_top_shape">
+        <first ref="box_with_ppd9_shape" />
+        <second ref="ppd_10_shape" />
+        <position name="layer_2_top_shapeppd_10_shapepos" x="26.640000000000001" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <union name="layer_3_top_shape">
+        <first ref="box_with_ppd9_shape" />
+        <second ref="ppd_10_shape" />
+        <position name="layer_3_top_shapeppd_10_shapepos" x="26.640000000000001" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <union name="layer_4_top_shape">
+        <first ref="box_with_ppd9_shape" />
+        <second ref="ppd_10_shape" />
+        <position name="layer_4_top_shapeppd_10_shapepos" x="26.640000000000001" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <union name="layer_1_bottom_shape">
+        <first ref="box_with_ppd9_shape" />
+        <second ref="ppd_10_shape" />
+        <position name="layer_1_bottom_shapeppd_10_shapepos" x="26.640000000000001" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <union name="layer_2_bottom_shape">
+        <first ref="box_with_ppd9_shape" />
+        <second ref="ppd_10_shape" />
+        <position name="layer_2_bottom_shapeppd_10_shapepos" x="26.640000000000001" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <union name="layer_3_bottom_shape">
+        <first ref="box_with_ppd9_shape" />
+        <second ref="ppd_10_shape" />
+        <position name="layer_3_bottom_shapeppd_10_shapepos" x="26.640000000000001" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <union name="layer_4_bottom_shape">
+        <first ref="box_with_ppd9_shape" />
+        <second ref="ppd_10_shape" />
+        <position name="layer_4_bottom_shapeppd_10_shapepos" x="26.640000000000001" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <para name="ppd_left2_shape" x="0.40000000000000002" y="1.3999999999999999" z="20.100000000000001" alpha="0" theta="0.96999999999999997" phi="0" aunit="deg" lunit="cm" />
+      <union name="layer_5a1_1_shape">
+        <first ref="ecal_box_minus_inner2_shape" />
+        <second ref="ppd_left2_shape" />
+        <position name="layer_5a1_1_shapeppd_left2_shapepos" x="-1.903" y="0" z="0" unit="cm" />
+      </union>
+      <para name="ppd_left1_shape" x="0.502" y="1.3999999999999999" z="1.5" alpha="0" theta="0.96999999999999997" phi="0" aunit="deg" lunit="cm" />
+      <union name="layer_5a1_shape">
+        <first ref="layer_5a1_1_shape" />
+        <second ref="ppd_left1_shape" />
+        <position name="layer_5a1_shapeppd_left1_shapepos" x="-1.6499999999999999" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <trd name="electron_hole_left_shape" x1="38.177" x2="38.856999999999999" y1="4" y2="4" z="20.199999999999999" lunit="cm" />
+      <subtraction name="layer_5a2_shape">
+        <first ref="layer_5a1_shape" />
+        <second ref="electron_hole_left_shape" />
+        <position name="layer_5a2_shapeelectron_hole_left_shapepos" x="-21.361499999999999" y="0" z="0" unit="cm" />
+      </subtraction>
+      <union name="layer_5a3_shape">
+        <first ref="layer_5a2_shape" />
+        <second ref="ppd_6_shape" />
+        <position name="layer_5a3_shapeppd_6_shapepos" x="5.2400000000000002" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <union name="layer_5a4_shape">
+        <first ref="layer_5a3_shape" />
+        <second ref="ppd_7_shape" />
+        <position name="layer_5a4_shapeppd_7_shapepos" x="10.5" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <union name="layer_5a5_shape">
+        <first ref="layer_5a4_shape" />
+        <second ref="ppd_8_shape" />
+        <position name="layer_5a5_shapeppd_8_shapepos" x="15.800000000000001" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <union name="layer_5a6_shape">
+        <first ref="layer_5a5_shape" />
+        <second ref="ppd_9_shape" />
+        <position name="layer_5a6_shapeppd_9_shapepos" x="21.170000000000002" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <union name="layer_5a7_shape">
+        <first ref="layer_5a6_shape" />
+        <second ref="ppd_10_shape" />
+        <position name="layer_5a7_shapeppd_10_shapepos" x="26.640000000000001" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <union name="layer_5T_left_shape">
+        <first ref="layer_5a7_shape" />
+        <second ref="ppd_0_shape" />
+        <position name="layer_5T_left_shapeppd_0_shapepos" x="0" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <union name="layer_5B_left_shape">
+        <first ref="layer_5a7_shape" />
+        <second ref="ppd_0_shape" />
+        <position name="layer_5B_left_shapeppd_0_shapepos" x="0" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <box name="steel_bar_shape" x="3" y="1.5" z="20" lunit="cm" />
+      <tube name="cu_Tpipe_inner_left_shape" rmin="0.29999999999999999" rmax="0.40000000000000002" z="20.100000000000001" startphi="0" deltaphi="360" aunit="deg" lunit="cm" />
+      <tube name="cu_Tpipe_inner_right_shape" rmin="0.29999999999999999" rmax="0.40000000000000002" z="20.100000000000001" startphi="0" deltaphi="360" aunit="deg" lunit="cm" />
+      <tube name="cu_Bpipe_inner_left_shape" rmin="0.29999999999999999" rmax="0.40000000000000002" z="20.100000000000001" startphi="0" deltaphi="360" aunit="deg" lunit="cm" />
+      <tube name="cu_Bpipe_inner_right_shape" rmin="0.29999999999999999" rmax="0.40000000000000002" z="20.100000000000001" startphi="0" deltaphi="360" aunit="deg" lunit="cm" />
+      <eltube name="cu_Tpipe_outer_right1_shape" dx="0.5" dy="0.10000000000000001" dz="10" lunit="cm" />
+      <eltube name="cu_Tpipe_outer_right2_shape" dx="0.5" dy="0.10000000000000001" dz="10" lunit="cm" />
+      <tube name="cu_Tpipe_outer_right3_shape" rmin="0.29999999999999999" rmax="0.40000000000000002" z="8" startphi="0" deltaphi="360" aunit="deg" lunit="cm" />
+      <tube name="cu_Bpipe_outer_right_shape" rmin="0.29999999999999999" rmax="0.40000000000000002" z="8" startphi="0" deltaphi="360" aunit="deg" lunit="cm" />
+      <eltube name="cu_Bpipe_outer_right1_shape" dx="0.5" dy="0.10000000000000001" dz="10" lunit="cm" />
+      <eltube name="cu_Bpipe_outer_right2_shape" dx="0.5" dy="0.10000000000000001" dz="10" lunit="cm" />
+      <tube name="al_pipe_across_top1_shape" rmin="0.29999999999999999" rmax="0.40000000000000002" z="66" startphi="0" deltaphi="360" aunit="deg" lunit="cm" />
+      <tube name="al_pipe_across_top2_shape" rmin="0.29999999999999999" rmax="0.40000000000000002" z="74" startphi="0" deltaphi="360" aunit="deg" lunit="cm" />
+      <tube name="al_pipe_across_bottom1_shape" rmin="0.29999999999999999" rmax="0.40000000000000002" z="70" startphi="0" deltaphi="360" aunit="deg" lunit="cm" />
+      <tube name="al_pipe_across_bottom2_shape" rmin="0.29999999999999999" rmax="0.40000000000000002" z="78" startphi="0" deltaphi="360" aunit="deg" lunit="cm" />
+      <para name="cu_plate_top_left_shape" x="40" y="0.10000000000000001" z="20" alpha="0" theta="0.96999999999999997" phi="0" aunit="deg" lunit="cm" />
+      <para name="cu_plate_bottom_left_shape" x="40" y="0.10000000000000001" z="20" alpha="0" theta="0.96999999999999997" phi="0" aunit="deg" lunit="cm" />
+      <para name="cu_plate_top_right_shape" x="22" y="0.10000000000000001" z="20" alpha="0" theta="9.6799999999999997" phi="180" aunit="deg" lunit="cm" />
+      <para name="cu_plate_bottom_right_shape" x="22" y="0.10000000000000001" z="20" alpha="0" theta="-9.6799999999999997" phi="0" aunit="deg" lunit="cm" />
+      <trd name="cu_plate_top_middle_shape" x1="7" x2="9.8000000000000007" y1="0.10000000000000001" y2="0.10000000000000001" z="20" lunit="cm" />
+      <trd name="cu_plate_bottom_middle_shape" x1="7" x2="9.8000000000000007" y1="0.10000000000000001" y2="0.10000000000000001" z="20" lunit="cm" />
+      <box name="tracking_volume_solid" x="2000" y="2000" z="2000" lunit="cm" />
+      <box name="hodo_flange_outer_shape" x="76.835000000000008" y="45.719999999999999" z="5" lunit="cm" />
+      <box name="hodo_flange_inner_shape" x="65.035000000000011" y="33.480000000000004" z="5.0010000000000003" lunit="cm" />
+      <subtraction name="hodo_flange_only_shape">
+        <first ref="hodo_flange_outer_shape" />
+        <second ref="hodo_flange_inner_shape" />
+      </subtraction>
+      <box name="Flange_extrusion_1_shape" x="2.5" y="3.5" z="1.5" lunit="cm" />
+      <union name="hodo_flange_ex1_shape">
+        <first ref="hodo_flange_only_shape" />
+        <second ref="Flange_extrusion_1_shape" />
+        <position name="hodo_flange_ex1_shapeFlange_extrusion_1_shapepos" x="19.400000000000002" y="14.990000000000002" z="-0.10000000000000001" unit="cm" />
+      </union>
+      <box name="Flange_extrusion_2_shape" x="2.5" y="3.5" z="1.5" lunit="cm" />
+      <union name="hodo_flange_ex2_shape">
+        <first ref="hodo_flange_ex1_shape" />
+        <second ref="Flange_extrusion_2_shape" />
+        <position name="hodo_flange_ex2_shapeFlange_extrusion_2_shapepos" x="19.400000000000002" y="-14.990000000000002" z="-0.10000000000000001" unit="cm" />
+      </union>
+      <box name="Flange_extrusion_3_shape" x="2.5" y="3.5" z="1.5" lunit="cm" />
+      <union name="hodo_flange_ex3_shape">
+        <first ref="hodo_flange_ex2_shape" />
+        <second ref="Flange_extrusion_3_shape" />
+        <position name="hodo_flange_ex3_shapeFlange_extrusion_3_shapepos" x="7.4000000000000004" y="14.990000000000002" z="-0.10000000000000001" unit="cm" />
+      </union>
+      <box name="Flange_extrusion_4_shape" x="2.5" y="3.5" z="1.5" lunit="cm" />
+      <union name="hodo_flange_shape">
+        <first ref="hodo_flange_ex3_shape" />
+        <second ref="Flange_extrusion_4_shape" />
+        <position name="hodo_flange_shapeFlange_extrusion_4_shapepos" x="7.4000000000000004" y="-14.990000000000002" z="-0.10000000000000001" unit="cm" />
+      </union>
+      <trap name="arms1_block1_shape" z="1.5" theta="3.9490533936242498" phi="90" x1="2.5" x2="2.5" x3="2.5" x4="2.5" y1="3.7071000000000001" y2="3.5" alpha1="0" alpha2="0" aunit="deg" lunit="cm" />
+      <trap name="arms1_block2_shape" z="1.5" theta="3.9490533936242498" phi="90" x1="2.5" x2="2.5" x3="2.5" x4="2.5" y1="3.7071000000000001" y2="3.5" alpha1="0" alpha2="0" aunit="deg" lunit="cm" />
+      <trap name="arms1_block3_shape" z="1.5" theta="-3.9490533936242498" phi="90" x1="2.5" x2="2.5" x3="2.5" x4="2.5" y1="3.7071000000000001" y2="3.5" alpha1="0" alpha2="0" aunit="deg" lunit="cm" />
+      <trap name="arms1_block4_shape" z="1.5" theta="-3.9490533936242498" phi="90" x1="2.5" x2="2.5" x3="2.5" x4="2.5" y1="3.7071000000000001" y2="3.5" alpha1="0" alpha2="0" aunit="deg" lunit="cm" />
+      <box name="cross_bar_top_shape" x="9.5" y="0.80000000000000004" z="1.5" lunit="cm" />
+      <box name="cross_bar_bottom_shape" x="9.5" y="0.80000000000000004" z="1.5" lunit="cm" />
+      <trap name="support_arm_bottom_left_arm_shape" z="21.700000000000003" theta="-9.8039344658558196" phi="90" x1="0.60000000000000009" x2="0.60000000000000009" x3="0.60000000000000009" x4="0.60000000000000009" y1="2.2938300486668619" y2="3.2271000000000001" alpha1="0" alpha2="0" aunit="deg" lunit="cm" />
+      <box name="support_arm_bottom_left_notch_shape" x="2" y="1.7800000000000002" z="1.401" lunit="cm" />
+      <box name="end_block_bottom_left_block_shape" x="2" y="0.78000000000000003" z="1.4000000000000001" lunit="cm" />
+      <box name="end_block_bottom_left_subs_shape" x="2.0010000000000003" y="1" z="1.401" lunit="cm" />
+      <subtraction name="support_arm_bottom_left_with_notch_shape">
+        <first ref="support_arm_bottom_left_arm_shape" />
+        <second ref="support_arm_bottom_left_notch_shape" />
+        <position name="support_arm_bottom_left_with_notch_shapesupport_arm_bottom_left_notch_shapepos" x="0" y="2.9215622772585932" z="-10.151000000000002" unit="cm" />
+      </subtraction>
+      <subtraction name="end_block_bottom_left_shape">
+        <first ref="end_block_bottom_left_block_shape" />
+        <second ref="end_block_bottom_left_subs_shape" />
+        <position name="end_block_bottom_left_shapeend_block_bottom_left_subs_shapepos" x="0" y="0.60999999999999999" z="-0.30099999999999999" unit="cm" />
+      </subtraction>
+      <union name="support_arm_bottom_left_plus_block_shape">
+        <first ref="support_arm_bottom_left_with_notch_shape" />
+        <second ref="end_block_bottom_left_shape" />
+        <position name="support_arm_bottom_left_plus_block_shapeend_block_bottom_left_shapepos" x="0" y="2.4215622772585932" z="-10.15" unit="cm" />
+      </union>
+      <union name="support_arm_bottom_right_shape">
+        <first ref="support_arm_bottom_left_with_notch_shape" />
+        <second ref="end_block_bottom_left_shape" />
+        <position name="support_arm_bottom_right_shapeend_block_bottom_left_shapepos" x="0" y="2.4215622772585932" z="-10.15" unit="cm" />
+      </union>
+      <union name="support_arm_top_left_shape">
+        <first ref="support_arm_bottom_left_with_notch_shape" />
+        <second ref="end_block_bottom_left_shape" />
+        <position name="support_arm_top_left_shapeend_block_bottom_left_shapepos" x="0" y="2.4215622772585932" z="-10.15" unit="cm" />
+      </union>
+      <union name="support_arm_top_right_shape">
+        <first ref="support_arm_bottom_left_with_notch_shape" />
+        <second ref="end_block_bottom_left_shape" />
+        <position name="support_arm_top_right_shapeend_block_bottom_left_shapepos" x="0" y="2.4215622772585932" z="-10.15" unit="cm" />
+      </union>
+      <box name="u_support_bar_bottom_shape" x="16" y="0.80000000000000004" z="0.90000000000000002" lunit="cm" />
+      <box name="u_support_bar_upper1_shape" x="16" y="1.8" z="0.40000000000000002" lunit="cm" />
+      <box name="u_support_bar_upper2_shape" x="16" y="1.8" z="0.30000000000000004" lunit="cm" />
+      <box name="u_support_bar_top_shape" x="16" y="0.80000000000000004" z="0.90000000000000002" lunit="cm" />
+      <box name="u_support_bar_upper3_shape" x="16" y="1.8" z="0.40000000000000002" lunit="cm" />
+      <box name="u_support_bar_upper4_shape" x="16" y="1.8" z="0.30000000000000004" lunit="cm" />
+      <box lunit="mm" name="svt_chamber_outer_box" x="454.152" y="203.2" z="1219.2" />
+      <box lunit="mm" name="svt_chamber_inner_box" x="416.052" y="177.8" z="1221.2" />
+      <subtraction name="svt_chamber_box">
+        <first ref="svt_chamber_outer_box" />
+        <second ref="svt_chamber_inner_box" />
+      </subtraction>
+      <trd lunit="mm" name="svt_chamber_outer_flare1" x1="454.152" x2="454.152" y1="203.2" y2="254.832" z="132.842" />
+      <trd lunit="mm" name="svt_chamber_inner_flare1" x1="416.052" x2="416.052" y1="172.864" y2="234.368" z="158.242" />
+      <subtraction name="svt_chamber_flare1">
+        <first ref="svt_chamber_outer_flare1" />
+        <second ref="svt_chamber_inner_flare1" />
+      </subtraction>
+      <trd lunit="mm" name="svt_chamber_outer_flare2" x1="454.152" x2="679.704" y1="254.832" y2="353.06" z="252.73" />
+      <trd lunit="mm" name="svt_chamber_inner_flare2" x1="404.718" x2="652.938" y1="224.496" y2="332.596" z="278.13" />
+      <subtraction name="svt_chamber_flare2">
+        <first ref="svt_chamber_outer_flare2" />
+        <second ref="svt_chamber_inner_flare2" />
+      </subtraction>
+      <box lunit="mm" name="svt_chamber_outer_flange" x="768.35" y="457.2" z="19.05" />
+      <box lunit="mm" name="svt_chamber_inner_flange" x="654.05" y="342.9" z="25.4" />
+      <subtraction name="svt_chamber_flange">
+        <first ref="svt_chamber_outer_flange" />
+        <second ref="svt_chamber_inner_flange" />
+      </subtraction>
+      <box lunit="mm" name="WorldBox" x="80000" y="80000" z="80000" />
+    </solids>
+    <structure>
+      <volume name="base_plate_volume">
+        <materialref ref="Aluminum" />
+        <solidref ref="base_plateBox" />
+        <visref ref="BasePlateVis" />
+      </volume>
+      <volume name="support_plate_bottom_L14_volume">
+        <materialref ref="Aluminum" />
+        <solidref ref="support_plate_bottom_L14Box" />
+        <visref ref="SupportPlateVis" />
+      </volume>
+      <volume name="support_plate_top_L14_volume">
+        <materialref ref="Aluminum" />
+        <solidref ref="support_plate_top_L14Box" />
+        <visref ref="SupportPlateVis" />
+      </volume>
+      <volume name="support_plate_bottom_L46_volume">
+        <materialref ref="Aluminum" />
+        <solidref ref="support_plate_bottom_L46Box" />
+        <visref ref="SupportPlateVis" />
+      </volume>
+      <volume name="support_plate_top_L46_volume">
+        <materialref ref="Aluminum" />
+        <solidref ref="support_plate_top_L46Box" />
+        <visref ref="SupportPlateVis" />
+      </volume>
+      <volume name="module_L1b_halfmodule_axial_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L1b_halfmodule_axial_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L1b_halfmodule_axial_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L1b_halfmodule_axial_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L1b_halfmodule_axial_sensor_active_volume" />
+          <positionref ref="module_L1b_halfmodule_axial_sensor_active_position" />
+          <rotationref ref="module_L1b_halfmodule_axial_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L1b_halfmodule_axial_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L1b_halfmodule_axialBox" />
+        <physvol>
+          <volumeref ref="module_L1b_halfmodule_axial_sensor_volume" />
+          <positionref ref="module_L1b_halfmodule_axial_sensor_position" />
+          <rotationref ref="module_L1b_halfmodule_axial_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <visref ref="HalfModuleVis" />
+      </volume>
+      <volume name="module_L1b_halfmodule_stereo_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L1b_halfmodule_stereo_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L1b_halfmodule_stereo_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L1b_halfmodule_stereo_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L1b_halfmodule_stereo_sensor_active_volume" />
+          <positionref ref="module_L1b_halfmodule_stereo_sensor_active_position" />
+          <rotationref ref="module_L1b_halfmodule_stereo_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L1b_halfmodule_stereo_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L1b_halfmodule_stereoBox" />
+        <physvol>
+          <volumeref ref="module_L1b_halfmodule_stereo_sensor_volume" />
+          <positionref ref="module_L1b_halfmodule_stereo_sensor_position" />
+          <rotationref ref="module_L1b_halfmodule_stereo_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <visref ref="HalfModuleVis" />
+      </volume>
+      <volume name="module_L1t_halfmodule_axial_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L1t_halfmodule_axial_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L1t_halfmodule_axial_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L1t_halfmodule_axial_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L1t_halfmodule_axial_sensor_active_volume" />
+          <positionref ref="module_L1t_halfmodule_axial_sensor_active_position" />
+          <rotationref ref="module_L1t_halfmodule_axial_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L1t_halfmodule_axial_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L1t_halfmodule_axialBox" />
+        <physvol>
+          <volumeref ref="module_L1t_halfmodule_axial_sensor_volume" />
+          <positionref ref="module_L1t_halfmodule_axial_sensor_position" />
+          <rotationref ref="module_L1t_halfmodule_axial_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <visref ref="HalfModuleVis" />
+      </volume>
+      <volume name="module_L1t_halfmodule_stereo_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L1t_halfmodule_stereo_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L1t_halfmodule_stereo_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L1t_halfmodule_stereo_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L1t_halfmodule_stereo_sensor_active_volume" />
+          <positionref ref="module_L1t_halfmodule_stereo_sensor_active_position" />
+          <rotationref ref="module_L1t_halfmodule_stereo_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L1t_halfmodule_stereo_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L1t_halfmodule_stereoBox" />
+        <physvol>
+          <volumeref ref="module_L1t_halfmodule_stereo_sensor_volume" />
+          <positionref ref="module_L1t_halfmodule_stereo_sensor_position" />
+          <rotationref ref="module_L1t_halfmodule_stereo_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <visref ref="HalfModuleVis" />
+      </volume>
+      <volume name="module_L2b_halfmodule_axial_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L2b_halfmodule_axial_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L2b_halfmodule_axial_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L2b_halfmodule_axial_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L2b_halfmodule_axial_sensor_active_volume" />
+          <positionref ref="module_L2b_halfmodule_axial_sensor_active_position" />
+          <rotationref ref="module_L2b_halfmodule_axial_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L2b_halfmodule_axial_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L2b_halfmodule_axialBox" />
+        <physvol>
+          <volumeref ref="module_L2b_halfmodule_axial_sensor_volume" />
+          <positionref ref="module_L2b_halfmodule_axial_sensor_position" />
+          <rotationref ref="module_L2b_halfmodule_axial_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <visref ref="HalfModuleVis" />
+      </volume>
+      <volume name="module_L2b_halfmodule_stereo_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L2b_halfmodule_stereo_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L2b_halfmodule_stereo_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L2b_halfmodule_stereo_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L2b_halfmodule_stereo_sensor_active_volume" />
+          <positionref ref="module_L2b_halfmodule_stereo_sensor_active_position" />
+          <rotationref ref="module_L2b_halfmodule_stereo_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L2b_halfmodule_stereo_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L2b_halfmodule_stereoBox" />
+        <physvol>
+          <volumeref ref="module_L2b_halfmodule_stereo_sensor_volume" />
+          <positionref ref="module_L2b_halfmodule_stereo_sensor_position" />
+          <rotationref ref="module_L2b_halfmodule_stereo_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <visref ref="HalfModuleVis" />
+      </volume>
+      <volume name="module_L2t_halfmodule_axial_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L2t_halfmodule_axial_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L2t_halfmodule_axial_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L2t_halfmodule_axial_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L2t_halfmodule_axial_sensor_active_volume" />
+          <positionref ref="module_L2t_halfmodule_axial_sensor_active_position" />
+          <rotationref ref="module_L2t_halfmodule_axial_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L2t_halfmodule_axial_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L2t_halfmodule_axialBox" />
+        <physvol>
+          <volumeref ref="module_L2t_halfmodule_axial_sensor_volume" />
+          <positionref ref="module_L2t_halfmodule_axial_sensor_position" />
+          <rotationref ref="module_L2t_halfmodule_axial_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <visref ref="HalfModuleVis" />
+      </volume>
+      <volume name="module_L2t_halfmodule_stereo_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L2t_halfmodule_stereo_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L2t_halfmodule_stereo_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L2t_halfmodule_stereo_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L2t_halfmodule_stereo_sensor_active_volume" />
+          <positionref ref="module_L2t_halfmodule_stereo_sensor_active_position" />
+          <rotationref ref="module_L2t_halfmodule_stereo_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L2t_halfmodule_stereo_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L2t_halfmodule_stereoBox" />
+        <physvol>
+          <volumeref ref="module_L2t_halfmodule_stereo_sensor_volume" />
+          <positionref ref="module_L2t_halfmodule_stereo_sensor_position" />
+          <rotationref ref="module_L2t_halfmodule_stereo_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <visref ref="HalfModuleVis" />
+      </volume>
+      <volume name="module_L3b_halfmodule_axial_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L3b_halfmodule_axial_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L3b_halfmodule_axial_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L3b_halfmodule_axial_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L3b_halfmodule_axial_sensor_active_volume" />
+          <positionref ref="module_L3b_halfmodule_axial_sensor_active_position" />
+          <rotationref ref="module_L3b_halfmodule_axial_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L3b_halfmodule_axial_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L3b_halfmodule_axial_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L3b_halfmodule_axial_cf_volume">
+        <materialref ref="CarbonFiber" />
+        <solidref ref="module_L3b_halfmodule_axial_cfBox" />
+        <visref ref="CarbonFiberVis" />
+      </volume>
+      <volume name="module_L3b_halfmodule_axial_hybrid_volume">
+        <materialref ref="G10" />
+        <solidref ref="module_L3b_halfmodule_axial_hybridBox" />
+        <visref ref="HybridVis" />
+      </volume>
+      <volume name="module_L3b_halfmodule_axial_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L3b_halfmodule_axialBox" />
+        <physvol>
+          <volumeref ref="module_L3b_halfmodule_axial_sensor_volume" />
+          <positionref ref="module_L3b_halfmodule_axial_sensor_position" />
+          <rotationref ref="module_L3b_halfmodule_axial_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L3b_halfmodule_axial_lamination_volume" />
+          <positionref ref="module_L3b_halfmodule_axial_lamination_position" />
+          <rotationref ref="module_L3b_halfmodule_axial_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L3b_halfmodule_axial_cf_volume" />
+          <positionref ref="module_L3b_halfmodule_axial_cf_position" />
+          <rotationref ref="module_L3b_halfmodule_axial_cf_rotation" />
+          <physvolid field_name="component" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L3b_halfmodule_axial_hybrid_volume" />
+          <positionref ref="module_L3b_halfmodule_axial_hybrid_position" />
+          <rotationref ref="module_L3b_halfmodule_axial_hybrid_rotation" />
+          <physvolid field_name="component" value="3" />
+        </physvol>
+        <visref ref="HalfModuleVis" />
+      </volume>
+      <volume name="module_L3b_halfmodule_stereo_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L3b_halfmodule_stereo_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L3b_halfmodule_stereo_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L3b_halfmodule_stereo_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L3b_halfmodule_stereo_sensor_active_volume" />
+          <positionref ref="module_L3b_halfmodule_stereo_sensor_active_position" />
+          <rotationref ref="module_L3b_halfmodule_stereo_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L3b_halfmodule_stereo_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L3b_halfmodule_stereo_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L3b_halfmodule_stereo_cf_volume">
+        <materialref ref="CarbonFiber" />
+        <solidref ref="module_L3b_halfmodule_stereo_cfBox" />
+        <visref ref="CarbonFiberVis" />
+      </volume>
+      <volume name="module_L3b_halfmodule_stereo_hybrid_volume">
+        <materialref ref="G10" />
+        <solidref ref="module_L3b_halfmodule_stereo_hybridBox" />
+        <visref ref="HybridVis" />
+      </volume>
+      <volume name="module_L3b_halfmodule_stereo_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L3b_halfmodule_stereoBox" />
+        <physvol>
+          <volumeref ref="module_L3b_halfmodule_stereo_sensor_volume" />
+          <positionref ref="module_L3b_halfmodule_stereo_sensor_position" />
+          <rotationref ref="module_L3b_halfmodule_stereo_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L3b_halfmodule_stereo_lamination_volume" />
+          <positionref ref="module_L3b_halfmodule_stereo_lamination_position" />
+          <rotationref ref="module_L3b_halfmodule_stereo_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L3b_halfmodule_stereo_cf_volume" />
+          <positionref ref="module_L3b_halfmodule_stereo_cf_position" />
+          <rotationref ref="module_L3b_halfmodule_stereo_cf_rotation" />
+          <physvolid field_name="component" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L3b_halfmodule_stereo_hybrid_volume" />
+          <positionref ref="module_L3b_halfmodule_stereo_hybrid_position" />
+          <rotationref ref="module_L3b_halfmodule_stereo_hybrid_rotation" />
+          <physvolid field_name="component" value="3" />
+        </physvol>
+        <visref ref="HalfModuleVis" />
+      </volume>
+      <volume name="module_L3t_halfmodule_axial_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L3t_halfmodule_axial_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L3t_halfmodule_axial_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L3t_halfmodule_axial_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L3t_halfmodule_axial_sensor_active_volume" />
+          <positionref ref="module_L3t_halfmodule_axial_sensor_active_position" />
+          <rotationref ref="module_L3t_halfmodule_axial_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L3t_halfmodule_axial_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L3t_halfmodule_axial_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L3t_halfmodule_axial_cf_volume">
+        <materialref ref="CarbonFiber" />
+        <solidref ref="module_L3t_halfmodule_axial_cfBox" />
+        <visref ref="CarbonFiberVis" />
+      </volume>
+      <volume name="module_L3t_halfmodule_axial_hybrid_volume">
+        <materialref ref="G10" />
+        <solidref ref="module_L3t_halfmodule_axial_hybridBox" />
+        <visref ref="HybridVis" />
+      </volume>
+      <volume name="module_L3t_halfmodule_axial_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L3t_halfmodule_axialBox" />
+        <physvol>
+          <volumeref ref="module_L3t_halfmodule_axial_sensor_volume" />
+          <positionref ref="module_L3t_halfmodule_axial_sensor_position" />
+          <rotationref ref="module_L3t_halfmodule_axial_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L3t_halfmodule_axial_lamination_volume" />
+          <positionref ref="module_L3t_halfmodule_axial_lamination_position" />
+          <rotationref ref="module_L3t_halfmodule_axial_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L3t_halfmodule_axial_cf_volume" />
+          <positionref ref="module_L3t_halfmodule_axial_cf_position" />
+          <rotationref ref="module_L3t_halfmodule_axial_cf_rotation" />
+          <physvolid field_name="component" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L3t_halfmodule_axial_hybrid_volume" />
+          <positionref ref="module_L3t_halfmodule_axial_hybrid_position" />
+          <rotationref ref="module_L3t_halfmodule_axial_hybrid_rotation" />
+          <physvolid field_name="component" value="3" />
+        </physvol>
+        <visref ref="HalfModuleVis" />
+      </volume>
+      <volume name="module_L3t_halfmodule_stereo_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L3t_halfmodule_stereo_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L3t_halfmodule_stereo_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L3t_halfmodule_stereo_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L3t_halfmodule_stereo_sensor_active_volume" />
+          <positionref ref="module_L3t_halfmodule_stereo_sensor_active_position" />
+          <rotationref ref="module_L3t_halfmodule_stereo_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L3t_halfmodule_stereo_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L3t_halfmodule_stereo_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L3t_halfmodule_stereo_cf_volume">
+        <materialref ref="CarbonFiber" />
+        <solidref ref="module_L3t_halfmodule_stereo_cfBox" />
+        <visref ref="CarbonFiberVis" />
+      </volume>
+      <volume name="module_L3t_halfmodule_stereo_hybrid_volume">
+        <materialref ref="G10" />
+        <solidref ref="module_L3t_halfmodule_stereo_hybridBox" />
+        <visref ref="HybridVis" />
+      </volume>
+      <volume name="module_L3t_halfmodule_stereo_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L3t_halfmodule_stereoBox" />
+        <physvol>
+          <volumeref ref="module_L3t_halfmodule_stereo_sensor_volume" />
+          <positionref ref="module_L3t_halfmodule_stereo_sensor_position" />
+          <rotationref ref="module_L3t_halfmodule_stereo_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L3t_halfmodule_stereo_lamination_volume" />
+          <positionref ref="module_L3t_halfmodule_stereo_lamination_position" />
+          <rotationref ref="module_L3t_halfmodule_stereo_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L3t_halfmodule_stereo_cf_volume" />
+          <positionref ref="module_L3t_halfmodule_stereo_cf_position" />
+          <rotationref ref="module_L3t_halfmodule_stereo_cf_rotation" />
+          <physvolid field_name="component" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L3t_halfmodule_stereo_hybrid_volume" />
+          <positionref ref="module_L3t_halfmodule_stereo_hybrid_position" />
+          <rotationref ref="module_L3t_halfmodule_stereo_hybrid_rotation" />
+          <physvolid field_name="component" value="3" />
+        </physvol>
+        <visref ref="HalfModuleVis" />
+      </volume>
+      <volume name="module_L4b_halfmodule_axial_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L4b_halfmodule_axial_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L4b_halfmodule_axial_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L4b_halfmodule_axial_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L4b_halfmodule_axial_sensor_active_volume" />
+          <positionref ref="module_L4b_halfmodule_axial_sensor_active_position" />
+          <rotationref ref="module_L4b_halfmodule_axial_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L4b_halfmodule_axial_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L4b_halfmodule_axial_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L4b_halfmodule_axial_cf_volume">
+        <materialref ref="CarbonFiber" />
+        <solidref ref="module_L4b_halfmodule_axial_cfBox" />
+        <visref ref="CarbonFiberVis" />
+      </volume>
+      <volume name="module_L4b_halfmodule_axial_hybrid_volume">
+        <materialref ref="G10" />
+        <solidref ref="module_L4b_halfmodule_axial_hybridBox" />
+        <visref ref="HybridVis" />
+      </volume>
+      <volume name="module_L4b_halfmodule_axial_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L4b_halfmodule_axialBox" />
+        <physvol>
+          <volumeref ref="module_L4b_halfmodule_axial_sensor_volume" />
+          <positionref ref="module_L4b_halfmodule_axial_sensor_position" />
+          <rotationref ref="module_L4b_halfmodule_axial_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L4b_halfmodule_axial_lamination_volume" />
+          <positionref ref="module_L4b_halfmodule_axial_lamination_position" />
+          <rotationref ref="module_L4b_halfmodule_axial_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L4b_halfmodule_axial_cf_volume" />
+          <positionref ref="module_L4b_halfmodule_axial_cf_position" />
+          <rotationref ref="module_L4b_halfmodule_axial_cf_rotation" />
+          <physvolid field_name="component" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L4b_halfmodule_axial_hybrid_volume" />
+          <positionref ref="module_L4b_halfmodule_axial_hybrid_position" />
+          <rotationref ref="module_L4b_halfmodule_axial_hybrid_rotation" />
+          <physvolid field_name="component" value="3" />
+        </physvol>
+        <visref ref="HalfModuleVis" />
+      </volume>
+      <volume name="module_L4b_halfmodule_stereo_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L4b_halfmodule_stereo_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L4b_halfmodule_stereo_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L4b_halfmodule_stereo_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L4b_halfmodule_stereo_sensor_active_volume" />
+          <positionref ref="module_L4b_halfmodule_stereo_sensor_active_position" />
+          <rotationref ref="module_L4b_halfmodule_stereo_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L4b_halfmodule_stereo_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L4b_halfmodule_stereo_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L4b_halfmodule_stereo_cf_volume">
+        <materialref ref="CarbonFiber" />
+        <solidref ref="module_L4b_halfmodule_stereo_cfBox" />
+        <visref ref="CarbonFiberVis" />
+      </volume>
+      <volume name="module_L4b_halfmodule_stereo_hybrid_volume">
+        <materialref ref="G10" />
+        <solidref ref="module_L4b_halfmodule_stereo_hybridBox" />
+        <visref ref="HybridVis" />
+      </volume>
+      <volume name="module_L4b_halfmodule_stereo_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L4b_halfmodule_stereoBox" />
+        <physvol>
+          <volumeref ref="module_L4b_halfmodule_stereo_sensor_volume" />
+          <positionref ref="module_L4b_halfmodule_stereo_sensor_position" />
+          <rotationref ref="module_L4b_halfmodule_stereo_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L4b_halfmodule_stereo_lamination_volume" />
+          <positionref ref="module_L4b_halfmodule_stereo_lamination_position" />
+          <rotationref ref="module_L4b_halfmodule_stereo_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L4b_halfmodule_stereo_cf_volume" />
+          <positionref ref="module_L4b_halfmodule_stereo_cf_position" />
+          <rotationref ref="module_L4b_halfmodule_stereo_cf_rotation" />
+          <physvolid field_name="component" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L4b_halfmodule_stereo_hybrid_volume" />
+          <positionref ref="module_L4b_halfmodule_stereo_hybrid_position" />
+          <rotationref ref="module_L4b_halfmodule_stereo_hybrid_rotation" />
+          <physvolid field_name="component" value="3" />
+        </physvol>
+        <visref ref="HalfModuleVis" />
+      </volume>
+      <volume name="module_L4t_halfmodule_axial_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L4t_halfmodule_axial_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L4t_halfmodule_axial_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L4t_halfmodule_axial_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L4t_halfmodule_axial_sensor_active_volume" />
+          <positionref ref="module_L4t_halfmodule_axial_sensor_active_position" />
+          <rotationref ref="module_L4t_halfmodule_axial_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L4t_halfmodule_axial_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L4t_halfmodule_axial_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L4t_halfmodule_axial_cf_volume">
+        <materialref ref="CarbonFiber" />
+        <solidref ref="module_L4t_halfmodule_axial_cfBox" />
+        <visref ref="CarbonFiberVis" />
+      </volume>
+      <volume name="module_L4t_halfmodule_axial_hybrid_volume">
+        <materialref ref="G10" />
+        <solidref ref="module_L4t_halfmodule_axial_hybridBox" />
+        <visref ref="HybridVis" />
+      </volume>
+      <volume name="module_L4t_halfmodule_axial_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L4t_halfmodule_axialBox" />
+        <physvol>
+          <volumeref ref="module_L4t_halfmodule_axial_sensor_volume" />
+          <positionref ref="module_L4t_halfmodule_axial_sensor_position" />
+          <rotationref ref="module_L4t_halfmodule_axial_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L4t_halfmodule_axial_lamination_volume" />
+          <positionref ref="module_L4t_halfmodule_axial_lamination_position" />
+          <rotationref ref="module_L4t_halfmodule_axial_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L4t_halfmodule_axial_cf_volume" />
+          <positionref ref="module_L4t_halfmodule_axial_cf_position" />
+          <rotationref ref="module_L4t_halfmodule_axial_cf_rotation" />
+          <physvolid field_name="component" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L4t_halfmodule_axial_hybrid_volume" />
+          <positionref ref="module_L4t_halfmodule_axial_hybrid_position" />
+          <rotationref ref="module_L4t_halfmodule_axial_hybrid_rotation" />
+          <physvolid field_name="component" value="3" />
+        </physvol>
+        <visref ref="HalfModuleVis" />
+      </volume>
+      <volume name="module_L4t_halfmodule_stereo_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L4t_halfmodule_stereo_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L4t_halfmodule_stereo_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L4t_halfmodule_stereo_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L4t_halfmodule_stereo_sensor_active_volume" />
+          <positionref ref="module_L4t_halfmodule_stereo_sensor_active_position" />
+          <rotationref ref="module_L4t_halfmodule_stereo_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L4t_halfmodule_stereo_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L4t_halfmodule_stereo_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L4t_halfmodule_stereo_cf_volume">
+        <materialref ref="CarbonFiber" />
+        <solidref ref="module_L4t_halfmodule_stereo_cfBox" />
+        <visref ref="CarbonFiberVis" />
+      </volume>
+      <volume name="module_L4t_halfmodule_stereo_hybrid_volume">
+        <materialref ref="G10" />
+        <solidref ref="module_L4t_halfmodule_stereo_hybridBox" />
+        <visref ref="HybridVis" />
+      </volume>
+      <volume name="module_L4t_halfmodule_stereo_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L4t_halfmodule_stereoBox" />
+        <physvol>
+          <volumeref ref="module_L4t_halfmodule_stereo_sensor_volume" />
+          <positionref ref="module_L4t_halfmodule_stereo_sensor_position" />
+          <rotationref ref="module_L4t_halfmodule_stereo_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L4t_halfmodule_stereo_lamination_volume" />
+          <positionref ref="module_L4t_halfmodule_stereo_lamination_position" />
+          <rotationref ref="module_L4t_halfmodule_stereo_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L4t_halfmodule_stereo_cf_volume" />
+          <positionref ref="module_L4t_halfmodule_stereo_cf_position" />
+          <rotationref ref="module_L4t_halfmodule_stereo_cf_rotation" />
+          <physvolid field_name="component" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L4t_halfmodule_stereo_hybrid_volume" />
+          <positionref ref="module_L4t_halfmodule_stereo_hybrid_position" />
+          <rotationref ref="module_L4t_halfmodule_stereo_hybrid_rotation" />
+          <physvolid field_name="component" value="3" />
+        </physvol>
+        <visref ref="HalfModuleVis" />
+      </volume>
+      <volume name="module_L5b_halfmodule_axial_hole_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L5b_halfmodule_axial_hole_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L5b_halfmodule_axial_hole_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L5b_halfmodule_axial_hole_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L5b_halfmodule_axial_hole_sensor_active_volume" />
+          <positionref ref="module_L5b_halfmodule_axial_hole_sensor_active_position" />
+          <rotationref ref="module_L5b_halfmodule_axial_hole_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L5b_halfmodule_axial_hole_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L5b_halfmodule_axial_hole_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L5b_halfmodule_axial_hole_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L5b_halfmodule_axial_holeBox" />
+        <physvol>
+          <volumeref ref="module_L5b_halfmodule_axial_hole_sensor_volume" />
+          <positionref ref="module_L5b_halfmodule_axial_hole_sensor_position" />
+          <rotationref ref="module_L5b_halfmodule_axial_hole_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L5b_halfmodule_axial_hole_lamination_volume" />
+          <positionref ref="module_L5b_halfmodule_axial_hole_lamination_position" />
+          <rotationref ref="module_L5b_halfmodule_axial_hole_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L5b_halfmodule_axial_slot_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L5b_halfmodule_axial_slot_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L5b_halfmodule_axial_slot_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L5b_halfmodule_axial_slot_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L5b_halfmodule_axial_slot_sensor_active_volume" />
+          <positionref ref="module_L5b_halfmodule_axial_slot_sensor_active_position" />
+          <rotationref ref="module_L5b_halfmodule_axial_slot_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L5b_halfmodule_axial_slot_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L5b_halfmodule_axial_slot_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L5b_halfmodule_axial_slot_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L5b_halfmodule_axial_slotBox" />
+        <physvol>
+          <volumeref ref="module_L5b_halfmodule_axial_slot_sensor_volume" />
+          <positionref ref="module_L5b_halfmodule_axial_slot_sensor_position" />
+          <rotationref ref="module_L5b_halfmodule_axial_slot_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L5b_halfmodule_axial_slot_lamination_volume" />
+          <positionref ref="module_L5b_halfmodule_axial_slot_lamination_position" />
+          <rotationref ref="module_L5b_halfmodule_axial_slot_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L5b_halfmodule_stereo_hole_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L5b_halfmodule_stereo_hole_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L5b_halfmodule_stereo_hole_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L5b_halfmodule_stereo_hole_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L5b_halfmodule_stereo_hole_sensor_active_volume" />
+          <positionref ref="module_L5b_halfmodule_stereo_hole_sensor_active_position" />
+          <rotationref ref="module_L5b_halfmodule_stereo_hole_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L5b_halfmodule_stereo_hole_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L5b_halfmodule_stereo_hole_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L5b_halfmodule_stereo_hole_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L5b_halfmodule_stereo_holeBox" />
+        <physvol>
+          <volumeref ref="module_L5b_halfmodule_stereo_hole_sensor_volume" />
+          <positionref ref="module_L5b_halfmodule_stereo_hole_sensor_position" />
+          <rotationref ref="module_L5b_halfmodule_stereo_hole_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L5b_halfmodule_stereo_hole_lamination_volume" />
+          <positionref ref="module_L5b_halfmodule_stereo_hole_lamination_position" />
+          <rotationref ref="module_L5b_halfmodule_stereo_hole_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L5b_halfmodule_stereo_slot_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L5b_halfmodule_stereo_slot_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L5b_halfmodule_stereo_slot_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L5b_halfmodule_stereo_slot_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L5b_halfmodule_stereo_slot_sensor_active_volume" />
+          <positionref ref="module_L5b_halfmodule_stereo_slot_sensor_active_position" />
+          <rotationref ref="module_L5b_halfmodule_stereo_slot_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L5b_halfmodule_stereo_slot_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L5b_halfmodule_stereo_slot_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L5b_halfmodule_stereo_slot_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L5b_halfmodule_stereo_slotBox" />
+        <physvol>
+          <volumeref ref="module_L5b_halfmodule_stereo_slot_sensor_volume" />
+          <positionref ref="module_L5b_halfmodule_stereo_slot_sensor_position" />
+          <rotationref ref="module_L5b_halfmodule_stereo_slot_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L5b_halfmodule_stereo_slot_lamination_volume" />
+          <positionref ref="module_L5b_halfmodule_stereo_slot_lamination_position" />
+          <rotationref ref="module_L5b_halfmodule_stereo_slot_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L5t_halfmodule_axial_hole_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L5t_halfmodule_axial_hole_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L5t_halfmodule_axial_hole_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L5t_halfmodule_axial_hole_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L5t_halfmodule_axial_hole_sensor_active_volume" />
+          <positionref ref="module_L5t_halfmodule_axial_hole_sensor_active_position" />
+          <rotationref ref="module_L5t_halfmodule_axial_hole_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L5t_halfmodule_axial_hole_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L5t_halfmodule_axial_hole_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L5t_halfmodule_axial_hole_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L5t_halfmodule_axial_holeBox" />
+        <physvol>
+          <volumeref ref="module_L5t_halfmodule_axial_hole_sensor_volume" />
+          <positionref ref="module_L5t_halfmodule_axial_hole_sensor_position" />
+          <rotationref ref="module_L5t_halfmodule_axial_hole_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L5t_halfmodule_axial_hole_lamination_volume" />
+          <positionref ref="module_L5t_halfmodule_axial_hole_lamination_position" />
+          <rotationref ref="module_L5t_halfmodule_axial_hole_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L5t_halfmodule_axial_slot_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L5t_halfmodule_axial_slot_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L5t_halfmodule_axial_slot_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L5t_halfmodule_axial_slot_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L5t_halfmodule_axial_slot_sensor_active_volume" />
+          <positionref ref="module_L5t_halfmodule_axial_slot_sensor_active_position" />
+          <rotationref ref="module_L5t_halfmodule_axial_slot_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L5t_halfmodule_axial_slot_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L5t_halfmodule_axial_slot_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L5t_halfmodule_axial_slot_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L5t_halfmodule_axial_slotBox" />
+        <physvol>
+          <volumeref ref="module_L5t_halfmodule_axial_slot_sensor_volume" />
+          <positionref ref="module_L5t_halfmodule_axial_slot_sensor_position" />
+          <rotationref ref="module_L5t_halfmodule_axial_slot_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L5t_halfmodule_axial_slot_lamination_volume" />
+          <positionref ref="module_L5t_halfmodule_axial_slot_lamination_position" />
+          <rotationref ref="module_L5t_halfmodule_axial_slot_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L5t_halfmodule_stereo_hole_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L5t_halfmodule_stereo_hole_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L5t_halfmodule_stereo_hole_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L5t_halfmodule_stereo_hole_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L5t_halfmodule_stereo_hole_sensor_active_volume" />
+          <positionref ref="module_L5t_halfmodule_stereo_hole_sensor_active_position" />
+          <rotationref ref="module_L5t_halfmodule_stereo_hole_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L5t_halfmodule_stereo_hole_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L5t_halfmodule_stereo_hole_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L5t_halfmodule_stereo_hole_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L5t_halfmodule_stereo_holeBox" />
+        <physvol>
+          <volumeref ref="module_L5t_halfmodule_stereo_hole_sensor_volume" />
+          <positionref ref="module_L5t_halfmodule_stereo_hole_sensor_position" />
+          <rotationref ref="module_L5t_halfmodule_stereo_hole_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L5t_halfmodule_stereo_hole_lamination_volume" />
+          <positionref ref="module_L5t_halfmodule_stereo_hole_lamination_position" />
+          <rotationref ref="module_L5t_halfmodule_stereo_hole_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L5t_halfmodule_stereo_slot_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L5t_halfmodule_stereo_slot_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L5t_halfmodule_stereo_slot_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L5t_halfmodule_stereo_slot_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L5t_halfmodule_stereo_slot_sensor_active_volume" />
+          <positionref ref="module_L5t_halfmodule_stereo_slot_sensor_active_position" />
+          <rotationref ref="module_L5t_halfmodule_stereo_slot_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L5t_halfmodule_stereo_slot_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L5t_halfmodule_stereo_slot_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L5t_halfmodule_stereo_slot_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L5t_halfmodule_stereo_slotBox" />
+        <physvol>
+          <volumeref ref="module_L5t_halfmodule_stereo_slot_sensor_volume" />
+          <positionref ref="module_L5t_halfmodule_stereo_slot_sensor_position" />
+          <rotationref ref="module_L5t_halfmodule_stereo_slot_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L5t_halfmodule_stereo_slot_lamination_volume" />
+          <positionref ref="module_L5t_halfmodule_stereo_slot_lamination_position" />
+          <rotationref ref="module_L5t_halfmodule_stereo_slot_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L6b_halfmodule_axial_hole_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L6b_halfmodule_axial_hole_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L6b_halfmodule_axial_hole_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L6b_halfmodule_axial_hole_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L6b_halfmodule_axial_hole_sensor_active_volume" />
+          <positionref ref="module_L6b_halfmodule_axial_hole_sensor_active_position" />
+          <rotationref ref="module_L6b_halfmodule_axial_hole_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L6b_halfmodule_axial_hole_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L6b_halfmodule_axial_hole_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L6b_halfmodule_axial_hole_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L6b_halfmodule_axial_holeBox" />
+        <physvol>
+          <volumeref ref="module_L6b_halfmodule_axial_hole_sensor_volume" />
+          <positionref ref="module_L6b_halfmodule_axial_hole_sensor_position" />
+          <rotationref ref="module_L6b_halfmodule_axial_hole_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L6b_halfmodule_axial_hole_lamination_volume" />
+          <positionref ref="module_L6b_halfmodule_axial_hole_lamination_position" />
+          <rotationref ref="module_L6b_halfmodule_axial_hole_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L6b_halfmodule_axial_slot_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L6b_halfmodule_axial_slot_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L6b_halfmodule_axial_slot_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L6b_halfmodule_axial_slot_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L6b_halfmodule_axial_slot_sensor_active_volume" />
+          <positionref ref="module_L6b_halfmodule_axial_slot_sensor_active_position" />
+          <rotationref ref="module_L6b_halfmodule_axial_slot_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L6b_halfmodule_axial_slot_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L6b_halfmodule_axial_slot_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L6b_halfmodule_axial_slot_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L6b_halfmodule_axial_slotBox" />
+        <physvol>
+          <volumeref ref="module_L6b_halfmodule_axial_slot_sensor_volume" />
+          <positionref ref="module_L6b_halfmodule_axial_slot_sensor_position" />
+          <rotationref ref="module_L6b_halfmodule_axial_slot_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L6b_halfmodule_axial_slot_lamination_volume" />
+          <positionref ref="module_L6b_halfmodule_axial_slot_lamination_position" />
+          <rotationref ref="module_L6b_halfmodule_axial_slot_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L6b_halfmodule_stereo_hole_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L6b_halfmodule_stereo_hole_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L6b_halfmodule_stereo_hole_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L6b_halfmodule_stereo_hole_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L6b_halfmodule_stereo_hole_sensor_active_volume" />
+          <positionref ref="module_L6b_halfmodule_stereo_hole_sensor_active_position" />
+          <rotationref ref="module_L6b_halfmodule_stereo_hole_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L6b_halfmodule_stereo_hole_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L6b_halfmodule_stereo_hole_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L6b_halfmodule_stereo_hole_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L6b_halfmodule_stereo_holeBox" />
+        <physvol>
+          <volumeref ref="module_L6b_halfmodule_stereo_hole_sensor_volume" />
+          <positionref ref="module_L6b_halfmodule_stereo_hole_sensor_position" />
+          <rotationref ref="module_L6b_halfmodule_stereo_hole_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L6b_halfmodule_stereo_hole_lamination_volume" />
+          <positionref ref="module_L6b_halfmodule_stereo_hole_lamination_position" />
+          <rotationref ref="module_L6b_halfmodule_stereo_hole_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L6b_halfmodule_stereo_slot_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L6b_halfmodule_stereo_slot_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L6b_halfmodule_stereo_slot_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L6b_halfmodule_stereo_slot_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L6b_halfmodule_stereo_slot_sensor_active_volume" />
+          <positionref ref="module_L6b_halfmodule_stereo_slot_sensor_active_position" />
+          <rotationref ref="module_L6b_halfmodule_stereo_slot_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L6b_halfmodule_stereo_slot_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L6b_halfmodule_stereo_slot_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L6b_halfmodule_stereo_slot_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L6b_halfmodule_stereo_slotBox" />
+        <physvol>
+          <volumeref ref="module_L6b_halfmodule_stereo_slot_sensor_volume" />
+          <positionref ref="module_L6b_halfmodule_stereo_slot_sensor_position" />
+          <rotationref ref="module_L6b_halfmodule_stereo_slot_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L6b_halfmodule_stereo_slot_lamination_volume" />
+          <positionref ref="module_L6b_halfmodule_stereo_slot_lamination_position" />
+          <rotationref ref="module_L6b_halfmodule_stereo_slot_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L6t_halfmodule_axial_hole_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L6t_halfmodule_axial_hole_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L6t_halfmodule_axial_hole_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L6t_halfmodule_axial_hole_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L6t_halfmodule_axial_hole_sensor_active_volume" />
+          <positionref ref="module_L6t_halfmodule_axial_hole_sensor_active_position" />
+          <rotationref ref="module_L6t_halfmodule_axial_hole_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L6t_halfmodule_axial_hole_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L6t_halfmodule_axial_hole_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L6t_halfmodule_axial_hole_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L6t_halfmodule_axial_holeBox" />
+        <physvol>
+          <volumeref ref="module_L6t_halfmodule_axial_hole_sensor_volume" />
+          <positionref ref="module_L6t_halfmodule_axial_hole_sensor_position" />
+          <rotationref ref="module_L6t_halfmodule_axial_hole_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L6t_halfmodule_axial_hole_lamination_volume" />
+          <positionref ref="module_L6t_halfmodule_axial_hole_lamination_position" />
+          <rotationref ref="module_L6t_halfmodule_axial_hole_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L6t_halfmodule_axial_slot_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L6t_halfmodule_axial_slot_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L6t_halfmodule_axial_slot_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L6t_halfmodule_axial_slot_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L6t_halfmodule_axial_slot_sensor_active_volume" />
+          <positionref ref="module_L6t_halfmodule_axial_slot_sensor_active_position" />
+          <rotationref ref="module_L6t_halfmodule_axial_slot_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L6t_halfmodule_axial_slot_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L6t_halfmodule_axial_slot_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L6t_halfmodule_axial_slot_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L6t_halfmodule_axial_slotBox" />
+        <physvol>
+          <volumeref ref="module_L6t_halfmodule_axial_slot_sensor_volume" />
+          <positionref ref="module_L6t_halfmodule_axial_slot_sensor_position" />
+          <rotationref ref="module_L6t_halfmodule_axial_slot_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L6t_halfmodule_axial_slot_lamination_volume" />
+          <positionref ref="module_L6t_halfmodule_axial_slot_lamination_position" />
+          <rotationref ref="module_L6t_halfmodule_axial_slot_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L6t_halfmodule_stereo_hole_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L6t_halfmodule_stereo_hole_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L6t_halfmodule_stereo_hole_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L6t_halfmodule_stereo_hole_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L6t_halfmodule_stereo_hole_sensor_active_volume" />
+          <positionref ref="module_L6t_halfmodule_stereo_hole_sensor_active_position" />
+          <rotationref ref="module_L6t_halfmodule_stereo_hole_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L6t_halfmodule_stereo_hole_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L6t_halfmodule_stereo_hole_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L6t_halfmodule_stereo_hole_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L6t_halfmodule_stereo_holeBox" />
+        <physvol>
+          <volumeref ref="module_L6t_halfmodule_stereo_hole_sensor_volume" />
+          <positionref ref="module_L6t_halfmodule_stereo_hole_sensor_position" />
+          <rotationref ref="module_L6t_halfmodule_stereo_hole_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L6t_halfmodule_stereo_hole_lamination_volume" />
+          <positionref ref="module_L6t_halfmodule_stereo_hole_lamination_position" />
+          <rotationref ref="module_L6t_halfmodule_stereo_hole_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L6t_halfmodule_stereo_slot_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L6t_halfmodule_stereo_slot_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L6t_halfmodule_stereo_slot_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L6t_halfmodule_stereo_slot_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L6t_halfmodule_stereo_slot_sensor_active_volume" />
+          <positionref ref="module_L6t_halfmodule_stereo_slot_sensor_active_position" />
+          <rotationref ref="module_L6t_halfmodule_stereo_slot_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L6t_halfmodule_stereo_slot_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L6t_halfmodule_stereo_slot_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L6t_halfmodule_stereo_slot_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L6t_halfmodule_stereo_slotBox" />
+        <physvol>
+          <volumeref ref="module_L6t_halfmodule_stereo_slot_sensor_volume" />
+          <positionref ref="module_L6t_halfmodule_stereo_slot_sensor_position" />
+          <rotationref ref="module_L6t_halfmodule_stereo_slot_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L6t_halfmodule_stereo_slot_lamination_volume" />
+          <positionref ref="module_L6t_halfmodule_stereo_slot_lamination_position" />
+          <rotationref ref="module_L6t_halfmodule_stereo_slot_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L7b_halfmodule_axial_hole_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L7b_halfmodule_axial_hole_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L7b_halfmodule_axial_hole_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L7b_halfmodule_axial_hole_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L7b_halfmodule_axial_hole_sensor_active_volume" />
+          <positionref ref="module_L7b_halfmodule_axial_hole_sensor_active_position" />
+          <rotationref ref="module_L7b_halfmodule_axial_hole_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L7b_halfmodule_axial_hole_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L7b_halfmodule_axial_hole_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L7b_halfmodule_axial_hole_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L7b_halfmodule_axial_holeBox" />
+        <physvol>
+          <volumeref ref="module_L7b_halfmodule_axial_hole_sensor_volume" />
+          <positionref ref="module_L7b_halfmodule_axial_hole_sensor_position" />
+          <rotationref ref="module_L7b_halfmodule_axial_hole_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L7b_halfmodule_axial_hole_lamination_volume" />
+          <positionref ref="module_L7b_halfmodule_axial_hole_lamination_position" />
+          <rotationref ref="module_L7b_halfmodule_axial_hole_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L7b_halfmodule_axial_slot_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L7b_halfmodule_axial_slot_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L7b_halfmodule_axial_slot_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L7b_halfmodule_axial_slot_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L7b_halfmodule_axial_slot_sensor_active_volume" />
+          <positionref ref="module_L7b_halfmodule_axial_slot_sensor_active_position" />
+          <rotationref ref="module_L7b_halfmodule_axial_slot_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L7b_halfmodule_axial_slot_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L7b_halfmodule_axial_slot_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L7b_halfmodule_axial_slot_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L7b_halfmodule_axial_slotBox" />
+        <physvol>
+          <volumeref ref="module_L7b_halfmodule_axial_slot_sensor_volume" />
+          <positionref ref="module_L7b_halfmodule_axial_slot_sensor_position" />
+          <rotationref ref="module_L7b_halfmodule_axial_slot_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L7b_halfmodule_axial_slot_lamination_volume" />
+          <positionref ref="module_L7b_halfmodule_axial_slot_lamination_position" />
+          <rotationref ref="module_L7b_halfmodule_axial_slot_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L7b_halfmodule_stereo_hole_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L7b_halfmodule_stereo_hole_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L7b_halfmodule_stereo_hole_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L7b_halfmodule_stereo_hole_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L7b_halfmodule_stereo_hole_sensor_active_volume" />
+          <positionref ref="module_L7b_halfmodule_stereo_hole_sensor_active_position" />
+          <rotationref ref="module_L7b_halfmodule_stereo_hole_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L7b_halfmodule_stereo_hole_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L7b_halfmodule_stereo_hole_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L7b_halfmodule_stereo_hole_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L7b_halfmodule_stereo_holeBox" />
+        <physvol>
+          <volumeref ref="module_L7b_halfmodule_stereo_hole_sensor_volume" />
+          <positionref ref="module_L7b_halfmodule_stereo_hole_sensor_position" />
+          <rotationref ref="module_L7b_halfmodule_stereo_hole_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L7b_halfmodule_stereo_hole_lamination_volume" />
+          <positionref ref="module_L7b_halfmodule_stereo_hole_lamination_position" />
+          <rotationref ref="module_L7b_halfmodule_stereo_hole_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L7b_halfmodule_stereo_slot_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L7b_halfmodule_stereo_slot_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L7b_halfmodule_stereo_slot_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L7b_halfmodule_stereo_slot_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L7b_halfmodule_stereo_slot_sensor_active_volume" />
+          <positionref ref="module_L7b_halfmodule_stereo_slot_sensor_active_position" />
+          <rotationref ref="module_L7b_halfmodule_stereo_slot_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L7b_halfmodule_stereo_slot_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L7b_halfmodule_stereo_slot_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L7b_halfmodule_stereo_slot_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L7b_halfmodule_stereo_slotBox" />
+        <physvol>
+          <volumeref ref="module_L7b_halfmodule_stereo_slot_sensor_volume" />
+          <positionref ref="module_L7b_halfmodule_stereo_slot_sensor_position" />
+          <rotationref ref="module_L7b_halfmodule_stereo_slot_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L7b_halfmodule_stereo_slot_lamination_volume" />
+          <positionref ref="module_L7b_halfmodule_stereo_slot_lamination_position" />
+          <rotationref ref="module_L7b_halfmodule_stereo_slot_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L7t_halfmodule_axial_hole_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L7t_halfmodule_axial_hole_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L7t_halfmodule_axial_hole_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L7t_halfmodule_axial_hole_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L7t_halfmodule_axial_hole_sensor_active_volume" />
+          <positionref ref="module_L7t_halfmodule_axial_hole_sensor_active_position" />
+          <rotationref ref="module_L7t_halfmodule_axial_hole_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L7t_halfmodule_axial_hole_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L7t_halfmodule_axial_hole_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L7t_halfmodule_axial_hole_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L7t_halfmodule_axial_holeBox" />
+        <physvol>
+          <volumeref ref="module_L7t_halfmodule_axial_hole_sensor_volume" />
+          <positionref ref="module_L7t_halfmodule_axial_hole_sensor_position" />
+          <rotationref ref="module_L7t_halfmodule_axial_hole_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L7t_halfmodule_axial_hole_lamination_volume" />
+          <positionref ref="module_L7t_halfmodule_axial_hole_lamination_position" />
+          <rotationref ref="module_L7t_halfmodule_axial_hole_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L7t_halfmodule_axial_slot_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L7t_halfmodule_axial_slot_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L7t_halfmodule_axial_slot_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L7t_halfmodule_axial_slot_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L7t_halfmodule_axial_slot_sensor_active_volume" />
+          <positionref ref="module_L7t_halfmodule_axial_slot_sensor_active_position" />
+          <rotationref ref="module_L7t_halfmodule_axial_slot_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L7t_halfmodule_axial_slot_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L7t_halfmodule_axial_slot_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L7t_halfmodule_axial_slot_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L7t_halfmodule_axial_slotBox" />
+        <physvol>
+          <volumeref ref="module_L7t_halfmodule_axial_slot_sensor_volume" />
+          <positionref ref="module_L7t_halfmodule_axial_slot_sensor_position" />
+          <rotationref ref="module_L7t_halfmodule_axial_slot_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L7t_halfmodule_axial_slot_lamination_volume" />
+          <positionref ref="module_L7t_halfmodule_axial_slot_lamination_position" />
+          <rotationref ref="module_L7t_halfmodule_axial_slot_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L7t_halfmodule_stereo_hole_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L7t_halfmodule_stereo_hole_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L7t_halfmodule_stereo_hole_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L7t_halfmodule_stereo_hole_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L7t_halfmodule_stereo_hole_sensor_active_volume" />
+          <positionref ref="module_L7t_halfmodule_stereo_hole_sensor_active_position" />
+          <rotationref ref="module_L7t_halfmodule_stereo_hole_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L7t_halfmodule_stereo_hole_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L7t_halfmodule_stereo_hole_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L7t_halfmodule_stereo_hole_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L7t_halfmodule_stereo_holeBox" />
+        <physvol>
+          <volumeref ref="module_L7t_halfmodule_stereo_hole_sensor_volume" />
+          <positionref ref="module_L7t_halfmodule_stereo_hole_sensor_position" />
+          <rotationref ref="module_L7t_halfmodule_stereo_hole_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L7t_halfmodule_stereo_hole_lamination_volume" />
+          <positionref ref="module_L7t_halfmodule_stereo_hole_lamination_position" />
+          <rotationref ref="module_L7t_halfmodule_stereo_hole_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L7t_halfmodule_stereo_slot_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L7t_halfmodule_stereo_slot_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L7t_halfmodule_stereo_slot_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L7t_halfmodule_stereo_slot_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L7t_halfmodule_stereo_slot_sensor_active_volume" />
+          <positionref ref="module_L7t_halfmodule_stereo_slot_sensor_active_position" />
+          <rotationref ref="module_L7t_halfmodule_stereo_slot_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L7t_halfmodule_stereo_slot_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L7t_halfmodule_stereo_slot_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L7t_halfmodule_stereo_slot_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L7t_halfmodule_stereo_slotBox" />
+        <physvol>
+          <volumeref ref="module_L7t_halfmodule_stereo_slot_sensor_volume" />
+          <positionref ref="module_L7t_halfmodule_stereo_slot_sensor_position" />
+          <rotationref ref="module_L7t_halfmodule_stereo_slot_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L7t_halfmodule_stereo_slot_lamination_volume" />
+          <positionref ref="module_L7t_halfmodule_stereo_slot_lamination_position" />
+          <rotationref ref="module_L7t_halfmodule_stereo_slot_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="base_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="baseBox" />
+        <physvol>
+          <volumeref ref="base_plate_volume" />
+          <positionref ref="base_plate_position" />
+          <rotationref ref="base_plate_rotation" />
+        </physvol>
+        <physvol>
+          <volumeref ref="support_plate_bottom_L14_volume" />
+          <positionref ref="support_plate_bottom_L14_position" />
+          <rotationref ref="support_plate_bottom_L14_rotation" />
+        </physvol>
+        <physvol>
+          <volumeref ref="support_plate_top_L14_volume" />
+          <positionref ref="support_plate_top_L14_position" />
+          <rotationref ref="support_plate_top_L14_rotation" />
+        </physvol>
+        <physvol>
+          <volumeref ref="support_plate_bottom_L46_volume" />
+          <positionref ref="support_plate_bottom_L46_position" />
+          <rotationref ref="support_plate_bottom_L46_rotation" />
+        </physvol>
+        <physvol>
+          <volumeref ref="support_plate_top_L46_volume" />
+          <positionref ref="support_plate_top_L46_position" />
+          <rotationref ref="support_plate_top_L46_rotation" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L1b_halfmodule_axial_volume" />
+          <positionref ref="module_L1b_halfmodule_axial_position" />
+          <rotationref ref="module_L1b_halfmodule_axial_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="2" />
+          <physvolid field_name="module" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L1b_halfmodule_stereo_volume" />
+          <positionref ref="module_L1b_halfmodule_stereo_position" />
+          <rotationref ref="module_L1b_halfmodule_stereo_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="1" />
+          <physvolid field_name="module" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L1t_halfmodule_axial_volume" />
+          <positionref ref="module_L1t_halfmodule_axial_position" />
+          <rotationref ref="module_L1t_halfmodule_axial_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="1" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L1t_halfmodule_stereo_volume" />
+          <positionref ref="module_L1t_halfmodule_stereo_position" />
+          <rotationref ref="module_L1t_halfmodule_stereo_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="2" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L2b_halfmodule_axial_volume" />
+          <positionref ref="module_L2b_halfmodule_axial_position" />
+          <rotationref ref="module_L2b_halfmodule_axial_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="4" />
+          <physvolid field_name="module" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L2b_halfmodule_stereo_volume" />
+          <positionref ref="module_L2b_halfmodule_stereo_position" />
+          <rotationref ref="module_L2b_halfmodule_stereo_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="3" />
+          <physvolid field_name="module" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L2t_halfmodule_axial_volume" />
+          <positionref ref="module_L2t_halfmodule_axial_position" />
+          <rotationref ref="module_L2t_halfmodule_axial_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="3" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L2t_halfmodule_stereo_volume" />
+          <positionref ref="module_L2t_halfmodule_stereo_position" />
+          <rotationref ref="module_L2t_halfmodule_stereo_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="4" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L3b_halfmodule_axial_volume" />
+          <positionref ref="module_L3b_halfmodule_axial_position" />
+          <rotationref ref="module_L3b_halfmodule_axial_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="6" />
+          <physvolid field_name="module" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L3b_halfmodule_stereo_volume" />
+          <positionref ref="module_L3b_halfmodule_stereo_position" />
+          <rotationref ref="module_L3b_halfmodule_stereo_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="5" />
+          <physvolid field_name="module" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L3t_halfmodule_axial_volume" />
+          <positionref ref="module_L3t_halfmodule_axial_position" />
+          <rotationref ref="module_L3t_halfmodule_axial_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="5" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L3t_halfmodule_stereo_volume" />
+          <positionref ref="module_L3t_halfmodule_stereo_position" />
+          <rotationref ref="module_L3t_halfmodule_stereo_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="6" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L4b_halfmodule_axial_volume" />
+          <positionref ref="module_L4b_halfmodule_axial_position" />
+          <rotationref ref="module_L4b_halfmodule_axial_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="8" />
+          <physvolid field_name="module" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L4b_halfmodule_stereo_volume" />
+          <positionref ref="module_L4b_halfmodule_stereo_position" />
+          <rotationref ref="module_L4b_halfmodule_stereo_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="7" />
+          <physvolid field_name="module" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L4t_halfmodule_axial_volume" />
+          <positionref ref="module_L4t_halfmodule_axial_position" />
+          <rotationref ref="module_L4t_halfmodule_axial_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="7" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L4t_halfmodule_stereo_volume" />
+          <positionref ref="module_L4t_halfmodule_stereo_position" />
+          <rotationref ref="module_L4t_halfmodule_stereo_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="8" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L5b_halfmodule_axial_hole_volume" />
+          <positionref ref="module_L5b_halfmodule_axial_hole_position" />
+          <rotationref ref="module_L5b_halfmodule_axial_hole_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="10" />
+          <physvolid field_name="module" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L5b_halfmodule_axial_slot_volume" />
+          <positionref ref="module_L5b_halfmodule_axial_slot_position" />
+          <rotationref ref="module_L5b_halfmodule_axial_slot_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="10" />
+          <physvolid field_name="module" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L5b_halfmodule_stereo_hole_volume" />
+          <positionref ref="module_L5b_halfmodule_stereo_hole_position" />
+          <rotationref ref="module_L5b_halfmodule_stereo_hole_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="9" />
+          <physvolid field_name="module" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L5b_halfmodule_stereo_slot_volume" />
+          <positionref ref="module_L5b_halfmodule_stereo_slot_position" />
+          <rotationref ref="module_L5b_halfmodule_stereo_slot_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="9" />
+          <physvolid field_name="module" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L5t_halfmodule_axial_hole_volume" />
+          <positionref ref="module_L5t_halfmodule_axial_hole_position" />
+          <rotationref ref="module_L5t_halfmodule_axial_hole_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="9" />
+          <physvolid field_name="module" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L5t_halfmodule_axial_slot_volume" />
+          <positionref ref="module_L5t_halfmodule_axial_slot_position" />
+          <rotationref ref="module_L5t_halfmodule_axial_slot_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="9" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L5t_halfmodule_stereo_hole_volume" />
+          <positionref ref="module_L5t_halfmodule_stereo_hole_position" />
+          <rotationref ref="module_L5t_halfmodule_stereo_hole_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="10" />
+          <physvolid field_name="module" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L5t_halfmodule_stereo_slot_volume" />
+          <positionref ref="module_L5t_halfmodule_stereo_slot_position" />
+          <rotationref ref="module_L5t_halfmodule_stereo_slot_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="10" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L6b_halfmodule_axial_hole_volume" />
+          <positionref ref="module_L6b_halfmodule_axial_hole_position" />
+          <rotationref ref="module_L6b_halfmodule_axial_hole_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="12" />
+          <physvolid field_name="module" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L6b_halfmodule_axial_slot_volume" />
+          <positionref ref="module_L6b_halfmodule_axial_slot_position" />
+          <rotationref ref="module_L6b_halfmodule_axial_slot_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="12" />
+          <physvolid field_name="module" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L6b_halfmodule_stereo_hole_volume" />
+          <positionref ref="module_L6b_halfmodule_stereo_hole_position" />
+          <rotationref ref="module_L6b_halfmodule_stereo_hole_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="11" />
+          <physvolid field_name="module" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L6b_halfmodule_stereo_slot_volume" />
+          <positionref ref="module_L6b_halfmodule_stereo_slot_position" />
+          <rotationref ref="module_L6b_halfmodule_stereo_slot_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="11" />
+          <physvolid field_name="module" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L6t_halfmodule_axial_hole_volume" />
+          <positionref ref="module_L6t_halfmodule_axial_hole_position" />
+          <rotationref ref="module_L6t_halfmodule_axial_hole_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="11" />
+          <physvolid field_name="module" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L6t_halfmodule_axial_slot_volume" />
+          <positionref ref="module_L6t_halfmodule_axial_slot_position" />
+          <rotationref ref="module_L6t_halfmodule_axial_slot_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="11" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L6t_halfmodule_stereo_hole_volume" />
+          <positionref ref="module_L6t_halfmodule_stereo_hole_position" />
+          <rotationref ref="module_L6t_halfmodule_stereo_hole_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="12" />
+          <physvolid field_name="module" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L6t_halfmodule_stereo_slot_volume" />
+          <positionref ref="module_L6t_halfmodule_stereo_slot_position" />
+          <rotationref ref="module_L6t_halfmodule_stereo_slot_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="12" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L7b_halfmodule_axial_hole_volume" />
+          <positionref ref="module_L7b_halfmodule_axial_hole_position" />
+          <rotationref ref="module_L7b_halfmodule_axial_hole_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="14" />
+          <physvolid field_name="module" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L7b_halfmodule_axial_slot_volume" />
+          <positionref ref="module_L7b_halfmodule_axial_slot_position" />
+          <rotationref ref="module_L7b_halfmodule_axial_slot_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="14" />
+          <physvolid field_name="module" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L7b_halfmodule_stereo_hole_volume" />
+          <positionref ref="module_L7b_halfmodule_stereo_hole_position" />
+          <rotationref ref="module_L7b_halfmodule_stereo_hole_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="13" />
+          <physvolid field_name="module" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L7b_halfmodule_stereo_slot_volume" />
+          <positionref ref="module_L7b_halfmodule_stereo_slot_position" />
+          <rotationref ref="module_L7b_halfmodule_stereo_slot_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="13" />
+          <physvolid field_name="module" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L7t_halfmodule_axial_hole_volume" />
+          <positionref ref="module_L7t_halfmodule_axial_hole_position" />
+          <rotationref ref="module_L7t_halfmodule_axial_hole_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="13" />
+          <physvolid field_name="module" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L7t_halfmodule_axial_slot_volume" />
+          <positionref ref="module_L7t_halfmodule_axial_slot_position" />
+          <rotationref ref="module_L7t_halfmodule_axial_slot_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="13" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L7t_halfmodule_stereo_hole_volume" />
+          <positionref ref="module_L7t_halfmodule_stereo_hole_position" />
+          <rotationref ref="module_L7t_halfmodule_stereo_hole_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="14" />
+          <physvolid field_name="module" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L7t_halfmodule_stereo_slot_volume" />
+          <positionref ref="module_L7t_halfmodule_stereo_slot_position" />
+          <rotationref ref="module_L7t_halfmodule_stereo_slot_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="14" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <visref ref="SvtBoxVis" />
+      </volume>
+      <volume name="BeamLeftVolume_component0Sensor0">
+        <materialref ref="Vacuum" />
+        <solidref ref="BeamLeftVolume_component0Sensor0Box" />
+        <sdref ref="ECalScoring" />
+      </volume>
+      <volume name="BeamLeftVolume_component0">
+        <materialref ref="Vacuum" />
+        <solidref ref="BeamLeftVolume_component0Box" />
+        <physvol>
+          <volumeref ref="BeamLeftVolume_component0Sensor0" />
+          <positionref ref="BeamLeftVolume_component0Sensor0Position" />
+          <rotationref ref="BeamLeftVolume_component0Sensor0Rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+      </volume>
+      <volume name="BeamLeftVolume">
+        <materialref ref="Vacuum" />
+        <solidref ref="BeamLeftBox" />
+        <physvol>
+          <volumeref ref="BeamLeftVolume_component0" />
+          <positionref ref="BeamLeftVolume_component0_position" />
+          <rotationref ref="BeamLeftVolume_component0_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+      </volume>
+      <volume name="ElectronGapVolume_component0Sensor0">
+        <materialref ref="Vacuum" />
+        <solidref ref="ElectronGapVolume_component0Sensor0Box" />
+        <sdref ref="ECalScoring" />
+      </volume>
+      <volume name="ElectronGapVolume_component0">
+        <materialref ref="Vacuum" />
+        <solidref ref="ElectronGapVolume_component0Box" />
+        <physvol>
+          <volumeref ref="ElectronGapVolume_component0Sensor0" />
+          <positionref ref="ElectronGapVolume_component0Sensor0Position" />
+          <rotationref ref="ElectronGapVolume_component0Sensor0Rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+      </volume>
+      <volume name="ElectronGapVolume">
+        <materialref ref="Vacuum" />
+        <solidref ref="ElectronGapBox" />
+        <physvol>
+          <volumeref ref="ElectronGapVolume_component0" />
+          <positionref ref="ElectronGapVolume_component0_position" />
+          <rotationref ref="ElectronGapVolume_component0_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+      </volume>
+      <volume name="BeamRightVolume_component0Sensor0">
+        <materialref ref="Vacuum" />
+        <solidref ref="BeamRightVolume_component0Sensor0Box" />
+        <sdref ref="ECalScoring" />
+      </volume>
+      <volume name="BeamRightVolume_component0">
+        <materialref ref="Vacuum" />
+        <solidref ref="BeamRightVolume_component0Box" />
+        <physvol>
+          <volumeref ref="BeamRightVolume_component0Sensor0" />
+          <positionref ref="BeamRightVolume_component0Sensor0Position" />
+          <rotationref ref="BeamRightVolume_component0Sensor0Rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+      </volume>
+      <volume name="BeamRightVolume">
+        <materialref ref="Vacuum" />
+        <solidref ref="BeamRightBox" />
+        <physvol>
+          <volumeref ref="BeamRightVolume_component0" />
+          <positionref ref="BeamRightVolume_component0_position" />
+          <rotationref ref="BeamRightVolume_component0_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+      </volume>
+      <volume name="crystal_volume">
+        <materialref ref="LeadTungstate" />
+        <solidref ref="crystal_trap" />
+        <sdref ref="Ecal" />
+        <visref ref="ECALVis" />
+      </volume>
+      <volume name="hodo_vol_L1TP0">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L1TP0" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L1TP0">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L1TP0" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L1TP0">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L1TP0" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L1TP0">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L1TP0" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_vol_L1BP0">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L1BP0" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L1BP0">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L1BP0" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L1BP0">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L1BP0" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L1BP0">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L1BP0" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_vol_L1TP1">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L1TP1" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L1TP1">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L1TP1" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L1TP1">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L1TP1" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L1TP1">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L1TP1" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_vol_L1BP1">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L1BP1" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L1BP1">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L1BP1" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L1BP1">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L1BP1" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L1BP1">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L1BP1" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_vol_L1TP2">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L1TP2" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L1TP2">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L1TP2" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L1TP2">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L1TP2" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L1TP2">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L1TP2" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_vol_L1BP2">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L1BP2" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L1BP2">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L1BP2" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L1BP2">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L1BP2" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L1BP2">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L1BP2" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_vol_L1TP3">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L1TP3" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L1TP3">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L1TP3" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L1TP3">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L1TP3" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L1TP3">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L1TP3" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_vol_L1BP3">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L1BP3" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L1BP3">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L1BP3" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L1BP3">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L1BP3" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L1BP3">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L1BP3" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_vol_L1TP4">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L1TP4" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L1TP4">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L1TP4" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L1TP4">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L1TP4" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L1TP4">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L1TP4" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_vol_L1BP4">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L1BP4" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L1BP4">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L1BP4" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L1BP4">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L1BP4" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L1BP4">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L1BP4" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_vol_L2TP0">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L2TP0" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L2TP0">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L2TP0" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L2TP0">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L2TP0" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L2TP0">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L2TP0" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_vol_L2BP0">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L2BP0" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L2BP0">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L2BP0" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L2BP0">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L2BP0" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L2BP0">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L2BP0" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_vol_L2TP1">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L2TP1" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L2TP1">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L2TP1" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L2TP1">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L2TP1" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L2TP1">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L2TP1" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_vol_L2BP1">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L2BP1" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L2BP1">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L2BP1" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L2BP1">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L2BP1" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L2BP1">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L2BP1" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_vol_L2TP2">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L2TP2" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L2TP2">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L2TP2" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L2TP2">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L2TP2" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L2TP2">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L2TP2" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_vol_L2BP2">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L2BP2" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L2BP2">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L2BP2" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L2BP2">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L2BP2" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L2BP2">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L2BP2" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_vol_L2TP3">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L2TP3" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L2TP3">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L2TP3" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L2TP3">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L2TP3" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L2TP3">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L2TP3" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_vol_L2BP3">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L2BP3" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L2BP3">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L2BP3" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L2BP3">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L2BP3" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L2BP3">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L2BP3" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_vol_L2TP4">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L2TP4" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L2TP4">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L2TP4" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L2TP4">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L2TP4" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L2TP4">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L2TP4" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_vol_L2BP4">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L2BP4" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L2BP4">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L2BP4" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L2BP4">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L2BP4" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L2BP4">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L2BP4" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_buffer_vol">
+        <materialref ref="Carbon" />
+        <solidref ref="hodo_buffer" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="front_flange">
+        <materialref ref="G4_Al" />
+        <solidref ref="front_flange_shape" />
+      </volume>
+      <volume name="back_flange">
+        <materialref ref="G4_Al" />
+        <solidref ref="back_flange_shape" />
+      </volume>
+      <volume name="ECAL_chamber">
+        <materialref ref="G4_Al" />
+        <solidref ref="ECAL_chamber_shape" />
+      </volume>
+      <volume name="al_honeycomb">
+        <materialref ref="AlHoneycomb" />
+        <solidref ref="al_honeycomb_shape" />
+      </volume>
+      <volume name="layer_1_top">
+        <materialref ref="G4_Al" />
+        <solidref ref="layer_1_top_shape" />
+      </volume>
+      <volume name="layer_2_top">
+        <materialref ref="G4_Al" />
+        <solidref ref="layer_2_top_shape" />
+      </volume>
+      <volume name="layer_3_top">
+        <materialref ref="G4_Al" />
+        <solidref ref="layer_3_top_shape" />
+      </volume>
+      <volume name="layer_4_top">
+        <materialref ref="G4_Al" />
+        <solidref ref="layer_4_top_shape" />
+      </volume>
+      <volume name="layer_1_bottom">
+        <materialref ref="G4_Al" />
+        <solidref ref="layer_1_bottom_shape" />
+      </volume>
+      <volume name="layer_2_bottom">
+        <materialref ref="G4_Al" />
+        <solidref ref="layer_2_bottom_shape" />
+      </volume>
+      <volume name="layer_3_bottom">
+        <materialref ref="G4_Al" />
+        <solidref ref="layer_3_bottom_shape" />
+      </volume>
+      <volume name="layer_4_bottom">
+        <materialref ref="G4_Al" />
+        <solidref ref="layer_4_bottom_shape" />
+      </volume>
+      <volume name="layer_5T_left">
+        <materialref ref="G4_Al" />
+        <solidref ref="layer_5T_left_shape" />
+      </volume>
+      <volume name="layer_5B_left">
+        <materialref ref="G4_Al" />
+        <solidref ref="layer_5B_left_shape" />
+      </volume>
+      <volume name="steel_bar">
+        <materialref ref="StainlessSteel" />
+        <solidref ref="steel_bar_shape" />
+      </volume>
+      <volume name="cu_Tpipe_inner_left">
+        <materialref ref="G4_Cu" />
+        <solidref ref="cu_Tpipe_inner_left_shape" />
+      </volume>
+      <volume name="cu_Tpipe_inner_right">
+        <materialref ref="G4_Cu" />
+        <solidref ref="cu_Tpipe_inner_right_shape" />
+      </volume>
+      <volume name="cu_Bpipe_inner_left">
+        <materialref ref="G4_Cu" />
+        <solidref ref="cu_Bpipe_inner_left_shape" />
+      </volume>
+      <volume name="cu_Bpipe_inner_right">
+        <materialref ref="G4_Cu" />
+        <solidref ref="cu_Bpipe_inner_right_shape" />
+      </volume>
+      <volume name="cu_Tpipe_outer_right1">
+        <materialref ref="G4_Cu" />
+        <solidref ref="cu_Tpipe_outer_right1_shape" />
+      </volume>
+      <volume name="cu_Tpipe_outer_right2">
+        <materialref ref="G4_Cu" />
+        <solidref ref="cu_Tpipe_outer_right2_shape" />
+      </volume>
+      <volume name="cu_Tpipe_outer_right3">
+        <materialref ref="G4_Cu" />
+        <solidref ref="cu_Tpipe_outer_right3_shape" />
+      </volume>
+      <volume name="cu_Bpipe_outer_right">
+        <materialref ref="G4_Cu" />
+        <solidref ref="cu_Bpipe_outer_right_shape" />
+      </volume>
+      <volume name="cu_Bpipe_outer_right1">
+        <materialref ref="G4_Cu" />
+        <solidref ref="cu_Bpipe_outer_right1_shape" />
+      </volume>
+      <volume name="cu_Bpipe_outer_right2">
+        <materialref ref="G4_Cu" />
+        <solidref ref="cu_Bpipe_outer_right2_shape" />
+      </volume>
+      <volume name="al_pipe_across_top1">
+        <materialref ref="G4_Al" />
+        <solidref ref="al_pipe_across_top1_shape" />
+      </volume>
+      <volume name="al_pipe_across_top2">
+        <materialref ref="G4_Al" />
+        <solidref ref="al_pipe_across_top2_shape" />
+      </volume>
+      <volume name="al_pipe_across_bottom1">
+        <materialref ref="G4_Al" />
+        <solidref ref="al_pipe_across_bottom1_shape" />
+      </volume>
+      <volume name="al_pipe_across_bottom2">
+        <materialref ref="G4_Al" />
+        <solidref ref="al_pipe_across_bottom2_shape" />
+      </volume>
+      <volume name="cu_plate_top_left">
+        <materialref ref="G4_Cu" />
+        <solidref ref="cu_plate_top_left_shape" />
+      </volume>
+      <volume name="cu_plate_bottom_left">
+        <materialref ref="G4_Cu" />
+        <solidref ref="cu_plate_bottom_left_shape" />
+      </volume>
+      <volume name="cu_plate_top_right">
+        <materialref ref="G4_Cu" />
+        <solidref ref="cu_plate_top_right_shape" />
+      </volume>
+      <volume name="cu_plate_bottom_right">
+        <materialref ref="G4_Cu" />
+        <solidref ref="cu_plate_bottom_right_shape" />
+      </volume>
+      <volume name="cu_plate_top_middle">
+        <materialref ref="G4_Cu" />
+        <solidref ref="cu_plate_top_middle_shape" />
+      </volume>
+      <volume name="cu_plate_bottom_middle">
+        <materialref ref="G4_Cu" />
+        <solidref ref="cu_plate_bottom_middle_shape" />
+      </volume>
+      <volume name="hodo_flange">
+        <materialref ref="Aluminum" />
+        <solidref ref="hodo_flange_shape" />
+      </volume>
+      <volume name="arms1_block1">
+        <materialref ref="G10_FR4" />
+        <solidref ref="arms1_block1_shape" />
+      </volume>
+      <volume name="arms1_block2">
+        <materialref ref="G10_FR4" />
+        <solidref ref="arms1_block2_shape" />
+      </volume>
+      <volume name="arms1_block3">
+        <materialref ref="G10_FR4" />
+        <solidref ref="arms1_block3_shape" />
+      </volume>
+      <volume name="arms1_block4">
+        <materialref ref="G10_FR4" />
+        <solidref ref="arms1_block4_shape" />
+      </volume>
+      <volume name="cross_bar_top">
+        <materialref ref="G10_FR4" />
+        <solidref ref="cross_bar_top_shape" />
+      </volume>
+      <volume name="cross_bar_bottom">
+        <materialref ref="G10_FR4" />
+        <solidref ref="cross_bar_bottom_shape" />
+      </volume>
+      <volume name="support_arm_bottom_left_plus_block">
+        <materialref ref="G10_FR4" />
+        <solidref ref="support_arm_bottom_left_plus_block_shape" />
+      </volume>
+      <volume name="support_arm_bottom_right">
+        <materialref ref="G10_FR4" />
+        <solidref ref="support_arm_bottom_right_shape" />
+      </volume>
+      <volume name="support_arm_top_left">
+        <materialref ref="G10_FR4" />
+        <solidref ref="support_arm_top_left_shape" />
+      </volume>
+      <volume name="support_arm_top_right">
+        <materialref ref="G10_FR4" />
+        <solidref ref="support_arm_top_right_shape" />
+      </volume>
+      <volume name="u_support_bar_bottom">
+        <materialref ref="G10_FR4" />
+        <solidref ref="u_support_bar_bottom_shape" />
+      </volume>
+      <volume name="u_support_bar_upper1">
+        <materialref ref="G10_FR4" />
+        <solidref ref="u_support_bar_upper1_shape" />
+      </volume>
+      <volume name="u_support_bar_upper2">
+        <materialref ref="G10_FR4" />
+        <solidref ref="u_support_bar_upper2_shape" />
+      </volume>
+      <volume name="u_support_bar_top">
+        <materialref ref="G10_FR4" />
+        <solidref ref="u_support_bar_top_shape" />
+      </volume>
+      <volume name="u_support_bar_upper3">
+        <materialref ref="G10_FR4" />
+        <solidref ref="u_support_bar_upper3_shape" />
+      </volume>
+      <volume name="u_support_bar_upper4">
+        <materialref ref="G10_FR4" />
+        <solidref ref="u_support_bar_upper4_shape" />
+      </volume>
+      <volume name="svt_chamber_box_vol">
+        <materialref ref="Stainless_304" />
+        <solidref ref="svt_chamber_box" />
+      </volume>
+      <volume name="svt_chamber_flare1_vol">
+        <materialref ref="Stainless_304" />
+        <solidref ref="svt_chamber_flare1" />
+      </volume>
+      <volume name="svt_chamber_flare2_vol">
+        <materialref ref="Stainless_304" />
+        <solidref ref="svt_chamber_flare2" />
+      </volume>
+      <volume name="svt_chamber_flange_vol">
+        <materialref ref="Stainless_304" />
+        <solidref ref="svt_chamber_flange" />
+      </volume>
+      <volume name="tracking_volume">
+        <materialref ref="TrackingMaterial" />
+        <solidref ref="tracking_cylinder" />
+        <physvol>
+          <volumeref ref="base_volume" />
+          <positionref ref="base_position" />
+          <rotationref ref="base_rotation" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L1TP0" />
+          <positionref ref="hodo_pos_L1TP0" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="0" />
+          <physvolid field_name="ix" value="0" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1TP0" />
+          <positionref ref="hodo_forecover_pos_L1TP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1TP0" />
+          <positionref ref="hodo_postcover_pos_L1TP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1TP0" />
+          <positionref ref="hodo_sidereflR_pos_L1TP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1TP0" />
+          <positionref ref="hodo_siderefl2L_pos_L1TP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1TP0" />
+          <positionref ref="hodo_topreflT_pos_L1TP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1TP0" />
+          <positionref ref="hodo_toprefl2B_pos_L1TP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L1BP0" />
+          <positionref ref="hodo_pos_L1BP0" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="0" />
+          <physvolid field_name="ix" value="0" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1BP0" />
+          <positionref ref="hodo_forecover_pos_L1BP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1BP0" />
+          <positionref ref="hodo_postcover_pos_L1BP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1BP0" />
+          <positionref ref="hodo_sidereflR_pos_L1BP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1BP0" />
+          <positionref ref="hodo_siderefl2L_pos_L1BP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1BP0" />
+          <positionref ref="hodo_topreflT_pos_L1BP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1BP0" />
+          <positionref ref="hodo_toprefl2B_pos_L1BP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L1TP1" />
+          <positionref ref="hodo_pos_L1TP1" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="0" />
+          <physvolid field_name="ix" value="1" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1TP1" />
+          <positionref ref="hodo_forecover_pos_L1TP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1TP1" />
+          <positionref ref="hodo_postcover_pos_L1TP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1TP1" />
+          <positionref ref="hodo_sidereflR_pos_L1TP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1TP1" />
+          <positionref ref="hodo_siderefl2L_pos_L1TP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1TP1" />
+          <positionref ref="hodo_topreflT_pos_L1TP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1TP1" />
+          <positionref ref="hodo_toprefl2B_pos_L1TP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L1BP1" />
+          <positionref ref="hodo_pos_L1BP1" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="0" />
+          <physvolid field_name="ix" value="1" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1BP1" />
+          <positionref ref="hodo_forecover_pos_L1BP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1BP1" />
+          <positionref ref="hodo_postcover_pos_L1BP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1BP1" />
+          <positionref ref="hodo_sidereflR_pos_L1BP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1BP1" />
+          <positionref ref="hodo_siderefl2L_pos_L1BP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1BP1" />
+          <positionref ref="hodo_topreflT_pos_L1BP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1BP1" />
+          <positionref ref="hodo_toprefl2B_pos_L1BP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L1TP2" />
+          <positionref ref="hodo_pos_L1TP2" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="0" />
+          <physvolid field_name="ix" value="2" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1TP2" />
+          <positionref ref="hodo_forecover_pos_L1TP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1TP2" />
+          <positionref ref="hodo_postcover_pos_L1TP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1TP2" />
+          <positionref ref="hodo_sidereflR_pos_L1TP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1TP2" />
+          <positionref ref="hodo_siderefl2L_pos_L1TP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1TP2" />
+          <positionref ref="hodo_topreflT_pos_L1TP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1TP2" />
+          <positionref ref="hodo_toprefl2B_pos_L1TP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L1BP2" />
+          <positionref ref="hodo_pos_L1BP2" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="0" />
+          <physvolid field_name="ix" value="2" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1BP2" />
+          <positionref ref="hodo_forecover_pos_L1BP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1BP2" />
+          <positionref ref="hodo_postcover_pos_L1BP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1BP2" />
+          <positionref ref="hodo_sidereflR_pos_L1BP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1BP2" />
+          <positionref ref="hodo_siderefl2L_pos_L1BP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1BP2" />
+          <positionref ref="hodo_topreflT_pos_L1BP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1BP2" />
+          <positionref ref="hodo_toprefl2B_pos_L1BP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L1TP3" />
+          <positionref ref="hodo_pos_L1TP3" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="0" />
+          <physvolid field_name="ix" value="3" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1TP3" />
+          <positionref ref="hodo_forecover_pos_L1TP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1TP3" />
+          <positionref ref="hodo_postcover_pos_L1TP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1TP3" />
+          <positionref ref="hodo_sidereflR_pos_L1TP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1TP3" />
+          <positionref ref="hodo_siderefl2L_pos_L1TP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1TP3" />
+          <positionref ref="hodo_topreflT_pos_L1TP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1TP3" />
+          <positionref ref="hodo_toprefl2B_pos_L1TP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L1BP3" />
+          <positionref ref="hodo_pos_L1BP3" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="0" />
+          <physvolid field_name="ix" value="3" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1BP3" />
+          <positionref ref="hodo_forecover_pos_L1BP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1BP3" />
+          <positionref ref="hodo_postcover_pos_L1BP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1BP3" />
+          <positionref ref="hodo_sidereflR_pos_L1BP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1BP3" />
+          <positionref ref="hodo_siderefl2L_pos_L1BP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1BP3" />
+          <positionref ref="hodo_topreflT_pos_L1BP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1BP3" />
+          <positionref ref="hodo_toprefl2B_pos_L1BP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L1TP4" />
+          <positionref ref="hodo_pos_L1TP4" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="0" />
+          <physvolid field_name="ix" value="4" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1TP4" />
+          <positionref ref="hodo_forecover_pos_L1TP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1TP4" />
+          <positionref ref="hodo_postcover_pos_L1TP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1TP4" />
+          <positionref ref="hodo_sidereflR_pos_L1TP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1TP4" />
+          <positionref ref="hodo_siderefl2L_pos_L1TP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1TP4" />
+          <positionref ref="hodo_topreflT_pos_L1TP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1TP4" />
+          <positionref ref="hodo_toprefl2B_pos_L1TP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L1BP4" />
+          <positionref ref="hodo_pos_L1BP4" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="0" />
+          <physvolid field_name="ix" value="4" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1BP4" />
+          <positionref ref="hodo_forecover_pos_L1BP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1BP4" />
+          <positionref ref="hodo_postcover_pos_L1BP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1BP4" />
+          <positionref ref="hodo_sidereflR_pos_L1BP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1BP4" />
+          <positionref ref="hodo_siderefl2L_pos_L1BP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1BP4" />
+          <positionref ref="hodo_topreflT_pos_L1BP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1BP4" />
+          <positionref ref="hodo_toprefl2B_pos_L1BP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L2TP0" />
+          <positionref ref="hodo_pos_L2TP0" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="1" />
+          <physvolid field_name="ix" value="0" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2TP0" />
+          <positionref ref="hodo_forecover_pos_L2TP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2TP0" />
+          <positionref ref="hodo_postcover_pos_L2TP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2TP0" />
+          <positionref ref="hodo_sidereflR_pos_L2TP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2TP0" />
+          <positionref ref="hodo_siderefl2L_pos_L2TP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2TP0" />
+          <positionref ref="hodo_topreflT_pos_L2TP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2TP0" />
+          <positionref ref="hodo_toprefl2B_pos_L2TP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L2BP0" />
+          <positionref ref="hodo_pos_L2BP0" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="1" />
+          <physvolid field_name="ix" value="0" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2BP0" />
+          <positionref ref="hodo_forecover_pos_L2BP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2BP0" />
+          <positionref ref="hodo_postcover_pos_L2BP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2BP0" />
+          <positionref ref="hodo_sidereflR_pos_L2BP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2BP0" />
+          <positionref ref="hodo_siderefl2L_pos_L2BP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2BP0" />
+          <positionref ref="hodo_topreflT_pos_L2BP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2BP0" />
+          <positionref ref="hodo_toprefl2B_pos_L2BP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L2TP1" />
+          <positionref ref="hodo_pos_L2TP1" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="1" />
+          <physvolid field_name="ix" value="1" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2TP1" />
+          <positionref ref="hodo_forecover_pos_L2TP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2TP1" />
+          <positionref ref="hodo_postcover_pos_L2TP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2TP1" />
+          <positionref ref="hodo_sidereflR_pos_L2TP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2TP1" />
+          <positionref ref="hodo_siderefl2L_pos_L2TP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2TP1" />
+          <positionref ref="hodo_topreflT_pos_L2TP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2TP1" />
+          <positionref ref="hodo_toprefl2B_pos_L2TP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L2BP1" />
+          <positionref ref="hodo_pos_L2BP1" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="1" />
+          <physvolid field_name="ix" value="1" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2BP1" />
+          <positionref ref="hodo_forecover_pos_L2BP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2BP1" />
+          <positionref ref="hodo_postcover_pos_L2BP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2BP1" />
+          <positionref ref="hodo_sidereflR_pos_L2BP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2BP1" />
+          <positionref ref="hodo_siderefl2L_pos_L2BP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2BP1" />
+          <positionref ref="hodo_topreflT_pos_L2BP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2BP1" />
+          <positionref ref="hodo_toprefl2B_pos_L2BP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L2TP2" />
+          <positionref ref="hodo_pos_L2TP2" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="1" />
+          <physvolid field_name="ix" value="2" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2TP2" />
+          <positionref ref="hodo_forecover_pos_L2TP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2TP2" />
+          <positionref ref="hodo_postcover_pos_L2TP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2TP2" />
+          <positionref ref="hodo_sidereflR_pos_L2TP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2TP2" />
+          <positionref ref="hodo_siderefl2L_pos_L2TP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2TP2" />
+          <positionref ref="hodo_topreflT_pos_L2TP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2TP2" />
+          <positionref ref="hodo_toprefl2B_pos_L2TP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L2BP2" />
+          <positionref ref="hodo_pos_L2BP2" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="1" />
+          <physvolid field_name="ix" value="2" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2BP2" />
+          <positionref ref="hodo_forecover_pos_L2BP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2BP2" />
+          <positionref ref="hodo_postcover_pos_L2BP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2BP2" />
+          <positionref ref="hodo_sidereflR_pos_L2BP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2BP2" />
+          <positionref ref="hodo_siderefl2L_pos_L2BP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2BP2" />
+          <positionref ref="hodo_topreflT_pos_L2BP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2BP2" />
+          <positionref ref="hodo_toprefl2B_pos_L2BP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L2TP3" />
+          <positionref ref="hodo_pos_L2TP3" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="1" />
+          <physvolid field_name="ix" value="3" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2TP3" />
+          <positionref ref="hodo_forecover_pos_L2TP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2TP3" />
+          <positionref ref="hodo_postcover_pos_L2TP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2TP3" />
+          <positionref ref="hodo_sidereflR_pos_L2TP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2TP3" />
+          <positionref ref="hodo_siderefl2L_pos_L2TP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2TP3" />
+          <positionref ref="hodo_topreflT_pos_L2TP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2TP3" />
+          <positionref ref="hodo_toprefl2B_pos_L2TP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L2BP3" />
+          <positionref ref="hodo_pos_L2BP3" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="1" />
+          <physvolid field_name="ix" value="3" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2BP3" />
+          <positionref ref="hodo_forecover_pos_L2BP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2BP3" />
+          <positionref ref="hodo_postcover_pos_L2BP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2BP3" />
+          <positionref ref="hodo_sidereflR_pos_L2BP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2BP3" />
+          <positionref ref="hodo_siderefl2L_pos_L2BP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2BP3" />
+          <positionref ref="hodo_topreflT_pos_L2BP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2BP3" />
+          <positionref ref="hodo_toprefl2B_pos_L2BP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L2TP4" />
+          <positionref ref="hodo_pos_L2TP4" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="1" />
+          <physvolid field_name="ix" value="4" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2TP4" />
+          <positionref ref="hodo_forecover_pos_L2TP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2TP4" />
+          <positionref ref="hodo_postcover_pos_L2TP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2TP4" />
+          <positionref ref="hodo_sidereflR_pos_L2TP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2TP4" />
+          <positionref ref="hodo_siderefl2L_pos_L2TP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2TP4" />
+          <positionref ref="hodo_topreflT_pos_L2TP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2TP4" />
+          <positionref ref="hodo_toprefl2B_pos_L2TP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L2BP4" />
+          <positionref ref="hodo_pos_L2BP4" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="1" />
+          <physvolid field_name="ix" value="4" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2BP4" />
+          <positionref ref="hodo_forecover_pos_L2BP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2BP4" />
+          <positionref ref="hodo_postcover_pos_L2BP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2BP4" />
+          <positionref ref="hodo_sidereflR_pos_L2BP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2BP4" />
+          <positionref ref="hodo_siderefl2L_pos_L2BP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2BP4" />
+          <positionref ref="hodo_topreflT_pos_L2BP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2BP4" />
+          <positionref ref="hodo_toprefl2B_pos_L2BP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_buffer_vol" />
+          <positionref ref="hodo_bufferT_pos" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_buffer_vol" />
+          <positionref ref="hodo_bufferB_pos" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol name="hodo_flange_1">
+          <volumeref ref="hodo_flange" />
+          <positionref ref="hodo_flange_1intracking_volumepos" />
+        </physvol>
+        <physvol name="arms1_block1_1">
+          <volumeref ref="arms1_block1" />
+          <positionref ref="arms1_block1_1intracking_volumepos" />
+        </physvol>
+        <physvol name="arms1_block2_1">
+          <volumeref ref="arms1_block2" />
+          <positionref ref="arms1_block2_1intracking_volumepos" />
+        </physvol>
+        <physvol name="arms1_block3_1">
+          <volumeref ref="arms1_block3" />
+          <positionref ref="arms1_block3_1intracking_volumepos" />
+        </physvol>
+        <physvol name="arms1_block4_1">
+          <volumeref ref="arms1_block4" />
+          <positionref ref="arms1_block4_1intracking_volumepos" />
+        </physvol>
+        <physvol name="cross_bar_top_1">
+          <volumeref ref="cross_bar_top" />
+          <positionref ref="cross_bar_top_1intracking_volumepos" />
+        </physvol>
+        <physvol name="cross_bar_bottom_1">
+          <volumeref ref="cross_bar_bottom" />
+          <positionref ref="cross_bar_bottom_1intracking_volumepos" />
+        </physvol>
+        <physvol name="support_arm_bottom_left_plus_block_1">
+          <volumeref ref="support_arm_bottom_left_plus_block" />
+          <positionref ref="support_arm_bottom_left_plus_block_1intracking_volumepos" />
+        </physvol>
+        <physvol name="support_arm_bottom_right_1">
+          <volumeref ref="support_arm_bottom_right" />
+          <positionref ref="support_arm_bottom_right_1intracking_volumepos" />
+        </physvol>
+        <physvol name="support_arm_top_left_1">
+          <volumeref ref="support_arm_top_left" />
+          <positionref ref="support_arm_top_left_1intracking_volumepos" />
+          <rotationref ref="support_arm_top_left_1intracking_volumerot" />
+        </physvol>
+        <physvol name="support_arm_top_right_1">
+          <volumeref ref="support_arm_top_right" />
+          <positionref ref="support_arm_top_right_1intracking_volumepos" />
+          <rotationref ref="support_arm_top_right_1intracking_volumerot" />
+        </physvol>
+        <physvol name="u_support_bar_bottom_1">
+          <volumeref ref="u_support_bar_bottom" />
+          <positionref ref="u_support_bar_bottom_1intracking_volumepos" />
+        </physvol>
+        <physvol name="u_support_bar_upper1_1">
+          <volumeref ref="u_support_bar_upper1" />
+          <positionref ref="u_support_bar_upper1_1intracking_volumepos" />
+        </physvol>
+        <physvol name="u_support_bar_upper2_1">
+          <volumeref ref="u_support_bar_upper2" />
+          <positionref ref="u_support_bar_upper2_1intracking_volumepos" />
+        </physvol>
+        <physvol name="u_support_bar_top_1">
+          <volumeref ref="u_support_bar_top" />
+          <positionref ref="u_support_bar_top_1intracking_volumepos" />
+        </physvol>
+        <physvol name="u_support_bar_upper3_1">
+          <volumeref ref="u_support_bar_upper3" />
+          <positionref ref="u_support_bar_upper3_1intracking_volumepos" />
+        </physvol>
+        <physvol name="u_support_bar_upper4_1">
+          <volumeref ref="u_support_bar_upper4" />
+          <positionref ref="u_support_bar_upper4_1intracking_volumepos" />
+        </physvol>
+        <physvol>
+          <volumeref ref="svt_chamber_box_vol" />
+          <position name="svt_chamber_box_position" x="svt_chamber_x" y="0" z="svt_chamber_z+svt_chamber_box_z" />
+        </physvol>
+        <physvol>
+          <volumeref ref="svt_chamber_flare1_vol" />
+          <position name="svt_chamber_flare1_position" x="svt_chamber_x" y="0" z="svt_chamber_z+svt_chamber_flare1_z" />
+        </physvol>
+        <physvol>
+          <volumeref ref="svt_chamber_flare2_vol" />
+          <position name="svt_chamber_flare2_position" x="svt_chamber_x" y="0" z="svt_chamber_z+svt_chamber_flare2_z" />
+        </physvol>
+        <physvol>
+          <volumeref ref="svt_chamber_flange_vol" />
+          <position name="svt_chamber_flange_position" x="svt_chamber_x" y="0" z="svt_chamber_z+svt_chamber_flange_z" />
+        </physvol>
+        <regionref ref="TrackingRegion" />
+        <visref ref="TrackingVis" />
+      </volume>
+      <volume name="world_volume">
+        <materialref ref="WorldMaterial" />
+        <solidref ref="world_box" />
+        <physvol>
+          <volumeref ref="tracking_volume" />
+          <positionref ref="tracking_region_pos" />
+          <rotationref ref="identity_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="BeamLeftVolume" />
+          <positionref ref="ECalScoring_BeamLeft_layer1_module0_position" />
+          <rotationref ref="ECalScoring_BeamLeft_layer1_module0_rotation" />
+          <physvolid field_name="system" value="29" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="1" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="ElectronGapVolume" />
+          <positionref ref="ECalScoring_ElectronGap_layer1_module0_position" />
+          <rotationref ref="ECalScoring_ElectronGap_layer1_module0_rotation" />
+          <physvolid field_name="system" value="29" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="1" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="BeamRightVolume" />
+          <positionref ref="ECalScoring_BeamRight_layer1_module0_position" />
+          <rotationref ref="ECalScoring_BeamRight_layer1_module0_rotation" />
+          <physvolid field_name="system" value="29" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="1" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="BeamLeftVolume" />
+          <positionref ref="ECalScoring_BeamLeft_layer2_module0_position" />
+          <rotationref ref="ECalScoring_BeamLeft_layer2_module0_rotation" />
+          <physvolid field_name="system" value="29" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="2" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="ElectronGapVolume" />
+          <positionref ref="ECalScoring_ElectronGap_layer2_module0_position" />
+          <rotationref ref="ECalScoring_ElectronGap_layer2_module0_rotation" />
+          <physvolid field_name="system" value="29" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="2" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="BeamRightVolume" />
+          <positionref ref="ECalScoring_BeamRight_layer2_module0_position" />
+          <rotationref ref="ECalScoring_BeamRight_layer2_module0_rotation" />
+          <physvolid field_name="system" value="29" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="2" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-1_pos_pos_bot" />
+          <rotationref ref="crystal1-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="1" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-1_pos_neg_bot" />
+          <rotationref ref="crystal1-1_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-1" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-1_pos_pos_top" />
+          <rotationref ref="crystal1-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="1" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-1_pos_neg_top" />
+          <rotationref ref="crystal1-1_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-1" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal2-1_pos_pos_bot" />
+          <rotationref ref="crystal2-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="2" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal2-1_pos_pos_top" />
+          <rotationref ref="crystal2-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="2" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal3-1_pos_pos_bot" />
+          <rotationref ref="crystal3-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="3" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal3-1_pos_pos_top" />
+          <rotationref ref="crystal3-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="3" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal4-1_pos_pos_bot" />
+          <rotationref ref="crystal4-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="4" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal4-1_pos_pos_top" />
+          <rotationref ref="crystal4-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="4" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal5-1_pos_pos_bot" />
+          <rotationref ref="crystal5-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="5" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal5-1_pos_pos_top" />
+          <rotationref ref="crystal5-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="5" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal6-1_pos_pos_bot" />
+          <rotationref ref="crystal6-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="6" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal6-1_pos_pos_top" />
+          <rotationref ref="crystal6-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="6" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal7-1_pos_pos_bot" />
+          <rotationref ref="crystal7-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="7" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal7-1_pos_pos_top" />
+          <rotationref ref="crystal7-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="7" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal8-1_pos_pos_bot" />
+          <rotationref ref="crystal8-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="8" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal8-1_pos_pos_top" />
+          <rotationref ref="crystal8-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="8" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal9-1_pos_pos_bot" />
+          <rotationref ref="crystal9-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="9" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal9-1_pos_pos_top" />
+          <rotationref ref="crystal9-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="9" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal10-1_pos_pos_bot" />
+          <rotationref ref="crystal10-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="10" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal10-1_pos_pos_top" />
+          <rotationref ref="crystal10-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="10" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-1_pos_pos_bot" />
+          <rotationref ref="crystal11-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="11" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-1_pos_neg_bot" />
+          <rotationref ref="crystal11-1_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-11" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-1_pos_pos_top" />
+          <rotationref ref="crystal11-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="11" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-1_pos_neg_top" />
+          <rotationref ref="crystal11-1_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-11" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-1_pos_pos_bot" />
+          <rotationref ref="crystal12-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="12" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-1_pos_neg_bot" />
+          <rotationref ref="crystal12-1_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-12" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-1_pos_pos_top" />
+          <rotationref ref="crystal12-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="12" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-1_pos_neg_top" />
+          <rotationref ref="crystal12-1_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-12" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-1_pos_pos_bot" />
+          <rotationref ref="crystal13-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="13" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-1_pos_neg_bot" />
+          <rotationref ref="crystal13-1_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-13" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-1_pos_pos_top" />
+          <rotationref ref="crystal13-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="13" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-1_pos_neg_top" />
+          <rotationref ref="crystal13-1_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-13" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-1_pos_pos_bot" />
+          <rotationref ref="crystal14-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="14" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-1_pos_neg_bot" />
+          <rotationref ref="crystal14-1_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-14" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-1_pos_pos_top" />
+          <rotationref ref="crystal14-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="14" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-1_pos_neg_top" />
+          <rotationref ref="crystal14-1_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-14" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-1_pos_pos_bot" />
+          <rotationref ref="crystal15-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="15" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-1_pos_neg_bot" />
+          <rotationref ref="crystal15-1_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-15" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-1_pos_pos_top" />
+          <rotationref ref="crystal15-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="15" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-1_pos_neg_top" />
+          <rotationref ref="crystal15-1_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-15" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-1_pos_pos_bot" />
+          <rotationref ref="crystal16-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="16" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-1_pos_neg_bot" />
+          <rotationref ref="crystal16-1_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-16" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-1_pos_pos_top" />
+          <rotationref ref="crystal16-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="16" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-1_pos_neg_top" />
+          <rotationref ref="crystal16-1_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-16" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-1_pos_pos_bot" />
+          <rotationref ref="crystal17-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="17" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-1_pos_neg_bot" />
+          <rotationref ref="crystal17-1_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-17" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-1_pos_pos_top" />
+          <rotationref ref="crystal17-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="17" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-1_pos_neg_top" />
+          <rotationref ref="crystal17-1_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-17" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-1_pos_pos_bot" />
+          <rotationref ref="crystal18-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="18" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-1_pos_neg_bot" />
+          <rotationref ref="crystal18-1_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-18" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-1_pos_pos_top" />
+          <rotationref ref="crystal18-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="18" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-1_pos_neg_top" />
+          <rotationref ref="crystal18-1_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-18" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-1_pos_pos_bot" />
+          <rotationref ref="crystal19-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="19" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-1_pos_neg_bot" />
+          <rotationref ref="crystal19-1_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-19" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-1_pos_pos_top" />
+          <rotationref ref="crystal19-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="19" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-1_pos_neg_top" />
+          <rotationref ref="crystal19-1_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-19" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-1_pos_pos_bot" />
+          <rotationref ref="crystal20-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="20" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-1_pos_neg_bot" />
+          <rotationref ref="crystal20-1_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-20" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-1_pos_pos_top" />
+          <rotationref ref="crystal20-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="20" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-1_pos_neg_top" />
+          <rotationref ref="crystal20-1_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-20" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-1_pos_pos_bot" />
+          <rotationref ref="crystal21-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="21" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-1_pos_neg_bot" />
+          <rotationref ref="crystal21-1_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-21" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-1_pos_pos_top" />
+          <rotationref ref="crystal21-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="21" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-1_pos_neg_top" />
+          <rotationref ref="crystal21-1_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-21" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-1_pos_pos_bot" />
+          <rotationref ref="crystal22-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="22" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-1_pos_neg_bot" />
+          <rotationref ref="crystal22-1_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-22" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-1_pos_pos_top" />
+          <rotationref ref="crystal22-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="22" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-1_pos_neg_top" />
+          <rotationref ref="crystal22-1_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-22" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-1_pos_pos_bot" />
+          <rotationref ref="crystal23-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="23" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-1_pos_neg_bot" />
+          <rotationref ref="crystal23-1_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-23" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-1_pos_pos_top" />
+          <rotationref ref="crystal23-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="23" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-1_pos_neg_top" />
+          <rotationref ref="crystal23-1_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-23" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-2_pos_pos_bot" />
+          <rotationref ref="crystal1-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="1" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-2_pos_neg_bot" />
+          <rotationref ref="crystal1-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-1" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-2_pos_pos_top" />
+          <rotationref ref="crystal1-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="1" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-2_pos_neg_top" />
+          <rotationref ref="crystal1-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-1" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal2-2_pos_pos_bot" />
+          <rotationref ref="crystal2-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="2" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal2-2_pos_neg_bot" />
+          <rotationref ref="crystal2-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-2" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal2-2_pos_pos_top" />
+          <rotationref ref="crystal2-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="2" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal2-2_pos_neg_top" />
+          <rotationref ref="crystal2-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-2" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal3-2_pos_pos_bot" />
+          <rotationref ref="crystal3-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="3" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal3-2_pos_neg_bot" />
+          <rotationref ref="crystal3-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-3" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal3-2_pos_pos_top" />
+          <rotationref ref="crystal3-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="3" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal3-2_pos_neg_top" />
+          <rotationref ref="crystal3-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-3" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal4-2_pos_pos_bot" />
+          <rotationref ref="crystal4-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="4" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal4-2_pos_neg_bot" />
+          <rotationref ref="crystal4-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-4" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal4-2_pos_pos_top" />
+          <rotationref ref="crystal4-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="4" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal4-2_pos_neg_top" />
+          <rotationref ref="crystal4-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-4" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal5-2_pos_pos_bot" />
+          <rotationref ref="crystal5-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="5" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal5-2_pos_neg_bot" />
+          <rotationref ref="crystal5-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-5" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal5-2_pos_pos_top" />
+          <rotationref ref="crystal5-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="5" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal5-2_pos_neg_top" />
+          <rotationref ref="crystal5-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-5" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal6-2_pos_pos_bot" />
+          <rotationref ref="crystal6-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="6" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal6-2_pos_neg_bot" />
+          <rotationref ref="crystal6-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-6" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal6-2_pos_pos_top" />
+          <rotationref ref="crystal6-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="6" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal6-2_pos_neg_top" />
+          <rotationref ref="crystal6-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-6" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal7-2_pos_pos_bot" />
+          <rotationref ref="crystal7-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="7" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal7-2_pos_neg_bot" />
+          <rotationref ref="crystal7-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-7" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal7-2_pos_pos_top" />
+          <rotationref ref="crystal7-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="7" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal7-2_pos_neg_top" />
+          <rotationref ref="crystal7-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-7" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal8-2_pos_pos_bot" />
+          <rotationref ref="crystal8-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="8" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal8-2_pos_neg_bot" />
+          <rotationref ref="crystal8-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-8" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal8-2_pos_pos_top" />
+          <rotationref ref="crystal8-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="8" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal8-2_pos_neg_top" />
+          <rotationref ref="crystal8-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-8" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal9-2_pos_pos_bot" />
+          <rotationref ref="crystal9-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="9" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal9-2_pos_neg_bot" />
+          <rotationref ref="crystal9-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-9" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal9-2_pos_pos_top" />
+          <rotationref ref="crystal9-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="9" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal9-2_pos_neg_top" />
+          <rotationref ref="crystal9-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-9" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal10-2_pos_pos_bot" />
+          <rotationref ref="crystal10-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="10" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal10-2_pos_neg_bot" />
+          <rotationref ref="crystal10-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-10" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal10-2_pos_pos_top" />
+          <rotationref ref="crystal10-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="10" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal10-2_pos_neg_top" />
+          <rotationref ref="crystal10-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-10" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-2_pos_pos_bot" />
+          <rotationref ref="crystal11-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="11" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-2_pos_neg_bot" />
+          <rotationref ref="crystal11-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-11" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-2_pos_pos_top" />
+          <rotationref ref="crystal11-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="11" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-2_pos_neg_top" />
+          <rotationref ref="crystal11-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-11" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-2_pos_pos_bot" />
+          <rotationref ref="crystal12-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="12" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-2_pos_neg_bot" />
+          <rotationref ref="crystal12-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-12" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-2_pos_pos_top" />
+          <rotationref ref="crystal12-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="12" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-2_pos_neg_top" />
+          <rotationref ref="crystal12-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-12" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-2_pos_pos_bot" />
+          <rotationref ref="crystal13-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="13" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-2_pos_neg_bot" />
+          <rotationref ref="crystal13-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-13" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-2_pos_pos_top" />
+          <rotationref ref="crystal13-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="13" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-2_pos_neg_top" />
+          <rotationref ref="crystal13-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-13" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-2_pos_pos_bot" />
+          <rotationref ref="crystal14-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="14" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-2_pos_neg_bot" />
+          <rotationref ref="crystal14-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-14" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-2_pos_pos_top" />
+          <rotationref ref="crystal14-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="14" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-2_pos_neg_top" />
+          <rotationref ref="crystal14-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-14" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-2_pos_pos_bot" />
+          <rotationref ref="crystal15-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="15" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-2_pos_neg_bot" />
+          <rotationref ref="crystal15-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-15" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-2_pos_pos_top" />
+          <rotationref ref="crystal15-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="15" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-2_pos_neg_top" />
+          <rotationref ref="crystal15-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-15" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-2_pos_pos_bot" />
+          <rotationref ref="crystal16-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="16" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-2_pos_neg_bot" />
+          <rotationref ref="crystal16-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-16" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-2_pos_pos_top" />
+          <rotationref ref="crystal16-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="16" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-2_pos_neg_top" />
+          <rotationref ref="crystal16-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-16" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-2_pos_pos_bot" />
+          <rotationref ref="crystal17-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="17" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-2_pos_neg_bot" />
+          <rotationref ref="crystal17-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-17" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-2_pos_pos_top" />
+          <rotationref ref="crystal17-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="17" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-2_pos_neg_top" />
+          <rotationref ref="crystal17-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-17" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-2_pos_pos_bot" />
+          <rotationref ref="crystal18-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="18" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-2_pos_neg_bot" />
+          <rotationref ref="crystal18-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-18" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-2_pos_pos_top" />
+          <rotationref ref="crystal18-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="18" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-2_pos_neg_top" />
+          <rotationref ref="crystal18-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-18" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-2_pos_pos_bot" />
+          <rotationref ref="crystal19-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="19" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-2_pos_neg_bot" />
+          <rotationref ref="crystal19-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-19" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-2_pos_pos_top" />
+          <rotationref ref="crystal19-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="19" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-2_pos_neg_top" />
+          <rotationref ref="crystal19-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-19" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-2_pos_pos_bot" />
+          <rotationref ref="crystal20-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="20" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-2_pos_neg_bot" />
+          <rotationref ref="crystal20-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-20" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-2_pos_pos_top" />
+          <rotationref ref="crystal20-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="20" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-2_pos_neg_top" />
+          <rotationref ref="crystal20-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-20" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-2_pos_pos_bot" />
+          <rotationref ref="crystal21-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="21" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-2_pos_neg_bot" />
+          <rotationref ref="crystal21-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-21" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-2_pos_pos_top" />
+          <rotationref ref="crystal21-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="21" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-2_pos_neg_top" />
+          <rotationref ref="crystal21-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-21" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-2_pos_pos_bot" />
+          <rotationref ref="crystal22-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="22" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-2_pos_neg_bot" />
+          <rotationref ref="crystal22-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-22" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-2_pos_pos_top" />
+          <rotationref ref="crystal22-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="22" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-2_pos_neg_top" />
+          <rotationref ref="crystal22-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-22" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-2_pos_pos_bot" />
+          <rotationref ref="crystal23-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="23" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-2_pos_neg_bot" />
+          <rotationref ref="crystal23-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-23" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-2_pos_pos_top" />
+          <rotationref ref="crystal23-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="23" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-2_pos_neg_top" />
+          <rotationref ref="crystal23-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-23" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-3_pos_pos_bot" />
+          <rotationref ref="crystal1-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="1" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-3_pos_neg_bot" />
+          <rotationref ref="crystal1-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-1" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-3_pos_pos_top" />
+          <rotationref ref="crystal1-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="1" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-3_pos_neg_top" />
+          <rotationref ref="crystal1-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-1" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal2-3_pos_pos_bot" />
+          <rotationref ref="crystal2-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="2" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal2-3_pos_neg_bot" />
+          <rotationref ref="crystal2-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-2" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal2-3_pos_pos_top" />
+          <rotationref ref="crystal2-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="2" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal2-3_pos_neg_top" />
+          <rotationref ref="crystal2-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-2" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal3-3_pos_pos_bot" />
+          <rotationref ref="crystal3-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="3" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal3-3_pos_neg_bot" />
+          <rotationref ref="crystal3-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-3" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal3-3_pos_pos_top" />
+          <rotationref ref="crystal3-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="3" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal3-3_pos_neg_top" />
+          <rotationref ref="crystal3-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-3" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal4-3_pos_pos_bot" />
+          <rotationref ref="crystal4-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="4" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal4-3_pos_neg_bot" />
+          <rotationref ref="crystal4-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-4" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal4-3_pos_pos_top" />
+          <rotationref ref="crystal4-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="4" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal4-3_pos_neg_top" />
+          <rotationref ref="crystal4-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-4" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal5-3_pos_pos_bot" />
+          <rotationref ref="crystal5-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="5" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal5-3_pos_neg_bot" />
+          <rotationref ref="crystal5-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-5" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal5-3_pos_pos_top" />
+          <rotationref ref="crystal5-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="5" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal5-3_pos_neg_top" />
+          <rotationref ref="crystal5-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-5" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal6-3_pos_pos_bot" />
+          <rotationref ref="crystal6-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="6" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal6-3_pos_neg_bot" />
+          <rotationref ref="crystal6-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-6" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal6-3_pos_pos_top" />
+          <rotationref ref="crystal6-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="6" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal6-3_pos_neg_top" />
+          <rotationref ref="crystal6-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-6" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal7-3_pos_pos_bot" />
+          <rotationref ref="crystal7-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="7" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal7-3_pos_neg_bot" />
+          <rotationref ref="crystal7-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-7" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal7-3_pos_pos_top" />
+          <rotationref ref="crystal7-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="7" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal7-3_pos_neg_top" />
+          <rotationref ref="crystal7-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-7" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal8-3_pos_pos_bot" />
+          <rotationref ref="crystal8-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="8" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal8-3_pos_neg_bot" />
+          <rotationref ref="crystal8-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-8" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal8-3_pos_pos_top" />
+          <rotationref ref="crystal8-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="8" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal8-3_pos_neg_top" />
+          <rotationref ref="crystal8-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-8" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal9-3_pos_pos_bot" />
+          <rotationref ref="crystal9-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="9" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal9-3_pos_neg_bot" />
+          <rotationref ref="crystal9-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-9" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal9-3_pos_pos_top" />
+          <rotationref ref="crystal9-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="9" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal9-3_pos_neg_top" />
+          <rotationref ref="crystal9-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-9" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal10-3_pos_pos_bot" />
+          <rotationref ref="crystal10-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="10" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal10-3_pos_neg_bot" />
+          <rotationref ref="crystal10-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-10" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal10-3_pos_pos_top" />
+          <rotationref ref="crystal10-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="10" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal10-3_pos_neg_top" />
+          <rotationref ref="crystal10-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-10" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-3_pos_pos_bot" />
+          <rotationref ref="crystal11-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="11" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-3_pos_neg_bot" />
+          <rotationref ref="crystal11-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-11" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-3_pos_pos_top" />
+          <rotationref ref="crystal11-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="11" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-3_pos_neg_top" />
+          <rotationref ref="crystal11-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-11" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-3_pos_pos_bot" />
+          <rotationref ref="crystal12-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="12" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-3_pos_neg_bot" />
+          <rotationref ref="crystal12-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-12" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-3_pos_pos_top" />
+          <rotationref ref="crystal12-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="12" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-3_pos_neg_top" />
+          <rotationref ref="crystal12-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-12" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-3_pos_pos_bot" />
+          <rotationref ref="crystal13-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="13" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-3_pos_neg_bot" />
+          <rotationref ref="crystal13-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-13" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-3_pos_pos_top" />
+          <rotationref ref="crystal13-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="13" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-3_pos_neg_top" />
+          <rotationref ref="crystal13-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-13" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-3_pos_pos_bot" />
+          <rotationref ref="crystal14-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="14" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-3_pos_neg_bot" />
+          <rotationref ref="crystal14-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-14" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-3_pos_pos_top" />
+          <rotationref ref="crystal14-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="14" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-3_pos_neg_top" />
+          <rotationref ref="crystal14-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-14" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-3_pos_pos_bot" />
+          <rotationref ref="crystal15-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="15" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-3_pos_neg_bot" />
+          <rotationref ref="crystal15-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-15" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-3_pos_pos_top" />
+          <rotationref ref="crystal15-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="15" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-3_pos_neg_top" />
+          <rotationref ref="crystal15-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-15" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-3_pos_pos_bot" />
+          <rotationref ref="crystal16-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="16" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-3_pos_neg_bot" />
+          <rotationref ref="crystal16-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-16" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-3_pos_pos_top" />
+          <rotationref ref="crystal16-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="16" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-3_pos_neg_top" />
+          <rotationref ref="crystal16-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-16" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-3_pos_pos_bot" />
+          <rotationref ref="crystal17-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="17" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-3_pos_neg_bot" />
+          <rotationref ref="crystal17-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-17" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-3_pos_pos_top" />
+          <rotationref ref="crystal17-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="17" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-3_pos_neg_top" />
+          <rotationref ref="crystal17-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-17" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-3_pos_pos_bot" />
+          <rotationref ref="crystal18-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="18" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-3_pos_neg_bot" />
+          <rotationref ref="crystal18-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-18" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-3_pos_pos_top" />
+          <rotationref ref="crystal18-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="18" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-3_pos_neg_top" />
+          <rotationref ref="crystal18-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-18" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-3_pos_pos_bot" />
+          <rotationref ref="crystal19-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="19" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-3_pos_neg_bot" />
+          <rotationref ref="crystal19-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-19" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-3_pos_pos_top" />
+          <rotationref ref="crystal19-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="19" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-3_pos_neg_top" />
+          <rotationref ref="crystal19-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-19" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-3_pos_pos_bot" />
+          <rotationref ref="crystal20-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="20" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-3_pos_neg_bot" />
+          <rotationref ref="crystal20-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-20" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-3_pos_pos_top" />
+          <rotationref ref="crystal20-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="20" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-3_pos_neg_top" />
+          <rotationref ref="crystal20-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-20" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-3_pos_pos_bot" />
+          <rotationref ref="crystal21-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="21" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-3_pos_neg_bot" />
+          <rotationref ref="crystal21-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-21" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-3_pos_pos_top" />
+          <rotationref ref="crystal21-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="21" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-3_pos_neg_top" />
+          <rotationref ref="crystal21-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-21" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-3_pos_pos_bot" />
+          <rotationref ref="crystal22-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="22" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-3_pos_neg_bot" />
+          <rotationref ref="crystal22-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-22" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-3_pos_pos_top" />
+          <rotationref ref="crystal22-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="22" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-3_pos_neg_top" />
+          <rotationref ref="crystal22-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-22" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-3_pos_pos_bot" />
+          <rotationref ref="crystal23-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="23" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-3_pos_neg_bot" />
+          <rotationref ref="crystal23-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-23" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-3_pos_pos_top" />
+          <rotationref ref="crystal23-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="23" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-3_pos_neg_top" />
+          <rotationref ref="crystal23-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-23" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-4_pos_pos_bot" />
+          <rotationref ref="crystal1-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="1" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-4_pos_neg_bot" />
+          <rotationref ref="crystal1-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-1" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-4_pos_pos_top" />
+          <rotationref ref="crystal1-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="1" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-4_pos_neg_top" />
+          <rotationref ref="crystal1-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-1" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal2-4_pos_pos_bot" />
+          <rotationref ref="crystal2-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="2" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal2-4_pos_neg_bot" />
+          <rotationref ref="crystal2-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-2" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal2-4_pos_pos_top" />
+          <rotationref ref="crystal2-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="2" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal2-4_pos_neg_top" />
+          <rotationref ref="crystal2-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-2" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal3-4_pos_pos_bot" />
+          <rotationref ref="crystal3-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="3" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal3-4_pos_neg_bot" />
+          <rotationref ref="crystal3-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-3" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal3-4_pos_pos_top" />
+          <rotationref ref="crystal3-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="3" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal3-4_pos_neg_top" />
+          <rotationref ref="crystal3-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-3" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal4-4_pos_pos_bot" />
+          <rotationref ref="crystal4-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="4" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal4-4_pos_neg_bot" />
+          <rotationref ref="crystal4-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-4" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal4-4_pos_pos_top" />
+          <rotationref ref="crystal4-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="4" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal4-4_pos_neg_top" />
+          <rotationref ref="crystal4-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-4" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal5-4_pos_pos_bot" />
+          <rotationref ref="crystal5-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="5" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal5-4_pos_neg_bot" />
+          <rotationref ref="crystal5-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-5" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal5-4_pos_pos_top" />
+          <rotationref ref="crystal5-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="5" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal5-4_pos_neg_top" />
+          <rotationref ref="crystal5-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-5" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal6-4_pos_pos_bot" />
+          <rotationref ref="crystal6-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="6" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal6-4_pos_neg_bot" />
+          <rotationref ref="crystal6-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-6" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal6-4_pos_pos_top" />
+          <rotationref ref="crystal6-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="6" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal6-4_pos_neg_top" />
+          <rotationref ref="crystal6-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-6" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal7-4_pos_pos_bot" />
+          <rotationref ref="crystal7-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="7" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal7-4_pos_neg_bot" />
+          <rotationref ref="crystal7-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-7" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal7-4_pos_pos_top" />
+          <rotationref ref="crystal7-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="7" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal7-4_pos_neg_top" />
+          <rotationref ref="crystal7-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-7" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal8-4_pos_pos_bot" />
+          <rotationref ref="crystal8-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="8" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal8-4_pos_neg_bot" />
+          <rotationref ref="crystal8-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-8" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal8-4_pos_pos_top" />
+          <rotationref ref="crystal8-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="8" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal8-4_pos_neg_top" />
+          <rotationref ref="crystal8-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-8" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal9-4_pos_pos_bot" />
+          <rotationref ref="crystal9-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="9" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal9-4_pos_neg_bot" />
+          <rotationref ref="crystal9-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-9" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal9-4_pos_pos_top" />
+          <rotationref ref="crystal9-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="9" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal9-4_pos_neg_top" />
+          <rotationref ref="crystal9-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-9" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal10-4_pos_pos_bot" />
+          <rotationref ref="crystal10-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="10" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal10-4_pos_neg_bot" />
+          <rotationref ref="crystal10-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-10" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal10-4_pos_pos_top" />
+          <rotationref ref="crystal10-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="10" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal10-4_pos_neg_top" />
+          <rotationref ref="crystal10-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-10" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-4_pos_pos_bot" />
+          <rotationref ref="crystal11-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="11" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-4_pos_neg_bot" />
+          <rotationref ref="crystal11-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-11" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-4_pos_pos_top" />
+          <rotationref ref="crystal11-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="11" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-4_pos_neg_top" />
+          <rotationref ref="crystal11-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-11" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-4_pos_pos_bot" />
+          <rotationref ref="crystal12-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="12" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-4_pos_neg_bot" />
+          <rotationref ref="crystal12-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-12" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-4_pos_pos_top" />
+          <rotationref ref="crystal12-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="12" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-4_pos_neg_top" />
+          <rotationref ref="crystal12-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-12" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-4_pos_pos_bot" />
+          <rotationref ref="crystal13-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="13" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-4_pos_neg_bot" />
+          <rotationref ref="crystal13-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-13" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-4_pos_pos_top" />
+          <rotationref ref="crystal13-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="13" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-4_pos_neg_top" />
+          <rotationref ref="crystal13-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-13" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-4_pos_pos_bot" />
+          <rotationref ref="crystal14-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="14" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-4_pos_neg_bot" />
+          <rotationref ref="crystal14-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-14" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-4_pos_pos_top" />
+          <rotationref ref="crystal14-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="14" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-4_pos_neg_top" />
+          <rotationref ref="crystal14-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-14" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-4_pos_pos_bot" />
+          <rotationref ref="crystal15-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="15" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-4_pos_neg_bot" />
+          <rotationref ref="crystal15-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-15" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-4_pos_pos_top" />
+          <rotationref ref="crystal15-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="15" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-4_pos_neg_top" />
+          <rotationref ref="crystal15-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-15" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-4_pos_pos_bot" />
+          <rotationref ref="crystal16-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="16" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-4_pos_neg_bot" />
+          <rotationref ref="crystal16-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-16" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-4_pos_pos_top" />
+          <rotationref ref="crystal16-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="16" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-4_pos_neg_top" />
+          <rotationref ref="crystal16-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-16" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-4_pos_pos_bot" />
+          <rotationref ref="crystal17-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="17" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-4_pos_neg_bot" />
+          <rotationref ref="crystal17-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-17" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-4_pos_pos_top" />
+          <rotationref ref="crystal17-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="17" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-4_pos_neg_top" />
+          <rotationref ref="crystal17-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-17" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-4_pos_pos_bot" />
+          <rotationref ref="crystal18-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="18" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-4_pos_neg_bot" />
+          <rotationref ref="crystal18-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-18" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-4_pos_pos_top" />
+          <rotationref ref="crystal18-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="18" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-4_pos_neg_top" />
+          <rotationref ref="crystal18-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-18" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-4_pos_pos_bot" />
+          <rotationref ref="crystal19-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="19" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-4_pos_neg_bot" />
+          <rotationref ref="crystal19-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-19" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-4_pos_pos_top" />
+          <rotationref ref="crystal19-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="19" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-4_pos_neg_top" />
+          <rotationref ref="crystal19-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-19" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-4_pos_pos_bot" />
+          <rotationref ref="crystal20-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="20" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-4_pos_neg_bot" />
+          <rotationref ref="crystal20-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-20" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-4_pos_pos_top" />
+          <rotationref ref="crystal20-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="20" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-4_pos_neg_top" />
+          <rotationref ref="crystal20-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-20" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-4_pos_pos_bot" />
+          <rotationref ref="crystal21-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="21" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-4_pos_neg_bot" />
+          <rotationref ref="crystal21-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-21" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-4_pos_pos_top" />
+          <rotationref ref="crystal21-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="21" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-4_pos_neg_top" />
+          <rotationref ref="crystal21-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-21" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-4_pos_pos_bot" />
+          <rotationref ref="crystal22-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="22" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-4_pos_neg_bot" />
+          <rotationref ref="crystal22-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-22" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-4_pos_pos_top" />
+          <rotationref ref="crystal22-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="22" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-4_pos_neg_top" />
+          <rotationref ref="crystal22-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-22" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-4_pos_pos_bot" />
+          <rotationref ref="crystal23-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="23" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-4_pos_neg_bot" />
+          <rotationref ref="crystal23-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-23" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-4_pos_pos_top" />
+          <rotationref ref="crystal23-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="23" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-4_pos_neg_top" />
+          <rotationref ref="crystal23-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-23" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-5_pos_pos_bot" />
+          <rotationref ref="crystal1-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="1" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-5_pos_neg_bot" />
+          <rotationref ref="crystal1-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-1" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-5_pos_pos_top" />
+          <rotationref ref="crystal1-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="1" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-5_pos_neg_top" />
+          <rotationref ref="crystal1-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-1" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal2-5_pos_pos_bot" />
+          <rotationref ref="crystal2-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="2" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal2-5_pos_neg_bot" />
+          <rotationref ref="crystal2-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-2" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal2-5_pos_pos_top" />
+          <rotationref ref="crystal2-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="2" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal2-5_pos_neg_top" />
+          <rotationref ref="crystal2-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-2" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal3-5_pos_pos_bot" />
+          <rotationref ref="crystal3-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="3" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal3-5_pos_neg_bot" />
+          <rotationref ref="crystal3-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-3" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal3-5_pos_pos_top" />
+          <rotationref ref="crystal3-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="3" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal3-5_pos_neg_top" />
+          <rotationref ref="crystal3-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-3" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal4-5_pos_pos_bot" />
+          <rotationref ref="crystal4-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="4" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal4-5_pos_neg_bot" />
+          <rotationref ref="crystal4-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-4" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal4-5_pos_pos_top" />
+          <rotationref ref="crystal4-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="4" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal4-5_pos_neg_top" />
+          <rotationref ref="crystal4-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-4" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal5-5_pos_pos_bot" />
+          <rotationref ref="crystal5-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="5" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal5-5_pos_neg_bot" />
+          <rotationref ref="crystal5-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-5" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal5-5_pos_pos_top" />
+          <rotationref ref="crystal5-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="5" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal5-5_pos_neg_top" />
+          <rotationref ref="crystal5-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-5" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal6-5_pos_pos_bot" />
+          <rotationref ref="crystal6-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="6" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal6-5_pos_neg_bot" />
+          <rotationref ref="crystal6-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-6" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal6-5_pos_pos_top" />
+          <rotationref ref="crystal6-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="6" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal6-5_pos_neg_top" />
+          <rotationref ref="crystal6-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-6" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal7-5_pos_pos_bot" />
+          <rotationref ref="crystal7-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="7" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal7-5_pos_neg_bot" />
+          <rotationref ref="crystal7-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-7" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal7-5_pos_pos_top" />
+          <rotationref ref="crystal7-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="7" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal7-5_pos_neg_top" />
+          <rotationref ref="crystal7-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-7" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal8-5_pos_pos_bot" />
+          <rotationref ref="crystal8-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="8" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal8-5_pos_neg_bot" />
+          <rotationref ref="crystal8-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-8" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal8-5_pos_pos_top" />
+          <rotationref ref="crystal8-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="8" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal8-5_pos_neg_top" />
+          <rotationref ref="crystal8-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-8" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal9-5_pos_pos_bot" />
+          <rotationref ref="crystal9-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="9" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal9-5_pos_neg_bot" />
+          <rotationref ref="crystal9-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-9" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal9-5_pos_pos_top" />
+          <rotationref ref="crystal9-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="9" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal9-5_pos_neg_top" />
+          <rotationref ref="crystal9-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-9" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal10-5_pos_pos_bot" />
+          <rotationref ref="crystal10-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="10" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal10-5_pos_neg_bot" />
+          <rotationref ref="crystal10-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-10" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal10-5_pos_pos_top" />
+          <rotationref ref="crystal10-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="10" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal10-5_pos_neg_top" />
+          <rotationref ref="crystal10-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-10" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-5_pos_pos_bot" />
+          <rotationref ref="crystal11-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="11" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-5_pos_neg_bot" />
+          <rotationref ref="crystal11-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-11" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-5_pos_pos_top" />
+          <rotationref ref="crystal11-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="11" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-5_pos_neg_top" />
+          <rotationref ref="crystal11-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-11" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-5_pos_pos_bot" />
+          <rotationref ref="crystal12-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="12" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-5_pos_neg_bot" />
+          <rotationref ref="crystal12-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-12" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-5_pos_pos_top" />
+          <rotationref ref="crystal12-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="12" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-5_pos_neg_top" />
+          <rotationref ref="crystal12-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-12" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-5_pos_pos_bot" />
+          <rotationref ref="crystal13-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="13" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-5_pos_neg_bot" />
+          <rotationref ref="crystal13-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-13" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-5_pos_pos_top" />
+          <rotationref ref="crystal13-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="13" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-5_pos_neg_top" />
+          <rotationref ref="crystal13-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-13" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-5_pos_pos_bot" />
+          <rotationref ref="crystal14-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="14" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-5_pos_neg_bot" />
+          <rotationref ref="crystal14-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-14" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-5_pos_pos_top" />
+          <rotationref ref="crystal14-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="14" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-5_pos_neg_top" />
+          <rotationref ref="crystal14-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-14" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-5_pos_pos_bot" />
+          <rotationref ref="crystal15-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="15" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-5_pos_neg_bot" />
+          <rotationref ref="crystal15-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-15" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-5_pos_pos_top" />
+          <rotationref ref="crystal15-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="15" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-5_pos_neg_top" />
+          <rotationref ref="crystal15-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-15" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-5_pos_pos_bot" />
+          <rotationref ref="crystal16-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="16" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-5_pos_neg_bot" />
+          <rotationref ref="crystal16-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-16" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-5_pos_pos_top" />
+          <rotationref ref="crystal16-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="16" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-5_pos_neg_top" />
+          <rotationref ref="crystal16-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-16" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-5_pos_pos_bot" />
+          <rotationref ref="crystal17-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="17" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-5_pos_neg_bot" />
+          <rotationref ref="crystal17-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-17" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-5_pos_pos_top" />
+          <rotationref ref="crystal17-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="17" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-5_pos_neg_top" />
+          <rotationref ref="crystal17-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-17" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-5_pos_pos_bot" />
+          <rotationref ref="crystal18-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="18" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-5_pos_neg_bot" />
+          <rotationref ref="crystal18-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-18" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-5_pos_pos_top" />
+          <rotationref ref="crystal18-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="18" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-5_pos_neg_top" />
+          <rotationref ref="crystal18-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-18" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-5_pos_pos_bot" />
+          <rotationref ref="crystal19-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="19" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-5_pos_neg_bot" />
+          <rotationref ref="crystal19-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-19" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-5_pos_pos_top" />
+          <rotationref ref="crystal19-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="19" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-5_pos_neg_top" />
+          <rotationref ref="crystal19-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-19" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-5_pos_pos_bot" />
+          <rotationref ref="crystal20-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="20" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-5_pos_neg_bot" />
+          <rotationref ref="crystal20-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-20" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-5_pos_pos_top" />
+          <rotationref ref="crystal20-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="20" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-5_pos_neg_top" />
+          <rotationref ref="crystal20-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-20" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-5_pos_pos_bot" />
+          <rotationref ref="crystal21-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="21" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-5_pos_neg_bot" />
+          <rotationref ref="crystal21-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-21" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-5_pos_pos_top" />
+          <rotationref ref="crystal21-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="21" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-5_pos_neg_top" />
+          <rotationref ref="crystal21-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-21" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-5_pos_pos_bot" />
+          <rotationref ref="crystal22-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="22" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-5_pos_neg_bot" />
+          <rotationref ref="crystal22-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-22" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-5_pos_pos_top" />
+          <rotationref ref="crystal22-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="22" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-5_pos_neg_top" />
+          <rotationref ref="crystal22-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-22" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-5_pos_pos_bot" />
+          <rotationref ref="crystal23-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="23" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-5_pos_neg_bot" />
+          <rotationref ref="crystal23-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-23" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-5_pos_pos_top" />
+          <rotationref ref="crystal23-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="23" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-5_pos_neg_top" />
+          <rotationref ref="crystal23-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-23" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol name="front_flange_1">
+          <volumeref ref="front_flange" />
+          <positionref ref="front_flange_1inworld_volumepos" />
+        </physvol>
+        <physvol name="back_flange_1">
+          <volumeref ref="back_flange" />
+          <positionref ref="back_flange_1inworld_volumepos" />
+        </physvol>
+        <physvol name="ECAL_chamber_1">
+          <volumeref ref="ECAL_chamber" />
+          <positionref ref="ECAL_chamber_1inworld_volumepos" />
+        </physvol>
+        <physvol name="al_honeycomb_1">
+          <volumeref ref="al_honeycomb" />
+          <positionref ref="al_honeycomb_1inworld_volumepos" />
+        </physvol>
+        <physvol name="layer_1_top_1">
+          <volumeref ref="layer_1_top" />
+          <positionref ref="layer_1_top_1inworld_volumepos" />
+        </physvol>
+        <physvol name="layer_2_top_1">
+          <volumeref ref="layer_2_top" />
+          <positionref ref="layer_2_top_1inworld_volumepos" />
+        </physvol>
+        <physvol name="layer_3_top_1">
+          <volumeref ref="layer_3_top" />
+          <positionref ref="layer_3_top_1inworld_volumepos" />
+        </physvol>
+        <physvol name="layer_4_top_1">
+          <volumeref ref="layer_4_top" />
+          <positionref ref="layer_4_top_1inworld_volumepos" />
+        </physvol>
+        <physvol name="layer_1_bottom_1">
+          <volumeref ref="layer_1_bottom" />
+          <positionref ref="layer_1_bottom_1inworld_volumepos" />
+        </physvol>
+        <physvol name="layer_2_bottom_1">
+          <volumeref ref="layer_2_bottom" />
+          <positionref ref="layer_2_bottom_1inworld_volumepos" />
+        </physvol>
+        <physvol name="layer_3_bottom_1">
+          <volumeref ref="layer_3_bottom" />
+          <positionref ref="layer_3_bottom_1inworld_volumepos" />
+        </physvol>
+        <physvol name="layer_4_bottom_1">
+          <volumeref ref="layer_4_bottom" />
+          <positionref ref="layer_4_bottom_1inworld_volumepos" />
+        </physvol>
+        <physvol name="layer_5T_left_1">
+          <volumeref ref="layer_5T_left" />
+          <positionref ref="layer_5T_left_1inworld_volumepos" />
+        </physvol>
+        <physvol name="layer_5B_left_1">
+          <volumeref ref="layer_5B_left" />
+          <positionref ref="layer_5B_left_1inworld_volumepos" />
+        </physvol>
+        <physvol name="steel_bar_1">
+          <volumeref ref="steel_bar" />
+          <positionref ref="steel_bar_1inworld_volumepos" />
+        </physvol>
+        <physvol name="cu_Tpipe_inner_left_1">
+          <volumeref ref="cu_Tpipe_inner_left" />
+          <positionref ref="cu_Tpipe_inner_left_1inworld_volumepos" />
+          <rotationref ref="cu_Tpipe_inner_left_1inworld_volumerot" />
+        </physvol>
+        <physvol name="cu_Tpipe_inner_right_1">
+          <volumeref ref="cu_Tpipe_inner_right" />
+          <positionref ref="cu_Tpipe_inner_right_1inworld_volumepos" />
+          <rotationref ref="cu_Tpipe_inner_right_1inworld_volumerot" />
+        </physvol>
+        <physvol name="cu_Bpipe_inner_left_1">
+          <volumeref ref="cu_Bpipe_inner_left" />
+          <positionref ref="cu_Bpipe_inner_left_1inworld_volumepos" />
+          <rotationref ref="cu_Bpipe_inner_left_1inworld_volumerot" />
+        </physvol>
+        <physvol name="cu_Bpipe_inner_right_1">
+          <volumeref ref="cu_Bpipe_inner_right" />
+          <positionref ref="cu_Bpipe_inner_right_1inworld_volumepos" />
+          <rotationref ref="cu_Bpipe_inner_right_1inworld_volumerot" />
+        </physvol>
+        <physvol name="cu_Tpipe_outer_right1_1">
+          <volumeref ref="cu_Tpipe_outer_right1" />
+          <positionref ref="cu_Tpipe_outer_right1_1inworld_volumepos" />
+          <rotationref ref="cu_Tpipe_outer_right1_1inworld_volumerot" />
+        </physvol>
+        <physvol name="cu_Tpipe_outer_right2_1">
+          <volumeref ref="cu_Tpipe_outer_right2" />
+          <positionref ref="cu_Tpipe_outer_right2_1inworld_volumepos" />
+        </physvol>
+        <physvol name="cu_Tpipe_outer_right3_1">
+          <volumeref ref="cu_Tpipe_outer_right3" />
+          <positionref ref="cu_Tpipe_outer_right3_1inworld_volumepos" />
+          <rotationref ref="cu_Tpipe_outer_right3_1inworld_volumerot" />
+        </physvol>
+        <physvol name="cu_Bpipe_outer_right_1">
+          <volumeref ref="cu_Bpipe_outer_right" />
+          <positionref ref="cu_Bpipe_outer_right_1inworld_volumepos" />
+          <rotationref ref="cu_Bpipe_outer_right_1inworld_volumerot" />
+        </physvol>
+        <physvol name="cu_Bpipe_outer_right1_1">
+          <volumeref ref="cu_Bpipe_outer_right1" />
+          <positionref ref="cu_Bpipe_outer_right1_1inworld_volumepos" />
+          <rotationref ref="cu_Bpipe_outer_right1_1inworld_volumerot" />
+        </physvol>
+        <physvol name="cu_Bpipe_outer_right2_1">
+          <volumeref ref="cu_Bpipe_outer_right2" />
+          <positionref ref="cu_Bpipe_outer_right2_1inworld_volumepos" />
+        </physvol>
+        <physvol name="al_pipe_across_top1_1">
+          <volumeref ref="al_pipe_across_top1" />
+          <positionref ref="al_pipe_across_top1_1inworld_volumepos" />
+          <rotationref ref="al_pipe_across_top1_1inworld_volumerot" />
+        </physvol>
+        <physvol name="al_pipe_across_top2_1">
+          <volumeref ref="al_pipe_across_top2" />
+          <positionref ref="al_pipe_across_top2_1inworld_volumepos" />
+          <rotationref ref="al_pipe_across_top2_1inworld_volumerot" />
+        </physvol>
+        <physvol name="al_pipe_across_bottom1_1">
+          <volumeref ref="al_pipe_across_bottom1" />
+          <positionref ref="al_pipe_across_bottom1_1inworld_volumepos" />
+          <rotationref ref="al_pipe_across_bottom1_1inworld_volumerot" />
+        </physvol>
+        <physvol name="al_pipe_across_bottom2_1">
+          <volumeref ref="al_pipe_across_bottom2" />
+          <positionref ref="al_pipe_across_bottom2_1inworld_volumepos" />
+          <rotationref ref="al_pipe_across_bottom2_1inworld_volumerot" />
+        </physvol>
+        <physvol name="cu_plate_top_left_1">
+          <volumeref ref="cu_plate_top_left" />
+          <positionref ref="cu_plate_top_left_1inworld_volumepos" />
+        </physvol>
+        <physvol name="cu_plate_bottom_left_1">
+          <volumeref ref="cu_plate_bottom_left" />
+          <positionref ref="cu_plate_bottom_left_1inworld_volumepos" />
+        </physvol>
+        <physvol name="cu_plate_top_right_1">
+          <volumeref ref="cu_plate_top_right" />
+          <positionref ref="cu_plate_top_right_1inworld_volumepos" />
+        </physvol>
+        <physvol name="cu_plate_bottom_right_1">
+          <volumeref ref="cu_plate_bottom_right" />
+          <positionref ref="cu_plate_bottom_right_1inworld_volumepos" />
+        </physvol>
+        <physvol name="cu_plate_top_middle_1">
+          <volumeref ref="cu_plate_top_middle" />
+          <positionref ref="cu_plate_top_middle_1inworld_volumepos" />
+        </physvol>
+        <physvol name="cu_plate_bottom_middle_1">
+          <volumeref ref="cu_plate_bottom_middle" />
+          <positionref ref="cu_plate_bottom_middle_1inworld_volumepos" />
+        </physvol>
+        <visref ref="WorldVis" />
+      </volume>
+    </structure>
+    <setup name="Default" version="1.0">
+      <world ref="world_volume" />
+    </setup>
+  </gdml>
+  <fields>
+    <field_map_3d name="HPSDipoleFieldMap3D" lunit="mm" funit="tesla" filename="fieldmap/418acm2_10kg_corrected_unfolded_scaled_1.0319.dat" xoffset="21.17" yoffset="0.0" zoffset="457.2" />
+  </fields>
+</lcdd>
+

--- a/detector-data/detectors/HPS-PhysicsRun2019-v2-4pt5/SamplingFractions/Ecal.properties
+++ b/detector-data/detectors/HPS-PhysicsRun2019-v2-4pt5/SamplingFractions/Ecal.properties
@@ -1,0 +1,1 @@
+samplingFraction: 1.0

--- a/detector-data/detectors/HPS-PhysicsRun2019-v2-4pt5/SamplingFractions/Hodoscope.properties
+++ b/detector-data/detectors/HPS-PhysicsRun2019-v2-4pt5/SamplingFractions/Hodoscope.properties
@@ -1,0 +1,1 @@
+samplingFraction: 1.0

--- a/detector-data/detectors/HPS-PhysicsRun2019-v2-4pt5/compact.xml
+++ b/detector-data/detectors/HPS-PhysicsRun2019-v2-4pt5/compact.xml
@@ -1,0 +1,653 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lccdd xmlns:compact="http://www.lcsim.org/schemas/compact/1.0"
+       xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+       xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/compact/1.0/compact.xsd">
+  
+  <info name="HPS-PhysicsRun2019-v2-4pt5">
+    <comment>HPS detector for 2019 run with fieldmap,
+    Tracker at nominal opening angle, no SVT survey,  
+    this detector uses the corrected fieldmap scaled to -1.022T for 4.5 GeV.
+    Includes L0 and Hodoscope.
+    ECAL with survey alignment for HPSEcal3 (global y/z translations).
+    </comment>
+  </info>
+  
+  <define>
+    
+    <!-- world -->
+    <constant name="world_side" value="500.0*cm" />
+    <constant name="world_x" value="world_side" />
+    <constant name="world_y" value="world_side" />
+    <constant name="world_z" value="world_side" />
+    
+    <!-- beam -->
+    <constant name="beam_angle" value="0.03052"/> <!--30.52 mrad-->
+    
+    <!-- tracking region -->
+    <constant name="tracking_region_radius" value="200.0*cm"/>
+    <constant name="tracking_region_min" value="5.0*cm"/>
+    <constant name="tracking_region_zmax" value="136.8*cm"/>
+    
+    <!--  dipole magnet and  B-field -->
+    <constant name="dipoleMagnetPositionX" value="2.117*cm"/>
+    <constant name="dipoleMagnetPositionZ" value="45.72*cm"/>
+    <constant name="dipoleMagnetHeight" value="100*cm"/>
+    <constant name="dipoleMagnetWidth" value="100*cm"/>
+    <constant name="dipoleMagnetLength" value="108*cm"/>
+    <constant name="constBFieldY" value="-1.08"/><!-- set for 4.5GeV running -->
+    
+    
+    <!-- ECAL crystal dimensions -->
+    <constant name="ecal_front" value="13.3/2*mm" />
+    <constant name="ecal_back" value="16/2*mm" />
+    <constant name="ecal_z" value="160/2*mm" />
+    
+    <!-- ECal Z position -->
+    <!-- Old position without hodo :<constant name="ecal_dface" value="139.3*cm"/> -->
+    <constant name="ecal_dface" value="144.8*cm" /> <!-- plus 5.5 cm -->
+    
+    <!-- ECal placement parameters for NEW ECAL -->
+    <constant name="beam_angle" value="0.03052"/>
+    <constant name="ecal_front" value="13.3/2*mm" />
+    <constant name="ecal_back" value="16/2*mm" />
+    <constant name="ecal_z" value="160/2*mm" />
+    <!-- ECal Modules translation parameters -->
+    <constant name="top_tr_x" value="-0.71"/>
+    <constant name="top_tr_y" value="2.725"/>
+    <constant name="top_tr_z" value="4.9375"/>
+    <constant name="bot_tr_x" value="-0.405"/>
+    <constant name="bot_tr_y" value="-0.9125"/>
+    <constant name="bot_tr_z" value="2.6225"/>
+    <!-- ECal Modules rotation parameters(Rz(alpha)Ry(beta)Rx(gamma)) -->
+    <constant name="top_rot_alpha" value="0.00064964212772"/>
+    <constant name="top_rot_beta" value="0.0"/>
+    <constant name="top_rot_gamma" value="-0.00046882347412"/>
+    <constant name="bot_rot_alpha" value="0.0005150274940439"/>
+    <constant name="bot_rot_beta" value="0.0"/>
+    <constant name="bot_rot_gamma" value="0.0013469727279283583"/>
+
+    <!-- HODOSCOPE PARAMETERS -->
+    <!-- Hodoscope thickness -->
+    <constant name="hodoscopeXMin1" value="48-4.452"/>
+    <constant name="hodoscopeXMin2" value="48"/>
+    <constant name="hodoscopeThickness" value="10*mm"/>
+    <constant name="hodoscopePixelHeight" value="59.225*mm"/>
+    
+    <!-- Distance between hodoscope and scoring planes -->
+    <constant name="hodoscopeScoreDisplacement" value="1.000"/>
+    <constant name="hodoscopeZ" value="1098.5*mm" />
+
+
+    <!-- SVT PARAMETERS -->    
+    <!-- SVT module dimensions -->
+    <constant name="moduleLength" value="100.0"/>
+    <constant name="moduleWidth" value="40.34"/>
+    
+    <!-- SVT sensor dimensions -->
+    <constant name="sensorLength" value="98.33"/>
+    
+    <!--scoring plane thickness-->
+    <constant name="scoringThickness" value="0.001"/>
+    
+    <!--left and right edges of the electron gap for the ECal scoring plane, measured as distances from the BL edge of the flange-->
+    <constant name="electronGapLeftEdge" value="382.16+20*0.0166"/>
+    <constant name="electronGapRightEdge" value="471.94+20*0.1511"/>
+    
+    <!-- Sensor width slightly less than 38.34 mm so sisim works. -->
+    <constant name="sensorWidth" value="38.3399"/>
+    <constant name="zst" value="1" />
+    <constant name="SA1" value="0.1" />
+    <constant name="SA2" value="0.05" />
+    <constant name="PI" value="3.14159265359" />
+    <!-- positions derived from drawing assuming 1.35/1.2 degress open on top/bottom -->
+    
+    <constant name="x_rot_top" value="0" />  
+    <constant name="x_rot_bot" value="0" />    
+    
+    <!--  monkey with the rotations  -->    
+    <constant name="x_rot_top_add" value="0.00" />  <!-- -ive means further closed -->
+    <constant name="x_rot_bot_add" value="0.00" /> <!-- +ive means further closed -->
+    <!--  distance from target to pivot...this is from an email schematic from Tim on may 12, 2012 -->
+    <constant name="pivot" value="791" /> 
+    
+    <constant name="y_rot" value = "beam_angle"/>
+    <!--        <constant name="x_off" value = "-15.0"/> -->
+    <constant name="x_off" value = "0.0"/> 
+    
+    <!-- Positions of thin 15 cm planes -->
+    <constant name="y01t" value="150*sin(0.015)+sensorWidth/2" />
+    <constant name="y02t" value="150*sin(0.015)+sensorWidth/2" />
+    <constant name="y01b" value="-(150*sin(0.015)+sensorWidth/2)" />
+    <constant name="y02b" value="-(150*sin(0.015)+sensorWidth/2)" />
+    
+    <constant name="z01t" value="0+142.5-3.685" />
+    <constant name="z02t" value="0+142.5+3.685" />
+    <constant name="z01b" value="0+157.5-3.685" />
+    <constant name="z02b" value="0+157.5+3.685" />
+    
+  </define>
+  
+  <materials>
+    <!-- Set the world material to vacuum. -->
+    <material name="WorldMaterial">
+      <D type="density" unit="g/cm3" value="0.0000000000000001"/>
+      <fraction n="1.0" ref="Vacuum" />
+    </material>
+    <!-- Set tracking material to vacuum. -->
+    <material name="TrackingMaterial">
+      <D type="density" unit="g/cm3" value="0.0000000000000001"/>
+      <fraction n="1.0" ref="Vacuum" />
+    </material>
+    <!-- ECal crystal material. -->
+    <material name="LeadTungstate">
+      <D value="8.28" unit="g/cm3"/>
+      <composite n="1" ref="Pb"/>
+      <composite n="1" ref="W"/>
+      <composite n="4" ref="O"/>
+    </material>
+    <!-- Hodoscope material. -->
+    <material name="EJ204_PlasticScintillator">
+      <D value="1.032" unit="g/cm3"/>
+      <fraction n="0.523618" ref="H"/>
+      <fraction n="0.476382" ref="C"/>
+    </material>
+    <material name="TitaniumDioxide">
+      <D value="4.23" unit="g/cm3" />
+      <composite n="1" ref="Ti" />
+      <composite n="2" ref="O" />
+    </material>
+    <material name="Mylar">
+      <D value="1.4" unit="g/cm3" />
+      <fraction n="0.041958" ref="H"/>
+      <fraction n="0.625017" ref="C"/>
+      <fraction n="0.333025" ref="O"/>
+    </material>
+    <material name="GenericFoam">
+      <D value="0.052" unit="g/cm3" />
+      <fraction n="0.5" ref="H"/>
+      <fraction n="0.5" ref="C"/>
+    </material>
+  </materials>
+
+  
+  <display>
+    <vis name="ECALVis" r="0.8" g="0.5" b="0.1" />    
+    <vis name="HodoscopeVis" alpha="1.0" r="0.0" g="0.33725490196" b="0.50980392156" drawingStyle="solid" visible="true" />	
+    <vis name="ChamberVis" alpha="1.0" r="1.0" g="0.0" b="1.0" drawingStyle="wireframe" lineStyle="unbroken" showDaughters="true" visible="true"/>
+    <vis name="SvtBoxVis" alpha="1.0" r="1.0" g="1.0" b="0.0" drawingStyle="wireframe" lineStyle="unbroken" showDaughters="true" visible="true"/>
+    <vis name="SensorVis" alpha="1.0" r="1.0" g="0.0" b="0.0" drawingStyle="wireframe" lineStyle="unbroken" showDaughters="true" visible="true"/>
+    <vis name="ActiveSensorVis" alpha="1.0" r="1.0" g="0.0" b="0.0" drawingStyle="solid" lineStyle="unbroken" showDaughters="true" visible="true"/>
+    <vis name="CarbonFiberVis" alpha="1.0" r="0.88" g="0.88" b="0.88" drawingStyle="solid" lineStyle="unbroken" showDaughters="true" visible="true"/>
+    <vis name="KaptonVis" alpha="1.0" r="0.91" g="0.77" b="0.06" drawingStyle="solid" lineStyle="unbroken" showDaughters="true" visible="true"/>
+    <vis name="HybridVis" alpha="1.0" r="0.0" g="1.0" b="0" drawingStyle="solid" lineStyle="unbroken" showDaughters="true" visible="true"/>
+    <vis name="HalfModuleVis" alpha="1.0" r="1.0" g="1.0" b="1.0" drawingStyle="wireframe" lineStyle="dashed" showDaughters="true" visible="true"/>
+    <vis name="ColdBlockVis" alpha="1.0" r="0.75" g="0.73" b="0.75" drawingStyle="solid" lineStyle="dashed" showDaughters="true" visible="true"/>
+    <vis name="ModuleVis" alpha="1.0" r="1.0" g="1.0" b="1.0" drawingStyle="wireframe" lineStyle="dotted" showDaughters="true" visible="true"/>
+    <vis name="SupportPlateVis" alpha="1.0" r="0.45" g="0.45" b="0.45" drawingStyle="solid" lineStyle="dashed" showDaughters="true" visible="true"/>
+    <vis name="SupportVolumeVis" alpha="1.0" r="0.75" g="0.73" b="0.75" drawingStyle="wireframe" lineStyle="dashed" showDaughters="true" visible="true"/>
+    <vis name="BasePlateVis" alpha="1.0" r="0.35" g="0.35" b="0.35" drawingStyle="solid" lineStyle="dashed" showDaughters="true" visible="true"/>
+    <vis name="LayerVis" alpha="0.0" r="0.0" g="0.0" b="1.0" drawingStyle="wireframe" showDaughters="true" visible="false"/>
+    <vis name="ComponentVis" alpha="0.0" r="0.0" g="0.2" b="0.4" drawingStyle="solid" showDaughters="false" visible="false"/>
+    <vis name="BeamPlaneVis" alpha="1.0" r="1.0" g="1.0" b="1.0" drawingStyle="solid" lineStyle="unbroken" showDaughters="false" visible="true"/>
+  </display>
+  
+  <detectors>
+    
+    <detector id="1" name="Tracker" type="HPSTracker2019" readout="TrackerHits">
+  
+      <millepede_constants>
+        
+        <!-- top half-module translations -->
+        <millepede_constant name="11101" value="0.0"/>
+        <millepede_constant name="11102" value="0.0"/>
+        <millepede_constant name="11103" value="0.0"/>
+        <millepede_constant name="11104" value="0.0"/>
+        <millepede_constant name="11105" value="0.0"/>
+        <millepede_constant name="11106" value="0.0"/>
+        <millepede_constant name="11107" value="0.0"/>
+        <millepede_constant name="11108" value="0.0"/>
+        <millepede_constant name="11109" value="0.0"/>
+        <millepede_constant name="11110" value="0.0"/>
+        <millepede_constant name="11111" value="0.0"/>
+        <millepede_constant name="11112" value="0.0"/>
+        <millepede_constant name="11113" value="0.0"/>
+        <millepede_constant name="11114" value="0.0"/>
+        <millepede_constant name="11115" value="0.0"/>
+        <millepede_constant name="11116" value="0.0"/>
+        <millepede_constant name="11117" value="0.0"/>
+        <millepede_constant name="11118" value="0.0"/>
+        <millepede_constant name="11119" value="0.0"/>
+        <millepede_constant name="11120" value="0.0"/>
+        <millepede_constant name="11121" value="0.0"/>
+        <millepede_constant name="11122" value="0.0"/>
+	
+        <millepede_constant name="11201" value="0.0"/>
+        <millepede_constant name="11202" value="0.0"/>
+        <millepede_constant name="11203" value="0.0"/>
+        <millepede_constant name="11204" value="0.0"/>
+        <millepede_constant name="11205" value="0.0"/>
+        <millepede_constant name="11206" value="0.0"/>
+        <millepede_constant name="11207" value="0.0"/>
+        <millepede_constant name="11208" value="0.0"/>
+        <millepede_constant name="11209" value="0.0"/>
+        <millepede_constant name="11210" value="0.0"/>
+        <millepede_constant name="11211" value="0.0"/>
+        <millepede_constant name="11212" value="0.0"/>
+        <millepede_constant name="11213" value="0.0"/>
+        <millepede_constant name="11214" value="0.0"/>
+        <millepede_constant name="11215" value="0.0"/>
+        <millepede_constant name="11216" value="0.0"/>
+        <millepede_constant name="11217" value="0.0"/>
+        <millepede_constant name="11218" value="0.0"/>
+        <millepede_constant name="11219" value="0.0"/>
+        <millepede_constant name="11220" value="0.0"/>
+        <millepede_constant name="11221" value="0.0"/>
+        <millepede_constant name="11222" value="0.0"/>
+	
+        <millepede_constant name="11301" value="0.0"/>
+        <millepede_constant name="11302" value="0.0"/>
+        <millepede_constant name="11303" value="0.0"/>
+        <millepede_constant name="11304" value="0.0"/>
+        <millepede_constant name="11305" value="0.0"/>
+        <millepede_constant name="11306" value="0.0"/>
+        <millepede_constant name="11307" value="0.0"/>
+        <millepede_constant name="11308" value="0.0"/>
+        <millepede_constant name="11309" value="0.0"/>
+        <millepede_constant name="11310" value="0.0"/>
+        <millepede_constant name="11311" value="0.0"/>
+        <millepede_constant name="11312" value="0.0"/>
+        <millepede_constant name="11313" value="0.0"/>
+        <millepede_constant name="11314" value="0.0"/>
+        <millepede_constant name="11315" value="0.0"/>
+        <millepede_constant name="11316" value="0.0"/>
+        <millepede_constant name="11317" value="0.0"/>
+        <millepede_constant name="11318" value="0.0"/>
+        <millepede_constant name="11319" value="0.0"/>
+        <millepede_constant name="11320" value="0.0"/>
+        <millepede_constant name="11321" value="0.0"/>
+        <millepede_constant name="11322" value="0.0"/>
+        
+        <!-- top half-module rotations -->
+        
+        <millepede_constant name="12101" value="0.0"/>
+        <millepede_constant name="12102" value="0.0"/>
+        <millepede_constant name="12103" value="0.0"/>
+        <millepede_constant name="12104" value="0.0"/>
+        <millepede_constant name="12105" value="0.0"/>
+        <millepede_constant name="12106" value="0.0"/>
+        <millepede_constant name="12107" value="0.0"/>
+        <millepede_constant name="12108" value="0.0"/>
+        <millepede_constant name="12109" value="0.0"/>
+        <millepede_constant name="12110" value="0.0"/>
+        <millepede_constant name="12111" value="0.0"/>
+        <millepede_constant name="12112" value="0.0"/>
+        <millepede_constant name="12113" value="0.0"/>
+        <millepede_constant name="12114" value="0.0"/>
+        <millepede_constant name="12115" value="0.0"/>
+        <millepede_constant name="12116" value="0.0"/>
+        <millepede_constant name="12117" value="0.0"/>
+        <millepede_constant name="12118" value="0.0"/>
+        <millepede_constant name="12119" value="0.0"/>
+        <millepede_constant name="12120" value="0.0"/>
+        <millepede_constant name="12121" value="0.0"/>
+        <millepede_constant name="12122" value="0.0"/>
+	
+        <millepede_constant name="12201" value="0.0"/>
+        <millepede_constant name="12202" value="0.0"/>
+        <millepede_constant name="12203" value="0.0"/>
+        <millepede_constant name="12204" value="0.0"/>
+        <millepede_constant name="12205" value="0.0"/>
+        <millepede_constant name="12206" value="0.0"/>
+        <millepede_constant name="12207" value="0.0"/>
+        <millepede_constant name="12208" value="0.0"/>
+        <millepede_constant name="12209" value="0.0"/>
+        <millepede_constant name="12210" value="0.0"/>
+        <millepede_constant name="12211" value="0.0"/>
+        <millepede_constant name="12212" value="0.0"/>
+        <millepede_constant name="12213" value="0.0"/>
+        <millepede_constant name="12214" value="0.0"/>
+        <millepede_constant name="12215" value="0.0"/>
+        <millepede_constant name="12216" value="0.0"/>
+        <millepede_constant name="12217" value="0.0"/>
+        <millepede_constant name="12218" value="0.0"/>
+        <millepede_constant name="12219" value="0.0"/>
+        <millepede_constant name="12220" value="0.0"/>
+        <millepede_constant name="12221" value="0.0"/>
+        <millepede_constant name="12222" value="0.0"/>
+	
+        <millepede_constant name="12301" value="0.0"/>
+        <millepede_constant name="12302" value="0.0"/>
+        <millepede_constant name="12303" value="0.0"/>
+        <millepede_constant name="12304" value="0.0"/>
+        <millepede_constant name="12305" value="0.0"/>
+        <millepede_constant name="12306" value="0.0"/>
+        <millepede_constant name="12307" value="0.0"/>
+        <millepede_constant name="12308" value="0.0"/>
+        <millepede_constant name="12309" value="0.0"/>
+        <millepede_constant name="12310" value="0.0"/>
+        <millepede_constant name="12311" value="0.0"/>
+        <millepede_constant name="12312" value="0.0"/>
+        <millepede_constant name="12313" value="0.0"/>
+        <millepede_constant name="12314" value="0.0"/>
+        <millepede_constant name="12315" value="0.0"/>
+        <millepede_constant name="12316" value="0.0"/>
+        <millepede_constant name="12317" value="0.0"/>
+        <millepede_constant name="12318" value="0.0"/>
+        <millepede_constant name="12319" value="0.0"/>
+        <millepede_constant name="12320" value="0.0"/>
+        <millepede_constant name="12321" value="0.0"/>
+        <millepede_constant name="12322" value="0.0"/>
+        
+        <!-- bottom half-module translations -->
+        
+        <millepede_constant name="21101" value="0.0"/>
+        <millepede_constant name="21102" value="0.0"/>
+        <millepede_constant name="21103" value="0.0"/>
+        <millepede_constant name="21104" value="0.0"/>
+        <millepede_constant name="21105" value="0.0"/>
+        <millepede_constant name="21106" value="0.0"/>
+        <millepede_constant name="21107" value="0.0"/>
+        <millepede_constant name="21108" value="0.0"/>
+        <millepede_constant name="21109" value="0.0"/>
+        <millepede_constant name="21110" value="0.0"/>
+        <millepede_constant name="21111" value="0.0"/>
+        <millepede_constant name="21112" value="0.0"/>
+        <millepede_constant name="21113" value="0.0"/>
+        <millepede_constant name="21114" value="0.0"/>
+        <millepede_constant name="21115" value="0.0"/>
+        <millepede_constant name="21116" value="0.0"/>
+        <millepede_constant name="21117" value="0.0"/>
+        <millepede_constant name="21118" value="0.0"/>
+        <millepede_constant name="21119" value="0.0"/>
+        <millepede_constant name="21120" value="0.0"/>
+        <millepede_constant name="21121" value="0.0"/>
+        <millepede_constant name="21122" value="0.0"/>
+        
+        <millepede_constant name="21201" value="0.0"/>
+        <millepede_constant name="21202" value="0.0"/>
+        <millepede_constant name="21203" value="0.0"/>
+        <millepede_constant name="21204" value="0.0"/>
+        <millepede_constant name="21205" value="0.0"/>
+        <millepede_constant name="21206" value="0.0"/>
+        <millepede_constant name="21207" value="0.0"/>
+        <millepede_constant name="21208" value="0.0"/>
+        <millepede_constant name="21209" value="0.0"/>
+        <millepede_constant name="21210" value="0.0"/>
+        <millepede_constant name="21211" value="0.0"/>
+        <millepede_constant name="21212" value="0.0"/>
+        <millepede_constant name="21213" value="0.0"/>
+        <millepede_constant name="21214" value="0.0"/>
+        <millepede_constant name="21215" value="0.0"/>
+        <millepede_constant name="21216" value="0.0"/>
+        <millepede_constant name="21217" value="0.0"/>
+        <millepede_constant name="21218" value="0.0"/>
+        <millepede_constant name="21219" value="0.0"/>
+        <millepede_constant name="21220" value="0.0"/>
+        <millepede_constant name="21221" value="0.0"/>
+        <millepede_constant name="21222" value="0.0"/>
+	
+        <millepede_constant name="21301" value="0.0"/>
+        <millepede_constant name="21302" value="0.0"/>
+        <millepede_constant name="21303" value="0.0"/>
+        <millepede_constant name="21304" value="0.0"/>
+        <millepede_constant name="21305" value="0.0"/>
+        <millepede_constant name="21306" value="0.0"/>
+        <millepede_constant name="21307" value="0.0"/>
+        <millepede_constant name="21308" value="0.0"/>
+        <millepede_constant name="21309" value="0.0"/>
+        <millepede_constant name="21310" value="0.0"/>
+        <millepede_constant name="21311" value="0.0"/>
+        <millepede_constant name="21312" value="0.0"/>
+        <millepede_constant name="21313" value="0.0"/>
+        <millepede_constant name="21314" value="0.0"/>
+        <millepede_constant name="21315" value="0.0"/>
+        <millepede_constant name="21316" value="0.0"/>
+        <millepede_constant name="21317" value="0.0"/>
+        <millepede_constant name="21318" value="0.0"/>
+        <millepede_constant name="21319" value="0.0"/>
+        <millepede_constant name="21320" value="0.0"/>
+        <millepede_constant name="21321" value="0.0"/>
+        <millepede_constant name="21322" value="0.0"/>
+        
+        <!-- bottom half-module rotations -->
+        
+        <millepede_constant name="22101" value="0.0"/>
+        <millepede_constant name="22102" value="0.0"/>
+        <millepede_constant name="22103" value="0.0"/>
+        <millepede_constant name="22104" value="0.0"/>
+        <millepede_constant name="22105" value="0.0"/>
+        <millepede_constant name="22106" value="0.0"/>
+        <millepede_constant name="22107" value="0.0"/>
+        <millepede_constant name="22108" value="0.0"/>
+        <millepede_constant name="22109" value="0.0"/>
+        <millepede_constant name="22110" value="0.0"/>
+        <millepede_constant name="22111" value="0.0"/>
+        <millepede_constant name="22112" value="0.0"/>
+        <millepede_constant name="22113" value="0.0"/>
+        <millepede_constant name="22114" value="0.0"/>
+        <millepede_constant name="22115" value="0.0"/>
+        <millepede_constant name="22116" value="0.0"/>
+        <millepede_constant name="22117" value="0.0"/>
+        <millepede_constant name="22118" value="0.0"/>
+        <millepede_constant name="22119" value="0.0"/>
+        <millepede_constant name="22120" value="0.0"/>
+        <millepede_constant name="22121" value="0.0"/>
+        <millepede_constant name="22122" value="0.0"/>
+	
+        <millepede_constant name="22201" value="0.0"/>
+        <millepede_constant name="22202" value="0.0"/>
+        <millepede_constant name="22203" value="0.0"/>
+        <millepede_constant name="22204" value="0.0"/>
+        <millepede_constant name="22205" value="0.0"/>
+        <millepede_constant name="22206" value="0.0"/>
+        <millepede_constant name="22207" value="0.0"/>
+        <millepede_constant name="22208" value="0.0"/>
+        <millepede_constant name="22209" value="0.0"/>
+        <millepede_constant name="22210" value="0.0"/>
+        <millepede_constant name="22211" value="0.0"/>
+        <millepede_constant name="22212" value="0.0"/>
+        <millepede_constant name="22213" value="0.0"/>
+        <millepede_constant name="22214" value="0.0"/>
+        <millepede_constant name="22215" value="0.0"/>
+        <millepede_constant name="22216" value="0.0"/>
+        <millepede_constant name="22217" value="0.0"/>
+        <millepede_constant name="22218" value="0.0"/>
+        <millepede_constant name="22219" value="0.0"/>
+        <millepede_constant name="22220" value="0.0"/>
+        <millepede_constant name="22221" value="0.0"/>
+        <millepede_constant name="22222" value="0.0"/>
+	
+        <millepede_constant name="22301" value="0.0"/>
+        <millepede_constant name="22302" value="0.0"/>
+        <millepede_constant name="22303" value="0.0"/>
+        <millepede_constant name="22304" value="0.0"/>
+        <millepede_constant name="22305" value="0.0"/>
+        <millepede_constant name="22306" value="0.0"/>
+        <millepede_constant name="22307" value="0.0"/>
+        <millepede_constant name="22308" value="0.0"/>
+        <millepede_constant name="22309" value="0.0"/>
+        <millepede_constant name="22310" value="0.0"/>
+        <millepede_constant name="22311" value="0.0"/>
+        <millepede_constant name="22312" value="0.0"/>
+        <millepede_constant name="22313" value="0.0"/>
+        <millepede_constant name="22314" value="0.0"/>
+        <millepede_constant name="22315" value="0.0"/>
+        <millepede_constant name="22316" value="0.0"/>
+        <millepede_constant name="22317" value="0.0"/>
+        <millepede_constant name="22318" value="0.0"/>
+        <millepede_constant name="22319" value="0.0"/>
+        <millepede_constant name="22320" value="0.0"/>
+        <millepede_constant name="22321" value="0.0"/>
+        <millepede_constant name="22322" value="0.0"/>
+        
+        <!-- top support tilt angles -->
+	
+        <millepede_constant name="13100" value="-0.0001"/> <!-- + means opening-->
+        <millepede_constant name="13200" value="0.0"/>
+        <millepede_constant name="13300" value="0.0"/>
+        
+        <!-- bottom support tilt angles -->
+        <millepede_constant name="23100" value="0.0001"/>  <!-- - means opening -->
+        <millepede_constant name="23200" value="0.0"/>
+        <millepede_constant name="23300" value="0.0"/>
+        
+      </millepede_constants>
+    </detector>   
+    
+
+       
+    <detector id="29" name="ECalScoring" type="HPSTracker2" readout="TrackerHitsECal" insideTrackingVolume="false" >
+      <comment>Scoring plane after ECal flange for calibration studies</comment>
+      <module name="BeamLeft">
+        <box x="electronGapLeftEdge" y="457.2/2-17" />
+        <module_component thickness="scoringThickness" material = "Vacuum" sensitive="true"/>
+      </module>            
+      <module name="ElectronGap">
+        <box x="electronGapRightEdge-electronGapLeftEdge" y="(457.2-64.66)/2" />
+        <module_component thickness="scoringThickness" material = "Vacuum" sensitive="true"/>
+      </module>            
+      <module name="BeamRight">
+        <box x="768.35-electronGapRightEdge" y="457.2/2-14" />
+        <module_component thickness="scoringThickness" material = "Vacuum" sensitive="true"/>
+      </module>            
+      <layer id="1"><!--top-->
+        <module_placement name="BeamLeft" id="0" x="(768.35-electronGapLeftEdge)/2+21.17" y="(457.2/2+17)/2" z="1373+70+scoringThickness" rx="0" ry="0" rz="-PI/2"/>
+        <module_placement name="ElectronGap" id="0" x="768.35/2-electronGapRightEdge+(electronGapRightEdge-electronGapLeftEdge)/2+21.17" y="(457.2/2+64.66/2)/2" z="1373+70+scoringThickness" rx="0" ry="0" rz="-PI/2"/>
+        <module_placement name="BeamRight" id="0" x="-1*electronGapRightEdge/2+21.17" y="(457.2/2+14)/2" z="1373+70+scoringThickness" rx="0" ry="0" rz="-PI/2"/>
+      </layer>
+      <layer id="2"><!--bottom-->
+        <module_placement name="BeamLeft" id="0" x="(768.35-electronGapLeftEdge)/2+21.17" y="-1*(457.2/2+17)/2" z="1373+70+scoringThickness" rx="0" ry="0" rz="-3*PI/2"/>
+        <module_placement name="ElectronGap" id="0" x="768.35/2-electronGapRightEdge+(electronGapRightEdge-electronGapLeftEdge)/2+21.17" y="-1*(457.2/2+64.66/2)/2" z="1373+70+scoringThickness" rx="0" ry="0" rz="-3*PI/2"/>
+        <module_placement name="BeamRight" id="0" x="-1*electronGapRightEdge/2+21.17" y="-1*(457.2/2+14)/2" z="1373+70+scoringThickness" rx="0" ry="0" rz="-3*PI/2"/>
+      </layer>
+    </detector> 
+
+    <detector id="30" name="Hodoscope" type="Hodoscope_v1" readout="HodoscopeHits" insideTrackingVolume="true" vis="HodoscopeVis">
+      <!--
+	  It is mandatory to define hodoscope crystal materials!
+      -->
+      <scintillator_material value="Polystyrene" />
+      <cover_material value="TitaniumDioxide" />
+      <reflector_material value="Mylar" />
+      <buffer_material value="Carbon" />
+      
+      <!--
+	  These variables allow the hodoscope to be shifted
+	  without modification of the code. These variables do
+	  NOT need to be specified. If they are not declared,
+	  the nominal value will used instead. Note that any
+	  combination of these variables can be declared or
+	  excluded freely.
+      -->
+      <layer1_top_x value="44.56*mm" />
+      <layer1_top_y value="14.2*mm" />
+      <layer1_top_z value="hodoscopeZ" />
+      <layer1_bot_x value="44.56*mm" />
+      <layer1_bot_y value="14.2*mm" />
+      <layer1_bot_z value="hodoscopeZ" />
+      
+      <layer2_top_x value="47.9*mm" />
+      <layer2_top_y value="14.2*mm" />
+      <layer2_bot_x value="47.9*mm" />
+      <layer2_bot_y value="14.2*mm" />
+      
+      <scintillator_depth value="9.5*mm" />
+      <scintillator_depth_height value="59.9*mm" />
+      <cover_depth value="0.25*mm" />
+      <reflector_depth value="0.05*mm" />
+      
+      <buffer_depth value="2*mm" />
+      <buffer_width value="187.64*mm" />
+      <buffer_x value="39.0*mm" />
+      
+      <!--
+	  Defines the hodoscope pixel widths and count. One
+	  pixel will be added to the specified hodoscope layer
+	  for each entry in the list below. The pixel will be
+	  of the specified width in millimeters. Note that the
+	  top and bottom parts of the hodoscope will use the
+	  same set of widths. It is not necessary to define
+	  these arguments.
+      -->
+      <scintillator_width_layer1 value="15.7,34.1,44,44,44" />
+      <scintillator_width_layer2 value="19,44,44,44,30.8" />
+    </detector>
+    
+    
+    <!--  OLDER ECAL -->
+    <detector id="13" name="Ecal" type="HPSEcal3" insideTrackingVolume="false" readout="EcalHits" vis="ECALVis">
+      <comment>The crystal ECal</comment>
+      <material name="LeadTungstate" />
+      <dimensions x1="ecal_front" y1="ecal_front" x2="ecal_back" y2="ecal_back" z="ecal_z" />
+      <layout beamgapBottom="21.4*mm" beamgapTop="22.3*mm" nx="46" ny="5" dface="ecal_dface">
+        <remove ixmin="-10" ixmax="-2" iymin="-1" iymax="1" />
+        <top dx="(ecal_dface-50)*tan(beam_angle)" dy="0." dz="0."/>
+        <bottom dx="(ecal_dface-50)*tan(beam_angle)" dy="0." dz="0."/>
+      </layout>
+    </detector>
+  </detectors>
+  <!-- New adjustable ECAL -->
+  <!--
+      <detector id="13" name="Ecal" type="HPSEcal4" insideTrackingVolume="false" readout="EcalHits" vis="ECALVis">
+      <comment>The crystal ECal</comment>
+      <material name="LeadTungstate" />
+      <dimensions x1="ecal_front" y1="ecal_front" x2="ecal_back" y2="ecal_back" z="ecal_z" /> 
+      <translations top_tr_x="top_tr_x" top_tr_y="top_tr_y" top_tr_z="top_tr_z" bot_tr_x="bot_tr_x" bot_tr_y="bot_tr_y" bot_tr_z="bot_tr_z" />
+      <rotations top_rot_alpha="top_rot_alpha" top_rot_beta="top_rot_beta" top_rot_gamma="top_rot_gamma" bot_rot_alpha="bot_rot_alpha" bot_rot_beta="bot_rot_beta" bot_rot_gamma="bot_rot_gamma" />          
+      <layout beamgap="20.0*mm" nx="46" ny="5" dface="ecal_dface">
+      <remove ixmin="-10" ixmax="-2" iymin="-1" iymax="1" />
+      <top dx="ecal_dface*tan(beam_angle)" dy="0." dz="0."/>
+      <bottom dx="ecal_dface*tan(beam_angle)" dy="0." dz="0."/>
+      </layout>
+      </detector>
+  -->
+  
+  <readouts>   
+    <readout name="TrackerHits">
+      <id>system:6,barrel:3,layer:4,module:12,sensor:1,side:32:-2,strip:12</id> 
+    </readout>
+    <readout name="TrackerHitsFieldDef">
+      <id>system:6,barrel:3,layer:4,module:12,sensor:1,side:32:-2,strip:12</id> 
+      <processor type="ScoringTrackerHitProcessor" />        
+    </readout>
+    <readout name="TrackerHitsECal">
+      <id>system:6,barrel:3,layer:4,module:12,sensor:1,side:32:-2,strip:12</id> 
+      <processor type="ScoringTrackerHitProcessor" />        
+    </readout>
+    <readout name="HodoscopeHits">
+      <id>system:6,barrel:3,layer:4,ix:4,iy:-3,hole:-3</id>
+    </readout>
+    <readout name="HodoscopeForeHits">
+      <id>system:6,barrel:3,layer:4,module:12,sensor:1,side:32:-2,strip:12</id>
+      <processor type="ScoringTrackerHitProcessor"/>
+    </readout>
+    <readout name="EcalHits">
+      <segmentation type="GridXYZ" gridSizeX="0.0" gridSizeY="0.0" gridSizeZ="0.0" />
+      <id>system:6,layer:2,ix:-8,iy:-6</id>
+    </readout>
+    
+  </readouts>
+  
+  <fields>
+    <field 
+        type="FieldMap3D"
+        name="HPSDipoleFieldMap3D" 
+        filename="fieldmap/418acm2_10kg_corrected_unfolded_scaled_1.0319.dat" 
+        url="https://raw.githubusercontent.com/JeffersonLab/hps-fieldmaps/master/418acm2_10kg_corrected_unfolded_scaled_1.0319.tar.gz"
+        xoffset="2.117*cm"
+        yoffset="0.0*cm"
+        zoffset="45.72*cm"
+        />
+  </fields>
+  
+  <!--    
+       <fields>
+       <field type="BoxDipole" name="AnalyzingDipole" x="dipoleMagnetPositionX" y="0*cm" z="dipoleMagnetPositionZ" dx="dipoleMagnetWidth/2.0" dy="dipoleMagnetHeight/2.0" dz="dipoleMagnetLength/2.0" bx="0.0" by="constBFieldY" bz="0.0" />
+       </fields>
+  -->
+  <includes>
+    <gdmlFile file="gdml/ecal_vacuum_flange_complete_v3.gdml" /> 
+    <gdmlFile file="gdml/hps_hodoscope_assembly.gdml" /> 
+    <gdmlFile file="gdml/svt_chamber_v2.gdml" />
+  </includes>
+</lccdd>

--- a/detector-data/detectors/HPS-PhysicsRun2019-v2-4pt5/detector.properties
+++ b/detector-data/detectors/HPS-PhysicsRun2019-v2-4pt5/detector.properties
@@ -1,0 +1,1 @@
+name: HPS-PhysicsRun2019-v2-4pt5


### PR DESCRIPTION
* with y/z top/bottom shifts based on [surveys](https://confluence.slac.stanford.edu/pages/viewpage.action?pageId=263756689) and [calculations](https://jeffersonlab-my.sharepoint.com/:x:/g/personal/baltzell_jlab_org/EXAbm3RsWRhPnZtC6Th23m4Be9FeK0H0k4EzW_tlBWRLCA?e=HMvYdN)
* only for 0.5 mm SVT, the others I couldn't reproduce their v1 counterpart

