### PR TITLE
updates and corrections relative to singles3 trigger

### DIFF
--- a/ecal-readout-sim/src/main/java/org/hps/readout/hodoscope/HodoscopePatternReadoutDriver.java
+++ b/ecal-readout-sim/src/main/java/org/hps/readout/hodoscope/HodoscopePatternReadoutDriver.java
@@ -68,11 +68,6 @@ public class HodoscopePatternReadoutDriver extends ReadoutDriver {
     private double hodoHitThreshold = 200.0;
 
     /**
-     * Gain factor for raw energy (self-defined unit) of FADC hits
-     */
-    private double gainFactor = 1.25 / 2;
-
-    /**
      * Persistent time for hodoscope FADC hit in unit of ns
      */
     private double persistentTime = 60.0;
@@ -153,9 +148,7 @@ public class HodoscopePatternReadoutDriver extends ReadoutDriver {
                 int hole = channelMap.get(cellID).getHole();
 
                 Point point = new Point(x, hole);
-                // Energy of hits is scaled except hits at tiles 0 and 4
-                if(x == 0 || x == 4) energyListMapForLayerMap.get((layer + 1) * y).get(point).add(energy);
-                else energyListMapForLayerMap.get((layer + 1) * y).get(point).add(energy * gainFactor);
+                energyListMapForLayerMap.get((layer + 1) * y).get(point).add(energy);
             }
         }
 
@@ -372,14 +365,5 @@ public class HodoscopePatternReadoutDriver extends ReadoutDriver {
      */
     public void setTimeEarlierThanEcal(double timeEarlierThanEcal) {
         this.timeEarlierThanEcal = timeEarlierThanEcal;
-    }
-
-    /**
-     * Set gain factor for raw energy (self-defined unit) of FADC hits
-     * 
-     * @param gain factor for raw energy (self-defined unit) of FADC hits
-     */
-    public void setGainFactor(double gainFactor) {
-        this.gainFactor = gainFactor;
     }
 }

--- a/ecal-readout-sim/src/main/java/org/hps/readout/hodoscope/HodoscopePatternReadoutDriver.java
+++ b/ecal-readout-sim/src/main/java/org/hps/readout/hodoscope/HodoscopePatternReadoutDriver.java
@@ -153,7 +153,9 @@ public class HodoscopePatternReadoutDriver extends ReadoutDriver {
                 int hole = channelMap.get(cellID).getHole();
 
                 Point point = new Point(x, hole);
-                energyListMapForLayerMap.get((layer + 1) * y).get(point).add(energy * gainFactor);
+                // Energy of hits is scaled except hits at tiles 0 and 4
+                if(x == 0 || x == 4) energyListMapForLayerMap.get((layer + 1) * y).get(point).add(energy);
+                else energyListMapForLayerMap.get((layer + 1) * y).get(point).add(energy * gainFactor);
             }
         }
 
@@ -204,22 +206,32 @@ public class HodoscopePatternReadoutDriver extends ReadoutDriver {
                 flag = true;
             }
             if (maxEnergyMap.get(xHolePointList.get(0)) + maxEnergyMap.get(xHolePointList.get(1))
-                    + maxEnergyMap.get(xHolePointList.get(2)) > hodoHitThreshold) {
+                    + maxEnergyMap.get(xHolePointList.get(2)) > hodoHitThreshold
+                    && maxEnergyMap.get(xHolePointList.get(0)) != 0
+                    && (maxEnergyMap.get(xHolePointList.get(1)) != 0 || maxEnergyMap.get(xHolePointList.get(2)) != 0)) {
                 pattern.setHitStatus(HodoscopePattern.HODO_LX_CL_12, true);
                 flag = true;
             }
-            if (maxEnergyMap.get(xHolePointList.get(1)) + maxEnergyMap.get(xHolePointList.get(2)) + maxEnergyMap.get(xHolePointList.get(3))
-                    + maxEnergyMap.get(xHolePointList.get(4)) > hodoHitThreshold) {
+            if (maxEnergyMap.get(xHolePointList.get(1)) + maxEnergyMap.get(xHolePointList.get(2))
+                    + maxEnergyMap.get(xHolePointList.get(3))
+                    + maxEnergyMap.get(xHolePointList.get(4)) > hodoHitThreshold
+                    && (maxEnergyMap.get(xHolePointList.get(1)) != 0 || maxEnergyMap.get(xHolePointList.get(2)) != 0)
+                    && (maxEnergyMap.get(xHolePointList.get(3)) != 0 || maxEnergyMap.get(xHolePointList.get(4)) != 0)) {
                 pattern.setHitStatus(HodoscopePattern.HODO_LX_CL_23, true);
                 flag = true;
             }
-            if (maxEnergyMap.get(xHolePointList.get(3)) + maxEnergyMap.get(xHolePointList.get(4)) + maxEnergyMap.get(xHolePointList.get(5))
-                    + maxEnergyMap.get(xHolePointList.get(6)) > hodoHitThreshold) {
+            if (maxEnergyMap.get(xHolePointList.get(3)) + maxEnergyMap.get(xHolePointList.get(4))
+                    + maxEnergyMap.get(xHolePointList.get(5))
+                    + maxEnergyMap.get(xHolePointList.get(6)) > hodoHitThreshold
+                    && (maxEnergyMap.get(xHolePointList.get(3)) != 0 || maxEnergyMap.get(xHolePointList.get(4)) != 0)
+                    && (maxEnergyMap.get(xHolePointList.get(5)) != 0 || maxEnergyMap.get(xHolePointList.get(6)) != 0)) {
                 pattern.setHitStatus(HodoscopePattern.HODO_LX_CL_34, true);
                 flag = true;
             }
             if (maxEnergyMap.get(xHolePointList.get(5)) + maxEnergyMap.get(xHolePointList.get(6))
-                    + maxEnergyMap.get(xHolePointList.get(7)) > hodoHitThreshold) {
+                    + maxEnergyMap.get(xHolePointList.get(7)) > hodoHitThreshold
+                    && (maxEnergyMap.get(xHolePointList.get(5)) != 0 || maxEnergyMap.get(xHolePointList.get(6)) != 0)
+                    && maxEnergyMap.get(xHolePointList.get(7)) != 0) {
                 pattern.setHitStatus(HodoscopePattern.HODO_LX_CL_45, true);
                 flag = true;
             }

--- a/ecal-readout-sim/src/main/java/org/hps/readout/hodoscope/HodoscopePatternReadoutDriver.java
+++ b/ecal-readout-sim/src/main/java/org/hps/readout/hodoscope/HodoscopePatternReadoutDriver.java
@@ -76,7 +76,7 @@ public class HodoscopePatternReadoutDriver extends ReadoutDriver {
      * Time for hodoscope FADC hits earlier to enter the trigger system than Ecal
      * with unit of ns
      */
-    private double timeEarlierThanEcal = 20.0;
+    private double timeEarlierThanEcal = 0.0;
 
     /**
      * The length of time by which objects produced by this driver are shifted due

--- a/ecal-readout-sim/src/main/java/org/hps/readout/hodoscope/HodoscopePatternReadoutDriver.java
+++ b/ecal-readout-sim/src/main/java/org/hps/readout/hodoscope/HodoscopePatternReadoutDriver.java
@@ -68,6 +68,11 @@ public class HodoscopePatternReadoutDriver extends ReadoutDriver {
     private double hodoHitThreshold = 200.0;
 
     /**
+     * Gain scaling factor for raw energy (self-defined unit) of FADC hits
+     */
+    private double gainFactor = 1.25 / 2;
+
+    /**
      * Persistent time for hodoscope FADC hit in unit of ns
      */
     private double persistentTime = 60.0;
@@ -148,7 +153,9 @@ public class HodoscopePatternReadoutDriver extends ReadoutDriver {
                 int hole = channelMap.get(cellID).getHole();
 
                 Point point = new Point(x, hole);
-                energyListMapForLayerMap.get((layer + 1) * y).get(point).add(energy);
+                // Energy of hits is scaled except hits at tiles 0 and 4
+                if(x == 0 || x == 4) energyListMapForLayerMap.get((layer + 1) * y).get(point).add(energy);
+                else energyListMapForLayerMap.get((layer + 1) * y).get(point).add(energy * gainFactor);
             }
         }
 
@@ -365,5 +372,14 @@ public class HodoscopePatternReadoutDriver extends ReadoutDriver {
      */
     public void setTimeEarlierThanEcal(double timeEarlierThanEcal) {
         this.timeEarlierThanEcal = timeEarlierThanEcal;
+    }
+    
+    /**
+     * Set gain factor for raw energy (self-defined unit) of FADC hits
+     * 
+     * @param gain factor for raw energy (self-defined unit) of FADC hits
+     */
+    public void setGainFactor(double gainFactor) {
+        this.gainFactor = gainFactor;
     }
 }

--- a/ecal-readout-sim/src/main/java/org/hps/readout/trigger2019/SinglesTrigger2019ReadoutDriver.java
+++ b/ecal-readout-sim/src/main/java/org/hps/readout/trigger2019/SinglesTrigger2019ReadoutDriver.java
@@ -79,6 +79,11 @@ public class SinglesTrigger2019ReadoutDriver extends TriggerDriver {
     private static final double BIN_SIZE = 0.025;
     
     /**
+     * run number
+     */
+    private int runNumber = 10666;
+    
+    /**
      * If require geometry matching
      */
     private boolean geometryMatchingRequired = false;
@@ -94,7 +99,7 @@ public class SinglesTrigger2019ReadoutDriver extends TriggerDriver {
     private IHistogram1D[] clusterHitCount = new IHistogram1D[2];
     private IHistogram1D[] clusterTotalEnergy = new IHistogram1D[2];
     private IHistogram2D[] clusterDistribution = new IHistogram2D[2];
-    
+  
     
     @Override
     public void detectorChanged(Detector detector) {
@@ -105,6 +110,8 @@ public class SinglesTrigger2019ReadoutDriver extends TriggerDriver {
         } else {
             throw new IllegalStateException("Error: Unexpected calorimeter sub-detector of type \"" + ecalSub.getClass().getSimpleName() + "; expected HPSEcal3.");
         }
+        
+        this.runNumber = this.getConditionsManager().getRun();
     }
     
     @Override
@@ -173,7 +180,7 @@ public class SinglesTrigger2019ReadoutDriver extends TriggerDriver {
             }
            
             
-            if(geometryMatchingRequired && !triggerModule.geometryMatchingCut(clusterX, ixy.y, hodoPatternList)) {
+            if(geometryMatchingRequired && !triggerModule.geometryMatchingCut(clusterX, ixy.y, hodoPatternList, runNumber)) {
                 continue;
             }
             

--- a/ecal-readout-sim/src/main/java/org/hps/readout/trigger2019/SinglesTrigger2019ReadoutDriver.java
+++ b/ecal-readout-sim/src/main/java/org/hps/readout/trigger2019/SinglesTrigger2019ReadoutDriver.java
@@ -76,12 +76,7 @@ public class SinglesTrigger2019ReadoutDriver extends TriggerDriver {
     /**
      * Defines the size of an energy bin for trigger output plots.
      */
-    private static final double BIN_SIZE = 0.025;
-    
-    /**
-     * run number
-     */
-    private int runNumber = 10666;
+    private static final double BIN_SIZE = 0.025;   
     
     /**
      * If require geometry matching
@@ -109,9 +104,7 @@ public class SinglesTrigger2019ReadoutDriver extends TriggerDriver {
             ecal = (HPSEcal3) ecalSub;
         } else {
             throw new IllegalStateException("Error: Unexpected calorimeter sub-detector of type \"" + ecalSub.getClass().getSimpleName() + "; expected HPSEcal3.");
-        }
-        
-        this.runNumber = this.getConditionsManager().getRun();
+        }        
     }
     
     @Override
@@ -180,7 +173,7 @@ public class SinglesTrigger2019ReadoutDriver extends TriggerDriver {
             }
            
             
-            if(geometryMatchingRequired && !triggerModule.geometryMatchingCut(clusterX, ixy.y, hodoPatternList, runNumber)) {
+            if(geometryMatchingRequired && !triggerModule.geometryMatchingCut(clusterX, ixy.y, hodoPatternList)) {
                 continue;
             }
             

--- a/record-util/src/main/java/org/hps/readout/ReadoutDataManager.java
+++ b/record-util/src/main/java/org/hps/readout/ReadoutDataManager.java
@@ -639,7 +639,7 @@ public class ReadoutDataManager extends Driver {
     public static final void registerReadoutDriver(ReadoutDriver productionDriver) {
         // Trigger drivers are registered differently.
         if(productionDriver instanceof TriggerDriver) {
-            logger.warning(nl + "Error: Attempted to register TriggerDriver \"" + productionDriver.getClass().getSimpleName() + "\" as a readout driver."
+            logger.warning(nl + "Attempted to register TriggerDriver \"" + productionDriver.getClass().getSimpleName() + "\" as a readout driver."
                     + nl + "       Trigger drivers are registered via the method \"registerTrigger(TriggerDriver)\"."
                     + nl + "       Ignoring request.");
             return;

--- a/record-util/src/main/java/org/hps/record/triggerbank/TriggerModule2019.java
+++ b/record-util/src/main/java/org/hps/record/triggerbank/TriggerModule2019.java
@@ -331,10 +331,10 @@ public class TriggerModule2019 {
      * @return <code>true</code> if the geometry matching cut passes
      * and <code>false</code> if does not pass.
      */
-    public boolean geometryMatchingCut(int x, int y, List<HodoscopePattern> patternList, int runNumber) {
+    public boolean geometryMatchingCut(int x, int y, List<HodoscopePattern> patternList) {
         if(x < 1 || x > 23 || y == 0 || y < -5 || y > 5) throw new IllegalArgumentException(String.format("Parameter for x = %d is out of X-coordinate range [1, 23] or Parameter for y = %d out of Y-coordinate range [-5, -1] and [1, 5].", x, y));
-        if(y > 0 && geometryHodoL1L2Matching(patternList.get(0), patternList.get(1)) && geometryEcalHodoMatching(x, patternList.get(0), patternList.get(1), runNumber)) return true;
-        if(y < 0 && geometryHodoL1L2Matching(patternList.get(2), patternList.get(3)) && geometryEcalHodoMatching(x, patternList.get(2), patternList.get(3), runNumber)) return true;       
+        if(y > 0 && geometryHodoL1L2Matching(patternList.get(0), patternList.get(1)) && geometryEcalHodoMatching(x, patternList.get(0), patternList.get(1))) return true;
+        if(y < 0 && geometryHodoL1L2Matching(patternList.get(2), patternList.get(3)) && geometryEcalHodoMatching(x, patternList.get(2), patternList.get(3))) return true;       
         
         return false;
     }
@@ -375,71 +375,69 @@ public class TriggerModule2019 {
      * @return <code>true</code> if geometry matches
      * and <code>false</code> if does not pass.
      */
-    public boolean geometryEcalHodoMatching(int x, HodoscopePattern layer1, HodoscopePattern layer2, int runNumber) { 
+    public boolean geometryEcalHodoMatching(int x, HodoscopePattern layer1, HodoscopePattern layer2) { 
         if(x < 1 || x > 23) throw new IllegalArgumentException(String.format("Parameter \"%d\" is out of X-coordinage range [1, 23].", x));
         
         boolean flagLayer1 = false;
         boolean flagLayer2 = false;
         
-        // Before and after run 10189 for 2019 experiment, geometry mapping between hodoscope and Ecal changes.
-        if(runNumber < 10189) {
-            // Cluster X <-> Layer 1 Matching
-            if((x >= 5) && (x <= 9) && (layer1.getHitStatus(HodoscopePattern.HODO_LX_1) || layer1.getHitStatus(HodoscopePattern.HODO_LX_CL_12))) flagLayer1 = true;
-            if(flagLayer1 == false) {
-                if((x >= 6) && (x <= 11) && (layer1.getHitStatus(HodoscopePattern.HODO_LX_CL_12) || layer1.getHitStatus(HodoscopePattern.HODO_LX_2) || layer1.getHitStatus(HodoscopePattern.HODO_LX_CL_23))) flagLayer1 = true;
-                if(flagLayer1 == false) {
-                    if((x >= 10) && (x <= 16) && (layer1.getHitStatus(HodoscopePattern.HODO_LX_CL_23) || layer1.getHitStatus(HodoscopePattern.HODO_LX_3) || layer1.getHitStatus(HodoscopePattern.HODO_LX_CL_34))) flagLayer1 = true;
-                    if(flagLayer1 == false) {
-                        if((x >= 15) && (x <= 21) && (layer1.getHitStatus(HodoscopePattern.HODO_LX_CL_34) || layer1.getHitStatus(HodoscopePattern.HODO_LX_4) || layer1.getHitStatus(HodoscopePattern.HODO_LX_CL_45))) flagLayer1 = true;
-                        if(flagLayer1 == false) {
-                            if((x >= 19) && (x <= 23) && (layer1.getHitStatus(HodoscopePattern.HODO_LX_CL_45) || layer1.getHitStatus(HodoscopePattern.HODO_LX_5))) flagLayer1 = true;
-                        }
+        // Cluster X <-> Layer 1 Matching
+        if ((x >= 5) && (x <= 9) && (layer1.getHitStatus(HodoscopePattern.HODO_LX_1)
+                || layer1.getHitStatus(HodoscopePattern.HODO_LX_CL_12)))
+            flagLayer1 = true;
+        if (flagLayer1 == false) {
+            if ((x >= 6) && (x <= 12)
+                    && (layer1.getHitStatus(HodoscopePattern.HODO_LX_CL_12)
+                            || layer1.getHitStatus(HodoscopePattern.HODO_LX_2)
+                            || layer1.getHitStatus(HodoscopePattern.HODO_LX_CL_23)))
+                flagLayer1 = true;
+            if (flagLayer1 == false) {
+                if ((x >= 10) && (x <= 17)
+                        && (layer1.getHitStatus(HodoscopePattern.HODO_LX_CL_23)
+                                || layer1.getHitStatus(HodoscopePattern.HODO_LX_3)
+                                || layer1.getHitStatus(HodoscopePattern.HODO_LX_CL_34)))
+                    flagLayer1 = true;
+                if (flagLayer1 == false) {
+                    if ((x >= 15) && (x <= 21)
+                            && (layer1.getHitStatus(HodoscopePattern.HODO_LX_CL_34)
+                                    || layer1.getHitStatus(HodoscopePattern.HODO_LX_4)
+                                    || layer1.getHitStatus(HodoscopePattern.HODO_LX_CL_45)))
+                        flagLayer1 = true;
+                    if (flagLayer1 == false) {
+                        if ((x >= 18) && (x <= 23) && (layer1.getHitStatus(HodoscopePattern.HODO_LX_CL_45)
+                                || layer1.getHitStatus(HodoscopePattern.HODO_LX_5)))
+                            flagLayer1 = true;
                     }
                 }
             }
+        }
 
-            // Cluster X <-> Layer 2 Matching
-            if((x >= 5) && (x <= 8) && (layer2.getHitStatus(HodoscopePattern.HODO_LX_1) || layer2.getHitStatus(HodoscopePattern.HODO_LX_CL_12))) flagLayer2 = true;
-            if(flagLayer2 == false) {
-                if((x >= 7) && (x <= 12) && (layer2.getHitStatus(HodoscopePattern.HODO_LX_CL_12) || layer2.getHitStatus(HodoscopePattern.HODO_LX_2) || layer2.getHitStatus(HodoscopePattern.HODO_LX_CL_23))) flagLayer2 = true;
-                if(flagLayer2 == false) {
-                    if((x >= 12) && (x <= 17) && (layer2.getHitStatus(HodoscopePattern.HODO_LX_CL_23) || layer2.getHitStatus(HodoscopePattern.HODO_LX_3) || layer2.getHitStatus(HodoscopePattern.HODO_LX_CL_34))) flagLayer2 = true;
-                    if(flagLayer2 == false) {
-                        if((x >= 16) && (x <= 23) && (layer2.getHitStatus(HodoscopePattern.HODO_LX_CL_34) || layer2.getHitStatus(HodoscopePattern.HODO_LX_4) || layer2.getHitStatus(HodoscopePattern.HODO_LX_CL_45))) flagLayer2 = true;
-                        if(flagLayer2 == false) {
-                            if((x >= 20) && (x <= 23) && (layer2.getHitStatus(HodoscopePattern.HODO_LX_CL_45) || layer2.getHitStatus(HodoscopePattern.HODO_LX_5))) flagLayer2 = true;
-                        }
-                    }
-                }
-            }
-        }        
-        else {
-            // Cluster X <-> Layer 1 Matching
-            if((x >= 5) && (x <= 9) && (layer1.getHitStatus(HodoscopePattern.HODO_LX_1) || layer1.getHitStatus(HodoscopePattern.HODO_LX_CL_12))) flagLayer1 = true;
-            if(flagLayer1 == false) {
-                if((x >= 6) && (x <= 12) && (layer1.getHitStatus(HodoscopePattern.HODO_LX_CL_12) || layer1.getHitStatus(HodoscopePattern.HODO_LX_2) || layer1.getHitStatus(HodoscopePattern.HODO_LX_CL_23))) flagLayer1 = true;
-                if(flagLayer1 == false) {
-                    if((x >= 10) && (x <= 17) && (layer1.getHitStatus(HodoscopePattern.HODO_LX_CL_23) || layer1.getHitStatus(HodoscopePattern.HODO_LX_3) || layer1.getHitStatus(HodoscopePattern.HODO_LX_CL_34))) flagLayer1 = true;
-                    if(flagLayer1 == false) {
-                        if((x >= 15) && (x <= 21) && (layer1.getHitStatus(HodoscopePattern.HODO_LX_CL_34) || layer1.getHitStatus(HodoscopePattern.HODO_LX_4) || layer1.getHitStatus(HodoscopePattern.HODO_LX_CL_45))) flagLayer1 = true;
-                        if(flagLayer1 == false) {
-                            if((x >= 18) && (x <= 23) && (layer1.getHitStatus(HodoscopePattern.HODO_LX_CL_45) || layer1.getHitStatus(HodoscopePattern.HODO_LX_5))) flagLayer1 = true;
-                        }
-                    }
-                }
-            }
-
-            // Cluster X <-> Layer 2 Matching
-            if((x >= 5) && (x <= 9) && (layer2.getHitStatus(HodoscopePattern.HODO_LX_1) || layer2.getHitStatus(HodoscopePattern.HODO_LX_CL_12))) flagLayer2 = true;
-            if(flagLayer2 == false) {
-                if((x >= 6) && (x <= 14) && (layer2.getHitStatus(HodoscopePattern.HODO_LX_CL_12) || layer2.getHitStatus(HodoscopePattern.HODO_LX_2) || layer2.getHitStatus(HodoscopePattern.HODO_LX_CL_23))) flagLayer2 = true;
-                if(flagLayer2 == false) {
-                    if((x >= 12) && (x <= 18) && (layer2.getHitStatus(HodoscopePattern.HODO_LX_CL_23) || layer2.getHitStatus(HodoscopePattern.HODO_LX_3) || layer2.getHitStatus(HodoscopePattern.HODO_LX_CL_34))) flagLayer2 = true;
-                    if(flagLayer2 == false) {
-                        if((x >= 16) && (x <= 22) && (layer2.getHitStatus(HodoscopePattern.HODO_LX_CL_34) || layer2.getHitStatus(HodoscopePattern.HODO_LX_4) || layer2.getHitStatus(HodoscopePattern.HODO_LX_CL_45))) flagLayer2 = true;
-                        if(flagLayer2 == false) {
-                            if((x >= 20) && (x <= 23) && (layer2.getHitStatus(HodoscopePattern.HODO_LX_CL_45) || layer2.getHitStatus(HodoscopePattern.HODO_LX_5))) flagLayer2 = true;
-                        }
+        // Cluster X <-> Layer 2 Matching
+        if ((x >= 5) && (x <= 9) && (layer2.getHitStatus(HodoscopePattern.HODO_LX_1)
+                || layer2.getHitStatus(HodoscopePattern.HODO_LX_CL_12)))
+            flagLayer2 = true;
+        if (flagLayer2 == false) {
+            if ((x >= 6) && (x <= 14)
+                    && (layer2.getHitStatus(HodoscopePattern.HODO_LX_CL_12)
+                            || layer2.getHitStatus(HodoscopePattern.HODO_LX_2)
+                            || layer2.getHitStatus(HodoscopePattern.HODO_LX_CL_23)))
+                flagLayer2 = true;
+            if (flagLayer2 == false) {
+                if ((x >= 12) && (x <= 18)
+                        && (layer2.getHitStatus(HodoscopePattern.HODO_LX_CL_23)
+                                || layer2.getHitStatus(HodoscopePattern.HODO_LX_3)
+                                || layer2.getHitStatus(HodoscopePattern.HODO_LX_CL_34)))
+                    flagLayer2 = true;
+                if (flagLayer2 == false) {
+                    if ((x >= 16) && (x <= 22)
+                            && (layer2.getHitStatus(HodoscopePattern.HODO_LX_CL_34)
+                                    || layer2.getHitStatus(HodoscopePattern.HODO_LX_4)
+                                    || layer2.getHitStatus(HodoscopePattern.HODO_LX_CL_45)))
+                        flagLayer2 = true;
+                    if (flagLayer2 == false) {
+                        if ((x >= 20) && (x <= 23) && (layer2.getHitStatus(HodoscopePattern.HODO_LX_CL_45)
+                                || layer2.getHitStatus(HodoscopePattern.HODO_LX_5)))
+                            flagLayer2 = true;
                     }
                 }
             }

--- a/record-util/src/main/java/org/hps/record/triggerbank/TriggerModule2019.java
+++ b/record-util/src/main/java/org/hps/record/triggerbank/TriggerModule2019.java
@@ -305,7 +305,7 @@ public class TriggerModule2019 {
      * and <code>false</code> if the cluster does not.
      */
     public boolean clusterXMinCut(int x) {
-        if(x < -22 || x > 23) throw new IllegalArgumentException(String.format("Parameter \"%d\" is out of X-coordinage range [1, 23].", x));
+        if(x < -22 || x > 23) throw new IllegalArgumentException(String.format("Parameter \"%d\" is out of X-coordinage range [-22, 23].", x));
         else return (x >= singlesTriggerCuts.get(CLUSTER_XMIN));
     }
     
@@ -331,10 +331,10 @@ public class TriggerModule2019 {
      * @return <code>true</code> if the geometry matching cut passes
      * and <code>false</code> if does not pass.
      */
-    public boolean geometryMatchingCut(int x, int y, List<HodoscopePattern> patternList) {
+    public boolean geometryMatchingCut(int x, int y, List<HodoscopePattern> patternList, int runNumber) {
         if(x < 1 || x > 23 || y == 0 || y < -5 || y > 5) throw new IllegalArgumentException(String.format("Parameter for x = %d is out of X-coordinate range [1, 23] or Parameter for y = %d out of Y-coordinate range [-5, -1] and [1, 5].", x, y));
-        if(y > 0 && geometryHodoL1L2Matching(patternList.get(0), patternList.get(1)) && geometryEcalHodoMatching(x, patternList.get(0), patternList.get(1))) return true;
-        if(y < 0 && geometryHodoL1L2Matching(patternList.get(2), patternList.get(3)) && geometryEcalHodoMatching(x, patternList.get(2), patternList.get(3))) return true;       
+        if(y > 0 && geometryHodoL1L2Matching(patternList.get(0), patternList.get(1)) && geometryEcalHodoMatching(x, patternList.get(0), patternList.get(1), runNumber)) return true;
+        if(y < 0 && geometryHodoL1L2Matching(patternList.get(2), patternList.get(3)) && geometryEcalHodoMatching(x, patternList.get(2), patternList.get(3), runNumber)) return true;       
         
         return false;
     }
@@ -375,24 +375,77 @@ public class TriggerModule2019 {
      * @return <code>true</code> if geometry matches
      * and <code>false</code> if does not pass.
      */
-    public boolean geometryEcalHodoMatching(int x, HodoscopePattern layer1, HodoscopePattern layer2) { 
+    public boolean geometryEcalHodoMatching(int x, HodoscopePattern layer1, HodoscopePattern layer2, int runNumber) { 
         if(x < 1 || x > 23) throw new IllegalArgumentException(String.format("Parameter \"%d\" is out of X-coordinage range [1, 23].", x));
         
-        // Cluster X <-> Layer 1 Matching
-        if((x >= 5) && (x <= 9) && (layer1.getHitStatus(HodoscopePattern.HODO_LX_1) || layer1.getHitStatus(HodoscopePattern.HODO_LX_CL_12))) return true;
-        if((x >= 6) && (x <= 11) && (layer1.getHitStatus(HodoscopePattern.HODO_LX_CL_12) || layer1.getHitStatus(HodoscopePattern.HODO_LX_2) || layer1.getHitStatus(HodoscopePattern.HODO_LX_CL_23))) return true;
-        if((x >= 10) && (x <= 16) && (layer1.getHitStatus(HodoscopePattern.HODO_LX_CL_23) || layer1.getHitStatus(HodoscopePattern.HODO_LX_3) || layer1.getHitStatus(HodoscopePattern.HODO_LX_CL_34))) return true;
-        if((x >= 15) && (x <= 21) && (layer1.getHitStatus(HodoscopePattern.HODO_LX_CL_34) || layer1.getHitStatus(HodoscopePattern.HODO_LX_4) || layer1.getHitStatus(HodoscopePattern.HODO_LX_CL_45))) return true;
-        if((x >= 19) && (x <= 23) && (layer1.getHitStatus(HodoscopePattern.HODO_LX_CL_45) || layer1.getHitStatus(HodoscopePattern.HODO_LX_5))) return true;
+        boolean flagLayer1 = false;
+        boolean flagLayer2 = false;
         
-        // Cluster X <-> Layer 2 Matching
-        if((x >= 5) && (x <= 8) && (layer2.getHitStatus(HodoscopePattern.HODO_LX_1) || layer2.getHitStatus(HodoscopePattern.HODO_LX_CL_12))) return true;
-        if((x >= 7) && (x <= 12) && (layer2.getHitStatus(HodoscopePattern.HODO_LX_CL_12) || layer2.getHitStatus(HodoscopePattern.HODO_LX_2) || layer2.getHitStatus(HodoscopePattern.HODO_LX_CL_23))) return true;
-        if((x >= 12) && (x <= 17) && (layer2.getHitStatus(HodoscopePattern.HODO_LX_CL_23) || layer2.getHitStatus(HodoscopePattern.HODO_LX_3) || layer2.getHitStatus(HodoscopePattern.HODO_LX_CL_34))) return true;
-        if((x >= 16) && (x <= 23) && (layer2.getHitStatus(HodoscopePattern.HODO_LX_CL_34) || layer2.getHitStatus(HodoscopePattern.HODO_LX_4) || layer2.getHitStatus(HodoscopePattern.HODO_LX_CL_45))) return true;
-        if((x >= 20) && (x <= 23) && (layer2.getHitStatus(HodoscopePattern.HODO_LX_CL_45) || layer2.getHitStatus(HodoscopePattern.HODO_LX_5))) return true;         
+        // Before and after run 10189 for 2019 experiment, geometry mapping between hodoscope and Ecal changes.
+        if(runNumber < 10189) {
+            // Cluster X <-> Layer 1 Matching
+            if((x >= 5) && (x <= 9) && (layer1.getHitStatus(HodoscopePattern.HODO_LX_1) || layer1.getHitStatus(HodoscopePattern.HODO_LX_CL_12))) flagLayer1 = true;
+            if(flagLayer1 == false) {
+                if((x >= 6) && (x <= 11) && (layer1.getHitStatus(HodoscopePattern.HODO_LX_CL_12) || layer1.getHitStatus(HodoscopePattern.HODO_LX_2) || layer1.getHitStatus(HodoscopePattern.HODO_LX_CL_23))) flagLayer1 = true;
+                if(flagLayer1 == false) {
+                    if((x >= 10) && (x <= 16) && (layer1.getHitStatus(HodoscopePattern.HODO_LX_CL_23) || layer1.getHitStatus(HodoscopePattern.HODO_LX_3) || layer1.getHitStatus(HodoscopePattern.HODO_LX_CL_34))) flagLayer1 = true;
+                    if(flagLayer1 == false) {
+                        if((x >= 15) && (x <= 21) && (layer1.getHitStatus(HodoscopePattern.HODO_LX_CL_34) || layer1.getHitStatus(HodoscopePattern.HODO_LX_4) || layer1.getHitStatus(HodoscopePattern.HODO_LX_CL_45))) flagLayer1 = true;
+                        if(flagLayer1 == false) {
+                            if((x >= 19) && (x <= 23) && (layer1.getHitStatus(HodoscopePattern.HODO_LX_CL_45) || layer1.getHitStatus(HodoscopePattern.HODO_LX_5))) flagLayer1 = true;
+                        }
+                    }
+                }
+            }
+
+            // Cluster X <-> Layer 2 Matching
+            if((x >= 5) && (x <= 8) && (layer2.getHitStatus(HodoscopePattern.HODO_LX_1) || layer2.getHitStatus(HodoscopePattern.HODO_LX_CL_12))) flagLayer2 = true;
+            if(flagLayer2 == false) {
+                if((x >= 7) && (x <= 12) && (layer2.getHitStatus(HodoscopePattern.HODO_LX_CL_12) || layer2.getHitStatus(HodoscopePattern.HODO_LX_2) || layer2.getHitStatus(HodoscopePattern.HODO_LX_CL_23))) flagLayer2 = true;
+                if(flagLayer2 == false) {
+                    if((x >= 12) && (x <= 17) && (layer2.getHitStatus(HodoscopePattern.HODO_LX_CL_23) || layer2.getHitStatus(HodoscopePattern.HODO_LX_3) || layer2.getHitStatus(HodoscopePattern.HODO_LX_CL_34))) flagLayer2 = true;
+                    if(flagLayer2 == false) {
+                        if((x >= 16) && (x <= 23) && (layer2.getHitStatus(HodoscopePattern.HODO_LX_CL_34) || layer2.getHitStatus(HodoscopePattern.HODO_LX_4) || layer2.getHitStatus(HodoscopePattern.HODO_LX_CL_45))) flagLayer2 = true;
+                        if(flagLayer2 == false) {
+                            if((x >= 20) && (x <= 23) && (layer2.getHitStatus(HodoscopePattern.HODO_LX_CL_45) || layer2.getHitStatus(HodoscopePattern.HODO_LX_5))) flagLayer2 = true;
+                        }
+                    }
+                }
+            }
+        }        
+        else {
+            // Cluster X <-> Layer 1 Matching
+            if((x >= 5) && (x <= 9) && (layer1.getHitStatus(HodoscopePattern.HODO_LX_1) || layer1.getHitStatus(HodoscopePattern.HODO_LX_CL_12))) flagLayer1 = true;
+            if(flagLayer1 == false) {
+                if((x >= 6) && (x <= 12) && (layer1.getHitStatus(HodoscopePattern.HODO_LX_CL_12) || layer1.getHitStatus(HodoscopePattern.HODO_LX_2) || layer1.getHitStatus(HodoscopePattern.HODO_LX_CL_23))) flagLayer1 = true;
+                if(flagLayer1 == false) {
+                    if((x >= 10) && (x <= 17) && (layer1.getHitStatus(HodoscopePattern.HODO_LX_CL_23) || layer1.getHitStatus(HodoscopePattern.HODO_LX_3) || layer1.getHitStatus(HodoscopePattern.HODO_LX_CL_34))) flagLayer1 = true;
+                    if(flagLayer1 == false) {
+                        if((x >= 15) && (x <= 21) && (layer1.getHitStatus(HodoscopePattern.HODO_LX_CL_34) || layer1.getHitStatus(HodoscopePattern.HODO_LX_4) || layer1.getHitStatus(HodoscopePattern.HODO_LX_CL_45))) flagLayer1 = true;
+                        if(flagLayer1 == false) {
+                            if((x >= 18) && (x <= 23) && (layer1.getHitStatus(HodoscopePattern.HODO_LX_CL_45) || layer1.getHitStatus(HodoscopePattern.HODO_LX_5))) flagLayer1 = true;
+                        }
+                    }
+                }
+            }
+
+            // Cluster X <-> Layer 2 Matching
+            if((x >= 5) && (x <= 9) && (layer2.getHitStatus(HodoscopePattern.HODO_LX_1) || layer2.getHitStatus(HodoscopePattern.HODO_LX_CL_12))) flagLayer2 = true;
+            if(flagLayer2 == false) {
+                if((x >= 6) && (x <= 14) && (layer2.getHitStatus(HodoscopePattern.HODO_LX_CL_12) || layer2.getHitStatus(HodoscopePattern.HODO_LX_2) || layer2.getHitStatus(HodoscopePattern.HODO_LX_CL_23))) flagLayer2 = true;
+                if(flagLayer2 == false) {
+                    if((x >= 12) && (x <= 18) && (layer2.getHitStatus(HodoscopePattern.HODO_LX_CL_23) || layer2.getHitStatus(HodoscopePattern.HODO_LX_3) || layer2.getHitStatus(HodoscopePattern.HODO_LX_CL_34))) flagLayer2 = true;
+                    if(flagLayer2 == false) {
+                        if((x >= 16) && (x <= 22) && (layer2.getHitStatus(HodoscopePattern.HODO_LX_CL_34) || layer2.getHitStatus(HodoscopePattern.HODO_LX_4) || layer2.getHitStatus(HodoscopePattern.HODO_LX_CL_45))) flagLayer2 = true;
+                        if(flagLayer2 == false) {
+                            if((x >= 20) && (x <= 23) && (layer2.getHitStatus(HodoscopePattern.HODO_LX_CL_45) || layer2.getHitStatus(HodoscopePattern.HODO_LX_5))) flagLayer2 = true;
+                        }
+                    }
+                }
+            }
+        }
         
-        return false;    
+        return flagLayer1 && flagLayer2;    
     }
     
     

--- a/record-util/src/main/java/org/hps/record/triggerbank/TriggerModule2019.java
+++ b/record-util/src/main/java/org/hps/record/triggerbank/TriggerModule2019.java
@@ -299,14 +299,15 @@ public class TriggerModule2019 {
     }    
     
     /**
-     * Checks whether a cluster passes XMin cut. XMin is at least 0, i.e., located in positive part
+     * Checks whether a cluster passes XMin cut. XMin is at least 0, i.e., located
+     * in positive part
+     * 
      * @param x coordinate for a cluster
-     * @return Returns <code>true</code> if the cluster passes the cut
-     * and <code>false</code> if the cluster does not.
+     * @return Returns <code>true</code> if the cluster passes the cut and
+     *         <code>false</code> if the cluster does not.
      */
     public boolean clusterXMinCut(int x) {
-        if(x < -22 || x > 23) throw new IllegalArgumentException(String.format("Parameter \"%d\" is out of X-coordinage range [-22, 23].", x));
-        else return (x >= singlesTriggerCuts.get(CLUSTER_XMIN));
+        return (x >= singlesTriggerCuts.get(CLUSTER_XMIN));
     }
     
     /**

--- a/steering-files/src/main/resources/org/hps/steering/readout/PhysicsRun2019TrigSingles.lcsim
+++ b/steering-files/src/main/resources/org/hps/steering/readout/PhysicsRun2019TrigSingles.lcsim
@@ -377,7 +377,7 @@
 			<persistentTime>60</persistentTime>
 			<!--  Time for hodoscope FADC hits earlier to
 			     enter the trigger system than Ecal with unit of ns -->
-			<timeEarlierThanEcal>20</timeEarlierThanEcal>
+			<timeEarlierThanEcal>0</timeEarlierThanEcal>
 
 			<persistent>false</persistent>
 	</driver>  


### PR DESCRIPTION
After deep discussion and double check with Ben, there are some updates and corrections relative to singles3 trigger in the readout system. 
1) Geometry mapping between hodoscope and ecal changes a little bit before and after run 10189 for 2019 experiment. The setup after run 10189 is regarded as standard and  updated in the system.
2) Fix scaling for hodoscope hits. For gains in the DAQ configuration used by the trigger system, they have been scaled by 1.25/2 for hodo channels at tiles with two holes. Instead, such gains have not been scaled in DB.
3) For hodoscope pattern bits: CL_12, CL_23, CL_34, and CL_45, it requires that there is at least one hits at BOTH left and right tiles.

Overall, the updates of items 1 and 2 have ignorable effects on readout, and the setup of item 3 causes a little bit tighten to produce single3 trigger. According to tests, # of triggered events with the new setup of the singles3 trigger is a few percents less than the old setup.