### PR TITLE
Update PhysicsRun2019_pass0_recon.lcsim

### DIFF
--- a/steering-files/src/main/resources/org/hps/steering/recon/PhysicsRun2019_pass0_recon.lcsim
+++ b/steering-files/src/main/resources/org/hps/steering/recon/PhysicsRun2019_pass0_recon.lcsim
@@ -300,7 +300,7 @@
             <beamPositionY>0.04</beamPositionY>
             <beamSigmaY>0.020</beamSigmaY>
             <beamPositionZ>-7.5</beamPositionZ>
-            <maxElectronP>7.0</maxElectronP>
+            <maxElectronP>10.0</maxElectronP>
             <maxVertexP>7.0</maxVertexP>
             <minVertexChisqProb> 0.0 </minVertexChisqProb>
             <maxVertexClusterDt> 40.0 </maxVertexClusterDt>           
@@ -330,7 +330,7 @@
             <beamPositionY>0.04</beamPositionY>
             <beamSigmaY>0.020</beamSigmaY>
             <beamPositionZ>-7.5</beamPositionZ>
-            <maxElectronP>7.0</maxElectronP>
+            <maxElectronP>10.0</maxElectronP>
             <maxVertexP>7.0</maxVertexP>
             <minVertexChisqProb>0.0</minVertexChisqProb>
             <maxVertexClusterDt>40.0</maxVertexClusterDt>           


### PR DESCRIPTION
Increase maximum electron momentum from 7 to 10GeV to be included in FinalStateParticle collections. Until we fix the momentum reconstruction in the SVT top, cutting at 7GeV is too restrictive. Relax for now so we keep the higher momentum tracks in order to better understand what is going on.