### PR TITLE
Provide test reco driver for 2019 + some fixes for 2019 data processing

### DIFF
--- a/recon/src/main/java/org/hps/recon/particle/HpsReconParticleDriver.java
+++ b/recon/src/main/java/org/hps/recon/particle/HpsReconParticleDriver.java
@@ -378,7 +378,13 @@ public class HpsReconParticleDriver extends ReconParticleDriver {
                 }
                 
                 // Make V0 candidates
-                this.makeV0Candidates(electron, positron);
+                try {
+                    this.makeV0Candidates(electron, positron);
+                }
+                catch (RuntimeException e) {
+                    System.out.println("HpsReconParticleDriver::makeV0Candidates fails:: skipping ele/pos pair.");
+                    continue;
+                }
             }
         }
     }

--- a/recon/src/main/java/org/hps/recon/particle/HpsReconParticleDriver.java
+++ b/recon/src/main/java/org/hps/recon/particle/HpsReconParticleDriver.java
@@ -382,6 +382,7 @@ public class HpsReconParticleDriver extends ReconParticleDriver {
                     this.makeV0Candidates(electron, positron);
                 }
                 catch (RuntimeException e) {
+                    e.printStackTrace();
                     System.out.println("HpsReconParticleDriver::makeV0Candidates fails:: skipping ele/pos pair.");
                     continue;
                 }

--- a/steering-files/src/main/resources/org/hps/steering/recon/PhysicsRun2019_pass0_recon.lcsim
+++ b/steering-files/src/main/resources/org/hps/steering/recon/PhysicsRun2019_pass0_recon.lcsim
@@ -348,6 +348,7 @@
             <applyClusterCorrections>false</applyClusterCorrections>
             <useTrackPositionForClusterCorrection>false</useTrackPositionForClusterCorrection>
             <debug>false</debug>
+            <makeMollerCols>false</makeMollerCols>
         </driver>  
 
         <driver name="ReconParticleDriver_Kalman" type="org.hps.recon.particle.HpsReconParticleDriver" > 
@@ -377,6 +378,7 @@
             <applyClusterCorrections>false</applyClusterCorrections>
             <useTrackPositionForClusterCorrection>false</useTrackPositionForClusterCorrection>
             <debug>false</debug>
+	    <makeMollerCols>false</makeMollerCols>
         </driver>  
         
         <driver name="CleanupDriver" type="org.lcsim.recon.tracking.digitization.sisim.config.ReadoutCleanupDriver"/>

--- a/steering-files/src/main/resources/org/hps/steering/recon/PhysicsRun2019_pass0_recon.lcsim
+++ b/steering-files/src/main/resources/org/hps/steering/recon/PhysicsRun2019_pass0_recon.lcsim
@@ -43,7 +43,7 @@
         <driver name="TrackReconSeed456Conf3Extd127"/>
         <driver name="TrackReconSeed356Conf7Extd124"/>
         <driver name="TrackReconSeed235Conf6Extd147"/> 
-        <driver name="TrackReconSeed234Conf6Extd157"/>
+        <driver name="TrackReconSeed234Conf6Extd157"/> 
 
         <!-- 
            TrackDataDriver needs to be run before ReconParticleDriver so the
@@ -315,6 +315,7 @@
         <driver name="KalmanPatRecDriver" type="org.hps.recon.tracking.kalman.KalmanPatRecDriver">
             <!--<doDebugPlots>false</doDebugPlots>-->
             <!-- <siHitsLimit>50</siHitsLimit> -->
+            <seedCompThr>0.05</seedCompThr>
             <verbose>false</verbose>
           </driver>
           

--- a/steering-files/src/main/resources/org/hps/steering/recon/PhysicsRun2019_pass0_recon.lcsim
+++ b/steering-files/src/main/resources/org/hps/steering/recon/PhysicsRun2019_pass0_recon.lcsim
@@ -7,7 +7,6 @@
       @author PF <pbutti@slac.stanford.edu>
     -->
     <execute>
-        <driver name="EventMarkerDriver"/>
         <!-- Enable the following if re-processing lcio files -->
         <!--        <driver name="PreCleanupDriver"/>       -->
         <!--  Event Reconstruction  -->
@@ -80,11 +79,7 @@
         <driver name="CleanupDriver"/>
     </execute>    
     <drivers>    
-        
-        <driver name="EventMarkerDriver" type="org.lcsim.job.EventMarkerDriver">
-            <eventInterval>1000</eventInterval>
-        </driver> 
-        
+	    
         <driver name="PreCleanupDriver" type="org.hps.analysis.dataquality.ReadoutCleanupDriver">
             <collectionNames>EcalCalHits EcalClusters EcalClustersCorr FinalStateParticles UnconstrainedMollerCandidates UnconstrainedMollerVertices UnconstrainedV0Candidates UnconstrainedV0Vertices TargetConstrainedMollerCandidates TargetConstrainedMollerVertices TargetConstrainedV0Candidates TargetConstrainedV0Vertices BeamspotConstrainedMollerCandidates BeamspotConstrainedMollerVertices BeamspotConstrainedV0Candidates BeamspotConstrainedV0Vertices GBLKinkData GBLKinkDataRelations MatchedToGBLTrackRelations HelicalTrackHits HelicalTrackHitRelations MatchedTracks GBLTracks MatchedToGBLTrackRelations PartialTracks RotatedHelicalTrackHits RotatedHelicalTrackHitRelations SVTFittedRawTrackerHits  SVTShapeFitParameters StripClusterer_SiTrackerHitStrip1D TrackData TrackDataRelations TrackResiduals TrackResidualsRelations</collectionNames> 
         </driver>

--- a/steering-files/src/main/resources/org/hps/steering/recon/PhysicsRun2019_pass0_recon.lcsim
+++ b/steering-files/src/main/resources/org/hps/steering/recon/PhysicsRun2019_pass0_recon.lcsim
@@ -1,0 +1,436 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lcsim xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/lcsim/1.0/lcsim.xsd">
+    <!-- 
+      Steering file for running 2019 Reconstruction on readout data (LCIO or EVIO)
+      created:  9/24/19
+      @author Norman Graf <Norman.Graf@slac.stanford.edu>
+      @author PF <pbutti@slac.stanford.edu>
+    -->
+    <execute>
+        <driver name="EventMarkerDriver"/>
+        <!-- Enable the following if re-processing lcio files -->
+        <!--        <driver name="PreCleanupDriver"/>       -->
+        <!--  Event Reconstruction  -->
+        <!-- Skip events with known bad conditions -->
+        <!-- Not yet defined for 2019 data -->
+        <!--        <driver name="EventFlagFilter"/>  -->
+        <!--RF driver-->
+        <driver name="RfFitter"/>
+        <!-- Ecal reconstruction drivers -->        
+        <driver name="EcalRunningPedestal"/> 
+        <driver name="EcalRawConverter" />
+        <driver name="EcalTimeCorrection"/> 
+        <driver name="ReconClusterer" /> 
+        <driver name="CopyCluster" />
+
+        <!-- Hodoscope drivers -->
+        <driver name="HodoRunningPedestal"/>
+        <driver name="HodoRawConverter"/>
+ 
+        <!-- SVT reconstruction drivers -->
+        <driver name="RawTrackerHitSensorSetup"/>
+        <driver name="RawTrackerHitFitterDriver" />
+        <driver name="TrackerHitDriver"/>
+        
+        <driver name="HelicalTrackHitDriver"/> 
+        
+        <!-- Track finding and fitting using seed tracker. -->
+        
+        <driver name="TrackReconSeed123Conf4Extd56"/>    
+        <driver name="TrackReconSeed123Conf5Extd46"/>
+        
+        <driver name="TrackReconSeed567Conf4Extd123"/>
+        <driver name="TrackReconSeed456Conf3Extd127"/>
+        <driver name="TrackReconSeed356Conf7Extd124"/>
+        <driver name="TrackReconSeed235Conf6Extd147"/> 
+        <driver name="TrackReconSeed234Conf6Extd157"/>
+
+        <!-- 
+           TrackDataDriver needs to be run before ReconParticleDriver so the
+           ReconstructedParticle types are properly set.
+        -->
+        
+        <driver name="MergeTrackCollections"/>
+        <driver name="GBLRefitterDriver" />
+        <driver name="TrackDataDriver" />
+        <driver name="KalmanPatRecDriver"/>
+        <driver name="ReconParticleDriver" /> 
+        <driver name="ReconParticleDriver_Kalman" /> 
+        
+        <!--  DQM   -->
+              
+        <!-- Following are optional Analysis Drivers  -->
+<!--        
+        <driver name="EcalMonitoring"/>  
+        <driver name="EcalMonitoringCorr"/>  
+        <driver name="SVTMonitoring"/>
+        <driver name="TrackingMonitoring"/>  
+        <driver name="TrackingMonitoringMatched"/>        
+        <driver name="TrackingResiduals"/>
+        <driver name="FinalStateMonitoring"/>          
+        <driver name="V0Monitoring"/>          
+        <driver name="TridentMonitoring"/>           
+        <driver name="MuonCandidateMonitoring"/>    
+        -->      
+             
+        <driver name="LCIOWriter"/>
+        <!-- Toggle between saving in aida or root format -->
+        <!-- <driver name="AidaToRootSaveDriver"/> -->
+        <!-- <driver name="AidaSaveDriver"/> -->
+        <driver name="CleanupDriver"/>
+    </execute>    
+    <drivers>    
+        
+        <driver name="EventMarkerDriver" type="org.lcsim.job.EventMarkerDriver">
+            <eventInterval>1000</eventInterval>
+        </driver> 
+        
+        <driver name="PreCleanupDriver" type="org.hps.analysis.dataquality.ReadoutCleanupDriver">
+            <collectionNames>EcalCalHits EcalClusters EcalClustersCorr FinalStateParticles UnconstrainedMollerCandidates UnconstrainedMollerVertices UnconstrainedV0Candidates UnconstrainedV0Vertices TargetConstrainedMollerCandidates TargetConstrainedMollerVertices TargetConstrainedV0Candidates TargetConstrainedV0Vertices BeamspotConstrainedMollerCandidates BeamspotConstrainedMollerVertices BeamspotConstrainedV0Candidates BeamspotConstrainedV0Vertices GBLKinkData GBLKinkDataRelations MatchedToGBLTrackRelations HelicalTrackHits HelicalTrackHitRelations MatchedTracks GBLTracks MatchedToGBLTrackRelations PartialTracks RotatedHelicalTrackHits RotatedHelicalTrackHitRelations SVTFittedRawTrackerHits  SVTShapeFitParameters StripClusterer_SiTrackerHitStrip1D TrackData TrackDataRelations TrackResiduals TrackResidualsRelations</collectionNames> 
+        </driver>
+        
+        <driver name="HodoRunningPedestal" type="org.hps.recon.ecal.HodoRunningPedestalDriver"/>
+        <driver name="HodoRawConverter" type="org.hps.recon.ecal.HodoRawConverterDriver"/>
+  
+        <!-- Driver to reject "bad" events -->
+        <!-- Not yet implemented for 2019
+             <driver name="EventFlagFilter" type="org.hps.recon.filtering.EventFlagFilter"> 
+            <flagNames>svt_bias_good svt_position_good svt_burstmode_noise_good svt_event_header_good</flagNames> 
+        </driver> 
+        -->
+        
+        <driver name="RfFitter" type="org.hps.evio.RfFitterDriver"/>       
+
+        <!-- Ecal reconstruction drivers -->
+        <driver name="EcalRunningPedestal" type="org.hps.recon.ecal.EcalRunningPedestalDriver">
+            <logLevel>CONFIG</logLevel>
+        </driver>
+        <driver name="EcalRawConverter" type="org.hps.recon.ecal.EcalRawConverter2Driver">
+            <!-- ecalCollectionName>EcalCalHits</ecalCollectionName -->
+            <!-- fixShapeParameter>true</fixShapeParameter -->
+            <!-- globalFixedPulseWidth>2.4</globalFixedPulseWidth -->
+        </driver> 
+        <driver name="EcalTimeCorrection" type="org.hps.recon.ecal.EcalTimeCorrectionDriver"/> 
+        <driver name="ReconClusterer" type="org.hps.recon.ecal.cluster.ReconClusterDriver">
+            <logLevel>WARNING</logLevel>
+            <outputClusterCollectionName>EcalClusters</outputClusterCollectionName>
+        </driver> 
+        <driver name="CopyCluster" type="org.hps.recon.ecal.cluster.CopyClusterCollectionDriver">
+            <inputCollectionName>EcalClusters</inputCollectionName>
+            <outputCollectionName>EcalClustersCorr</outputCollectionName>
+        </driver>
+        
+        <!-- SVT reconstruction drivers -->
+        <driver name="RawTrackerHitSensorSetup" type="org.lcsim.recon.tracking.digitization.sisim.config.RawTrackerHitSensorSetup">
+            <readoutCollections>SVTRawTrackerHits</readoutCollections>
+        </driver>
+        
+        <driver name="RawTrackerHitFitterDriver" type="org.hps.recon.tracking.RawTrackerHitFitterDriver">
+            <fitAlgorithm>Pileup</fitAlgorithm>
+            <useTimestamps>false</useTimestamps>
+            <correctTimeOffset>true</correctTimeOffset>
+            <correctT0Shift>false</correctT0Shift>
+            <useTruthTime>false</useTruthTime>
+            <subtractTOF>true</subtractTOF>
+            <subtractTriggerTime>true</subtractTriggerTime>
+            <correctChanT0>false</correctChanT0>
+            <debug>false</debug>
+        </driver>
+       
+        <driver name="TrackerHitDriver" type="org.hps.recon.tracking.DataTrackerHitDriver">
+            <neighborDeltaT>8.0</neighborDeltaT>
+            <saveMonsterEvents>false</saveMonsterEvents>
+            <thresholdMonsterEvents>200</thresholdMonsterEvents>
+            <debug>false</debug>
+        </driver>
+      
+        <driver name="HelicalTrackHitDriver" type="org.hps.recon.tracking.HelicalTrackHitDriver">
+            <debug>false</debug>
+            <clusterTimeCut>40.0</clusterTimeCut>
+            <clusterAmplitudeCut>400.0</clusterAmplitudeCut>
+            <maxDt>20.0</maxDt>
+            <saveAxialHits>false</saveAxialHits>
+        </driver>   
+        
+        <!--   Track finding strategies -->
+        <!--   TrackReconSeed_ABC_Conf_D_Extd_EFG -->
+        <!--   Seed the track with a fit to the triplet of hits in layers ABC -->
+        <!--   Confirm that track with a hit in layer D -->
+        <!--   Extend that track to hits in layers EFG -->
+
+
+
+        <driver name="TrackReconSeed123Conf4Extd56" type="org.hps.recon.tracking.TrackerReconDriver">
+            <trackCollectionName>Tracks_s123_c4_e56</trackCollectionName>
+            <strategyResource>HPS_s123_c4_e56_4hit.xml</strategyResource>
+            <debug>false</debug>
+	        <rmsTimeCut>1000.0</rmsTimeCut>
+            <maxTrackerHits>250</maxTrackerHits>
+        </driver>
+        
+        <driver name="TrackReconSeed123Conf5Extd46" type="org.hps.recon.tracking.TrackerReconDriver">
+            <trackCollectionName>Tracks_s123_c5_e46</trackCollectionName>
+            <strategyResource>HPS_s123_c5_e46_4hit.xml</strategyResource>
+            <debug>false</debug>
+	        <rmsTimeCut>1000.0</rmsTimeCut>
+            <maxTrackerHits>250</maxTrackerHits>
+        </driver>
+
+
+        <driver name="TrackReconSeed567Conf4Extd123" type="org.hps.recon.tracking.TrackerReconDriver">
+            <trackCollectionName>Tracks_s567_c4_e123</trackCollectionName>
+            <strategyResource>HPS_s567_c4_e123.xml</strategyResource>
+            <debug>false</debug>
+            <!--<rmsTimeCut>8.0</rmsTimeCut>-->
+            <rmsTimeCut>20.0</rmsTimeCut>
+            <maxTrackerHits>250</maxTrackerHits>
+        </driver>
+        <driver name="TrackReconSeed456Conf3Extd127" type="org.hps.recon.tracking.TrackerReconDriver">
+            <trackCollectionName>Tracks_s456_c3_e127</trackCollectionName>
+            <strategyResource>HPS_s456_c3_e127.xml</strategyResource>
+            <debug>false</debug>
+            <!--<rmsTimeCut>8.0</rmsTimeCut>-->
+            <rmsTimeCut>20.0</rmsTimeCut>
+            <maxTrackerHits>250</maxTrackerHits>
+        </driver>
+        <driver name="TrackReconSeed356Conf7Extd124" type="org.hps.recon.tracking.TrackerReconDriver">
+            <trackCollectionName>Tracks_s356_c7_e124</trackCollectionName>
+            <strategyResource>HPS_s356_c7_e124.xml</strategyResource>
+            <debug>false</debug>
+            <!--<rmsTimeCut>8.0</rmsTimeCut>-->
+            <rmsTimeCut>20.0</rmsTimeCut>
+            <maxTrackerHits>250</maxTrackerHits>
+        </driver>
+        <driver name="TrackReconSeed235Conf6Extd147" type="org.hps.recon.tracking.TrackerReconDriver">
+            <trackCollectionName>Tracks_s235_c6_e147</trackCollectionName>
+            <strategyResource>HPS_s235_c6_e147.xml</strategyResource>
+            <debug>false</debug>
+            <!--<rmsTimeCut>8.0</rmsTimeCut>-->
+            <rmsTimeCut>20.0</rmsTimeCut>
+            <maxTrackerHits>250</maxTrackerHits>
+        </driver>
+        <driver name="TrackReconSeed234Conf6Extd157" type="org.hps.recon.tracking.TrackerReconDriver">
+            <trackCollectionName>Tracks_s234_c6_e157</trackCollectionName>
+            <strategyResource>HPS_s234_c6_e157.xml</strategyResource>
+            <debug>false</debug>
+            <!--<rmsTimeCut>8.0</rmsTimeCut>-->
+            <rmsTimeCut>20.0</rmsTimeCut>
+            <maxTrackerHits>250</maxTrackerHits>
+        </driver>
+        <driver name="TrackReconSeed345Conf2Extd16" type="org.hps.recon.tracking.TrackerReconDriver">
+            <trackCollectionName>Tracks_s345_c2_e16</trackCollectionName>
+            <strategyResource>HPS_s345_c2_e16.xml</strategyResource>
+            <debug>false</debug>
+            <rmsTimeCut>8.0</rmsTimeCut>
+            <maxTrackerHits>250</maxTrackerHits>
+        </driver>
+        <driver name="TrackReconSeed345Conf6Extd7" type="org.hps.recon.tracking.TrackerReconDriver">
+            <trackCollectionName>Tracks_s345_c6_e7</trackCollectionName>
+            <strategyResource>HPS_s345_c6_e7_2019.xml</strategyResource>
+            <debug>false</debug>
+            <rmsTimeCut>20.0</rmsTimeCut>
+            <maxTrackerHits>250</maxTrackerHits>
+        </driver>
+        <driver name="TrackReconSeed345Conf7Extd6" type="org.hps.recon.tracking.TrackerReconDriver">
+            <trackCollectionName>Tracks_s345_c7_e6</trackCollectionName>
+            <strategyResource>HPS_s345_c7_e6_2019.xml</strategyResource>
+            <debug>false</debug>
+            <rmsTimeCut>20.0</rmsTimeCut>
+            <maxTrackerHits>250</maxTrackerHits>
+        </driver>
+        <driver name="TrackReconSeed346Conf7Extd5" type="org.hps.recon.tracking.TrackerReconDriver">
+            <trackCollectionName>Tracks_s346_c7_e5</trackCollectionName>
+            <strategyResource>HPS_s346_c7_e5_2019.xml</strategyResource>
+            <debug>false</debug>
+            <rmsTimeCut>20.0</rmsTimeCut>
+            <maxTrackerHits>250</maxTrackerHits>
+        </driver>
+        <driver name="TrackReconSeed346Conf5Extd7" type="org.hps.recon.tracking.TrackerReconDriver">
+            <trackCollectionName>Tracks_s346_c5_e7</trackCollectionName>
+            <strategyResource>HPS_s346_c5_e7_2019.xml</strategyResource>
+            <debug>false</debug>
+            <rmsTimeCut>20.0</rmsTimeCut>
+            <maxTrackerHits>250</maxTrackerHits>
+        </driver>
+        <driver name="TrackReconSeed456Conf3Extd7" type="org.hps.recon.tracking.TrackerReconDriver">
+            <trackCollectionName>Tracks_s456_c3_e7</trackCollectionName>
+            <strategyResource>HPS_s456_c3_e7_2019.xml</strategyResource>
+            <debug>false</debug>
+            <rmsTimeCut>20.0</rmsTimeCut>
+            <maxTrackerHits>250</maxTrackerHits>
+        </driver>
+        <driver name="TrackReconSeed456Conf7Extd3" type="org.hps.recon.tracking.TrackerReconDriver">
+            <trackCollectionName>Tracks_s456_c7_e3</trackCollectionName>
+            <strategyResource>HPS_s456_c7_e3_2019.xml</strategyResource>
+            <debug>false</debug>
+            <rmsTimeCut>20.0</rmsTimeCut>
+            <maxTrackerHits>250</maxTrackerHits>
+        </driver>
+        <driver name="TrackReconSeed457Conf3Extd6" type="org.hps.recon.tracking.TrackerReconDriver">
+            <trackCollectionName>Tracks_s457_c3_e6</trackCollectionName>
+            <strategyResource>HPS_s457_c3_e6_2019.xml</strategyResource>
+            <debug>false</debug>
+            <rmsTimeCut>20.0</rmsTimeCut>
+            <maxTrackerHits>250</maxTrackerHits>
+        </driver>
+        <driver name="TrackReconSeed457Conf6Extd3" type="org.hps.recon.tracking.TrackerReconDriver">
+            <trackCollectionName>Tracks_s457_c6_e3</trackCollectionName>
+            <strategyResource>HPS_s457_c6_e3_2019.xml</strategyResource>
+            <debug>false</debug>
+            <rmsTimeCut>20.0</rmsTimeCut>
+            <maxTrackerHits>250</maxTrackerHits>
+        </driver>
+        <driver name="TrackReconSeed567Conf3Extd4" type="org.hps.recon.tracking.TrackerReconDriver">
+            <trackCollectionName>Tracks_s567_c3_e4</trackCollectionName>
+            <strategyResource>HPS_s567_c3_e4_2019.xml</strategyResource>
+            <debug>false</debug>
+            <rmsTimeCut>20.0</rmsTimeCut>
+            <maxTrackerHits>250</maxTrackerHits>
+        </driver>
+        <driver name="TrackReconSeed567Conf4Extd3" type="org.hps.recon.tracking.TrackerReconDriver">
+            <trackCollectionName>Tracks_s567_c4_e3</trackCollectionName>
+            <strategyResource>HPS_s567_c4_e3_2019.xml</strategyResource>
+            <debug>false</debug>
+            <rmsTimeCut>20.0</rmsTimeCut>
+            <maxTrackerHits>250</maxTrackerHits>
+        </driver>
+       
+       <!-- Resolve duplicate tracks found with different strategies -->
+        <driver name="MergeTrackCollections" type="org.hps.recon.tracking.MergeTrackCollections" />
+
+        <!-- Refit tracks using the GBL algorithm -->
+        <driver name="GBLRefitterDriver" type="org.hps.recon.tracking.gbl.GBLRefitterDriver" >
+          <!--            <maxTrackChisq5hits> 60. </maxTrackChisq5hits>
+               <maxTrackChisq6hits> 84. </maxTrackChisq6hits>-->
+          <includeNoHitScatters>true</includeNoHitScatters>
+          <gblRefitIterations>5</gblRefitIterations>
+          <storeTrackStates>false</storeTrackStates>
+          <writeMilleBinary>false</writeMilleBinary>
+          <milleBinaryFileName>${outputFile}_millepede.bin</milleBinaryFileName>
+          <!--<maxTrackChisq5hits> 100. </maxTrackChisq5hits> -->
+          <!--<maxTrackChisq6hits> 100. </maxTrackChisq6hits> -->
+        </driver> 
+        
+        
+        <driver name="KalmanPatRecDriver" type="org.hps.recon.tracking.kalman.KalmanPatRecDriver">
+            <!--<doDebugPlots>false</doDebugPlots>-->
+            <!-- <siHitsLimit>50</siHitsLimit> -->
+            <verbose>false</verbose>
+          </driver>
+          
+
+        <driver name="GBLOutputDriver" type="org.hps.recon.tracking.gbl.GBLOutputDriver">
+          <outputPlotsFilename>${outputFile}_gblplots.root</outputPlotsFilename>
+          <trackCollectionName>GBLTracks</trackCollectionName>
+        </driver>
+                
+        <driver name="TrackDataDriver" type="org.hps.recon.tracking.TrackDataDriver" />
+        
+        <!-- Create Reconstructed Particles by pairing up tracks and clusters when possible - Beamspot location and size valid for 10031 -->
+        <driver name="ReconParticleDriver" type="org.hps.recon.particle.HpsReconParticleDriver" > 
+            <ecalClusterCollectionName>EcalClustersCorr</ecalClusterCollectionName>
+            <trackCollectionNames>GBLTracks</trackCollectionNames>          
+            <includeUnmatchedTracksInFSP>true</includeUnmatchedTracksInFSP>
+            <useInternalVertexXYPositions>false</useInternalVertexXYPositions>
+            <requireClustersForV0>false</requireClustersForV0>
+            <beamPositionX>0.180</beamPositionX>
+            <beamSigmaX>0.05</beamSigmaX>
+            <beamPositionY>0.04</beamPositionY>
+            <beamSigmaY>0.020</beamSigmaY>
+            <beamPositionZ>-10</beamPositionZ>
+            <maxElectronP>7.0</maxElectronP>
+            <maxVertexP>7.0</maxVertexP>
+            <minVertexChisqProb> 0.0 </minVertexChisqProb>
+            <maxVertexClusterDt> 40.0 </maxVertexClusterDt>           
+            <maxMatchDt>40</maxMatchDt>
+            <trackClusterTimeOffset>40</trackClusterTimeOffset>
+            <useCorrectedClusterPositionsForMatching>false</useCorrectedClusterPositionsForMatching>
+            <applyClusterCorrections>false</applyClusterCorrections>
+            <useTrackPositionForClusterCorrection>false</useTrackPositionForClusterCorrection>
+            <debug>false</debug>
+        </driver>  
+
+        <driver name="ReconParticleDriver_Kalman" type="org.hps.recon.particle.HpsReconParticleDriver" > 
+            <ecalClusterCollectionName>EcalClustersCorr</ecalClusterCollectionName>
+            <trackCollectionNames>KalmanFullTracks</trackCollectionNames>          
+            <unconstrainedV0CandidatesColName>UnconstrainedV0Candidates_KF</unconstrainedV0CandidatesColName>
+            <unconstrainedV0VerticesColName>UnconstrainedV0Vertices_KF</unconstrainedV0VerticesColName>
+            <beamConV0CandidatesColName>BeamspotConstrainedV0Candidates_KF</beamConV0CandidatesColName>
+            <beamConV0VerticesColName>BeamspotConstrainedV0Vertices_KF</beamConV0VerticesColName>
+            <targetConV0CandidatesColName>TargetConstrainedV0Candidates_KF</targetConV0CandidatesColName>
+            <targetConV0VerticesColName>TargetConstrainedV0Vertices_KF</targetConV0VerticesColName>
+            <includeUnmatchedTracksInFSP>true</includeUnmatchedTracksInFSP>
+            <useInternalVertexXYPositions>false</useInternalVertexXYPositions>
+            <requireClustersForV0>false</requireClustersForV0>
+            <beamPositionX>0.180</beamPositionX>
+            <beamSigmaX>0.05</beamSigmaX>
+            <beamPositionY>0.04</beamPositionY>
+            <beamSigmaY>0.020</beamSigmaY>
+            <beamPositionZ>-10</beamPositionZ>
+            <maxElectronP>7.0</maxElectronP>
+            <maxVertexP>7.0</maxVertexP>
+            <minVertexChisqProb>0.0</minVertexChisqProb>
+            <maxVertexClusterDt>40.0</maxVertexClusterDt>           
+            <maxMatchDt>40</maxMatchDt>
+            <trackClusterTimeOffset>40</trackClusterTimeOffset>
+            <useCorrectedClusterPositionsForMatching>false</useCorrectedClusterPositionsForMatching>
+            <applyClusterCorrections>false</applyClusterCorrections>
+            <useTrackPositionForClusterCorrection>false</useTrackPositionForClusterCorrection>
+            <debug>false</debug>
+        </driver>  
+        
+        <driver name="CleanupDriver" type="org.lcsim.recon.tracking.digitization.sisim.config.ReadoutCleanupDriver"/>
+
+        <driver name="LCIOWriter" type="org.lcsim.util.loop.LCIODriver">
+            <outputFilePath>${outputFile}.slcio</outputFilePath>
+        </driver>       
+        <driver name="AidaSaveDriver" type="org.lcsim.job.AidaSaveDriver">
+            <outputFileName>${outputFile}.root</outputFileName>
+        </driver>
+        <driver name="AidaToRootSaveDriver" type="org.lcsim.job.AidaSaveDriver">
+            <outputFileName>${outputFile}.root</outputFileName>
+        </driver>
+
+        <!-- all triggers  -->
+        <driver name="EcalMonitoring" type="org.hps.analysis.dataquality.EcalMonitoring">         
+            <triggerType>all</triggerType>
+        </driver>
+        <driver name="MuonCandidateMonitoring" type="org.hps.analysis.dataquality.MuonCandidateMonitoring">         
+            <triggerType>all</triggerType>
+            <isGBL>true</isGBL>
+        </driver>      
+        <driver name="EcalMonitoringCorr" type="org.hps.analysis.dataquality.EcalMonitoring">         
+            <triggerType>all</triggerType>
+            <clusterCollectionName>EcalClustersCorr</clusterCollectionName>
+            <fillHitPlots>false</fillHitPlots>
+        </driver>
+        <driver name="SVTMonitoring" type="org.hps.analysis.dataquality.SvtMonitoring">         
+            <triggerType>all</triggerType>
+        </driver>      
+        <driver name="TrackingMonitoring" type="org.hps.analysis.dataquality.TrackingMonitoring">
+            <triggerType>all</triggerType>
+            <trackCollectionName>GBLTracks</trackCollectionName>
+        </driver>     
+        <driver name="TrackingResiduals" type="org.hps.analysis.dataquality.TrackingResiduals">
+            <triggerType>all</triggerType>
+        </driver>                 
+        <driver name="FinalStateMonitoring" type="org.hps.analysis.dataquality.FinalStateMonitoring">
+            <triggerType>all</triggerType>
+            <isGBL>true</isGBL>
+        </driver>
+        <driver name="V0Monitoring" type="org.hps.analysis.dataquality.V0Monitoring">
+            <triggerType>all</triggerType>
+            <isGBL>true</isGBL>
+        </driver>
+        <driver name="TridentMonitoring" type="org.hps.analysis.dataquality.TridentMonitoring">
+            <triggerType>all</triggerType>
+            <isGBL>true</isGBL>
+        </driver>
+
+        <driver name="TrackingMonitoringMatched" type="org.hps.analysis.dataquality.TrackingMonitoring">
+            <triggerType>all</triggerType>           
+        </driver>   
+
+    </drivers>
+</lcsim>
+

--- a/tracking/src/main/java/org/hps/recon/tracking/DataTrackerHitDriver.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/DataTrackerHitDriver.java
@@ -63,7 +63,14 @@ public class DataTrackerHitDriver extends Driver {
     private StripMaker stripClusterer;
     // private DumbShaperFit shaperFit;
     int[] counts = new int[14];
+    
+    //If flag is false do not save the StripCluster Collection if bigger than threshold (to remove monster events)
+    private boolean saveMonsterEvents = true;
+    
+    //Threshold to decide if this is a monster event
 
+    private int thresholdMonsterEvents = 50;
+    
     public void setDebug(boolean debug) {
         this.debug = debug;
     }
@@ -133,6 +140,14 @@ public class DataTrackerHitDriver extends Driver {
 
     public void setUseWeights(boolean useWeights) {
         this.useWeights = useWeights;
+    }
+
+    public void setSaveMonsterEvents(boolean saveMonsterEvents) {
+        this.saveMonsterEvents = saveMonsterEvents;
+    }
+
+    public void setThresholdMonsterEvents(int thresholdMonsterEvents) {
+        this.thresholdMonsterEvents = thresholdMonsterEvents;
     }
 
     /**
@@ -225,12 +240,18 @@ public class DataTrackerHitDriver extends Driver {
                         + this.fittedTrackerHitCollectionName + " has " + event.get(LCRelation.class, fittedTrackerHitCollectionName).size() + " hits.");
             System.out.println("TrackerHit collection " + this.stripHitOutputCollectionName + " has " + stripHits1D.size() + " hits.");
         }
-
+        
+        if (debug)
+            System.out.println("[ DataTrackerHitDriver ] - " + this.stripHitOutputCollectionName + " has " + stripHits1D.size() + " hits.");
+        
+        //Clear the stripHits array = PF::Hack
+        if (!saveMonsterEvents && stripHits1D.size()>thresholdMonsterEvents)
+            stripHits1D = new ArrayList<SiTrackerHit>();
+                
         // Put output hits into collection.
         int flag = LCIOUtil.bitSet(0, 31, true); // Turn on 64-bit cell ID.        
         event.put(this.stripHitOutputCollectionName, stripHits1D, SiTrackerHitStrip1D.class, 0, toString());
-        if (debug)
-            System.out.println("[ DataTrackerHitDriver ] - " + this.stripHitOutputCollectionName + " has " + stripHits1D.size() + " hits.");
+        
         for (SiTrackerHit stripHit : stripHits1D)
             counts[((SiTrackerHitStrip1D) stripHit).getRawHits().get(0).getLayerNumber()-1]++;
 

--- a/tracking/src/main/java/org/hps/recon/tracking/TrackUtils.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/TrackUtils.java
@@ -278,7 +278,7 @@ public class TrackUtils {
             // watch out for ambiguity        
             double dphi = phinew - phi0;
             if (Math.abs(dphi) > Math.PI)
-                throw new RuntimeException("dphi is large " + dphi + " from phi0 " + phi0 + " and phinew " + phinew + " take care of the ambiguity!!??");
+                System.out.println("TrackUtils::WARNING::dphi is large " + dphi + " from phi0 " + phi0 + " and phinew " + phinew + " take care of the ambiguity!!??");
 
             // calculate new dca
             dcanew += dx * sinphi - dy * cosphi + (dx * cosphi + dy * sinphi) * Math.tan(dphi / 2.);

--- a/tracking/src/main/java/org/hps/recon/tracking/gbl/HpsGblRefitter.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/gbl/HpsGblRefitter.java
@@ -262,35 +262,44 @@ public class HpsGblRefitter {
 
             // go to next point
             s += step;
-
+            
         } // strips
-
+        
         // create the trajectory
-        GblTrajectory traj = new GblTrajectory(listOfPoints); // ,seedLabel, clSeed);
+        GblTrajectory traj = null;
+        
+        try {
+            traj = new GblTrajectory(listOfPoints); // ,seedLabel, clSeed);
+            
+            
+            if (!traj.isValid()) {
+                System.out.println("HpsGblFitter: " + " Invalid GblTrajectory -> skip");
+                return null; // 1;//INVALIDTRAJ;
+            }
 
-        if (!traj.isValid()) {
-            System.out.println("HpsGblFitter: " + " Invalid GblTrajectory -> skip");
-            return null; // 1;//INVALIDTRAJ;
+            // print the trajectory
+            if (debug) {
+                System.out.println("%%%% Gbl Trajectory ");
+                traj.printTrajectory(1);
+                traj.printData();
+                traj.printPoints(4);
+            }
+            // fit trajectory
+            double[] dVals = new double[2];
+            int[] iVals = new int[1];
+            traj.fit(dVals, iVals, "");
+            LOGGER.info("fit result: Chi2=" + dVals[0] + " Ndf=" + iVals[0] + " Lost=" + dVals[1]);
+
+            FittedGblTrajectory fittedTraj = new FittedGblTrajectory(traj, dVals[0], iVals[0], dVals[1]);
+            fittedTraj.setPathLengthMap(pathLengthMap);
+            fittedTraj.setSensorMap(sensorMap);
+
+            return fittedTraj;
         }
-
-        // print the trajectory
-        if (debug) {
-            System.out.println("%%%% Gbl Trajectory ");
-            traj.printTrajectory(1);
-            traj.printData();
-            traj.printPoints(4);
+        catch (RuntimeException e) {
+            System.out.println("HpsGblFitter: Invalid GblTrajectory -> skip"); 
+            return null;
         }
-        // fit trajectory
-        double[] dVals = new double[2];
-        int[] iVals = new int[1];
-        traj.fit(dVals, iVals, "");
-        LOGGER.info("fit result: Chi2=" + dVals[0] + " Ndf=" + iVals[0] + " Lost=" + dVals[1]);
-
-        FittedGblTrajectory fittedTraj = new FittedGblTrajectory(traj, dVals[0], iVals[0], dVals[1]);
-        fittedTraj.setPathLengthMap(pathLengthMap);
-        fittedTraj.setSensorMap(sensorMap);
-
-        return fittedTraj;
     }
 
     private static Matrix gblSimpleJacobianLambdaPhi(double ds, double cosl, double bfac) {

--- a/tracking/src/main/java/org/hps/recon/tracking/gbl/HpsGblRefitter.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/gbl/HpsGblRefitter.java
@@ -297,6 +297,7 @@ public class HpsGblRefitter {
             return fittedTraj;
         }
         catch (RuntimeException e) {
+            e.printStackTrace();
             System.out.println("HpsGblFitter: Invalid GblTrajectory -> skip"); 
             return null;
         }

--- a/tracking/src/main/java/org/hps/recon/tracking/kalman/KalmanInterface.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/kalman/KalmanInterface.java
@@ -505,9 +505,10 @@ public class KalmanInterface {
         
         // other track properties
         newTrack.setChisq(kT.chi2);
+        newTrack.setNDF(kT.SiteList.size() - 5);
         newTrack.setTrackType(BaseTrack.TrackType.Y_FIELD.ordinal());
         newTrack.setFitSuccess(true);
-
+        
         return newTrack;
     }
 

--- a/tracking/src/main/java/org/hps/recon/tracking/kalman/KalmanParams.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/kalman/KalmanParams.java
@@ -22,6 +22,7 @@ public class KalmanParams {
     int [] minStereo;
     int minAxial;
     double mxTdif;
+    double seedCompThr;           // Compatibility threshold for seedTracks helix parameters
     ArrayList<int[]> [] lyrList;
     private int[] Swap = {1,0, 3,2, 5,4, 7,6, 9,8, 11,10, 13,12};
     
@@ -66,6 +67,7 @@ public class KalmanParams {
         minAxial = 2;       // Minimum number of axial hits
         mxShared = 2;       // Maximum number of shared hits
         mxTdif = 30.;       // Maximum time difference of hits in a track
+        seedCompThr = -1;   // Remove SeedTracks with all Helix params within relative seedCompThr . If -1 do not apply duplicate removal
         
         // Load the default search strategies
         // Index 0 is for the bottom tracker (+z), 1 for the top (-z)
@@ -254,6 +256,14 @@ public class KalmanParams {
     public void setMaxTimeRange(double mxT) {
         System.out.format("KalmanParams: setting the maximum time range for hits on a track to %8.2f ns\n", mxT);
         mxTdif = mxT;
+    }
+
+    public void setSeedCompThr(double seedComp_Thr) {
+        
+        if (seedComp_Thr < 0)
+            return;
+        System.out.format("KalmanParams: setting the SeedTracks duplicate removal threshold to %f percent \n",seedComp_Thr*100.);
+        seedCompThr = seedComp_Thr;
     }
     
     public void clrStrategies() {

--- a/tracking/src/main/java/org/hps/recon/tracking/kalman/KalmanPatRecDriver.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/kalman/KalmanPatRecDriver.java
@@ -73,6 +73,7 @@ public class KalmanPatRecDriver extends Driver {
     private boolean doDebugPlots;      // Whether to make all the debugging histograms 
     private int siHitsLimit;           // Maximum number of SiClusters in one event allowed for KF pattern reco 
                                        // (protection against monster events) 
+    private double seedCompThr;        // Threshold for seedTrack helix parameters compatibility
     
     public String getOutputFullTrackCollectionName() {
         return outputFullTrackCollectionName;
@@ -100,6 +101,10 @@ public class KalmanPatRecDriver extends Driver {
     
     public void setSiHitsLimit(int input) {
         siHitsLimit = input;
+    }
+    
+    public void setSeedCompThr(double thr) {
+        seedCompThr = thr;
     }
     
     @Override
@@ -146,6 +151,7 @@ public class KalmanPatRecDriver extends Driver {
         if (minChi2IncBad != 0.0) kPar.setMinChi2IncBad(minChi2IncBad);
         if (maxResidShare != 0.0) kPar.setMxResidShare(maxResidShare);
         if (maxChi2IncShare != 0.0) kPar.setMxChi2double(maxChi2IncShare);
+        if (seedCompThr != 0.0) kPar.setSeedCompThr(seedCompThr);
         
         // Here we can replace or add search strategies to the pattern recognition (not, as yet, controlled by the steering file)
         // Layers are numbered 0 through 13, and the numbering here corresponds to the bottom tracker. The top-tracker lists are

--- a/tracking/src/main/java/org/hps/recon/tracking/kalman/KalmanPatRecDriver.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/kalman/KalmanPatRecDriver.java
@@ -71,7 +71,9 @@ public class KalmanPatRecDriver extends Driver {
     private double maxChi2IncShare;    // Maximum increment in chi^2 for a hit shared with another track
     private int numEvtPlots;           // Number of event displays to plot (gnuplot files)
     private boolean doDebugPlots;      // Whether to make all the debugging histograms 
-
+    private int siHitsLimit;           // Maximum number of SiClusters in one event allowed for KF pattern reco 
+                                       // (protection against monster events) 
+    
     public String getOutputFullTrackCollectionName() {
         return outputFullTrackCollectionName;
     }
@@ -95,7 +97,11 @@ public class KalmanPatRecDriver extends Driver {
 
     public void setTrackCollectionName(String input) {
     }
-
+    
+    public void setSiHitsLimit(int input) {
+        siHitsLimit = input;
+    }
+    
     @Override
     public void detectorChanged(Detector det) {
         _materialManager = new MaterialSupervisor();
@@ -113,6 +119,7 @@ public class KalmanPatRecDriver extends Driver {
 
         // Instantiate the interface to the Kalman-Filter code and set up the geometry
         KI = new KalmanInterface(verbose, uniformB);
+        KI.setSiHitsLimit(siHitsLimit);
         KI.createSiModules(detPlanes, fm);
         
         decoder = det.getSubdetector("Tracker").getIDDecoder();

--- a/tracking/src/main/java/org/hps/recon/tracking/kalman/KalmanPatRecHPS.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/kalman/KalmanPatRecHPS.java
@@ -885,7 +885,12 @@ class KalmanPatRecHPS {
             if (removeIt) {
                 TkrList.remove(tkr);
                 for (MeasurementSite site : tkr.SiteList) {
-                    site.m.hits.get(site.hitID).tracks.remove(tkr);
+                    if (site.hitID!=-1) {
+                        site.m.hits.get(site.hitID).tracks.remove(tkr);
+                    }
+                    else {
+                        System.out.format("KalmanPatRecHPS: Removing track from measurement site with hitID=-1. Skipping removal.");
+                    }
                     site.hitID = -1;
                 }
                 continue;

--- a/tracking/src/main/java/org/hps/recon/tracking/kalman/SeedTrack.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/kalman/SeedTrack.java
@@ -375,13 +375,32 @@ class SeedTrack {
             Vec pInt1 = t1.planeIntersection(p0);
             Vec pInt2 = t2.planeIntersection(p0);
             double diff = pInt1.mag() - pInt2.mag();
-            if (diff > 0.) {
+            
+            //if (Math.abs(diff) < 1e-8) {
+            //  System.out.println("SeedTrack::WARNING::Probably duplicate seed.");
+            //}
+            
+            if (diff >= 0.) {
                 return 1;
             } else {
                 return -1;
             }
         }
     };
+
+    //Check if two seeds are compatible given a certain relative threshold
+    boolean isCompatibleTo(SeedTrack st, double rel_eps) {
+        Vec st_hp = st.helixParams();
+        boolean compatible = true;
+        for (int i=0; i<5; i++) {
+            if (Math.abs((st_hp.v[i] - hParm.v[i])/hParm.v[i]) > rel_eps) {
+                compatible = false;
+                break;
+            }
+        }
+        return compatible;
+    }
+    
 
     Vec planeIntersection(Plane p) {
         double arg = (K / alpha) * ((drho + (alpha / K)) * Math.sin(phi0) - (p.X().v[1] - yOrigin));


### PR DESCRIPTION
In this pull request:
- Protection against large number of SiClusters in the KalmanPatRecoDriver
- Protection against large numbre of SiClusters in the DataTrackerHitDriver => Should be removed when a proper EventFilter for 2019 for SVT conditions is going to be defined. 
- 2 try-catch blocks around:

   - GBLTrack trajectory refit: to protect against non invertible matrix when calculating GBLPoint derivatives => The JAMA port in gbl code doesn't allow easy check on matrix rank. To be reviewed in the future, if needed.  This change also closes PR 568
https://github.com/JeffersonLab/hps-java/pull/568
as effectively addresses the same issue. 

    - MakeV0Candidates in the HpsReconDriver to protect against non-invertible matrices. In principle we should add an internal check, but this removes the run-time issue for a reasonable timescale for the April 2020 workshop on 2019 data processing.

- Added steering file for 2019 processing with both GBL and KF tracks, little bit fine tuned for 10031 

- Empty Kalman track collections (and their relations/TrackData/etc ) are now added to the event collection even if empty so doesn't break the EDM