### PR TITLE
add a steering file for overlaying MC signal with pulser data

### DIFF
--- a/steering-files/src/main/resources/org/hps/steering/readout/Overlay.lcsim
+++ b/steering-files/src/main/resources/org/hps/steering/readout/Overlay.lcsim
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lcsim xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/lcsim/1.0/lcsim.xsd">
+    <execute>
+        <driver name="OverlayDriver" />
+        <driver name="OutputDriver" />
+    </execute>
+    <drivers>
+        <driver name="OverlayDriver" type="org.hps.digi.DataOverlayDriver">
+            <!-- overlay file -->
+            <inputFile>${overlayFile}.slcio</inputFile>
+        </driver>
+        <driver name="OutputDriver" type="org.lcsim.util.loop.LCIODriver">
+            <!-- output file will contain MC collections from signal and data collections from background -->
+            <outputFilePath>${outputFile}.slcio</outputFilePath>
+        </driver>
+    </drivers>
+</lcsim>

--- a/steering-files/src/main/resources/org/hps/steering/readout/PhysicsRun2019TrigSinglesWithPulserDataMerging.lcsim
+++ b/steering-files/src/main/resources/org/hps/steering/readout/PhysicsRun2019TrigSinglesWithPulserDataMerging.lcsim
@@ -405,8 +405,6 @@
             <!-- Units of 2 ns beam bunches. -->
             <deadTime>15</deadTime>            
 
-	    <geometryMatchingRequired>true</geometryMatchingRequired>
-
         </driver>
                     
 


### PR DESCRIPTION
A steering file for overlay MC signal with pulser data was developed.
Additionally, readout steering file with signal-pulserData as input was slight changed.