### PR TITLE
Iss864

### DIFF
--- a/recon/src/main/java/org/hps/recon/particle/HpsReconParticleDriver.java
+++ b/recon/src/main/java/org/hps/recon/particle/HpsReconParticleDriver.java
@@ -42,7 +42,7 @@ import hep.physics.vec.VecOp;
  * candidates and does vertex fits.
  */
 public class HpsReconParticleDriver extends ReconParticleDriver {
-    
+
     private Logger LOGGER = Logger.getLogger(HpsReconParticleDriver.class.getPackage().getName());
 
     /**
@@ -55,7 +55,7 @@ public class HpsReconParticleDriver extends ReconParticleDriver {
      * spot constraints.
      */
     protected String beamConMollerCandidatesColName = "BeamspotConstrainedMollerCandidates";
-    
+
     /**
      * LCIO collection name for Moller candidate particles generated with target
      * constraints.
@@ -118,31 +118,31 @@ public class HpsReconParticleDriver extends ReconParticleDriver {
     protected List<Vertex> unconstrainedVcVertices;
 
     private boolean makeConversionCols = true;
-    
+
     private boolean makeMollerCols = true;
-    
+
     private boolean includeUnmatchedTracksInFSP = true;
-        
+
     /**
-     * Whether to read beam positions from the conditions database.
-     * By default this is turned off.
+     * Whether to read beam positions from the conditions database. By default
+     * this is turned off.
      */
     private boolean useBeamPositionConditions = false;
-    
+
     /**
-     * Whether to use a fixed Z position for the 2016 run.
-     * By default this is turned on.
+     * Whether to use a fixed Z position for the 2016 run. By default this is
+     * turned on.
      */
     private boolean useFixedVertexZPosition = true;
 
     /**
      * The actual beam position passed to the vertex fitter.
-     * 
-     * This can come from the parent class's default or steering settings,
-     * or the conditions database, depending on flag settings.
+     *
+     * This can come from the parent class's default or steering settings, or
+     * the conditions database, depending on flag settings.
      */
     private double[] beamPositionToUse = new double[3];
-    private boolean requireClustersForV0=true;
+    private boolean requireClustersForV0 = true;
 
     /**
      * Represents a type of constraint for vertex fitting.
@@ -172,23 +172,23 @@ public class HpsReconParticleDriver extends ReconParticleDriver {
     public HpsReconParticleDriver() {
         super();
     }
-    
+
     protected void detectorChanged(Detector detector) {
 
         // Make sure super-class setup is activated.
         super.detectorChanged(detector);
-        
+
         // Setup optional usage of beam positions from database.
         final DatabaseConditionsManager mgr = DatabaseConditionsManager.getInstance();
         if (this.useBeamPositionConditions && mgr.hasConditionsRecord("beam_positions")) {
             LOGGER.config("Using beam position from conditions database");
-            BeamPositionCollection beamPositions = 
-                    mgr.getCachedConditions(BeamPositionCollection.class, "beam_positions").getCachedData();
-            BeamPosition beamPositionCond = beamPositions.get(0);            
+            BeamPositionCollection beamPositions
+                    = mgr.getCachedConditions(BeamPositionCollection.class, "beam_positions").getCachedData();
+            BeamPosition beamPositionCond = beamPositions.get(0);
             beamPositionToUse = new double[]{
-                    beamPositionCond.getPositionZ(),
-                    beamPositionCond.getPositionX(),
-                    beamPositionCond.getPositionY()
+                beamPositionCond.getPositionZ(),
+                beamPositionCond.getPositionX(),
+                beamPositionCond.getPositionY()
             };
             if (this.useFixedVertexZPosition) {
                 LOGGER.config("Using fixed Z position: " + this.beamPosition[0]);
@@ -249,34 +249,38 @@ public class HpsReconParticleDriver extends ReconParticleDriver {
     }
 
     /**
-     * This method used to activate usage of the internal map of run numbers to beam positions.
-     * 
-     * Now, it activates usage of the beam positions from the conditions database instead.
-     * This should result in the same behavior as before, and steering files should not need
-     * to be updated (though eventually they should be).
-     * 
+     * This method used to activate usage of the internal map of run numbers to
+     * beam positions.
+     *
+     * Now, it activates usage of the beam positions from the conditions
+     * database instead. This should result in the same behavior as before, and
+     * steering files should not need to be updated (though eventually they
+     * should be).
+     *
      * @deprecated Use {@link #setUseBeamPositionConditions(boolean)} instead.
      */
-    @Deprecated 
+    @Deprecated
     public void setUseInternalVertexXYPositions(boolean b) {
         // Changed this method to activate reading of conditions from the database. --JM
         this.useBeamPositionConditions = b;
         LOGGER.warning("The method HpsReconParticleDriver.setUseInternalVertexXYPositions() is deprecated.  Use setUseBeamPositionConditions() instead.");
     }
-    
+
     /**
      * Set whether to use beam positions from the database.
+     *
      * @param b True to use beam positions from the database
      */
     public void setUseBeamPositionConditions(boolean b) {
         this.useBeamPositionConditions = b;
     }
-        
-    public void setStoreCovTrkMomList(boolean b){
-        _storeCovTrkMomList=b;
+
+    public void setStoreCovTrkMomList(boolean b) {
+        _storeCovTrkMomList = b;
     }
-    public void setRequireClustersForV0(boolean b){
-        this.requireClustersForV0=b;
+
+    public void setRequireClustersForV0(boolean b) {
+        this.requireClustersForV0 = b;
     }
 
     /**
@@ -296,7 +300,7 @@ public class HpsReconParticleDriver extends ReconParticleDriver {
             // only use one target z position
             beamPositionToUse[0] = beamPosition[0];
         }
-        */
+         */
         if (makeMollerCols) {
             unconstrainedMollerCandidates = new ArrayList<ReconstructedParticle>();
             beamConMollerCandidates = new ArrayList<ReconstructedParticle>();
@@ -314,17 +318,17 @@ public class HpsReconParticleDriver extends ReconParticleDriver {
         super.process(event);
 
         if (makeMollerCols) {
-            event.put(unconstrainedMollerCandidatesColName, unconstrainedMollerCandidates, ReconstructedParticle.class,0);
-            event.put(beamConMollerCandidatesColName, beamConMollerCandidates, ReconstructedParticle.class,0);
-            event.put(targetConMollerCandidatesColName, targetConMollerCandidates, ReconstructedParticle.class,0);
-            event.put(unconstrainedMollerVerticesColName, unconstrainedMollerVertices, Vertex.class,0);
-            event.put(beamConMollerVerticesColName, beamConMollerVertices, Vertex.class,0);
-            event.put(targetConMollerVerticesColName, targetConMollerVertices, Vertex.class,0);
+            event.put(unconstrainedMollerCandidatesColName, unconstrainedMollerCandidates, ReconstructedParticle.class, 0);
+            event.put(beamConMollerCandidatesColName, beamConMollerCandidates, ReconstructedParticle.class, 0);
+            event.put(targetConMollerCandidatesColName, targetConMollerCandidates, ReconstructedParticle.class, 0);
+            event.put(unconstrainedMollerVerticesColName, unconstrainedMollerVertices, Vertex.class, 0);
+            event.put(beamConMollerVerticesColName, beamConMollerVertices, Vertex.class, 0);
+            event.put(targetConMollerVerticesColName, targetConMollerVertices, Vertex.class, 0);
 
         }
         if (makeConversionCols) {
-            event.put(unconstrainedVcCandidatesColName, unconstrainedVcCandidates, ReconstructedParticle.class,0);
-            event.put(unconstrainedVcVerticesColName, unconstrainedVcVertices, Vertex.class,0);
+            event.put(unconstrainedVcCandidatesColName, unconstrainedVcCandidates, ReconstructedParticle.class, 0);
+            event.put(unconstrainedVcVerticesColName, unconstrainedVcVertices, Vertex.class, 0);
         }
     }
 
@@ -373,12 +377,11 @@ public class HpsReconParticleDriver extends ReconParticleDriver {
                 if (TrackType.isGBL(positron.getType()) != TrackType.isGBL(electron.getType())) {
                     continue;
                 }
-                
+
                 // Make V0 candidates
                 try {
                     this.makeV0Candidates(electron, positron);
-                }
-                catch (RuntimeException e) {
+                } catch (RuntimeException e) {
                     e.printStackTrace();
                     System.out.println("HpsReconParticleDriver::makeV0Candidates fails:: skipping ele/pos pair.");
                     continue;
@@ -571,14 +574,13 @@ public class HpsReconParticleDriver extends ReconParticleDriver {
      *
      */
     private void makeV0Candidates(ReconstructedParticle electron, ReconstructedParticle positron) {
-        
+
         //boolean eleIsTop = (electron.getTracks().get(0).getTrackerHits().get(0).getPosition()[2] > 0);
         //boolean posIsTop = (positron.getTracks().get(0).getTrackerHits().get(0).getPosition()[2] > 0);
-        
         //This eleIsTop/posIsTop logic is valid for all track types [both Helix+GBL and Kalman]
         boolean eleIsTop = (electron.getTracks().get(0).getTrackStates().get(0).getTanLambda() > 0);
         boolean posIsTop = (positron.getTracks().get(0).getTrackStates().get(0).getTanLambda() > 0);
-        
+
         if ((eleIsTop == posIsTop) && (!makeConversionCols)) {
             return;
         }
@@ -586,10 +588,10 @@ public class HpsReconParticleDriver extends ReconParticleDriver {
         if (electron.getClusters() == null || positron.getClusters() == null) {
             return;
         }
-        if (requireClustersForV0&&(electron.getClusters().isEmpty() || positron.getClusters().isEmpty())) {
+        if (requireClustersForV0 && (electron.getClusters().isEmpty() || positron.getClusters().isEmpty())) {
             return;
         }
-        if(requireClustersForV0){
+        if (requireClustersForV0) {
             double eleClusTime = ClusterUtilities.getSeedHitTime(electron.getClusters().get(0));
             double posClusTime = ClusterUtilities.getSeedHitTime(positron.getClusters().get(0));
 
@@ -610,7 +612,7 @@ public class HpsReconParticleDriver extends ReconParticleDriver {
         if (candidate.getStartVertex().getProbability() < cuts.getMinVertexChisqProb()) {
             return;
         }
-        
+
         // patch the track parameters at the found vertex
         if (_patchVertexTrackParameters) {
             patchVertex(vtxFit);
@@ -625,8 +627,9 @@ public class HpsReconParticleDriver extends ReconParticleDriver {
 
         // Create candidate particles for the other two constraints.
         for (Constraint constraint : Constraint.values()) {
-            if(constraint == Constraint.UNCONSTRAINED) continue;           // Skip the UNCONSTRAINED case, done already
-            
+            if (constraint == Constraint.UNCONSTRAINED) {
+                continue;           // Skip the UNCONSTRAINED case, done already
+            }
             // Generate a candidate vertex and particle.
             vtxFit = fitVertex(constraint, electron, positron);
 

--- a/recon/src/main/java/org/hps/recon/particle/ReconParticleDriver.java
+++ b/recon/src/main/java/org/hps/recon/particle/ReconParticleDriver.java
@@ -57,8 +57,8 @@ public abstract class ReconParticleDriver extends Driver {
     protected boolean isMC = false;
     private boolean disablePID = false;
     protected StandardCuts cuts = new StandardCuts();
-    RelationalTable hitToRotated = null;
-    RelationalTable hitToStrips = null;
+//    RelationalTable hitToRotated = null;
+//    RelationalTable hitToStrips = null;
     //Track to Cluster matching algorithms interfaced from
     //TrackClusteMatcherInter and the specific algorithm is chosen by name using
     //TrackClusterMatcherFactory 
@@ -714,8 +714,8 @@ public abstract class ReconParticleDriver extends Driver {
             }
         }
 
-        hitToRotated = TrackUtils.getHitToRotatedTable(event);
-        hitToStrips = TrackUtils.getHitToStripsTable(event);
+//        hitToRotated = TrackUtils.getHitToRotatedTable(event);
+//        hitToStrips = TrackUtils.getHitToStripsTable(event);
 
         // Instantiate new lists to store reconstructed particles and
         // V0 candidate particles and vertices.

--- a/recon/src/main/java/org/hps/recon/particle/ReconParticleDriver.java
+++ b/recon/src/main/java/org/hps/recon/particle/ReconParticleDriver.java
@@ -14,7 +14,6 @@ import java.util.Set;
 
 import org.hps.conditions.beam.BeamEnergy.BeamEnergyCollection;
 import org.hps.recon.tracking.CoordinateTransformations;
-import org.hps.recon.tracking.TrackUtils;
 import org.hps.record.StandardCuts;
 
 import org.hps.recon.utils.TrackClusterMatcher;
@@ -23,7 +22,6 @@ import org.hps.recon.utils.TrackClusterMatcherFactory;
 import org.lcsim.event.Cluster;
 import org.lcsim.event.EventHeader;
 import org.lcsim.event.ReconstructedParticle;
-import org.lcsim.event.RelationalTable;
 import org.lcsim.event.Track;
 import org.lcsim.event.Vertex;
 import org.lcsim.event.base.BaseCluster;

--- a/steering-files/src/main/resources/org/hps/steering/recon/PhysicsRun2019_pass0_KFOnly.lcsim
+++ b/steering-files/src/main/resources/org/hps/steering/recon/PhysicsRun2019_pass0_KFOnly.lcsim
@@ -111,7 +111,9 @@
           
         <driver name="ReconParticleDriver_Kalman" type="org.hps.recon.particle.HpsReconParticleDriver" > 
             <ecalClusterCollectionName>EcalClustersCorr</ecalClusterCollectionName>
-            <trackCollectionNames>KalmanFullTracks</trackCollectionNames>          
+            <trackCollectionNames>KalmanFullTracks</trackCollectionNames>  
+            <matcherTrackCollectionName>KalmanFullTracks</matcherTrackCollectionName>
+            <trackClusterMatcherAlgo>TrackClusterMatcherMinDistance</trackClusterMatcherAlgo>        
             <unconstrainedV0CandidatesColName>UnconstrainedV0Candidates_KF</unconstrainedV0CandidatesColName>
             <unconstrainedV0VerticesColName>UnconstrainedV0Vertices_KF</unconstrainedV0VerticesColName>
             <beamConV0CandidatesColName>BeamspotConstrainedV0Candidates_KF</beamConV0CandidatesColName>
@@ -127,7 +129,7 @@
             <beamPositionY>0.04</beamPositionY>
             <beamSigmaY>0.020</beamSigmaY>
             <beamPositionZ>-7.5</beamPositionZ>
-            <maxElectronP>7.0</maxElectronP>
+            <maxElectronP>10.0</maxElectronP>
             <maxVertexP>7.0</maxVertexP>
             <minVertexChisqProb>0.0</minVertexChisqProb>
             <maxVertexClusterDt>40.0</maxVertexClusterDt>           
@@ -135,7 +137,7 @@
             <trackClusterTimeOffset>40</trackClusterTimeOffset>
             <useCorrectedClusterPositionsForMatching>false</useCorrectedClusterPositionsForMatching>
             <applyClusterCorrections>true</applyClusterCorrections>
-            <useTrackPositionForClusterCorrection>false</useTrackPositionForClusterCorrection>
+            <useTrackPositionForClusterCorrection>true</useTrackPositionForClusterCorrection>
             <debug>false</debug>
 	    <makeMollerCols>false</makeMollerCols>
         </driver>  

--- a/steering-files/src/main/resources/org/hps/steering/recon/PhysicsRun2019_pass0_KFOnly.lcsim
+++ b/steering-files/src/main/resources/org/hps/steering/recon/PhysicsRun2019_pass0_KFOnly.lcsim
@@ -89,7 +89,7 @@
        
         <driver name="TrackerHitDriver" type="org.hps.recon.tracking.DataTrackerHitDriver">
             <neighborDeltaT>8.0</neighborDeltaT>
-            <saveMonsterEvents>false</saveMonsterEvents>
+            <saveMonsterEvents>true</saveMonsterEvents>
             <thresholdMonsterEvents>200</thresholdMonsterEvents>
             <debug>false</debug>
         </driver>

--- a/steering-files/src/main/resources/org/hps/steering/recon/PhysicsRun2019_pass0_KFOnly.lcsim
+++ b/steering-files/src/main/resources/org/hps/steering/recon/PhysicsRun2019_pass0_KFOnly.lcsim
@@ -31,8 +31,10 @@
         <driver name="RawTrackerHitFitterDriver" />
         <driver name="TrackerHitDriver"/>
 
+        <!--
         <driver name="HelicalTrackHitDriver"/> 
-        
+        -->
+
         <driver name="KalmanPatRecDriver"/>
         <driver name="ReconParticleDriver_Kalman" /> 
         


### PR DESCRIPTION
I removed superfluous code in ReconParticleDriver that accessed the rotated helical track hits for no reason.
One can now run the Kalman Filter track finding and fitting without having to create HelicalTrackHits.
The [KF only steering file](https://github.com/JeffersonLab/hps-java/compare/master...iss864#diff-486de823c08371045aebe80b2e41e45995f8031b417d0fbfa0b1f97bdf615272) has been modified to remove that Driver.
It has also been updated to use the distance-based track cluster matcher.
It also now keeps monster events instead of zeroing out the 1D strip hit collection.