### PR TITLE
Update PhysicsRun2019MCRecon.lcsim

### DIFF
--- a/steering-files/src/main/resources/org/hps/steering/recon/PhysicsRun2019MCRecon.lcsim
+++ b/steering-files/src/main/resources/org/hps/steering/recon/PhysicsRun2019MCRecon.lcsim
@@ -225,6 +225,7 @@
             <beamConV0VerticesColName>BeamspotConstrainedV0Vertices_KF</beamConV0VerticesColName>
             <targetConV0CandidatesColName>TargetConstrainedV0Candidates_KF</targetConV0CandidatesColName>
             <targetConV0VerticesColName>TargetConstrainedV0Vertices_KF</targetConV0VerticesColName>
+	    <finalStateParticlesColName>FinalStateParticles_KF</finalStateParticlesColName>
             <beamPositionX> 0  </beamPositionX>
             <beamSigmaX> 0.05 </beamSigmaX>
             <beamPositionY> 0 </beamPositionY>


### PR DESCRIPTION
minor fix in collection name in the Kalman ReconParticleDriver. Trivial.