### PR TITLE
Iss893: update Hodoscope reconstruction drivers to work for MC

### DIFF
--- a/ecal-recon/src/main/java/org/hps/recon/ecal/HodoRawConverter.java
+++ b/ecal-recon/src/main/java/org/hps/recon/ecal/HodoRawConverter.java
@@ -20,6 +20,8 @@ public class HodoRawConverter {
     private boolean useUserGain = false;
     private double userGains = 0;
     private int tet = HodoConstants.TET_AllCh;
+    
+    private boolean isMC = false;
 
     public ArrayList<Integer> FindThresholdCrossings(RawTrackerHit hit, double ped) {
 
@@ -117,8 +119,13 @@ public class HodoRawConverter {
         if (useRunningPedestal && event != null) {
 
             Map<HodoscopeChannel, Double> runningPedMap = (Map<HodoscopeChannel, Double>) event.get("HodoRunningPedestals");
-            HodoscopeChannel chan = hodoConditions.getChannels().findGeometric(cellid);
-
+            
+            HodoscopeChannel chan;
+            if(!isMC)
+                chan = hodoConditions.getChannels().findGeometric(cellid);
+            else
+                chan = hodoConditions.getChannels().findChannel((int)cellid);
+            
             return runningPedMap.get(chan);
         } else {
             return findChannel(cellid).getCalibration().getPedestal();
@@ -130,18 +137,27 @@ public class HodoRawConverter {
     }
 
     public HodoscopeChannelConstants findChannel(long cellID) {
-        //System.out.println(hodoConditions.getChannels().findGeometric(cellID));
-        return hodoConditions.getChannelConstants(hodoConditions.getChannels().findGeometric(cellID));
+        if(!isMC)
+            return hodoConditions.getChannelConstants(hodoConditions.getChannels().findGeometric(cellID));
+        else
+            return hodoConditions.getChannelConstants(hodoConditions.getChannels().findChannel((int)cellID));
     }
 
     // =========== Computed Hodoscop identifiers from cellID
     public int[] getHodoIdentifiers(long cellID) {
 
+        HodoscopeChannel chan;
+        if(!isMC) 
+            chan = hodoConditions.getChannels().findGeometric(cellID);
+        else 
+            chan = hodoConditions.getChannels().findChannel((int)cellID);
+
         int[] hodo_ids = new int[4];
-        hodo_ids[0] = hodoConditions.getChannels().findGeometric(cellID).getIX();
-        hodo_ids[1] = hodoConditions.getChannels().findGeometric(cellID).getIY();
-        hodo_ids[2] = hodoConditions.getChannels().findGeometric(cellID).getLayer();
-        hodo_ids[3] = hodoConditions.getChannels().findGeometric(cellID).getHole();
+        hodo_ids[0] = chan.getIX();
+        hodo_ids[1] = chan.getIY();
+        hodo_ids[2] = chan.getLayer();
+        hodo_ids[3] = chan.getHole();
+
 
         return hodo_ids;
     }
@@ -158,6 +174,15 @@ public class HodoRawConverter {
 
         this.userGains = a_usergain;
         useUserGain = true;
+    }
+    
+    /**
+     * Set MC mode.
+     *
+     * @param isMC   
+     */
+    public void setIsMC(final boolean isMC) {
+        this.isMC = isMC;
     }
 
 }

--- a/ecal-recon/src/main/java/org/hps/recon/ecal/HodoRawConverterDriver.java
+++ b/ecal-recon/src/main/java/org/hps/recon/ecal/HodoRawConverterDriver.java
@@ -20,6 +20,8 @@ public class HodoRawConverterDriver extends Driver {
     private HodoscopeConditions hodoConditions = null;
 
     private HodoRawConverter converter = null;
+    
+    private boolean isMC = false;
 
     // ===== The Mode1 Hodo hit collection name =====
     private String rawCollectionName = "HodoReadoutHits";
@@ -41,6 +43,17 @@ public class HodoRawConverterDriver extends Driver {
     
     public void setUseUserGains(double aUserGain){
         converter.setUseUserGain(aUserGain);
+    }
+    
+    
+    /**
+     * Set MC mode.
+     *
+     * @param isMC   
+     */
+    public void setIsMC(boolean isMC){
+        this.isMC = isMC;
+        converter.setIsMC(isMC);
     }
 
     public void setTETAllChannels(int arg_tet) {
@@ -157,8 +170,11 @@ public class HodoRawConverterDriver extends Driver {
                     cl_layer = ArrayUtils.add(cl_layer, hit_ilayer);
                     cl_Energy = ArrayUtils.add(cl_Energy, this_hit.getRawEnergy());
                     cl_Time = ArrayUtils.add(cl_Time, this_hit.getTime());
-                    cl_detid = ArrayUtils.add(cl_detid, (int)this_hit.getDetectorElement().getIdentifier().getValue());
-
+                    if(!isMC)
+                        cl_detid = ArrayUtils.add(cl_detid, (int)this_hit.getDetectorElement().getIdentifier().getValue());
+                    else
+                        cl_detid = ArrayUtils.add(cl_detid, (int)this_hit.getCellID());
+                    
                     continue;
                 }
 
@@ -189,7 +205,11 @@ public class HodoRawConverterDriver extends Driver {
                         cl_ix = ArrayUtils.add(cl_ix, hit_ix);
                         cl_iy = ArrayUtils.add(cl_iy, hit_iy);
                         cl_layer = ArrayUtils.add(cl_layer, hit_ilayer);
-                        cl_detid = ArrayUtils.add(cl_detid, (int)this_hit.getDetectorElement().getIdentifier().getValue());
+                        
+                        if(!isMC)
+                            cl_detid = ArrayUtils.add(cl_detid, (int)this_hit.getDetectorElement().getIdentifier().getValue());
+                        else
+                            cl_detid = ArrayUtils.add(cl_detid, (int)this_hit.getCellID());
 
                         double energy = HodoConstants.cl_Esum_scale * (this_hit.getRawEnergy() + that_hit.getRawEnergy()) / 2.;
 
@@ -239,6 +259,15 @@ public class HodoRawConverterDriver extends Driver {
             event.put("HodoGenericClusters", hodo_cl_list, SimpleGenericObject.class, 0);
 
         }
+    }
+    
+    /**
+     * Set the input collection name (source).
+     *
+     * @param inputCollectionName the input collection name
+     */
+    public void setInputCollectionName(final String inputCollectionName) {
+        this.rawCollectionName = inputCollectionName;
     }
 
     /**

--- a/ecal-recon/src/main/java/org/hps/recon/ecal/HodoRunningPedestalDriver.java
+++ b/ecal-recon/src/main/java/org/hps/recon/ecal/HodoRunningPedestalDriver.java
@@ -36,7 +36,7 @@ public class HodoRunningPedestalDriver extends Driver {
     // (discard older readouts ; negative = no time limit)
     private long maxLookbackTime = -1; // units = ms
 
-    private static final String rawCollectionName = "HodoReadoutHits";
+    private String rawCollectionName = "HodoReadoutHits";
     private static final String extraDataRelationsName = "HodoReadoutExtraDataRelations";
     private static final String runningPedestalsName = "HodoRunningPedestals";
 
@@ -55,6 +55,8 @@ public class HodoRunningPedestalDriver extends Driver {
 
     private boolean debug = false;
     private HodoscopeConditions hodoConditions = null;
+    
+    private boolean isMC = false;
 
     public HodoRunningPedestalDriver() {
     }
@@ -276,12 +278,35 @@ public class HodoRunningPedestalDriver extends Driver {
         return hodoConditions.getChannels().findChannel(channel_id);
     }
 
-    public HodoscopeChannel findChannel(RawTrackerHit hit) {        
-        return hodoConditions.getChannels().findGeometric(hit.getCellID());
+    public HodoscopeChannel findChannel(RawTrackerHit hit) {
+        if(!isMC)
+            return hodoConditions.getChannels().findGeometric(hit.getCellID());
+        else
+            return hodoConditions.getChannels().findChannel((int)hit.getCellID());
     }
 
     public HodoscopeChannel findChannel(RawCalorimeterHit hit) {
-        return hodoConditions.getChannels().findGeometric(hit.getCellID());
+        if(!isMC)            
+            return hodoConditions.getChannels().findGeometric(hit.getCellID());
+        else
+            return hodoConditions.getChannels().findChannel((int)hit.getCellID());
     }
-
+    
+    /**
+     * Set the input collection name (source).
+     *
+     * @param inputCollectionName the input collection name
+     */
+    public void setInputCollectionName(final String inputCollectionName) {
+        this.rawCollectionName = inputCollectionName;
+    }
+    
+    /**
+     * Set MC mode.
+     *
+     * @param isMC   
+     */
+    public void setIsMC(final boolean isMC) {
+        this.isMC = isMC;
+    }    
 }

--- a/steering-files/src/main/resources/org/hps/steering/recon/PhysicsRun2019MCRecon.lcsim
+++ b/steering-files/src/main/resources/org/hps/steering/recon/PhysicsRun2019MCRecon.lcsim
@@ -53,13 +53,18 @@
             <outputCollectionName>EcalClustersCorr</outputCollectionName>
         </driver>
         <!-- Hodo reconstruction drivers -->
-        <driver name="HodoRunningPedestal" type="org.hps.recon.ecal.HodoRunningPedestalDriver">
+        <driver name="HodoRunningPedestal"
+		type="org.hps.recon.ecal.HodoRunningPedestalDriver">
+            <inputCollectionName>HodoscopeReadoutHits</inputCollectionName>
             <logLevel>CONFIG</logLevel>
+            <isMC>true</isMC>
         </driver>
         <driver name="HodoRawConverter" type="org.hps.recon.ecal.HodoRawConverterDriver">
            <useRunningPedestal>true</useRunningPedestal>
+            <inputCollectionName>HodoscopeReadoutHits</inputCollectionName>
            <tETAllChannels>8</tETAllChannels>
            <logLevel>CONFIG</logLevel>
+            <isMC>true</isMC>
         </driver>
         <!-- SVT reconstruction drivers -->
         <!-- Driver used to associate raw tracker hits to corresponding sensor. -->

--- a/steering-files/src/main/resources/org/hps/steering/recon/PhysicsRun2019MCRecon_LCIO.lcsim
+++ b/steering-files/src/main/resources/org/hps/steering/recon/PhysicsRun2019MCRecon_LCIO.lcsim
@@ -89,13 +89,17 @@
         <!-- Hodo reconstruction drivers -->
 
         <driver name="HodoRunningPedestal" type="org.hps.recon.ecal.HodoRunningPedestalDriver">
+            <inputCollectionName>HodoscopeReadoutHits</inputCollectionName>
             <logLevel>CONFIG</logLevel>
+            <isMC>true</isMC>
         </driver>
 
         <driver name="HodoRawConverter" type="org.hps.recon.ecal.HodoRawConverterDriver">
            <useRunningPedestal>true</useRunningPedestal>
+            <inputCollectionName>HodoscopeReadoutHits</inputCollectionName>
            <tETAllChannels>8</tETAllChannels>
            <logLevel>CONFIG</logLevel>
+            <isMC>true</isMC>
         </driver>
         
         <!-- SVT reconstruction drivers -->


### PR DESCRIPTION
Recently, it was found that hodoscope reconstruction drivers not to work for MC.
The drivers are developed to process data, and work well. However, there are several differences between data from Hodo evio reader and samples from MC reaout:
1) Output collection name is different
2) Cell ID is different
3) Detector element is not set for Hodo hits in MC readout, while it is set in Hodo evio reader.

The evio reader and MC readout were developed by different authors at different time. So format of output collections from them is not uniform. The issue has not been found before since we have not taken detailed analysis for MC recon Hodo samples.

With the updates, format of output collection from recon. drivers is uniform for data and MC. For ids of Hodo hits, the same logic is processed for MC as logic in Hodo evio reader. The logic is commented by Rafo in the Hodo evio reader:
        // ====================== Rafo =======================
        // Unlike to the ECal case, where each detector element is readout with a single channel
        // here for the hodoscope, there are detector elements (tiles) that are readout with two different channels
        // 
        // The code below, previously was assigning the hole value to 0, 
        // That way you would get an iD, which is ok for the detector element identification, howevere
        // This id is not correct, when one wants to knwo which PMT channel is actually this hit belongs to.
        // In particular during the recon, I was getting an error, that it can not find a cellID
        
        // Now as a possible solution (Possibly not the best solution), this method will return two IDs
        // The 1st one, is clauclulated taking into account the hit, while the 2nd one is calculated with 
        // the "hole=0" assumption.
        
        // Further depending on the intention, one can use ids.get(0) if one wants to check the hit ID, or ids.get(1), if onw
        // wants to identify the detector element.

Besides drivers, all related steering files for MC recon have been updated.