### PR TITLE
add fixing of stuck ECAL FADC bits

### DIFF
--- a/evio/src/main/java/org/hps/evio/StuckFADCBit.java
+++ b/evio/src/main/java/org/hps/evio/StuckFADCBit.java
@@ -1,0 +1,210 @@
+package org.hps.evio;
+
+import org.hps.conditions.ecal.EcalChannel;
+import org.hps.conditions.ecal.EcalChannel.DaqId;
+import org.hps.conditions.ecal.EcalConditions;
+import org.jlab.coda.jevio.CompositeData;
+import org.lcsim.event.RawTrackerHit;
+
+/**
+ * Tools to resolve stuck FADC bit in 2019 run, based on comparing
+ * measured and expected pedestal values.
+ * @author baltzell
+ */
+public class StuckFADCBit {
+   
+    static final int N_PEDESTAL_SAMPLES = 7;
+ 
+    public static class Stuck {
+        int index;
+        int state;
+        public Stuck(int bitIndex, int bitState) {
+            index = bitIndex;
+            state = bitState;
+        }
+        public int unStick(int value) {
+            if (state == 0) {
+                // set the bit:
+                return value | (1<<index);
+            }
+            else {
+                // unset the bit:
+                return value & ~(1<<index);
+            }
+        }
+        public boolean isStuck(int value) {
+            return ((value >> index) & 1) == state;
+        }
+        public boolean arePartners(int x, int y) {
+            // the stuck bit:
+            int bx = x & (1<<index);
+            int by = y & (1<<index);
+            // all the others:
+            int ox = x & ~(1<<index);
+            int oy = y & ~(1<<index);
+            return ox==oy && bx!=by;
+        }
+    }
+
+    /**
+     * Get the measured pedestal for a given readout.
+     * @param cdata FADC samples
+     * @return the average of the first samples
+     */
+    public static float getPedestal(CompositeData cdata) {
+        final CompositeData tmp = (CompositeData)cdata.clone();
+        final int maxSamples = tmp.getNValue();
+        float pedestal = 0;
+        int nSamples = 0;
+        for (int ii=0; ii<N_PEDESTAL_SAMPLES && ii<maxSamples; ii++) {
+            pedestal += cdata.getShort();
+            nSamples++;
+        }
+        return pedestal/nSamples;
+    }
+
+    /**
+     * Get the measured pedestal for a given readout.
+     * @param hit
+     * @return the average of the first samples
+     */
+    public static float getPedestal(RawTrackerHit hit) {
+        float pedestal = 0;
+        int nSamples = 0;
+        for (int ii=0; ii<N_PEDESTAL_SAMPLES && ii<hit.getADCValues().length; ii++) {
+            pedestal += hit.getADCValues()[ii];
+            nSamples++;
+        }
+        return pedestal/nSamples;
+    }
+
+    /**
+     * Get the conditions database pedestal for a given channel.
+     * @param condi
+     * @param daqId
+     * @return the pedestal
+     */
+    public static double getPedestal(EcalConditions condi, DaqId daqId) {
+        return condi.getChannelConstants(
+               condi.getChannelCollection().findChannel(daqId)).getCalibration().getPedestal();
+    }
+
+    /**
+     * Get the conditions database pedestal. 
+     * @param condi
+     * @param c
+     * @return 
+     */
+    public static double getPedestal(EcalConditions condi, EcalChannel c) {
+        return getPedestal(condi,new DaqId(new int[]{c.getCrate(),c.getSlot(),c.getChannel()}));
+    }
+
+    /**
+     * Just format a channel as crate/slot/channel
+     * @param c
+     * @return
+     */
+    public static String toString(EcalChannel c) {
+        return String.format("%d/%d/%d", c.getCrate(), c.getSlot(), c.getChannel());
+    }
+
+    /**
+     * 
+     * @param condi
+     * @param crate
+     * @param slot
+     * @param channel
+     * @return 
+     */
+    public static EcalChannel getChannel(EcalConditions condi, int crate, int slot, int channel) {
+        return condi.getChannelCollection().findChannel(new DaqId(new int[]{crate,slot,channel}));
+    }
+
+    /**
+     * Compare two EcalChannel objects based on crate/slot/channel.
+     * Shouldn't EcalChannel provide this itself?
+     * @param c1
+     * @param c2
+     * @return
+     */
+    public static boolean equals(EcalChannel c1, EcalChannel c2) {
+        if (c1.getCrate() != c2.getCrate()) {
+            return false;
+        }
+        if (c1.getSlot() != c2.getSlot()) {
+            return false;
+        }
+        if (c1.getChannel() != c2.getChannel()) {
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Get the channel after unsetting the given bit. 
+     * @param condi
+     * @param channel
+     * @param stuck
+     * @return 
+     */
+    public static EcalChannel unstick(EcalConditions condi, EcalChannel channel, Stuck stuck) {
+        final int unstuckChannel = stuck.unStick(channel.getChannel());
+        return getChannel(condi, channel.getCrate(), channel.getSlot(), unstuckChannel);
+    }
+
+    /**
+     * Get the corrected channel.
+     * @param condi
+     * @param channel
+     * @param cdata
+     * @param stuck
+     * @return 
+     */
+    public static EcalChannel fix(EcalConditions condi, EcalChannel channel, CompositeData cdata, Stuck stuck) {
+        EcalChannel ret = channel;
+        if (stuck.isStuck(ret.getChannel())) {
+            final EcalChannel newChan = unstick(condi, ret, stuck);
+            final double oldPed = getPedestal(condi, ret);
+            final double newPed = getPedestal(condi, newChan);
+            final double measPed = getPedestal(cdata);
+            if (Math.abs(newPed-measPed) < Math.abs(oldPed-measPed)) {
+                ret = newChan;
+            }
+        }
+        return ret;
+    }
+
+    /**
+     * Get the corrected channel.
+     * @param condi
+     * @param hit
+     * @param stuck
+     * @return 
+     */
+    public static EcalChannel fix(EcalConditions condi, RawTrackerHit hit, Stuck stuck) {
+        EcalChannel ret = condi.getChannelCollection().findGeometric(hit.getCellID());
+        if (stuck.isStuck(ret.getChannel())) {
+            final EcalChannel newChan = unstick(condi, ret, stuck);
+            final double oldPed = getPedestal(condi, ret);
+            final double newPed = getPedestal(condi, newChan);
+            final double measPed = getPedestal(hit);
+            if (Math.abs(newPed-measPed) < Math.abs(oldPed-measPed)) {
+                ret = newChan;
+            }
+        }
+        return ret;
+    }
+
+    /**
+     * Get the corrected channel. 
+     * @param condi
+     * @param daqId
+     * @param cdata
+     * @param stuck
+     * @return 
+     */
+    public static EcalChannel fix(EcalConditions condi, DaqId daqId, CompositeData cdata, Stuck stuck) {
+        return fix(condi,condi.getChannelCollection().findChannel(daqId), cdata, stuck);
+    }
+
+}

--- a/evio/src/main/java/org/hps/evio/StuckFADCBit.java
+++ b/evio/src/main/java/org/hps/evio/StuckFADCBit.java
@@ -38,6 +38,9 @@ public class StuckFADCBit {
         public boolean isStuck(int value) {
             return ((value >> index) & 1) == state;
         }
+        public boolean isStuck(EcalChannel c) {
+            return isStuck(c.getChannel());
+        }
         public boolean arePartners(int x, int y) {
             // the stuck bit:
             int bx = x & (1<<index);
@@ -117,7 +120,7 @@ public class StuckFADCBit {
      * @return
      */
     public static String toString(EcalChannel c) {
-        return String.format("%d/%d/%d(%4s)", c.getCrate(), c.getSlot(), c.getChannel(),
+        return String.format("%02d/%02d/%02d(%4s)", c.getCrate(), c.getSlot(), c.getChannel(),
                 Integer.toBinaryString(c.getChannel())).replace(' ','0');
     }
 
@@ -160,7 +163,7 @@ public class StuckFADCBit {
      * @param stuck
      * @return 
      */
-    public static EcalChannel unstick(EcalConditions condi, EcalChannel channel, Stuck stuck) {
+    public static EcalChannel unStick(EcalConditions condi, EcalChannel channel, Stuck stuck) {
         final int unstuckChannel = stuck.unStick(channel.getChannel());
         return getChannel(condi, channel.getCrate(), channel.getSlot(), unstuckChannel);
     }
@@ -188,7 +191,7 @@ public class StuckFADCBit {
     public static EcalChannel fix(EcalConditions condi, EcalChannel channel, CompositeData cdata, Stuck stuck) {
         EcalChannel ret = channel;
         if (stuck.isStuck(ret.getChannel())) {
-            final EcalChannel newChan = unstick(condi, ret, stuck);
+            final EcalChannel newChan = unStick(condi, ret, stuck);
             final double oldPed = getPedestal(condi, ret);
             final double newPed = getPedestal(condi, newChan);
             final double measPed = getPedestal(cdata);
@@ -209,7 +212,7 @@ public class StuckFADCBit {
     public static EcalChannel fix(EcalConditions condi, RawTrackerHit hit, Stuck stuck) {
         EcalChannel ret = condi.getChannelCollection().findGeometric(hit.getCellID());
         if (stuck.isStuck(ret.getChannel())) {
-            final EcalChannel newChan = unstick(condi, ret, stuck);
+            final EcalChannel newChan = unStick(condi, ret, stuck);
             final double oldPed = getPedestal(condi, ret);
             final double newPed = getPedestal(condi, newChan);
             final double measPed = getPedestal(hit);

--- a/evio/src/main/java/org/hps/evio/StuckFADCBit.java
+++ b/evio/src/main/java/org/hps/evio/StuckFADCBit.java
@@ -32,6 +32,9 @@ public class StuckFADCBit {
                 return value & ~(1<<index);
             }
         }
+        public int toggle(int value) {
+            return value ^ (1<<index);
+        }
         public boolean isStuck(int value) {
             return ((value >> index) & 1) == state;
         }
@@ -43,6 +46,15 @@ public class StuckFADCBit {
             int ox = x & ~(1<<index);
             int oy = y & ~(1<<index);
             return ox==oy && bx!=by;
+        }
+        public boolean arePartners(EcalChannel x, EcalChannel y) {
+            if (x.getCrate() != y.getCrate()) {
+                return false;
+            }
+            if (x.getSlot() != y.getSlot()) {
+                return false;
+            }
+            return arePartners(x.getChannel(), y.getChannel());
         }
     }
 
@@ -105,7 +117,8 @@ public class StuckFADCBit {
      * @return
      */
     public static String toString(EcalChannel c) {
-        return String.format("%d/%d/%d", c.getCrate(), c.getSlot(), c.getChannel());
+        return String.format("%d/%d/%d(%4s)", c.getCrate(), c.getSlot(), c.getChannel(),
+                Integer.toBinaryString(c.getChannel())).replace(' ','0');
     }
 
     /**
@@ -149,6 +162,18 @@ public class StuckFADCBit {
      */
     public static EcalChannel unstick(EcalConditions condi, EcalChannel channel, Stuck stuck) {
         final int unstuckChannel = stuck.unStick(channel.getChannel());
+        return getChannel(condi, channel.getCrate(), channel.getSlot(), unstuckChannel);
+    }
+
+    /**
+     * Get the channel after toggling the given bit. 
+     * @param condi
+     * @param channel
+     * @param stuck
+     * @return 
+     */
+    public static EcalChannel toggle(EcalConditions condi, EcalChannel channel, Stuck stuck) {
+        final int unstuckChannel = stuck.toggle(channel.getChannel());
         return getChannel(condi, channel.getCrate(), channel.getSlot(), unstuckChannel);
     }
 

--- a/evio/src/main/java/org/hps/evio/StuckFADCBitDriver.java
+++ b/evio/src/main/java/org/hps/evio/StuckFADCBitDriver.java
@@ -1,0 +1,373 @@
+package org.hps.evio;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.hps.conditions.database.DatabaseConditionsManager;
+import org.hps.conditions.ecal.EcalChannel;
+import org.hps.conditions.ecal.EcalChannel.DaqId;
+import org.hps.conditions.ecal.EcalChannel.GeometryId;
+import org.hps.conditions.ecal.EcalConditions;
+import org.lcsim.detector.identifier.IIdentifierHelper;
+import org.lcsim.detector.identifier.Identifier;
+import org.lcsim.event.EventHeader;
+import org.lcsim.event.RawTrackerHit;
+import org.lcsim.event.SimTrackerHit;
+import org.lcsim.event.base.BaseRawTrackerHit;
+import org.lcsim.geometry.Detector;
+import org.lcsim.geometry.Subdetector;
+import org.lcsim.util.Driver;
+
+/**
+ * Modify FADC waveform collection to fix stuck channel bits during 2019 run.
+ * 
+ * Configuration is left hard-coded; hopefully we'll never need this again.
+ *
+ * @author baltzell
+ */
+public class StuckFADCBitDriver extends Driver {
+    
+    private static final int RUN_MIN = 10651;
+    private static final int RUN_MAX = 10678;
+    private static final Set<CrateSlot> STUCK_SLOTS = new HashSet<>(Arrays.asList(new CrateSlot(1,3)));
+    private static final StuckFADCBit.Stuck STUCK_BIT = new StuckFADCBit.Stuck(1,0);
+    
+    private static final String READOUT_NAME= "EcalHits";
+    private static final String SUBDETECTOR_NAME = "Ecal";
+
+    private static final Class HIT_CLASS = RawTrackerHit.class;
+    private static final String HIT_COLLECTION_NAME = "EcalReadoutHits";
+
+    private Subdetector subDetector = null;
+    private IIdentifierHelper helper = null;
+    private EcalConditions ecalConditions = null;
+
+    private int nOldBad = 0;
+    private int nNewBad = 0;
+
+    private final Map<EcalChannel,EcalChannel> swaps = new HashMap<>();
+ 
+    public static class CrateSlot {
+        public int crate,slot;
+        public CrateSlot(int crate, int slot) {
+            this.crate = crate;
+            this.slot = slot;
+        }
+        @Override
+        public boolean equals(Object o) {
+            if (o instanceof CrateSlot) {
+                return ((CrateSlot)o).crate==this.crate && ((CrateSlot)o).slot==this.slot;
+            }
+            return false;
+        }
+        @Override
+        public int hashCode() {
+            int hash = 3;
+            hash = 37 * hash + this.crate;
+            hash = 37 * hash + this.slot;
+            return hash;
+        }
+    }
+
+    @Override
+    public void detectorChanged(Detector detector) {
+        subDetector = DatabaseConditionsManager.getInstance().getDetectorObject().getSubdetector(SUBDETECTOR_NAME);
+        helper = subDetector.getDetectorElement().getIdentifierHelper();
+        ecalConditions = DatabaseConditionsManager.getInstance().getEcalConditions();
+    }
+  
+    @Override
+    public void endOfData() {
+        Logger.getLogger(this.getClass().getCanonicalName()).log(Level.INFO, "Old Bad:  {0}", nOldBad);
+        Logger.getLogger(this.getClass().getCanonicalName()).log(Level.INFO, "New Bad:  {0}", nNewBad);
+    }
+    
+    /**
+     * Replace all affected hits with fixed ones.
+     * @param event 
+     */
+    @Override
+    public void process(EventHeader event) {
+
+        if (!event.hasCollection(HIT_CLASS, HIT_COLLECTION_NAME)) return;
+
+        if (event.getRunNumber() < RUN_MIN || event.getRunNumber() > RUN_MAX) return;
+
+        List<RawTrackerHit> oldHits = event.get(HIT_CLASS, HIT_COLLECTION_NAME);
+
+        if (!analyze(oldHits)) {
+            nOldBad++;
+        }
+
+        List<RawTrackerHit> newHits = fixSafe(oldHits);
+
+        //analyze(oldHits,newHits);
+
+        event.remove(HIT_COLLECTION_NAME);
+        event.put(HIT_COLLECTION_NAME, newHits, HIT_CLASS, 0, READOUT_NAME);
+
+        if (!analyze(event.get(HIT_CLASS, HIT_COLLECTION_NAME))) {
+            nNewBad++;
+        }
+    }
+
+    /**
+     * Query whether this channel is potentially affected by stuck FADC bit
+     * @param channel
+     * @return
+     */
+    private boolean isAffected(EcalChannel channel) {
+        return STUCK_SLOTS.contains(new CrateSlot(channel.getCrate(), channel.getSlot()));
+    }
+
+    /**
+     * Get whether the two channels are stuck-bit partners, i.e. they differ only
+     * by the stuck channel bit.
+     * @param c1
+     * @param c2
+     * @return 
+     */
+    private boolean arePartners(EcalChannel c1, EcalChannel c2) {
+        boolean ret = false;
+        if (c1.getCrate() == c2.getCrate()) {
+            if (c1.getSlot() == c2.getSlot()) {
+                ret = STUCK_BIT.arePartners(c1.getChannel(), c2.getChannel());
+            }
+        }
+        return ret;
+    }
+
+    /**
+     * Get the EcalChannel object corresponding to a hit.
+     * @param hit
+     * @return
+     */
+    private EcalChannel getChannel(RawTrackerHit hit) {
+        return ecalConditions.getChannelCollection().findGeometric(hit.getCellID());
+    }
+
+    /**
+     * Register the swapping, log if first time. 
+     * @param stuck
+     * @param unstuck 
+     */
+    private void register(EcalChannel stuck, EcalChannel unstuck) {
+        if (!StuckFADCBit.equals(stuck,unstuck) && !swaps.containsKey(stuck)) {
+            swaps.put(stuck,unstuck);
+            String msg = String.format("Unsticking FADC Bit:  %s -> %s",
+                    StuckFADCBit.toString(stuck),StuckFADCBit.toString(unstuck));
+            Logger.getLogger(this.getClass().getCanonicalName()).warning(msg);
+        }
+    }
+
+    /**
+     * Get channel with the stuck bit unstuck.
+     * @param channel
+     * @return 
+     */
+    private EcalChannel unStick(EcalChannel channel) {
+        EcalChannel newChan = StuckFADCBit.unstick(ecalConditions, channel, STUCK_BIT); 
+        register(channel, newChan);
+        return newChan;
+    }
+
+    /**
+     * Get hit with the stuck bit unstuck. 
+     * @param hit
+     * @return 
+     */
+    private RawTrackerHit unStick(RawTrackerHit hit) {
+        EcalChannel newChan = unStick(getChannel(hit));
+        return makeECalRawHit(0, newChan, hit.getADCValues());
+    }
+    
+    /**
+     * Get hit with the stuck bit unstuck, if appropriate based on pedestal.
+     * @param hit
+     * @return 
+     */
+    private RawTrackerHit fix(RawTrackerHit hit) {
+        RawTrackerHit ret = hit;
+        EcalChannel oldChan = getChannel(hit);
+        if (isAffected(oldChan)) {
+            EcalChannel newChan = StuckFADCBit.fix(ecalConditions, hit, STUCK_BIT);
+            register(oldChan, newChan);
+            ret = makeECalRawHit(0, newChan, hit.getADCValues());
+        }
+        return ret;
+    }
+
+    /**
+     * Unstick any FADC bits if appropriate.  Use channel ordering if possible,
+     * otherwise pedestals, to determine their stuckness.
+     * @param hits
+     * @return 
+     */
+    private List<RawTrackerHit> fixSafe(List<RawTrackerHit> hits) {
+
+        List<RawTrackerHit> ret = new ArrayList<>(hits.size());
+        boolean[] stuckCandidate = new boolean[hits.size()];
+        for (int ii=0; ii<stuckCandidate.length; ii++) stuckCandidate[ii] = true;
+
+        // first address "easy" cases:
+        for (int i1=0; i1<hits.size(); i1++){
+
+            RawTrackerHit h1 = hits.get(i1);
+            EcalChannel c1 = getChannel(h1);
+
+            ret.add(hits.get(i1));
+
+            // unaffected crate/slot or already marked as unstuck: 
+            if (!isAffected(c1) || !stuckCandidate[i1]) {
+                stuckCandidate[i1] = false;
+                continue;
+            }
+                
+            for (int i2=i1+1; i2<hits.size(); i2++) {
+
+                RawTrackerHit h2 = hits.get(i2);
+                EcalChannel c2 = getChannel(hits.get(i2));
+
+                // two identical channels in the same event, unstick one of them
+                // based on ordering of the hits in the event:
+                if (StuckFADCBit.equals(c1,c2)) {
+                    if (STUCK_BIT.state == 0) {
+                        hits.set(i2, unStick(h2));
+                    }
+                    else {
+                        ret.set(i1, unStick(h1));
+                    }
+                    stuckCandidate[i1] = false;
+                    stuckCandidate[i2] = false;
+                    break;
+                }
+
+                // two non-identical partner channels in the same event,
+                // mark both as unstuck:
+                else if (arePartners(c1,c2)) {
+                    stuckCandidate[i1] = false;
+                    stuckCandidate[i2] = false;
+                    break;
+                }
+            }
+        }
+
+        // then use pedestal to determine stuckness:
+        for (int ii=0; ii<ret.size(); ii++) {
+            if (stuckCandidate[ii]) {
+                ret.set(ii, fix(ret.get(ii)));
+            }
+        }
+
+        return ret;
+    }
+ 
+    /**
+     * Check for identical hits.
+     * @param hits
+     * @return 
+     */
+    private boolean analyze(List<RawTrackerHit> hits) {
+        for (int i1=0; i1<hits.size(); i1++){
+            EcalChannel c1 = getChannel(hits.get(i1));
+            for (int i2=i1+1; i2<hits.size(); i2++) {
+                EcalChannel c2 = getChannel(hits.get(i2));
+                if (StuckFADCBit.equals(c1,c2)) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+ 
+    /**
+     * For cases where two channels in the same event are identical due to 
+     * stuck bit, after the correction the 1st one should have had the stuck bit
+     * unset.  Here we test for cases where the pedestal-based correction gets
+     * it wrong by unsticking the 2nd hit's bit.  We also check for identical
+     * channels when the stuck bit isn't set prior to correction.
+     * @param oldHits
+     * @param newHits
+     * @return 
+     */
+    private boolean analyze(List<RawTrackerHit> oldHits, List<RawTrackerHit> newHits) {
+        boolean ret = true;
+        for (int i1=0; i1<oldHits.size(); i1++){
+            EcalChannel c1old = getChannel(oldHits.get(i1));
+            EcalChannel c1new = getChannel(newHits.get(i1));
+            for (int i2=i1+1; i2<oldHits.size(); i2++) {
+                EcalChannel c2old = getChannel(oldHits.get(i2));
+                EcalChannel c2new = getChannel(newHits.get(i2));
+                if (StuckFADCBit.equals(c1old,c2old)) {
+                    // if unfixed, they both should have the stuck bit stuck:
+                    if (!STUCK_BIT.isStuck(c1old.getChannel())) {
+                        String msg = "This should never happen (4) "+StuckFADCBit.toString(c1old)+" -> "+StuckFADCBit.toString(c2old);
+                        Logger.getLogger(this.getClass().getCanonicalName()).info(msg);
+                        ret = false;
+                    }
+                    // if fixed, the 1st should have the stuck bit unset:
+                    if ((c1new.getChannel()&(1<<STUCK_BIT.index)) != 0) {
+                        String msg = "This should never happen (2) "+StuckFADCBit.toString(c1new)+" -> "+StuckFADCBit.toString(c2new);
+                        Logger.getLogger(this.getClass().getCanonicalName()).info(msg);
+                        ret = false;
+                    }
+                    // if fixed, the 2nd should have the stuck bit set:
+                    if ((c2new.getChannel()&(1<<STUCK_BIT.index)) == 0) {
+                        String msg = "This should never happen (3) "+StuckFADCBit.toString(c1new)+" -> "+StuckFADCBit.toString(c2new);
+                        Logger.getLogger(this.getClass().getCanonicalName()).info(msg);
+                        ret = false;
+                    }
+                }
+                // if fixed, there should never be identical hits:
+                if (StuckFADCBit.equals(c1new,c2new)) {
+                    String msg = "This should never happen (5) "+StuckFADCBit.toString(c1new)+" -> "+StuckFADCBit.toString(c2new);
+                    Logger.getLogger(this.getClass().getCanonicalName()).info(msg);
+                    ret = false;
+                }
+            }
+        }
+        return ret;
+    }
+
+    /**
+     * Copied from EcalEvioReader
+     * @param time
+     * @param channel
+     * @param samples
+     * @return 
+     */
+    private BaseRawTrackerHit makeECalRawHit(int time, EcalChannel channel, short[] samples) {
+        long daqId = daqToGeometryId(channel.getCrate(),channel.getSlot(),channel.getChannel());
+        return new BaseRawTrackerHit(
+                time,
+                daqId,
+                samples,
+                new ArrayList<SimTrackerHit>(),
+                subDetector.getDetectorElement().findDetectorElement(new Identifier(daqId)).get(0));
+    }
+
+    /**
+     * Copied from EcalEvioReader
+     * @param crate
+     * @param slot
+     * @param channel
+     * @return 
+     */
+    private Long daqToGeometryId(int crate, int slot, int channel) {
+        DaqId daqId = new DaqId(new int[]{crate, slot, channel});
+        EcalChannel ecalChannel = ecalConditions.getChannelCollection().findChannel(daqId);
+        if (ecalChannel == null) return null;
+        int ix = ecalChannel.getX();
+        int iy = ecalChannel.getY();
+        GeometryId geometryId = new GeometryId(helper, new int[]{subDetector.getSystemID(), ix, iy});
+        Long id = geometryId.encode();
+        return id;
+    }
+
+}

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-  </dependency> 
+    </dependency> 
     <dependency>
       <groupId>org.hps</groupId>
       <artifactId>hps-test-data</artifactId>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-    </dependency>    
+  </dependency> 
     <dependency>
       <groupId>org.hps</groupId>
       <artifactId>hps-test-data</artifactId>

--- a/steering-files/src/main/resources/org/hps/steering/recon/PhysicsRun2019FullRecon.lcsim
+++ b/steering-files/src/main/resources/org/hps/steering/recon/PhysicsRun2019FullRecon.lcsim
@@ -13,6 +13,10 @@
         <!-- Skip events with known bad conditions -->
         <!-- Not yet defined for 2019 data -->
         <!--        <driver name="EventFlagFilter"/>  -->
+
+        <!-- FADC stuck bits driver -->
+        <driver name="StuckFADCBit"/>
+
         <!--RF driver-->
         <driver name="RfFitter"/>
         <!-- Hodoscope drivers -->
@@ -25,6 +29,7 @@
         <driver name="EcalTimeCorrection"/> 
         <driver name="ReconClusterer" /> 
         <driver name="CopyCluster" />
+
         <!-- SVT reconstruction drivers -->
         <driver name="RawTrackerHitSensorSetup"/>
         <driver name="RawTrackerHitFitterDriver" />
@@ -96,7 +101,9 @@
             <flagNames>svt_bias_good svt_position_good svt_burstmode_noise_good svt_event_header_good</flagNames> 
         </driver> 
         -->
-        
+
+        <driver name="StuckFADCBit" type="org.hps.evio.StuckFADCBitDriver"/>
+
         <driver name="RfFitter" type="org.hps.evio.RfFitterDriver"/>       
 
         <!-- Ecal reconstruction drivers -->


### PR DESCRIPTION
* For a small run range, and one slot in one crate, one of the bits in the FADC channel number got stuck in the low state.
* This addresses that as a driver that reads and rewrites the waveform collections after fixing the stuck bit like so:
1. If not in an affected crate+slot+run, leave it as is
2.  If duplicate channels are in the same event, fix it based on channel readout ordering
3. Otherwise fix it based on comparison of measured pedestal in given readout to that in the conditions database

See also:  https://heavyphotonsearch.slack.com/archives/CKEER7XDF/p1605400346036100