### PR TITLE
Iss872

### DIFF
--- a/tracking/src/main/java/org/hps/recon/tracking/RawTrackerHitFitterDriver.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/RawTrackerHitFitterDriver.java
@@ -50,7 +50,7 @@ public class RawTrackerHitFitterDriver extends Driver {
 
     private double tsCorrectionScale = 240;
 
-    private boolean _dropOutOfTimeFits = true;
+    private boolean _dropOutOfTimeFits = false;
     private double _minT0 = -50;
     private double _maxT0 = 50.;
 


### PR DESCRIPTION
In cases where the APV25 waveform is fit to two pulses, this code only saves the fit whose time is closer to t=0.
Additionally, all fits with times less than a settable time _minT0_ or greater than a settable time _maxT0_ can be dropped by setting _dropOutOfTimeFits_ in the steering file.

This pull request produces some differences to three of the integration test plots, so will require the reference plots to be updated. 

Failed tests:
  EngRun2015V0ReconTest>ReconTest.testRecon:380->ReconTest.comparePlots:252->ReconTest.compareTrees:272->ReconTest.compareHistograms:293 Bin 99 is different for: V0 Vertex x expected:<63> but was:<64>
  PhysRun2016MollerReconTest>ReconTest.testRecon:380->ReconTest.comparePlots:252->ReconTest.compareTrees:272->ReconTest.compareHistograms:293 Bin 61 is different for: Moller Bottom Track Momentum expected:<119> but was:<118>
  PhysRun2016V0ReconTest>ReconTest.testRecon:380->ReconTest.comparePlots:252->ReconTest.compareTrees:272->ReconTest.compareHistograms:293 Bin 66 is different for: V0 Track Chisq Prob expected:<89> but was:<90>


