### PR TITLE
Fix an issue in the digitization readout driver

### DIFF
--- a/ecal-readout-sim/src/main/java/org/hps/readout/DigitizationReadoutDriver.java
+++ b/ecal-readout-sim/src/main/java/org/hps/readout/DigitizationReadoutDriver.java
@@ -469,7 +469,7 @@ public abstract class DigitizationReadoutDriver<D extends Subdetector> extends R
             double currentValue = voltageBuffer.getValue() * ((Math.pow(2, nBit) - 1) / maxVolt);
             
             // Get the pedestal for the channel.
-            int pedestal = (int) Math.round(getDAQPedestalConditions(cellID));            
+            int pedestal = (int) Math.round(getPedestalConditions(cellID));            
             
             // An ADC value is not allowed to exceed 4095. If a
             // larger value is observed, 4096 (overflow) is given
@@ -974,15 +974,7 @@ public abstract class DigitizationReadoutDriver<D extends Subdetector> extends R
      * <code>double</code>.
      */
     protected abstract double getPedestalConditions(long channelID);
-    
-    
-    /**
-     * Gets the pedestal for the indicated subdetector channel.
-     * @param channelID - The channel ID.
-     * @return Returns the value of the pedestal from the DAQ configuration in units of ADC as a
-     * <code>double</code>.
-     */
-    protected abstract double getDAQPedestalConditions(long channelID);
+        
     
     @Override
     protected boolean isPersistent() {
@@ -1113,7 +1105,7 @@ public abstract class DigitizationReadoutDriver<D extends Subdetector> extends R
             for(int i = 0; i < adcValues.length; i++) {
                 // Check that there is a threshold-crossing at some
                 // point in the ADC buffer.
-                if(adcValues[i] > getDAQPedestalConditions(cellID) + integrationThreshold) {
+                if(adcValues[i] > getPedestalConditions(cellID) + integrationThreshold) {
                     isAboveThreshold = true;
                     break;
                 }
@@ -1155,8 +1147,8 @@ public abstract class DigitizationReadoutDriver<D extends Subdetector> extends R
                     if (numSamplesToRead == 0) {
                         hits.add(new BaseRawTrackerHit(cellID, thresholdCrossing, adcValues));
                     }
-                } else if ((i == 0 || window[i - 1] <= getDAQPedestalConditions(cellID) + integrationThreshold) && window[i]
-                        > getDAQPedestalConditions(cellID) + integrationThreshold) {
+                } else if ((i == 0 || window[i - 1] <= getPedestalConditions(cellID) + integrationThreshold) && window[i]
+                        > getPedestalConditions(cellID) + integrationThreshold) {
                     thresholdCrossing = i;
                     pointerOffset = Math.min(numSamplesBefore, i);
                     numSamplesToRead = pointerOffset + Math.min(numSamplesAfter, ReadoutDataManager.getReadoutWindow() - i - pointerOffset - 1);
@@ -1197,8 +1189,8 @@ public abstract class DigitizationReadoutDriver<D extends Subdetector> extends R
                         if(numSamplesToRead == 0) {
                             hits.add(new BaseRawCalorimeterHit(cellID, adcSum, 64 * thresholdCrossing));
                         }
-                    } else if((i == 0 || window[i - 1] <= getDAQPedestalConditions(cellID) + integrationThreshold)
-                            && window[i] > getDAQPedestalConditions(cellID) + integrationThreshold) {
+                    } else if((i == 0 || window[i - 1] <= getPedestalConditions(cellID) + integrationThreshold)
+                            && window[i] > getPedestalConditions(cellID) + integrationThreshold) {
                         thresholdCrossing = i;
                         pointerOffset = Math.min(numSamplesBefore, i);
                         numSamplesToRead = pointerOffset + Math.min(numSamplesAfter, ReadoutDataManager.getReadoutWindow() - i - pointerOffset - 1);

--- a/ecal-readout-sim/src/main/java/org/hps/readout/ecal/updated/EcalDigitizationReadoutDriver.java
+++ b/ecal-readout-sim/src/main/java/org/hps/readout/ecal/updated/EcalDigitizationReadoutDriver.java
@@ -29,6 +29,7 @@ import org.lcsim.geometry.subdetector.HPSEcal3;
 public class EcalDigitizationReadoutDriver extends DigitizationReadoutDriver<HPSEcal3> {    
     // The DAQ configuration manager for FADC parameters.
     private FADCConfigEcal2019 config = new FADCConfigEcal2019();
+    private boolean configStat = false; // Indicates if DAQ configuration is loaded
     
     // The number of nanoseconds in a clock-cycle (sample).
     private static final int nsPerSample = 4;
@@ -79,6 +80,7 @@ public class EcalDigitizationReadoutDriver extends DigitizationReadoutDriver<HPS
                     
                     // Get the FADC configuration.
                     config = daq.getEcalFADCConfig();
+                    configStat = true;
                     integrationThreshold = config.getThreshold((int)10);
                 }
             });
@@ -114,14 +116,10 @@ public class EcalDigitizationReadoutDriver extends DigitizationReadoutDriver<HPS
     }
     
     @Override
-    protected double getPedestalConditions(long cellID) {        
-        return findChannel(cellID).getCalibration().getPedestal();
-    }
-    
-    @Override
-    protected double getDAQPedestalConditions(long cellID) {        
-        return config.getPedestal(geoMap.findGeometric(cellID));
-    }
+    protected double getPedestalConditions(long cellID) { 
+        if(configStat == true) return config.getPedestal(geoMap.findGeometric(cellID)); 
+        else return findChannel(cellID).getCalibration().getPedestal();
+    }   
     
     @Override
     protected double getTimeShiftConditions(long cellID) {

--- a/ecal-readout-sim/src/main/java/org/hps/readout/hodoscope/HodoscopeDigitizationReadoutDriver.java
+++ b/ecal-readout-sim/src/main/java/org/hps/readout/hodoscope/HodoscopeDigitizationReadoutDriver.java
@@ -39,6 +39,7 @@ import org.lcsim.geometry.subdetector.Hodoscope_v1;
 public class HodoscopeDigitizationReadoutDriver extends DigitizationReadoutDriver<Hodoscope_v1> {    
     // The DAQ configuration manager for FADC parameters.
     private FADCConfigHodo2019 config = new FADCConfigHodo2019();
+    private boolean configStat = false; // Indicates if DAQ configuration is loaded
     
     // The number of nanoseconds in a clock-cycle (sample).
     private static final int nsPerSample = 4;   
@@ -100,6 +101,7 @@ public class HodoscopeDigitizationReadoutDriver extends DigitizationReadoutDrive
                     
                     // Get the FADC configuration.
                     config = daq.getHodoFADCConfig();
+                    configStat = true;
                     integrationThreshold = config.getThreshold((int)10);
                 }
             });
@@ -141,19 +143,17 @@ public class HodoscopeDigitizationReadoutDriver extends DigitizationReadoutDrive
     }
     
     @Override
-    protected double getPedestalConditions(long channelID) {        
-        if (channelToCalibrationsMap.containsKey(Long.valueOf(channelID))) {
-            return channelToCalibrationsMap.get(Long.valueOf(channelID)).getPedestal();
-        } else {
-            throw new IllegalArgumentException(
-                    "No pedestal conditions exist for hodoscope channel ID \"" + channelID + "\".");
+    protected double getPedestalConditions(long channelID) { 
+        if(configStat == true) return config.getPedestal((int)channelID);
+        else {
+            if (channelToCalibrationsMap.containsKey(Long.valueOf(channelID))) {
+                return channelToCalibrationsMap.get(Long.valueOf(channelID)).getPedestal();
+            } else {
+                throw new IllegalArgumentException(
+                        "No pedestal conditions exist for hodoscope channel ID \"" + channelID + "\".");
+            }
         }
-    }
-    
-    @Override
-    protected double getDAQPedestalConditions(long channelID) {        
-        return config.getPedestal((int)channelID);
-    }
+    }    
     
     @Override
     protected double getTimeShiftConditions(long channelID) {


### PR DESCRIPTION
After updates with application of DAQ configuration for 2019 MC, pedestal from DAQ configuration is forced to be applied in the digitization readout driver. It causes that the readout system cant not work well for 2016 MC since pedestal for 2016 MC is obtained from database. With the update for the issue, the pedestal is optionally obtained from DAQ configuration or database. It depends on if we apply the DAQ configuration driver at the beginning of the readout steering file.  For the current readout system in hps-java, pedestal is from DAQ configuration for 2019 MC, while pedestal is from database for 2016 MC.