### PR TITLE
Iss776: Change global logging level to warning for test output

### DIFF
--- a/logging/src/main/resources/org/hps/logging/config/test_logging.properties
+++ b/logging/src/main/resources/org/hps/logging/config/test_logging.properties
@@ -1,20 +1,20 @@
-#
-# Global logging configuration for HPS Java tests
-#
-# This is assigned to tests automatically via the top-level POM file.
-#
-# @author Jeremy McCormick, SLAC
-#
+#######################################################################
+#                                                                     #
+# Global logging configuration for HPS Java tests                     #
+#                                                                     #
+# This is assigned to tests automatically via the top-level POM file. #
+#                                                                     #
+#######################################################################
 
-# Available log levels
-# SEVERE (highest value)
+# Available log levels:
+# SEVERE
 # WARNING
 # INFO
 # CONFIG
 # FINE
 # FINER
-# FINEST (lowest value)
-# ALL (always prints)
+# FINEST 
+# ALL 
 
 # default global level
 .level = WARNING
@@ -36,52 +36,10 @@ java.util.logging.SimpleFormatter.format = %3$s:%4$s %5$s%6$s%n
 java.util.logging.ConsoleHandler.level = ALL
 java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
 
-#
-# Only override loggers with settings that are different from the default of 'WARNING'.
-# Any custom settings needed for debugging particular tests should be changed or added here.
-#
+############################################################################################
+# Only override loggers with settings that are different from the default of 'WARNING'.    #
+# Any custom settings needed logcally for debugging particular tests should be added here. #
+############################################################################################
 
 # turn minuit off
 org.freehep.math.minuit.level = OFF
-
-# lcsim job manager
-org.lcsim.job.level = CONFIG
-org.lcsim.job.EventPrintLoopAdapter = ALL
-
-# conditions
-org.hps.conditions.database.level = INFO
-org.hps.conditions.cli.level = WARNING
-org.hps.conditions.ecal.level = WARNING
-org.hps.conditions.svt.level = WARNING
-
-# monitoring-drivers
-org.hps.monitoring.drivers.svt.level = WARNING
-org.hps.monitoring.plotting.level = WARNING
-
-# evio
-org.hps.evio.level = WARNING
-org.hps.evio.AugmentedSvtEvioReader.level = WARNING
-
-# analysis
-org.hps.analysis.trigger.level = WARNING
-org.hps.analysis.dataquality.level = WARNING
-
-# crawler
-org.hps.crawler.level = WARNING
-
-# datacat
-org.hps.datacat.level = WARNING
-
-# ecal-recon
-org.hps.recon.ecal.level = WARNING
-org.hps.recon.ecal.cluster.level = WARNING
-
-# recon
-org.hps.recon.particle.level = CONFIG
-org.hps.recon.vertexing.level = CONFIG
-
-# test data
-org.hps.data.test.level = INFO
-
-# test util
-org.hps.test.util.level = ALL


### PR DESCRIPTION
Modify log properties for test output so global log level is set to WARNING and remove package specific log settings.