### PR TITLE
Modify PhysicsRun2019MCRecon.lcsim to solve a bug 

### DIFF
--- a/steering-files/src/main/resources/org/hps/steering/recon/PhysicsRun2019MCRecon.lcsim
+++ b/steering-files/src/main/resources/org/hps/steering/recon/PhysicsRun2019MCRecon.lcsim
@@ -157,6 +157,8 @@
         <driver name="ReconParticleDriver" type="org.hps.recon.particle.HpsReconParticleDriver" > 
             <ecalClusterCollectionName>EcalClustersCorr</ecalClusterCollectionName>
             <trackCollectionNames>GBLTracks</trackCollectionNames>
+            <matcherTrackCollectionName>GBLTracks</matcherTrackCollectionName>
+            <trackClusterMatcherAlgo>TrackClusterMatcherMinDistance</trackClusterMatcherAlgo>
             <beamPositionX> 0 </beamPositionX>
             <beamSigmaX> 0.05 </beamSigmaX>
             <beamPositionY> 0 </beamPositionY>
@@ -174,6 +176,8 @@
         <driver name="ReconParticleDriver_Kalman" type="org.hps.recon.particle.HpsReconParticleDriver" > 
             <ecalClusterCollectionName>EcalClustersCorr</ecalClusterCollectionName>
             <trackCollectionNames>KalmanFullTracks</trackCollectionNames>
+            <matcherTrackCollectionName>KalmanFullTracks</matcherTrackCollectionName>
+            <trackClusterMatcherAlgo>TrackClusterMatcherMinDistance</trackClusterMatcherAlgo>
             <unconstrainedV0CandidatesColName>UnconstrainedV0Candidates_KF</unconstrainedV0CandidatesColName>
             <unconstrainedV0VerticesColName>UnconstrainedV0Vertices_KF</unconstrainedV0VerticesColName>
             <beamConV0CandidatesColName>BeamspotConstrainedV0Candidates_KF</beamConV0CandidatesColName>
@@ -181,6 +185,7 @@
             <targetConV0CandidatesColName>TargetConstrainedV0Candidates_KF</targetConV0CandidatesColName>
             <targetConV0VerticesColName>TargetConstrainedV0Vertices_KF</targetConV0VerticesColName>
             <finalStateParticlesColName>FinalStateParticles_KF</finalStateParticlesColName>
+            <otherElectronsColName>OtherElectrons_KF</otherElectronsColName>
             <beamPositionX> 0  </beamPositionX>
             <beamSigmaX> 0.05 </beamSigmaX>
             <beamPositionY> 0 </beamPositionY>

--- a/steering-files/src/main/resources/org/hps/steering/recon/PhysicsRun2019MCRecon.lcsim
+++ b/steering-files/src/main/resources/org/hps/steering/recon/PhysicsRun2019MCRecon.lcsim
@@ -7,7 +7,6 @@
     <execute>
         <driver name="EventMarkerDriver"/>
         <!-- Ecal reconstruction drivers -->        
-        <driver name="EcalRunningPedestal"/>
         <driver name="EcalRawConverter" />
         <driver name="EcalTimeCorrection"/>
         <driver name="ReconClusterer" />
@@ -43,9 +42,6 @@
             <eventInterval>10</eventInterval>
         </driver>
         <!-- Ecal reconstruction drivers -->
-        <driver name="EcalRunningPedestal" type="org.hps.recon.ecal.EcalRunningPedestalDriver">
-            <logLevel>CONFIG</logLevel>
-        </driver>
         <driver name="EcalRawConverter" type="org.hps.recon.ecal.EcalRawConverter2Driver"/>
         <driver name="EcalTimeCorrection" type="org.hps.recon.ecal.EcalTimeCorrectionDriver"/>
         <driver name="ReconClusterer" type="org.hps.recon.ecal.cluster.ReconClusterDriver">
@@ -173,6 +169,7 @@
             <maxElectronP>7.0</maxElectronP> 
             <maxVertexP>7.0</maxVertexP>
             <requireClustersForV0>false</requireClustersForV0>
+	    <applyClusterCorrections>true</applyClusterCorrections>
         </driver>         
         <driver name="ReconParticleDriver_Kalman" type="org.hps.recon.particle.HpsReconParticleDriver" > 
             <ecalClusterCollectionName>EcalClustersCorr</ecalClusterCollectionName>
@@ -196,6 +193,7 @@
             <maxElectronP>7.0</maxElectronP>
             <maxVertexP>7.0</maxVertexP>
             <requireClustersForV0>false</requireClustersForV0>
+	    <applyClusterCorrections>false</applyClusterCorrections>
         </driver>         
         <driver name="GBLRefitterDriver" type="org.hps.recon.tracking.gbl.GBLRefitterDriver"/>        
         <driver name="KalmanPatRecDriver" type="org.hps.recon.tracking.kalman.KalmanPatRecDriver">

--- a/steering-files/src/main/resources/org/hps/steering/recon/PhysicsRun2019MCRecon.lcsim
+++ b/steering-files/src/main/resources/org/hps/steering/recon/PhysicsRun2019MCRecon.lcsim
@@ -32,8 +32,8 @@
         <driver name="KalmanPatRecDriver"/> 
         <driver name="TrackTruthMatching_KF" />
         <driver name="TrackTruthMatching_GBL" /> 
-        <driver name="ReconParticleDriver" />
         <driver name="ReconParticleDriver_Kalman" />
+        <driver name="ReconParticleDriver" />
         <driver name="LCIOWriter"/>
         <driver name="CleanupDriver"/>
     </execute>    
@@ -169,7 +169,7 @@
             <maxElectronP>7.0</maxElectronP> 
             <maxVertexP>7.0</maxVertexP>
             <requireClustersForV0>false</requireClustersForV0>
-	    <applyClusterCorrections>true</applyClusterCorrections>
+            <applyClusterCorrections>false</applyClusterCorrections>
         </driver>         
         <driver name="ReconParticleDriver_Kalman" type="org.hps.recon.particle.HpsReconParticleDriver" > 
             <ecalClusterCollectionName>EcalClustersCorr</ecalClusterCollectionName>
@@ -193,7 +193,7 @@
             <maxElectronP>7.0</maxElectronP>
             <maxVertexP>7.0</maxVertexP>
             <requireClustersForV0>false</requireClustersForV0>
-	    <applyClusterCorrections>false</applyClusterCorrections>
+            <applyClusterCorrections>true</applyClusterCorrections>
         </driver>         
         <driver name="GBLRefitterDriver" type="org.hps.recon.tracking.gbl.GBLRefitterDriver"/>        
         <driver name="KalmanPatRecDriver" type="org.hps.recon.tracking.kalman.KalmanPatRecDriver">

--- a/steering-files/src/main/resources/org/hps/steering/recon/PhysicsRun2019MCRecon_LCIO.lcsim
+++ b/steering-files/src/main/resources/org/hps/steering/recon/PhysicsRun2019MCRecon_LCIO.lcsim
@@ -14,7 +14,7 @@
         <driver name="EcalRawConverter" />
         <driver name="EcalTimeCorrection"/>
         <driver name="ReconClusterer" />
-	    <driver name="CopyCluster" />
+        <driver name="CopyCluster" />
 
         <driver name="HodoRunningPedestal"/>
         <driver name="HodoRawConverter"/> -->
@@ -31,25 +31,21 @@
         
         <driver name="TrackReconSeed123Conf4Extd56"/>    
         <driver name="TrackReconSeed123Conf5Extd46"/>
-	    <driver name="TrackReconSeed567Conf4Extd123"/> 
+        <driver name="TrackReconSeed567Conf4Extd123"/> 
         <driver name="TrackReconSeed456Conf3Extd127"/> 
         <driver name="TrackReconSeed356Conf7Extd124"/>  
         <driver name="TrackReconSeed235Conf6Extd147"/> 
         
         <!-- <driver name="TrackReconSeed234Conf6Extd157"/> -->
         
-        
-        
         <driver name="MergeTrackCollections"/>
         <driver name="GBLRefitterDriver" />
         <driver name="TrackDataDriver" />
         <driver name="TrackTruthMatching_GBL" /> 
-        <driver name="ReconParticleDriver" />
-        
-        
         <driver name="KalmanPatRecDriver"/> 
         <driver name="TrackTruthMatching_KF" />
         <driver name="ReconParticleDriver_Kalman" />
+        <driver name="ReconParticleDriver" />
         <driver name="LCIOWriter"/>
         <driver name="CleanupDriver"/>
     
@@ -152,7 +148,7 @@
             <clusterTimeCut>100.0</clusterTimeCut>
             <maxDt>100.0</maxDt>
             <clusterAmplitudeCut>400.0</clusterAmplitudeCut>
-	    </driver>
+        </driver>
         
 
         <!-- 
@@ -163,7 +159,7 @@
             <trackCollectionName>Tracks_s123_c4_e56</trackCollectionName>
             <strategyResource>HPS_s123_c4_e56_4hit.xml</strategyResource>
             <debug>false</debug>
-	        <rmsTimeCut>1000.0</rmsTimeCut>
+            <rmsTimeCut>1000.0</rmsTimeCut>
             <maxTrackerHits>250</maxTrackerHits>
         </driver>
         
@@ -171,7 +167,7 @@
             <trackCollectionName>Tracks_s123_c5_e46</trackCollectionName>
             <strategyResource>HPS_s123_c5_e46_4hit.xml</strategyResource>
             <debug>false</debug>
-	        <rmsTimeCut>1000.0</rmsTimeCut>
+            <rmsTimeCut>1000.0</rmsTimeCut>
             <maxTrackerHits>250</maxTrackerHits>
         </driver>
 
@@ -179,7 +175,7 @@
             <trackCollectionName>Tracks_s567_c4_e123</trackCollectionName>
             <strategyResource>HPS_s567_c4_e123.xml</strategyResource>
             <debug>false</debug>
-	        <rmsTimeCut>1000.0</rmsTimeCut>
+            <rmsTimeCut>1000.0</rmsTimeCut>
             <maxTrackerHits>250</maxTrackerHits>
         </driver>
 
@@ -211,7 +207,7 @@
             <trackCollectionName>Tracks_s234_c5_e157</trackCollectionName>
             <strategyResource>HPS_s234_c5_e167_4hit.xml</strategyResource>
             <debug>false</debug>
-	        <rmsTimeCut>1000.0</rmsTimeCut>
+            <rmsTimeCut>1000.0</rmsTimeCut>
             <maxTrackerHits>250</maxTrackerHits>
         </driver>
 
@@ -222,6 +218,8 @@
         <driver name="ReconParticleDriver" type="org.hps.recon.particle.HpsReconParticleDriver" > 
             <ecalClusterCollectionName>EcalClustersCorr</ecalClusterCollectionName>
             <trackCollectionNames>GBLTracks</trackCollectionNames>
+            <matcherTrackCollectionName>GBLTracks</matcherTrackCollectionName>
+            <trackClusterMatcherAlgo>TrackClusterMatcherMinDistance</trackClusterMatcherAlgo>
             <beamPositionX> 0 </beamPositionX>
             <beamSigmaX> 0.05 </beamSigmaX>
             <beamPositionY> 0 </beamPositionY>
@@ -231,6 +229,7 @@
             <useInternalVertexXYPositions>false</useInternalVertexXYPositions>
             <minVertexChisqProb> 0.0 </minVertexChisqProb>
             <requireClustersForV0>false</requireClustersForV0>
+            <applyClusterCorrections>false</applyClusterCorrections>
             <disablePID>true</disablePID>
         </driver>         
 
@@ -238,12 +237,15 @@
         <driver name="ReconParticleDriver_Kalman" type="org.hps.recon.particle.HpsReconParticleDriver" > 
             <ecalClusterCollectionName>EcalClustersCorr</ecalClusterCollectionName>
             <trackCollectionNames>KalmanFullTracks</trackCollectionNames>
+            <matcherTrackCollectionName>KalmanFullTracks</matcherTrackCollectionName>
+            <trackClusterMatcherAlgo>TrackClusterMatcherMinDistance</trackClusterMatcherAlgo>
             <unconstrainedV0CandidatesColName>UnconstrainedV0Candidates_KF</unconstrainedV0CandidatesColName>
             <unconstrainedV0VerticesColName>UnconstrainedV0Vertices_KF</unconstrainedV0VerticesColName>
             <beamConV0CandidatesColName>BeamspotConstrainedV0Candidates_KF</beamConV0CandidatesColName>
             <beamConV0VerticesColName>BeamspotConstrainedV0Vertices_KF</beamConV0VerticesColName>
             <targetConV0CandidatesColName>TargetConstrainedV0Candidates_KF</targetConV0CandidatesColName>
             <targetConV0VerticesColName>TargetConstrainedV0Vertices_KF</targetConV0VerticesColName>
+            <otherElectronsColName>OtherElectrons_KF</otherElectronsColName>
             <beamPositionX> 0  </beamPositionX>
             <beamSigmaX> 0.05 </beamSigmaX>
             <beamPositionY> 0 </beamPositionY>
@@ -253,6 +255,7 @@
             <useInternalVertexXYPositions>false</useInternalVertexXYPositions>
             <minVertexChisqProb> 0.0 </minVertexChisqProb>
             <requireClustersForV0>false</requireClustersForV0>
+            <applyClusterCorrections>true</applyClusterCorrections>
             <disablePID>true</disablePID>
         </driver>         
 


### PR DESCRIPTION
Modify PhysicsRun2019MCRecon.lcsim to solve a bug  that the Ecal cluster corrections are applied twice when recon particles by both GBL and KF tracks. Meanwhile, following what we did for 2016 MC, pedestals from DB are applied for MC, instead of running pedestal. So EcalRunningPedestal is removed.