### PR TITLE
Update PhysicsRun2019MCRecon.lcsim

### DIFF
--- a/steering-files/src/main/resources/org/hps/steering/recon/PhysicsRun2019MCRecon.lcsim
+++ b/steering-files/src/main/resources/org/hps/steering/recon/PhysicsRun2019MCRecon.lcsim
@@ -210,6 +210,8 @@
             <trackClusterTimeOffset>28</trackClusterTimeOffset>
             <useInternalVertexXYPositions>false</useInternalVertexXYPositions>
             <minVertexChisqProb> 0.0 </minVertexChisqProb>
+	    <maxElectronP>7.0</maxElectronP> 
+            <maxVertexP>7.0</maxVertexP>
             <requireClustersForV0>false</requireClustersForV0>
         </driver>         
 
@@ -231,6 +233,8 @@
             <trackClusterTimeOffset>28</trackClusterTimeOffset>
             <useInternalVertexXYPositions>false</useInternalVertexXYPositions>
             <minVertexChisqProb> 0.0 </minVertexChisqProb>
+	    <maxElectronP>7.0</maxElectronP>
+	    <maxVertexP>7.0</maxVertexP>
             <requireClustersForV0>false</requireClustersForV0>
             
         </driver>         


### PR DESCRIPTION
Reconstruction picks 2016 beamEnergy and the StandardCuts need to be overrided by steering file (otherwise 2019 projections won't be informative). 
- This PR adds a patch to the PhysicsRun2019MCRecon.lcsim to override wrongly defaulted mouse cuts.
