### PR TITLE
Handle rare cases where KF track extrapolation fails

### DIFF
--- a/recon/src/main/java/org/hps/recon/utils/TrackClusterMatcherMinDistance.java
+++ b/recon/src/main/java/org/hps/recon/utils/TrackClusterMatcherMinDistance.java
@@ -328,6 +328,11 @@ public class TrackClusterMatcherMinDistance extends AbstractTrackClusterMatcher{
         else {
             TrackData trackdata = (TrackData) trackToData.from(track);
             TrackState ts_ecal = track.getTrackStates().get(track.getTrackStates().size()-1);
+            //If trackstate is null, upstream extrapolation error. Skip this
+            //Track
+            if(ts_ecal == null){
+                return null;
+            }
             double[] ts_ecalPos = ts_ecal.getReferencePoint();
             trackx = ts_ecalPos[1];
             tracky = ts_ecalPos[2];
@@ -425,6 +430,12 @@ public class TrackClusterMatcherMinDistance extends AbstractTrackClusterMatcher{
 
                 //Track positions depend on GBL or KF
                 List<Double> trackPos = this.getTrackPositionAtEcal(track);
+                //If trackPos null, Track extrapolation to Ecal failed. Skip.
+                if(trackPos == null){
+                    //
+                    trackClusterResidualsMap.put(track, null);
+                    continue;
+                }
                 double trackx = trackPos.get(0);
                 double tracky = trackPos.get(1);
                 double trackz = trackPos.get(2);
@@ -567,6 +578,10 @@ public class TrackClusterMatcherMinDistance extends AbstractTrackClusterMatcher{
             double trackPmag = new BasicHep3Vector(track.getTrackStates().get(0).getMomentum()).magnitude();
             //Track position
             List<Double> trackPos = this.getTrackPositionAtEcal(track);
+            //If trackPos is null, Track extrapolation to Ecal failed. Skip.
+            if(trackPos == null){
+                continue;
+            }
             double trackx = trackPos.get(0);
             double tracky = trackPos.get(1);
             double trackz = trackPos.get(2);
@@ -702,6 +717,10 @@ public class TrackClusterMatcherMinDistance extends AbstractTrackClusterMatcher{
             double smallestdr = 99999.0;
             Cluster smallestdrCluster = null;
             Map<Cluster, Double> cluster_dr_Map = trackClusterResidualsMap.get(track);
+            if(trackClusterResidualsMap == null){
+                Map.put(track, null);
+                continue;
+            }
             for(Cluster c : cluster_dr_Map.keySet()){
                 double dr = cluster_dr_Map.get(c);
                 if(dr < smallestdr){
@@ -728,6 +747,9 @@ public class TrackClusterMatcherMinDistance extends AbstractTrackClusterMatcher{
         boolean isTop;
 
         List<Double> trackPos = getTrackPositionAtEcal(track);
+        //If trackPos null, failed Track extrapolation. Skip Track
+        if(trackPos == null)
+            return;
         double trackx = trackPos.get(0);
         double tracky = trackPos.get(1);
         double trackz = trackPos.get(2);


### PR DESCRIPTION
Fixed rare bug in TrackClusterMatcherMinDistance. Check to make sure that trackstate at Ecal exists before matching Track to clusters. If no trackstate at Ecal, match this Track to null Cluster.