### PR TITLE
Iss735: FEE trigger driver and relative steering file for 2019 MC

### DIFF
--- a/ecal-readout-sim/src/main/java/org/hps/readout/trigger2019/FEETrigger2019ReadoutDriver.java
+++ b/ecal-readout-sim/src/main/java/org/hps/readout/trigger2019/FEETrigger2019ReadoutDriver.java
@@ -1,0 +1,152 @@
+package org.hps.readout.trigger2019;
+
+import java.util.Collection;
+
+import org.hps.readout.ReadoutDataManager;
+import org.hps.readout.TriggerDriver;
+import org.hps.recon.ecal.EcalUtils;
+import org.hps.record.triggerbank.TriggerModule2019;
+import org.lcsim.event.Cluster;
+import org.lcsim.event.EventHeader;
+
+/**
+ * <code>FEETrigger2019ReadoutDriver</code> simulates an HPS FEE trigger
+ * for 2019 MC. It takes in clusters produced by the
+ * {@link org.hps.readout.ecal.updated.GTPClusterReadoutDriver
+ * GTPClusterReadoutDriver}, and perform the necessary trigger
+ * logic on them. If a trigger is detected, it is sent to the readout data
+ * manager so that a triggered readout event may be written.
+ * 
+ * Prescale for various regions are not set. 
+ * 
+ * @author Tongtong Cao <caot@jlab.org>
+ */
+
+public class FEETrigger2019ReadoutDriver extends TriggerDriver{
+
+    // ==================================================================
+    // ==== Trigger General Default Parameters ==========================
+    // ==================================================================
+    private String inputCollectionName = "EcalClustersGTP";       // Name for the LCIO cluster collection.
+    private TriggerModule2019 triggerModule = new TriggerModule2019();
+    
+    // ==================================================================
+    // ==== Driver Internal Variables ===================================
+    // ==================================================================
+    private double localTime = 0.0;                                // Stores the internal time clock for the driver.
+    
+    @Override
+    public void startOfData() {
+        // Define the driver collection dependencies.
+        addDependency(inputCollectionName);
+        
+        // Register the trigger.
+        ReadoutDataManager.registerTrigger(this);
+        
+        // Make sure that a valid cluster collection name has been
+        // defined. If it has not, throw an exception.
+        if(inputCollectionName == null) {
+            throw new RuntimeException("The parameter inputCollectionName was not set!");
+        }       
+        
+        // Run the superclass method.
+        super.startOfData();
+    }
+    
+    @Override
+    public void process(EventHeader event) {
+        // If there is no data ready, then nothing can be done/
+        if(!ReadoutDataManager.checkCollectionStatus(inputCollectionName, localTime)) {
+            return;
+        }
+        
+        // Otherwise, get the input clusters from the present time.
+        Collection<Cluster> clusters = ReadoutDataManager.getData(localTime, localTime + 4.0, inputCollectionName, Cluster.class); 
+        
+        // Check that if a trigger exists, if the trigger is not in
+        // dead time. If it is, no trigger may be issued, so this is
+        // not necessary.
+        if(!isInDeadTime() && testTrigger(clusters)) { sendTrigger(); }
+        
+        // Increment the local time.
+        localTime += 4.0;
+    }
+    
+    @Override
+    protected double getTimeDisplacement() {
+        return 0;
+    }
+    
+    @Override
+    protected double getTimeNeededForLocalOutput() {
+        return 0;
+    }
+    
+    /**
+     * Sets the name of the LCIO collection that contains the clusters.
+     * @param clusterCollectionName - The cluster LCIO collection name.
+     */
+    public void setInputCollectionName(String clusterCollectionName) {
+        inputCollectionName = clusterCollectionName;
+    }
+    
+    /**
+     * Sets the minimum number of hits needed for a cluster to pass
+     * the hit count single cluster cut.
+     * @param minHitCount - The parameter value.
+     */
+    public void setMinHitCount(int minHitCount) {
+        triggerModule.setCutValue(TriggerModule2019.CLUSTER_HIT_COUNT_LOW, minHitCount);
+    }
+    
+    /**
+     * Sets the highest allowed energy a cluster may have and still
+     * pass the cluster total energy single cluster cut. Value uses
+     * units of GeV.
+     * @param clusterEnergyHigh - The parameter value.
+     */
+    public void setClusterEnergyHigh(double clusterEnergyHigh) {
+        triggerModule.setCutValue(TriggerModule2019.CLUSTER_TOTAL_ENERGY_HIGH, clusterEnergyHigh * EcalUtils.GeV);
+    }
+    
+    /**
+     * Sets the lowest allowed energy a cluster may have and still
+     * pass the cluster total energy single cluster cut. Value uses
+     * units of GeV.
+     * @param clusterEnergyLow - The parameter value.
+     */
+    public void setClusterEnergyLow(double clusterEnergyLow) {
+        triggerModule.setCutValue(TriggerModule2019.CLUSTER_TOTAL_ENERGY_LOW, clusterEnergyLow * EcalUtils.GeV);
+    }
+    
+    private boolean testTrigger(Collection<Cluster> clusters) {  
+        // Track whether a trigger has occurred.
+        boolean triggered = false;
+        
+        // Sort through the cluster list and add clusters that pass
+        // the single cluster cuts to the good list.
+        clusterLoop:
+        for(Cluster cluster : clusters) {
+            // ==== Cluster Hit Count Cut ==================================
+            // =============================================================
+            // If the cluster fails the cut, skip to the next cluster.
+            if(!triggerModule.clusterHitCountCut(cluster)) {
+                continue clusterLoop;
+            }
+            
+            // ==== Cluster Total Energy Cut ===============================
+            // =============================================================
+            // If the cluster fails the cut, skip to the next cluster.
+            if(!triggerModule.clusterTotalEnergyCut(cluster)) {
+                continue clusterLoop;
+            }
+            
+            // Clusters that pass all of the pair cuts produce a trigger.
+            triggered = true;
+        }
+        
+        // Return the good clusters.
+        return triggered;
+    }
+    
+}

--- a/recon/src/main/java/org/hps/recon/filtering/FEEFilterDriver.java
+++ b/recon/src/main/java/org/hps/recon/filtering/FEEFilterDriver.java
@@ -3,13 +3,10 @@ package org.hps.recon.filtering;
 import org.lcsim.event.CalorimeterHit;
 import org.lcsim.event.Cluster;
 
-import java.util.List;
-
 import org.hps.conditions.database.DatabaseConditionsManager;
 import org.hps.conditions.ecal.EcalChannel;
 import org.hps.conditions.ecal.EcalConditions;
 import org.hps.recon.ecal.cluster.ClusterUtilities;
-import org.hps.record.epics.EpicsData;
 //import org.hps.record.triggerbank.AbstractIntData;
 //import org.hps.record.triggerbank.TIData;
 import org.lcsim.event.EventHeader;
@@ -43,7 +40,7 @@ public class FEEFilterDriver extends EventReconFilter {
 
     /**
      * Set the cut value for seed energy in GeV
-     * 
+     *
      * @param seedCut
      */
     public void setSeedCut(double seedCut) {
@@ -52,7 +49,7 @@ public class FEEFilterDriver extends EventReconFilter {
 
     /**
      * Set the cut value for cluster energy in GeV
-     * 
+     *
      * @param clusterCut
      */
     public void setClusterCut(double clusterCut) {
@@ -65,7 +62,6 @@ public class FEEFilterDriver extends EventReconFilter {
         // (could also do this via event tag=31)
         //    final EpicsData data = EpicsData.read(event);
         //    if (data != null) return;
-
         incrementEventProcessed();
 
         // only keep singles triggers:
@@ -105,11 +101,15 @@ public class FEEFilterDriver extends EventReconFilter {
             // keep events with a single cluster over 2.0 GeV and seed over 1.2 GeV for 2019 running, and with no other clusters (threshold = 0.4 GeV)
             if (cc.getEnergy() > clusterCut && ClusterUtilities.findSeedHit(cc).getCorrectedEnergy() > seedCut && cc.getCalorimeterHits().size() >= minHits) {
                 nGood++;
-                if (nGood >= 2) break;
+                if (nGood >= 2) {
+                    break;
+                }
             }
             if (cc.getEnergy() > clusterCutThr) {
                 nAll++;
-                if (nAll >= 2) break;
+                if (nAll >= 2) {
+                    break;
+                }
             }
         }
         if ((nGood == 1) && (nAll == 1)) {

--- a/steering-files/src/main/resources/org/hps/steering/readout/PhysicsRun2019TrigFEE.lcsim
+++ b/steering-files/src/main/resources/org/hps/steering/readout/PhysicsRun2019TrigFEE.lcsim
@@ -2,7 +2,7 @@
 <lcsim xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
        xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/lcsim/1.0/lcsim.xsd">
     <!-- 
-      @Readout steering file with pairs trigger for 2019 MC.
+      @Readout steering file with FEE trigger for 2019 MC.
       @author <a href="mailto:caot@jlab.org">Tongtong Cao</a>
     -->
     <execute>

--- a/steering-files/src/main/resources/org/hps/steering/readout/PhysicsRun2019TrigFEE.lcsim
+++ b/steering-files/src/main/resources/org/hps/steering/readout/PhysicsRun2019TrigFEE.lcsim
@@ -1,0 +1,338 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lcsim xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+       xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/lcsim/1.0/lcsim.xsd">
+    <!-- 
+      @Readout steering file with pairs trigger for 2019 MC.
+      @author <a href="mailto:caot@jlab.org">Tongtong Cao</a>
+    -->
+    <execute>
+        <!-- SLiC Data Readout Drivers -->
+        <driver name="EcalHitsOutputDriver"/>
+        <driver name="MCParticleOutputDriver"/>
+        <driver name="HodoscopeHitsOutputDriver"/>
+        <driver name="TrackerHitsSVTOutputDriver"/>
+        <driver name="TrackerHitsEcalOutputDriver"/>
+        
+        <!-- SVT Readout Drivers -->
+        <driver name="SVTReadoutDriver" />
+        
+        <!-- Hodoscope Readout Simulation Drivers -->
+        <driver name="HodoscopePreprocessingDriver"/>
+        <driver name="HodoscopeDigitizationDriver"/>
+        
+        <!-- Calorimeter Readout Simulation Drivers -->
+        <driver name="EcalDigitizationDriver"/>
+        <driver name="EcalRawConverterDriver"/>
+        <driver name="GTPReadoutDriver"/>
+        
+        <!-- Trigger Simulation -->
+        <driver name="FEETrigger"/>
+        
+        <!-- LCIO Output and Data Management Driver -->
+        <driver name="ReadoutManagerDriver"/>
+        
+        <driver name="CleanupDriver" />
+    </execute> 
+    
+    <drivers>
+        <!--
+             Truth handler drivers load truth information from the input SLIC file
+             and pass them off to the readout data manager, where they may be
+             accessed by other readout drivers.
+             
+             It is required that these drivers specify the name of the collection
+             that they manage, and be of the appropriate handler type that matches
+             the object type of the collection. They may also, optionally, specify
+             whether the truth collection managed by the driver should be output
+             into the readout file, and if so, over what time range.
+             
+             By default, SLIC truth data is not written out. If no output window is
+             specified, and truth is written, the output window will be derived
+             from the readout window and trigger offset parameters of the readout
+             data manager.
+             
+             In general, calorimeter truth information (and the related particles
+             data) are best handled by including truth readout in the calorimeter
+             simulation. This will automatically include all calorimeter truth hits
+             and related MC particles in the readout file.
+          -->
+        <driver name="EcalHitsOutputDriver" type="org.hps.readout.SimCalorimeterHitReadoutDriver">
+            <collectionName>EcalHits</collectionName>
+            
+            <!-- Units of ns. -->
+            <readoutWindowBefore>8.0</readoutWindowBefore>
+            <readoutWindowAfter>32.0</readoutWindowAfter>
+            <persistent>true</persistent>
+        </driver>
+        
+        <driver name="MCParticleOutputDriver" type="org.hps.readout.MCParticleReadoutDriver">
+            <collectionName>MCParticle</collectionName>
+            
+            <!-- Units of ns. -->
+            <readoutWindowBefore>32.0</readoutWindowBefore>
+            <readoutWindowAfter>32.0</readoutWindowAfter>
+            <persistent>true</persistent>
+        </driver>
+        
+        <driver name="TrackerHitsSVTOutputDriver" type="org.hps.readout.svt.SVTTrackerHitReadoutDriver">
+            <collectionName>TrackerHits</collectionName>
+            <readoutWindowBefore>8.0</readoutWindowBefore>
+            <readoutWindowAfter>32.0</readoutWindowAfter>
+            <persistent>true</persistent>
+        </driver>
+        
+        <driver name="TrackerHitsEcalOutputDriver" type="org.hps.readout.SimTrackerHitReadoutDriver">
+            <collectionName>TrackerHitsECal</collectionName>
+            <readoutWindowBefore>8.0</readoutWindowBefore>
+            <readoutWindowAfter>32.0</readoutWindowAfter>
+            <persistent>true</persistent>
+        </driver>
+        
+        <driver name="HodoscopeHitsOutputDriver" type="org.hps.readout.SimTrackerHitReadoutDriver">
+            <collectionName>HodoscopeHits</collectionName>
+            
+            <!-- Units of ns. -->
+            <readoutWindowBefore>8.0</readoutWindowBefore>
+            <readoutWindowAfter>32.0</readoutWindowAfter>
+            <persistent>true</persistent>
+        </driver>
+        
+        
+        <!--
+            The SVT driver. Works just like before. Documentation is left to
+            the SVT group.
+        -->
+
+        <driver name="SVTReadoutDriver" type="org.hps.readout.svt.SVTReadoutDriver">
+            <enablePileupCut>false</enablePileupCut>
+            <useTimingConditions>true</useTimingConditions>
+            <addNoise>true</addNoise>
+        </driver>
+
+        <!--
+             The calorimeter readout driver handles conversion of SLIC truth
+             hits into voltage pulses and ultimately into ADC counts every 4 ns
+             sample. These samples are then integrated and output as hits which
+             are used internally by the readout simulation in the collection
+             set by variable "outputHitCollectionName".
+             
+             When a trigger occurs, the ADC buffer is used to generate readout
+             hits. The exact form these take differs based on the mode that is
+             simulated, but they are always output to the collection defined by
+             variable "readoutHitCollectionName".
+             
+             If truth information is enabled, then a set of truth relations are
+             output as well that link each readout hit to all of the truth hits
+             that are associated with it. Additionally, all truth hits as well
+             as the particle (and its parents) that generated that truth hit
+             are written out to ensure that they are available post-readout.
+             The additional truth information is automatically written to the
+             same collection name as the input truth data. If a truth handler
+             driver also outputs data into this collection, the two will merge.
+          -->
+        <driver name="EcalDigitizationDriver" type="org.hps.readout.ecal.updated.EcalDigitizationReadoutDriver">
+            <!-- LCIO Collection Names -->
+            <inputHitCollectionName>EcalHits</inputHitCollectionName>
+            <outputHitCollectionName>EcalRawHits</outputHitCollectionName>
+            <readoutHitCollectionName>EcalReadoutHits</readoutHitCollectionName>
+            <truthRelationsCollectionName>EcalTruthRelations</truthRelationsCollectionName>
+            <triggerPathTruthRelationsCollectionName>TriggerPathTruthRelations</triggerPathTruthRelationsCollectionName>
+            
+            <!-- Driver Parameters -->
+            <mode>1</mode>                                  <!-- Allowed values: 1, 3, or 7. -->
+            <addNoise>true</addNoise>
+            
+            <!-- 
+                 Readout offset is not the same as the old system - it measures
+                 amount of samples that are included before the trigger time in
+                 the ADC readout window. The old version can be converted by
+                 selecting a readout window equal to (readoutLatency - 64).
+              -->
+            <readoutOffset>10</readoutOffset>               <!-- Units of 4 ns clock-cycles. -->
+            <readoutWindow>48</readoutWindow>               <!-- Units of 4 ns clock-cycles. -->
+            <numberSamplesAfter>23</numberSamplesAfter>     <!-- Units of 4 ns clock-cycles. -->
+            <numberSamplesBefore>3</numberSamplesBefore>    <!-- Units of 4 ns clock-cycles. -->
+            <integrationThreshold>18</integrationThreshold> <!-- Units of ADC. -->
+            
+            <!--
+                The digitization driver produces as output a list of ADC values
+                within a specified window, in emulation of Mode-1 data. This
+                removes the truth information that is otherwise present in the
+                original SLiC output. Setting this option to true creates new
+                LCRelation objects that link the ADC list to the truth hits that
+                created it and stores this in readout. For production running,
+                this should generally be off to save space. Truth hits will be
+                included in readout automatically - the truth hit driver above
+                does not need to be persistent.
+            -->
+            <writeTruth>true</writeTruth>
+            
+            <!--
+                As above, except that truth relations are persisted for the
+                readout hits that are seen by the clusterer and trigger. This
+                is useful if some analysis needs to be performed at the readout
+                level. Otherwise, this should be left off.
+            -->
+            <writeTriggerPathTruth>false</writeTriggerPathTruth>
+        </driver>
+        
+        <!--
+             The raw converter handles the conversion of simulated ADC pulses from
+             the calorimeter readout driver into proper hits that can be used for
+             triggering.
+             
+             Note that it allows for these hits to be written to LCIO if desired,
+             though by default they are not persisted. This is generally unneeded,
+             since the clusterer will automatically output the hits which appear in
+             GTP clusters if cluster output is enabled.
+          -->
+        <driver name="EcalRawConverterDriver" type="org.hps.readout.ecal.updated.EcalRawConverterReadoutDriver">
+		    <!--
+				Define the LCIO collection names. The input collection should
+				come from the digitization driver.
+			-->
+			<inputCollectionName>EcalRawHits</inputCollectionName>
+			<outputCollectionName>EcalCorrectedHits</outputCollectionName>
+		    
+            <!--
+                NSA and NSB must match the digitization driver settings.
+            -->
+            <numberSamplesAfter>23</numberSamplesAfter>     <!-- Units of 4 ns clock-cycles. -->
+            <numberSamplesBefore>3</numberSamplesBefore>    <!-- Units of 4 ns clock-cycles. -->
+            
+            <!--
+                Outputs all the trigger-level hits within the readout window.
+                This is not generally necessary outside of specialized
+                circumstances. Note that all readout hits associated with GTP
+                clusters will automatically be included if GTP clusters are
+                persisted.
+            -->
+            <persistent>false</persistent>
+        </driver>
+        
+        <!--
+             The GTP clusterer creates clusters from converted calorimeter hits
+             for use in the trigger. It take two parametesr: the clustering
+             window, which specifies the number of clock-cycles in which a seed
+             hit candidate must be a spatiotemporal maximum, and seed energy
+             threshold, which specifies how much energy a seed hit candidate
+             must have in order to be used.
+             
+             The GTP clusterer is able to be persisted into LCIO. If persisted,
+             it will output all of the clusters in the readout window range
+             (either specified manually as with the truth drivers or using the
+             default readout window and trigger offset of the manager). It will
+             also output all of the hits contained in each cluster into the
+             output file as well.
+          -->
+        <driver name="GTPReadoutDriver" type="org.hps.readout.ecal.updated.GTPClusterReadoutDriver">
+            <!-- Units of 4 ns clock-cycles. -->
+            <clusterWindow>4</clusterWindow>
+            <!-- Units of GeV. -->
+            <seedEnergyThreshold>0.050</seedEnergyThreshold>
+            
+            <!--
+                Specifies whether GTP clusters should be persisted in the
+                output LCIO data. This should generally be false for production
+                running to save space, but can be useful for some analyses, as
+                the exact trigger-time clusters are not otherwise recoverable
+                after readout.
+            -->
+            <persistent>false</persistent>
+        </driver>
+        
+        <!--
+            The hodoscope preprocessing driver is responsible for taking SLiC
+            truth hits and converting them to a form usable by the simulation.
+            Truth hits are of the type SimTrackerHit and need to be converted
+            to the type SimCalorimeterHit. Additionally, SLiC is not able to
+            produce hits on multiple channels from the same scintillator. Some
+            scintillators do have multiple channels in the actual detector. As
+            such, it is necessary to split the energies of hits occurring on
+            scintillators with mutliple channels across the relevant channels.
+            This is handled by this driver.
+        -->
+        <driver name="HodoscopePreprocessingDriver" type="org.hps.readout.hodoscope.HodoscopePreprocessingDriver">
+            <truthHitCollectionName>HodoscopeHits</truthHitCollectionName>
+            <outputHitCollectionName>HodoscopePreprocessedHits</outputHitCollectionName>
+
+            <persistent>true</persistent>
+        </driver>
+        
+        <!--
+             The hodoscope digitization driver works identically to the
+             calorimeter digitization driver, except for the hodoscope.
+          -->
+        <driver name="HodoscopeDigitizationDriver" type="org.hps.readout.hodoscope.HodoscopeDigitizationReadoutDriver">
+            <!-- LCIO Collection Names -->
+            <inputHitCollectionName>HodoscopePreprocessedHits</inputHitCollectionName>
+            <outputHitCollectionName>HodoscopeRawHits</outputHitCollectionName>
+            <readoutHitCollectionName>HodoscopeReadoutHits</readoutHitCollectionName>
+            <truthRelationsCollectionName>HodoscopeTruthRelations</truthRelationsCollectionName>
+            <triggerPathTruthRelationsCollectionName>HodoscopeTriggerPathTruthRelations</triggerPathTruthRelationsCollectionName>
+            
+            <!-- Driver Parameters -->
+            <mode>1</mode>                                  <!-- Allowed values: 1, 3, or 7. -->
+            <addNoise>false</addNoise>
+            
+            <!-- 
+                 Readout offset is not the same as the old system - it measures
+                 amount of samples that are included before the trigger time in
+                 the ADC readout window. The old version can be converted by
+                 selecting a readout window equal to (readoutLatency - 64).
+              -->
+            <readoutOffset>10</readoutOffset>               <!-- Units of 4 ns clock-cycles. -->
+            <readoutWindow>32</readoutWindow>               <!-- Units of 4 ns clock-cycles. -->
+            <numberSamplesAfter>13</numberSamplesAfter>     <!-- Units of 4 ns clock-cycles. -->
+            <numberSamplesBefore>5</numberSamplesBefore>    <!-- Units of 4 ns clock-cycles. -->
+            <integrationThreshold>12</integrationThreshold> <!-- Units
+	    of ADC. -->
+
+	    <!--Factor for gain conversion from self-defined unit/ADC to
+	    MeV/ADC. -->            
+	    <factorGainConversion>0.000833333</factorGainConversion>
+            
+            <!--
+                The digitization driver produces as output a list of ADC values
+                within a specified window, in emulation of Mode-1 data. This
+                removes the truth information that is otherwise present in the
+                original SLiC output. Setting this option to true creates new
+                LCRelation objects that link the ADC list to the truth hits that
+                created it and stores this in readout. For production running,
+                this should generally be off to save space. Truth hits will be
+                included in readout automatically - the truth hit driver above
+                does not need to be persistent.
+            -->
+            <writeTruth>true</writeTruth>
+            
+            <!--
+                As above, except that truth relations are persisted for the
+                readout hits that are seen by the clusterer and trigger. This
+                is useful if some analysis needs to be performed at the readout
+                level. Otherwise, this should be left off.
+            -->
+            <writeTriggerPathTruth>false</writeTriggerPathTruth>
+        </driver>        
+        
+        <driver name="FEETrigger" type="org.hps.readout.trigger2019.FEETrigger2019ReadoutDriver">
+            <inputCollectionName>EcalClustersGTP</inputCollectionName>
+            
+            <!-- Units of 2 ns beam bunches. -->
+            <deadTime>15</deadTime> 
+            
+            <!-- Units of cluster hits. -->
+            <minHitCount>3</minHitCount>
+            <!-- Units of GeV. -->
+            <clusterEnergyLow>2.6</clusterEnergyLow>
+            <!-- Units of GeV. -->
+            <clusterEnergyHigh>5.2</clusterEnergyHigh>
+        </driver>
+        
+        <driver name="ReadoutManagerDriver" type="org.hps.readout.ReadoutDataManager">
+            <readoutWindow>200</readoutWindow>
+            <outputFile>${outputFile}.slcio</outputFile>
+        </driver>
+        
+        <driver name="CleanupDriver" type="org.lcsim.recon.tracking.digitization.sisim.config.ReadoutCleanupDriver" />
+    </drivers>
+</lcsim>


### PR DESCRIPTION
The FEE trigger driver and the relative steering file are developed for FEE sample of 2019 MC.
In the steering file, # of hits and energy range of Ecal clusters are set for the FEE trigger.