### PR TITLE
Fixed pass0 steering files

### DIFF
--- a/steering-files/src/main/resources/org/hps/steering/recon/PhysicsRun2019_pass0_KFOnly.lcsim
+++ b/steering-files/src/main/resources/org/hps/steering/recon/PhysicsRun2019_pass0_KFOnly.lcsim
@@ -124,7 +124,7 @@
             <beamSigmaX>0.05</beamSigmaX>
             <beamPositionY>0.04</beamPositionY>
             <beamSigmaY>0.020</beamSigmaY>
-            <beamPositionZ>-10</beamPositionZ>
+            <beamPositionZ>-7.5</beamPositionZ>
             <maxElectronP>7.0</maxElectronP>
             <maxVertexP>7.0</maxVertexP>
             <minVertexChisqProb>0.0</minVertexChisqProb>
@@ -132,7 +132,7 @@
             <maxMatchDt>40</maxMatchDt>
             <trackClusterTimeOffset>40</trackClusterTimeOffset>
             <useCorrectedClusterPositionsForMatching>false</useCorrectedClusterPositionsForMatching>
-            <applyClusterCorrections>false</applyClusterCorrections>
+            <applyClusterCorrections>true</applyClusterCorrections>
             <useTrackPositionForClusterCorrection>false</useTrackPositionForClusterCorrection>
             <debug>false</debug>
 	    <makeMollerCols>false</makeMollerCols>

--- a/steering-files/src/main/resources/org/hps/steering/recon/PhysicsRun2019_pass0_recon.lcsim
+++ b/steering-files/src/main/resources/org/hps/steering/recon/PhysicsRun2019_pass0_recon.lcsim
@@ -337,7 +337,7 @@
             <maxMatchDt>40</maxMatchDt>
             <trackClusterTimeOffset>40</trackClusterTimeOffset>
             <useCorrectedClusterPositionsForMatching>false</useCorrectedClusterPositionsForMatching>
-            <applyClusterCorrections>true</applyClusterCorrections>
+            <applyClusterCorrections>false</applyClusterCorrections>
             <useTrackPositionForClusterCorrection>true</useTrackPositionForClusterCorrection>
             <debug>false</debug>
 	    <makeMollerCols>false</makeMollerCols>


### PR DESCRIPTION
Fixed the situation where either the Ecal cluster corrections were being applied twice, or not at all.
Also modified target z position to reflect current guess of -7.5mm.