### PR TITLE
add readout and recon steering files for 2021 trigger tuning

### DIFF
--- a/steering-files/src/main/resources/org/hps/steering/readout/TriggerTuning2021TrigPulse.lcsim
+++ b/steering-files/src/main/resources/org/hps/steering/readout/TriggerTuning2021TrigPulse.lcsim
@@ -1,0 +1,365 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lcsim xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+       xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/lcsim/1.0/lcsim.xsd">
+    <!-- 
+      @Readout steering file with pulse trigger for 2021 MC samples,
+      where are produced for 2021 trigger tuning analysis.
+      @author <a href="mailto:caot@jlab.org">Tongtong Cao</a>
+    -->
+    <execute>
+        <!-- Parameters in the DAQ configuration are applied by the
+             	     readout system -->
+        <driver name="DAQConfig2019"/>
+
+        <!-- SLiC Data Readout Drivers -->
+        <driver name="EcalHitsOutputDriver"/>
+        <driver name="MCParticleOutputDriver"/>
+        <driver name="HodoscopeHitsOutputDriver"/>
+        <driver name="TrackerHitsSVTOutputDriver"/>
+        <driver name="TrackerHitsEcalOutputDriver"/>
+        
+        <!-- SVT Readout Drivers -->
+        <driver name="SVTReadoutDriver" />
+        
+        <!-- Hodoscope Readout Simulation Drivers -->
+        <driver name="HodoscopePreprocessingDriver"/>
+        <driver name="HodoscopeDigitizationDriver"/>
+        <driver name="HodoscopeRawConverterDriver"/>
+
+        
+        <!-- Calorimeter Readout Simulation Drivers -->
+        <driver name="EcalDigitizationDriver"/>
+        <driver name="EcalRawConverterDriver"/>
+        <driver name="GTPReadoutDriver"/>
+ 
+        
+        <!-- Trigger Simulation -->
+        <driver name="PulseTrigger"/>
+        
+        <!-- LCIO Output and Data Management Driver -->
+        <driver name="ReadoutManagerDriver"/>
+        
+        <driver name="CleanupDriver" />
+    </execute> 
+    
+    <drivers>
+        <!--
+             	     The driver handles the DAQ configuration
+	-->
+        <driver name="DAQConfig2019" type="org.hps.record.daqconfig2019.DAQConfig2019Driver">
+            <daqConfigurationAppliedintoReadout>true</daqConfigurationAppliedintoReadout>      
+        </driver>
+
+        <!--
+             Truth handler drivers load truth information from the input SLIC file
+             and pass them off to the readout data manager, where they may be
+             accessed by other readout drivers.
+             
+             It is required that these drivers specify the name of the collection
+             that they manage, and be of the appropriate handler type that matches
+             the object type of the collection. They may also, optionally, specify
+             whether the truth collection managed by the driver should be output
+             into the readout file, and if so, over what time range.
+             
+             By default, SLIC truth data is not written out. If no output window is
+             specified, and truth is written, the output window will be derived
+             from the readout window and trigger offset parameters of the readout
+             data manager.
+             
+             In general, calorimeter truth information (and the related particles
+             data) are best handled by including truth readout in the calorimeter
+             simulation. This will automatically include all calorimeter truth hits
+             and related MC particles in the readout file.
+          -->
+        <driver name="EcalHitsOutputDriver" type="org.hps.readout.SimCalorimeterHitReadoutDriver">
+            <collectionName>EcalHits</collectionName>
+            
+            <!-- Units of ns. -->
+            <readoutWindowBefore>8.0</readoutWindowBefore>
+            <readoutWindowAfter>32.0</readoutWindowAfter>
+            <persistent>false</persistent>
+        </driver>
+        
+        <driver name="MCParticleOutputDriver" type="org.hps.readout.MCParticleReadoutDriver">
+            <collectionName>MCParticle</collectionName>
+            
+            <!-- Units of ns. -->
+            <readoutWindowBefore>32.0</readoutWindowBefore>
+            <readoutWindowAfter>32.0</readoutWindowAfter>
+            <persistent>false</persistent>
+        </driver>
+        
+        <driver name="TrackerHitsSVTOutputDriver" type="org.hps.readout.svt.SVTTrackerHitReadoutDriver">
+            <collectionName>TrackerHits</collectionName>
+            <readoutWindowBefore>8.0</readoutWindowBefore>
+            <readoutWindowAfter>32.0</readoutWindowAfter>
+            <persistent>false</persistent>
+        </driver>
+        
+        <driver name="TrackerHitsEcalOutputDriver" type="org.hps.readout.SimTrackerHitReadoutDriver">
+            <collectionName>TrackerHitsECal</collectionName>
+            <readoutWindowBefore>8.0</readoutWindowBefore>
+            <readoutWindowAfter>32.0</readoutWindowAfter>
+            <persistent>false</persistent>
+        </driver>
+        
+        <driver name="HodoscopeHitsOutputDriver" type="org.hps.readout.SimTrackerHitReadoutDriver">
+            <collectionName>HodoscopeHits</collectionName>
+            
+            <!-- Units of ns. -->
+            <readoutWindowBefore>8.0</readoutWindowBefore>
+            <readoutWindowAfter>32.0</readoutWindowAfter>
+            <persistent>false</persistent>
+        </driver>
+        
+        
+        <!--
+            The SVT driver. Works just like before. Documentation is left to
+            the SVT group.
+        -->
+
+        <driver name="SVTReadoutDriver" type="org.hps.readout.svt.SVTReadoutDriver">
+            <enablePileupCut>false</enablePileupCut>
+            <useTimingConditions>true</useTimingConditions>
+            <addNoise>true</addNoise>
+        </driver>
+  
+        <!--
+             The calorimeter readout driver handles conversion of SLIC truth
+             hits into voltage pulses and ultimately into ADC counts every 4 ns
+             sample. These samples are then integrated and output as hits which
+             are used internally by the readout simulation in the collection
+             set by variable "outputHitCollectionName".
+             
+             When a trigger occurs, the ADC buffer is used to generate readout
+             hits. The exact form these take differs based on the mode that is
+             simulated, but they are always output to the collection defined by
+             variable "readoutHitCollectionName".
+             
+             If truth information is enabled, then a set of truth relations are
+             output as well that link each readout hit to all of the truth hits
+             that are associated with it. Additionally, all truth hits as well
+             as the particle (and its parents) that generated that truth hit
+             are written out to ensure that they are available post-readout.
+             The additional truth information is automatically written to the
+             same collection name as the input truth data. If a truth handler
+             driver also outputs data into this collection, the two will merge.
+          -->
+        <driver name="EcalDigitizationDriver" type="org.hps.readout.ecal.updated.EcalDigitizationReadoutDriver">
+            <!-- LCIO Collection Names -->
+            <inputHitCollectionName>EcalHits</inputHitCollectionName>
+            <outputHitCollectionName>EcalRawHits</outputHitCollectionName>
+            <readoutHitCollectionName>EcalReadoutHits</readoutHitCollectionName>
+            <truthRelationsCollectionName>EcalTruthRelations</truthRelationsCollectionName>
+            <triggerPathTruthRelationsCollectionName>TriggerPathTruthRelations</triggerPathTruthRelationsCollectionName>
+
+            <daqConfigurationAppliedintoReadout>true</daqConfigurationAppliedintoReadout>   
+            
+            <!-- Driver Parameters -->
+            <mode>1</mode>                                  <!-- Allowed values: 1, 3, or 7. -->
+            <addNoise>true</addNoise>
+            
+            <!-- 
+                 Readout offset is not the same as the old system - it measures
+                 amount of samples that are included before the trigger time in
+                 the ADC readout window. The old version can be converted by
+                 selecting a readout window equal to (readoutLatency - 64).
+              -->
+            <readoutOffset>10</readoutOffset>               <!-- Units of 4 ns clock-cycles. -->
+            
+            <!--
+                The digitization driver produces as output a list of ADC values
+                within a specified window, in emulation of Mode-1 data. This
+                removes the truth information that is otherwise present in the
+                original SLiC output. Setting this option to true creates new
+                LCRelation objects that link the ADC list to the truth hits that
+                created it and stores this in readout. For production running,
+                this should generally be off to save space. Truth hits will be
+                included in readout automatically - the truth hit driver above
+                does not need to be persistent.
+            -->
+            <writeTruth>true</writeTruth>
+            
+            <!--
+                As above, except that truth relations are persisted for the
+                readout hits that are seen by the clusterer and trigger. This
+                is useful if some analysis needs to be performed at the readout
+                level. Otherwise, this should be left off.
+            -->
+            <writeTriggerPathTruth>false</writeTriggerPathTruth>
+        </driver>
+
+        <!--
+                          The raw converter handles the conversion of simulated ADC pulses from
+             the calorimeter readout driver into proper hits that can be used for
+             triggering.
+             
+             Note that it allows for these hits to be written to LCIO if desired,
+             though by default they are not persisted. This is generally unneeded,
+             since the clusterer will automatically output the hits which appear in
+             GTP clusters if cluster output is enabled.
+          -->
+        <driver name="EcalRawConverterDriver" type="org.hps.readout.ecal.updated.EcalRawConverterReadoutDriver">
+			<inputCollectionName>EcalRawHits</inputCollectionName>
+			<outputCollectionName>EcalCorrectedHits</outputCollectionName>
+
+            <daqConfigurationAppliedintoReadout>true</daqConfigurationAppliedintoReadout>   
+
+            <!--
+                                 Outputs all the trigger-level hits within the readout window.
+                This is not generally necessary outside of specialized
+                circumstances. Note that all readout hits associated with GTP
+                clusters will automatically be included if GTP clusters are
+                persisted.
+            -->
+            <persistent>false</persistent>
+        </driver>
+        
+        <!--
+                          The GTP clusterer creates clusters from converted calorimeter hits
+             for use in the trigger. It take two parametesr: the clustering
+             window, which specifies the number of clock-cycles in which a seed
+             hit candidate must be a spatiotemporal maximum, and seed energy
+             threshold, which specifies how much energy a seed hit candidate
+             must have in order to be used.
+             
+             The GTP clusterer is able to be persisted into LCIO. If persisted,
+             it will output all of the clusters in the readout window range
+             (either specified manually as with the truth drivers or using the
+             default readout window and trigger offset of the manager). It will
+             also output all of the hits contained in each cluster into the
+             output file as well.
+          -->
+        <driver name="GTPReadoutDriver" type="org.hps.readout.ecal.updated.GTPClusterReadoutDriver">
+            <daqConfigurationAppliedintoReadout>true</daqConfigurationAppliedintoReadout>   
+
+            <!--
+                                 Specifies whether GTP clusters should be persisted in the
+                output LCIO data. This should generally be false for production
+                running to save space, but can be useful for some analyses, as
+                the exact trigger-time clusters are not otherwise recoverable
+                after readout.
+            -->
+            <persistent>true</persistent>
+        </driver>
+
+        
+        <!--
+            The hodoscope preprocessing driver is responsible for taking SLiC
+            truth hits and converting them to a form usable by the simulation.
+            Truth hits are of the type SimTrackerHit and need to be converted
+            to the type SimCalorimeterHit. Additionally, SLiC is not able to
+            produce hits on multiple channels from the same scintillator. Some
+            scintillators do have multiple channels in the actual detector. As
+            such, it is necessary to split the energies of hits occurring on
+            scintillators with mutliple channels across the relevant channels.
+            This is handled by this driver.
+        -->
+        <driver name="HodoscopePreprocessingDriver" type="org.hps.readout.hodoscope.HodoscopePreprocessingDriver">
+            <truthHitCollectionName>HodoscopeHits</truthHitCollectionName>
+            <outputHitCollectionName>HodoscopePreprocessedHits</outputHitCollectionName>
+
+            <persistent>true</persistent>
+        </driver>
+        
+        <!--
+             The hodoscope digitization driver works identically to the
+             calorimeter digitization driver, except for the hodoscope.
+          -->
+        <driver name="HodoscopeDigitizationDriver" type="org.hps.readout.hodoscope.HodoscopeDigitizationReadoutDriver">
+            <!-- LCIO Collection Names -->
+            <inputHitCollectionName>HodoscopePreprocessedHits</inputHitCollectionName>
+            <outputHitCollectionName>HodoscopeRawHits</outputHitCollectionName>
+            <readoutHitCollectionName>HodoscopeReadoutHits</readoutHitCollectionName>
+            <truthRelationsCollectionName>HodoscopeTruthRelations</truthRelationsCollectionName>
+            <triggerPathTruthRelationsCollectionName>HodoscopeTriggerPathTruthRelations</triggerPathTruthRelationsCollectionName>
+
+            <daqConfigurationAppliedintoReadout>true</daqConfigurationAppliedintoReadout>   
+            
+            <!-- Driver Parameters -->
+            <mode>1</mode>                                  <!-- Allowed values: 1, 3, or 7. -->
+            <addNoise>false</addNoise>
+            
+            <!-- 
+                 Readout offset is not the same as the old system - it measures
+                 amount of samples that are included before the trigger time in
+                 the ADC readout window. The old version can be converted by
+                 selecting a readout window equal to (readoutLatency - 64).
+              -->
+            <readoutOffset>10</readoutOffset>               <!-- Units of 4 ns clock-cycles. -->
+
+	    <!--Factor for gain conversion from self-defined unit/ADC to
+	    MeV/ADC. -->            
+	    <factorGainConversion>0.000833333</factorGainConversion>
+            
+            <!--
+                The digitization driver produces as output a list of ADC values
+                within a specified window, in emulation of Mode-1 data. This
+                removes the truth information that is otherwise present in the
+                original SLiC output. Setting this option to true creates new
+                LCRelation objects that link the ADC list to the truth hits that
+                created it and stores this in readout. For production running,
+                this should generally be off to save space. Truth hits will be
+                included in readout automatically - the truth hit driver above
+                does not need to be persistent.
+            -->
+            <writeTruth>true</writeTruth>
+            
+            <!--
+                As above, except that truth relations are persisted for the
+                readout hits that are seen by the clusterer and trigger. This
+                is useful if some analysis needs to be performed at the readout
+                level. Otherwise, this should be left off.
+            -->
+            <writeTriggerPathTruth>false</writeTriggerPathTruth>
+        </driver>
+
+
+            <!--
+                The hodoscope raw converter functions as per the calorimeter raw
+                converter driver.
+            -->
+        <driver name="HodoscopeRawConverterDriver" type="org.hps.readout.hodoscope.HodoscopeRawConverterReadoutDriver">
+            <!--
+		 Define the LCIO collection names. The input collection should
+		 come from the digitization driver.
+	    -->
+		<inputCollectionName>HodoscopeRawHits</inputCollectionName>
+		<outputCollectionName>HodoscopeCorrectedHits</outputCollectionName>
+
+            <daqConfigurationAppliedintoReadout>true</daqConfigurationAppliedintoReadout>   
+			
+	    <!--  
+	          Factor of unit conversion for returned value of the method
+	          AbstractBaseRawConverter:: adcToEnergy(). For hodo, unit of hit energy is self-defined for hodo FADC hits.  Conversion from self-defined-unit/ADC to MeV/ADC for true hits is take into account in HodoscopeDigitizationReadoutDriver  by factorGainConversion. Here, factor = 1 
+	    -->
+	    <factorUnitConversion>1</factorUnitConversion>
+            <!--
+                  Outputs all the trigger-level hits within the readout window.
+                  This is not generally necessary outside of specialized
+                  circumstances. Note that all readout hits associated with GTP
+                  clusters will automatically be included if GTP clusters are
+                  persisted.
+            -->
+            <persistent>true</persistent>
+        </driver>
+
+        <driver name="PulseTrigger"
+		type="org.hps.readout.trigger.PulserReadoutDriver">
+
+	  <!-- Sets the rate of the pulser. It will trigger every
+	       $argument clocok-cycles, where two events is a clock
+	       cycle
+	  -->
+          <pulserRate>125</pulserRate>
+
+        </driver>
+        
+        <driver name="ReadoutManagerDriver" type="org.hps.readout.ReadoutDataManager">
+            <readoutWindow>200</readoutWindow>
+            <outputFile>${outputFile}.slcio</outputFile>
+        </driver>
+        
+        <driver name="CleanupDriver" type="org.lcsim.recon.tracking.digitization.sisim.config.ReadoutCleanupDriver" />
+    </drivers>
+</lcsim>

--- a/steering-files/src/main/resources/org/hps/steering/recon/TriggerTuning2021MCRecon_targetAt0_0_0.lcsim
+++ b/steering-files/src/main/resources/org/hps/steering/recon/TriggerTuning2021MCRecon_targetAt0_0_0.lcsim
@@ -1,0 +1,276 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lcsim xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/lcsim/1.0/lcsim.xsd">
+    <!-- 
+      @brief Steering file that will be used for the reconstruction of
+      2021 MC samples, where are produced for 2021 trigger tuning. 
+      @author <a href="mailto:omoreno1@ucsc.edu">Omar Moreno</a>
+      @author <a href="mailto:caot@jlab.org">Tongtong Cao</a>
+    -->
+    <execute>
+        <driver name="EventMarkerDriver"/>
+ 
+        <!-- Ecal reconstruction drivers -->        
+        <driver name="EcalRawConverter" />
+        <driver name="EcalTimeCorrection"/>
+        <driver name="ReconClusterer" />
+	    <driver name="CopyCluster" />
+
+        <driver name="HodoRunningPedestal"/>
+        <driver name="HodoRawConverter"/>
+
+        <!-- SVT hit reconstruction drivers -->
+        <driver name="RawTrackerHitSensorSetup"/>
+        <driver name="RawTrackerHitFitterDriver" />
+        <driver name="TrackerHitDriver"/>
+        <driver name="HelicalTrackHitDriver"/>
+    
+        <!-- Track finding and fitting using seed tracker. --> 
+        
+        <driver name="TrackReconSeed123Conf4Extd56"/>    
+        <driver name="TrackReconSeed123Conf5Extd46"/>
+	    <driver name="TrackReconSeed567Conf4Extd123"/> 
+        <driver name="TrackReconSeed456Conf3Extd127"/> 
+        <driver name="TrackReconSeed356Conf7Extd124"/>  
+        <driver name="TrackReconSeed235Conf6Extd147"/>  
+        
+        <!-- <driver name="TrackReconSeed234Conf6Extd157"/> -->
+        
+        <driver name="MergeTrackCollections"/>
+        <driver name="GBLRefitterDriver" />
+        <driver name="TrackDataDriver" />
+        <driver name="KalmanPatRecDriver"/> 
+        <driver name="TrackTruthMatching_KF" />
+        <driver name="TrackTruthMatching_GBL" /> 
+        <driver name="ReconParticleDriver_Kalman" />
+        <driver name="ReconParticleDriver" />
+        <driver name="LCIOWriter"/>
+        <driver name="CleanupDriver"/>
+    
+    </execute>    
+    <drivers>
+        <driver name="EventMarkerDriver" type="org.lcsim.job.EventMarkerDriver">
+            <eventInterval>10</eventInterval>
+        </driver>
+
+        <!-- Ecal reconstruction drivers -->
+        <driver name="EcalRawConverter" type="org.hps.recon.ecal.EcalRawConverter2Driver">
+        </driver>
+        <driver name="EcalTimeCorrection" type="org.hps.recon.ecal.EcalTimeCorrectionDriver"/>
+
+        <driver name="ReconClusterer" type="org.hps.recon.ecal.cluster.ReconClusterDriver">
+            <logLevel>WARNING</logLevel>
+            <outputClusterCollectionName>EcalClusters</outputClusterCollectionName>
+        </driver>
+        
+        <driver name="CopyCluster" type="org.hps.recon.ecal.cluster.CopyClusterCollectionDriver">
+            <inputCollectionName>EcalClusters</inputCollectionName>
+            <outputCollectionName>EcalClustersCorr</outputCollectionName>
+        </driver>
+
+        <!-- Hodo reconstruction drivers -->
+
+        <driver name="HodoRunningPedestal" type="org.hps.recon.ecal.HodoRunningPedestalDriver">
+            <logLevel>CONFIG</logLevel>
+        </driver>
+
+        <driver name="HodoRawConverter" type="org.hps.recon.ecal.HodoRawConverterDriver">
+           <useRunningPedestal>true</useRunningPedestal>
+           <tETAllChannels>8</tETAllChannels>
+           <logLevel>CONFIG</logLevel>
+        </driver>
+        
+        <!-- SVT reconstruction drivers -->
+
+        <!-- 
+             Driver used to associate raw tracker hits to corresponding sensor.
+        -->
+        <driver name="RawTrackerHitSensorSetup" type="org.lcsim.recon.tracking.digitization.sisim.config.RawTrackerHitSensorSetup">
+            <readoutCollections>SVTRawTrackerHits</readoutCollections>
+        </driver>
+
+
+        <!-- 
+             Fit the six raw samples and extract the amplitude and t0.
+        --> 
+        <driver name="RawTrackerHitFitterDriver" type="org.hps.recon.tracking.RawTrackerHitFitterDriver">
+            <fitAlgorithm>Pileup</fitAlgorithm>
+            <!--use this to correct for trigger time in MC instead of subtractTriggerTime-->   
+            <useTimestamps>false</useTimestamps>     
+            <!--offset to get times centered at 0 after timestamp correction-->                 
+            <!--<tsCorrectionScale>121</tsCorrectionScale>-->    
+            <!--correct for the SVT fit time offset...this should be on if <useTimingConditions> is turned on in readout-->        
+            <correctTimeOffset>true</correctTimeOffset>   
+            <!--per sensor shift...set false becasue it's not in readout sim-->       
+            <correctT0Shift>true</correctT0Shift>      
+            <!--use truth time for MC???  typically not used-->             
+            <useTruthTime>false</useTruthTime>    
+            <!--time of flight corrections-->              
+            <subtractTOF>true</subtractTOF>     
+            <!--set this false for MC, true for data-->              
+            <subtractTriggerTime>true</subtractTriggerTime>           
+            <!--per-strip timing correction from database...this should be on i f <useTimingConditions> is turned on in readout  -->  
+            <correctChanT0>true</correctChanT0>          
+            <debug>false</debug>
+        </driver>
+
+        <!-- 
+             Use the fitted raw tracker hits and create 1D clusters using a 
+             nearest neighbor algorithm. 
+        --> 
+        <driver name="TrackerHitDriver" type="org.hps.recon.tracking.DataTrackerHitDriver">
+            <neighborDeltaT>50</neighborDeltaT>
+        </driver>
+
+        <!-- 
+             Create 3D hits from pairs of 1D clusters on adjecent sensors.
+        -->        
+        <driver name="HelicalTrackHitDriver" type="org.hps.recon.tracking.HelicalTrackHitDriver">
+            <debug>false</debug>
+            <clusterTimeCut>100.0</clusterTimeCut>
+            <maxDt>100.0</maxDt>
+            <clusterAmplitudeCut>400.0</clusterAmplitudeCut>
+	    </driver>
+        
+
+        <!-- 
+             SVT Track finding and fitting. 
+        -->
+        
+        <driver name="TrackReconSeed123Conf4Extd56" type="org.hps.recon.tracking.TrackerReconDriver">
+            <trackCollectionName>Tracks_s123_c4_e56</trackCollectionName>
+            <strategyResource>HPS_s123_c4_e56_4hit.xml</strategyResource>
+            <debug>false</debug>
+	        <rmsTimeCut>1000.0</rmsTimeCut>
+            <maxTrackerHits>250</maxTrackerHits>
+        </driver>
+        
+        <driver name="TrackReconSeed123Conf5Extd46" type="org.hps.recon.tracking.TrackerReconDriver">
+            <trackCollectionName>Tracks_s123_c5_e46</trackCollectionName>
+            <strategyResource>HPS_s123_c5_e46_4hit.xml</strategyResource>
+            <debug>false</debug>
+	        <rmsTimeCut>1000.0</rmsTimeCut>
+            <maxTrackerHits>250</maxTrackerHits>
+        </driver>
+
+        <driver name="TrackReconSeed567Conf4Extd123" type="org.hps.recon.tracking.TrackerReconDriver">
+            <trackCollectionName>Tracks_s567_c4_e123</trackCollectionName>
+            <strategyResource>HPS_s567_c4_e123.xml</strategyResource>
+            <debug>false</debug>
+	        <rmsTimeCut>1000.0</rmsTimeCut>
+            <maxTrackerHits>250</maxTrackerHits>
+        </driver>
+
+        <driver name="TrackReconSeed456Conf3Extd127" type="org.hps.recon.tracking.TrackerReconDriver">
+            <trackCollectionName>Tracks_s456_c3_e127</trackCollectionName>
+            <strategyResource>HPS_s456_c3_e127.xml</strategyResource>
+            <debug>false</debug>
+            <rmsTimeCut>1000.0</rmsTimeCut>
+            <maxTrackerHits>250</maxTrackerHits>
+        </driver>
+
+        <driver name="TrackReconSeed356Conf7Extd124" type="org.hps.recon.tracking.TrackerReconDriver">
+            <trackCollectionName>Tracks_s356_c7_e124</trackCollectionName>
+            <strategyResource>HPS_s356_c7_e124.xml</strategyResource>
+            <debug>false</debug>
+            <rmsTimeCut>1000.0</rmsTimeCut>
+            <maxTrackerHits>250</maxTrackerHits>
+        </driver>
+
+        <driver name="TrackReconSeed235Conf6Extd147" type="org.hps.recon.tracking.TrackerReconDriver">
+            <trackCollectionName>Tracks_s235_c6_e147</trackCollectionName>
+            <strategyResource>HPS_s235_c6_e147.xml</strategyResource>
+            <debug>false</debug>
+            <rmsTimeCut>1000.0</rmsTimeCut>
+            <maxTrackerHits>250</maxTrackerHits>
+        </driver>
+
+        <driver name="TrackReconSeed234Conf6Extd157" type="org.hps.recon.tracking.TrackerReconDriver">
+            <trackCollectionName>Tracks_s234_c5_e157</trackCollectionName>
+            <strategyResource>HPS_s234_c5_e167_4hit.xml</strategyResource>
+            <debug>false</debug>
+	        <rmsTimeCut>1000.0</rmsTimeCut>
+            <maxTrackerHits>250</maxTrackerHits>
+        </driver>
+
+        <!-- --> 
+
+        <driver name="MergeTrackCollections" type="org.hps.recon.tracking.MergeTrackCollections" />
+        <driver name="TrackDataDriver" type="org.hps.recon.tracking.TrackDataDriver" />
+        <driver name="ReconParticleDriver" type="org.hps.recon.particle.HpsReconParticleDriver" > 
+            <ecalClusterCollectionName>EcalClustersCorr</ecalClusterCollectionName>
+            <trackCollectionNames>GBLTracks</trackCollectionNames>
+            <beamPositionX> 0 </beamPositionX>
+            <beamSigmaX> 0.05 </beamSigmaX>
+            <beamPositionY> 0 </beamPositionY>
+            <beamSigmaY> 0.02 </beamSigmaY>
+            <beamPositionZ> 0 </beamPositionZ>
+            <trackClusterTimeOffset>40</trackClusterTimeOffset>
+            <maxMatchDt>1000</maxMatchDt>
+            <useInternalVertexXYPositions>false</useInternalVertexXYPositions>
+            <minVertexChisqProb> 0.0 </minVertexChisqProb>
+	        <maxElectronP>7.0</maxElectronP> 
+            <maxVertexP>7.0</maxVertexP>	
+            <requireClustersForV0>false</requireClustersForV0>
+            <applyClusterCorrections>false</applyClusterCorrections>  	
+	    <isMC>true</isMC>
+        </driver>         
+
+
+        <driver name="ReconParticleDriver_Kalman" type="org.hps.recon.particle.HpsReconParticleDriver" > 
+            <ecalClusterCollectionName>EcalClustersCorr</ecalClusterCollectionName>
+            <trackCollectionNames>KalmanFullTracks</trackCollectionNames>
+            <unconstrainedV0CandidatesColName>UnconstrainedV0Candidates_KF</unconstrainedV0CandidatesColName>
+            <unconstrainedV0VerticesColName>UnconstrainedV0Vertices_KF</unconstrainedV0VerticesColName>
+            <beamConV0CandidatesColName>BeamspotConstrainedV0Candidates_KF</beamConV0CandidatesColName>
+            <beamConV0VerticesColName>BeamspotConstrainedV0Vertices_KF</beamConV0VerticesColName>
+            <targetConV0CandidatesColName>TargetConstrainedV0Candidates_KF</targetConV0CandidatesColName>
+            <targetConV0VerticesColName>TargetConstrainedV0Vertices_KF</targetConV0VerticesColName>
+	        <finalStateParticlesColName>FinalStateParticles_KF</finalStateParticlesColName>
+            <beamPositionX> 0  </beamPositionX>
+            <beamSigmaX> 0.05 </beamSigmaX>
+            <beamPositionY> 0 </beamPositionY>
+            <beamSigmaY> 0.02 </beamSigmaY>
+            <beamPositionZ> 0 </beamPositionZ>
+            <trackClusterTimeOffset>40</trackClusterTimeOffset>
+            <maxMatchDt>1000</maxMatchDt>
+            <useInternalVertexXYPositions>false</useInternalVertexXYPositions>
+            <minVertexChisqProb> 0.0 </minVertexChisqProb>
+	        <maxElectronP>7.0</maxElectronP>
+	        <maxVertexP>7.0</maxVertexP>
+            <requireClustersForV0>false</requireClustersForV0>
+	    <applyClusterCorrections>true</applyClusterCorrections>           
+	    <isMC>true</isMC>
+		
+        </driver>         
+
+
+
+
+
+        <driver name="GBLRefitterDriver" type="org.hps.recon.tracking.gbl.GBLRefitterDriver"/>        
+
+        <driver name="KalmanPatRecDriver" type="org.hps.recon.tracking.kalman.KalmanPatRecDriver">
+            <!--<doDebugPlots>false</doDebugPlots>-->
+            <verbose>false</verbose>
+          </driver>
+          
+          <driver name="TrackTruthMatching_KF" type="org.hps.analysis.MC.TrackToMCParticleRelationsDriver">
+          <trackCollectionName>KalmanFullTracks</trackCollectionName>
+          <kalmanTracks>true</kalmanTracks>
+          <debug>false</debug>
+        </driver>
+
+        <driver name="TrackTruthMatching_GBL" type="org.hps.analysis.MC.TrackToMCParticleRelationsDriver">
+          <trackCollectionName>GBLTracks</trackCollectionName>
+          <kalmanTracks>false</kalmanTracks>
+          <debug>false</debug>
+        </driver>
+
+        <driver name="LCIOWriter" type="org.lcsim.util.loop.LCIODriver">
+            <outputFilePath>${outputFile}.slcio</outputFilePath>
+        </driver>
+        
+        <driver name="CleanupDriver" type="org.lcsim.recon.tracking.digitization.sisim.config.ReadoutCleanupDriver"/>
+    
+    </drivers>
+</lcsim>


### PR DESCRIPTION
For trigger tuning analysis of the upcoming 2021 experiment, some special setup needs to be taken in readout and recon. steering files.

The steering files out of hps-java have been applied to produce MC samples for 2021 trigger tuning.

To let the files work for scripts of hps-mc, those files need to be added into hps-java.