### PR TITLE
fix bug pertaining to iss899. Wrong variable was checked for null

### DIFF
--- a/recon/src/main/java/org/hps/recon/utils/TrackClusterMatcherMinDistance.java
+++ b/recon/src/main/java/org/hps/recon/utils/TrackClusterMatcherMinDistance.java
@@ -717,7 +717,7 @@ public class TrackClusterMatcherMinDistance extends AbstractTrackClusterMatcher{
             double smallestdr = 99999.0;
             Cluster smallestdrCluster = null;
             Map<Cluster, Double> cluster_dr_Map = trackClusterResidualsMap.get(track);
-            if(trackClusterResidualsMap == null){
+            if(cluster_dr_Map == null){
                 Map.put(track, null);
                 continue;
             }


### PR DESCRIPTION
simple fix. Changed which variable is being checked for null. Was typo. 