### PR TITLE
Patches to KF-based Alignment Pipeline

### DIFF
--- a/tracking/src/main/java/org/hps/recon/tracking/gbl/GBLOutputDriver.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/gbl/GBLOutputDriver.java
@@ -196,8 +196,9 @@ public class GBLOutputDriver extends Driver {
             //Remove tracks with less than 10 hits
             if ((TrackType == 0 && trk.getTrackerHits().size() < nHits) 
                     || (TrackType == 1 && trk.getTrackerHits().size() < 2*nHits)) {
-                System.out.println("DEBUG::Tom::"+trk.getClass().getSimpleName()
-                        +" got to GBLOutputDriver with "+trk.getTrackerHits().size()+" hits.");
+                System.out.println("WARNING:: "+trk.getClass().getSimpleName()
+                        +" got to GBLOutputDriver with "+trk.getTrackerHits().size()+" hits"
+                        +" which is below the cut that should have been already applied.");
                 continue;
             }
 

--- a/tracking/src/main/java/org/hps/recon/tracking/gbl/GBLOutputDriver.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/gbl/GBLOutputDriver.java
@@ -195,10 +195,10 @@ public class GBLOutputDriver extends Driver {
             
             //Remove tracks with less than 10 hits
             if ((TrackType == 0 && trk.getTrackerHits().size() < nHits) 
-                || (TrackType == 1 && trk.getTrackerHits().size() < 2*nHits)) {
-              System.out.println("DEBUG::Tom::"+trk.getClass().getSimpleName()
-                  +" got to GBLOutputDriver with "+trk.getTrackerHits().size()+" hits.");
-              continue;
+                    || (TrackType == 1 && trk.getTrackerHits().size() < 2*nHits)) {
+                System.out.println("DEBUG::Tom::"+trk.getClass().getSimpleName()
+                        +" got to GBLOutputDriver with "+trk.getTrackerHits().size()+" hits.");
+                continue;
             }
 
 

--- a/tracking/src/main/java/org/hps/recon/tracking/gbl/GblTrajectoryJna.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/gbl/GblTrajectoryJna.java
@@ -30,6 +30,7 @@ public class GblTrajectoryJna {
         void GblTrajectory_fit(Pointer self, DoubleByReference Chi2, IntByReference Ndf, DoubleByReference lostWeight, char [] optionList, int aLabel);
         void GblTrajectory_addPoint(Pointer self, Pointer point);
         int  GblTrajectory_isValid(Pointer self);
+        void GblTrajectory_delete(Pointer self);
         int  GblTrajectory_getNumPoints(Pointer self);
         void GblTrajectory_printTrajectory(Pointer self, int level);
         void GblTrajectory_printData(Pointer self);
@@ -62,7 +63,9 @@ public class GblTrajectoryJna {
         }
         
         self = GblTrajectoryInterface.INSTANCE.GblTrajectoryCtorPtrArray(ppoints, points.size(), flagCurv, flagU1dir, flagU2dir);
-        
+        if (self == Pointer.NULL)
+            System.out.println("Failed generating trajectory");
+                
     }
 
     //Simple trajectory constructor with seed 
@@ -157,7 +160,12 @@ public class GblTrajectoryJna {
         GblTrajectoryInterface.INSTANCE.GblTrajectory_printPoints(self,level);
     }
     
-
+    //Call delete on the underlying objects
+    public void delete() {
+        GblTrajectoryInterface.INSTANCE.GblTrajectory_delete(self);
+    }
+    
+    
     public void getMeasResults(int aLabel, int numData[], List<Double> aResiduals,List<Double> aMeasErrors, List<Double> aResErrors, List<Double> aDownWeights) {
         
         double[] d_aResiduals  = new double[2];

--- a/tracking/src/main/java/org/hps/recon/tracking/gbl/KalmanToGBLDriver.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/gbl/KalmanToGBLDriver.java
@@ -149,6 +149,8 @@ public class KalmanToGBLDriver extends Driver {
             
             
             // Compute the residuals
+            // sometimes the GBL trajectory isn't fitted properly and null is returned
+            // so we should make sure that the trajectory was fit before continuing
             if (computeGBLResiduals && fitGbl_traj != null) { 
                 
                 TrackResidualsData resData  = GblUtils.computeGblResiduals(trk, fitGbl_traj);

--- a/tracking/src/main/java/org/hps/recon/tracking/gbl/KalmanToGBLDriver.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/gbl/KalmanToGBLDriver.java
@@ -141,7 +141,6 @@ public class KalmanToGBLDriver extends Driver {
             //I'm using the OLD way to refit for the moment.
             
             FittedGblTrajectory fitGbl_traj = HpsGblRefitter.fit(list_kfSCDs, bfac, false);
-            GblTrajectory gbl_fit_trajectory =  fitGbl_traj.get_traj();
 
             /*
             System.out.println("DEBUG::Tom::KalmanToGBLDriver - converted KF track to GBL track with "
@@ -150,7 +149,7 @@ public class KalmanToGBLDriver extends Driver {
             
             
             // Compute the residuals
-            if (computeGBLResiduals) { 
+            if (computeGBLResiduals && fitGbl_traj != null) { 
                 
                 TrackResidualsData resData  = GblUtils.computeGblResiduals(trk, fitGbl_traj);
                 trackResidualsCollection.add(resData);
@@ -170,6 +169,7 @@ public class KalmanToGBLDriver extends Driver {
             // Get the derivatives
             
             /*
+            GblTrajectory gbl_fit_trajectory =  fitGbl_traj.get_traj();
             for (GblData gbldata : gbl_fit_trajectory.getTrajData()) {
             float vals[] = new float[2];
                 List<Integer> indLocal = new ArrayList<Integer>();

--- a/tracking/src/main/java/org/hps/recon/tracking/gbl/KalmanToGBLDriver.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/gbl/KalmanToGBLDriver.java
@@ -143,8 +143,10 @@ public class KalmanToGBLDriver extends Driver {
             FittedGblTrajectory fitGbl_traj = HpsGblRefitter.fit(list_kfSCDs, bfac, false);
             GblTrajectory gbl_fit_trajectory =  fitGbl_traj.get_traj();
 
+            /*
             System.out.println("DEBUG::Tom::KalmanToGBLDriver - converted KF track to GBL track with "
                 + gbl_fit_trajectory.getNumPoints() + " hits");
+             */
             
             
             // Compute the residuals

--- a/tracking/src/main/java/org/hps/recon/tracking/gbl/KalmanToGBLDriver.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/gbl/KalmanToGBLDriver.java
@@ -142,6 +142,9 @@ public class KalmanToGBLDriver extends Driver {
             
             FittedGblTrajectory fitGbl_traj = HpsGblRefitter.fit(list_kfSCDs, bfac, false);
             GblTrajectory gbl_fit_trajectory =  fitGbl_traj.get_traj();
+
+            System.out.println("DEBUG::Tom::KalmanToGBLDriver - converted KF track to GBL track with "
+                + gbl_fit_trajectory.getNumPoints() + " hits");
             
             
             // Compute the residuals

--- a/tracking/src/main/java/org/hps/recon/tracking/gbl/MakeGblTracks.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/gbl/MakeGblTracks.java
@@ -82,6 +82,9 @@ public class MakeGblTracks {
         BaseTrack trk = new BaseTrack();
 
         /*
+         * we could look into converting the points listed with the GBL
+         * trajectory into the actual TrackerHits in the GBL track.
+         * This was confusing so I didn't do it.
         // Add the hits to the track, converting them to 1D hits
         // that inherit from TrackerHit
         for (GblPoint pt : fittedGblTrajectory.get_traj().getSinglePoints()) {

--- a/tracking/src/main/java/org/hps/recon/tracking/gbl/MakeGblTracks.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/gbl/MakeGblTracks.java
@@ -81,9 +81,27 @@ public class MakeGblTracks {
         // Create a new SeedTrack
         BaseTrack trk = new BaseTrack();
 
-        // Add the hits to the track
+        /*
+        // Add the hits to the track, converting them to 1D hits
+        // that inherit from TrackerHit
+        for (GblPoint pt : fittedGblTrajectory.get_traj().getSinglePoints()) {
+           * GblPoint has
+           *  - P2P Jacobian
+           *  - Derivative matrices
+           *  - Position projected onto something?
+          SiTrackerHitStrip1D hit = new SiTrackerHitStrip1D(
+              ,// Hep3Vector position
+              ,// SymmetricMatrix covariance matrix
+              ,// double energy
+              ,// double time
+              ,// List<RawTrackerHit> raw hits
+              // TrackerHitType decoded type
+              );
+          trk.addHit(hit);
+        }
+        */
         for (TrackerHit hit : hitsOnTrack) {
-            trk.addHit(hit);
+          trk.addHit(hit);
         }
 
         // Set state at IP

--- a/tracking/src/main/java/org/hps/recon/tracking/gbl/MakeGblTracks.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/gbl/MakeGblTracks.java
@@ -101,7 +101,7 @@ public class MakeGblTracks {
         }
         */
         for (TrackerHit hit : hitsOnTrack) {
-          trk.addHit(hit);
+            trk.addHit(hit);
         }
 
         // Set state at IP

--- a/tracking/src/main/java/org/hps/recon/tracking/gbl/SimpleGBLTrajAliDriver.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/gbl/SimpleGBLTrajAliDriver.java
@@ -552,9 +552,13 @@ public class SimpleGBLTrajAliDriver extends Driver {
                 
                 //Momentum cut: 3.8 - 5.2
                 Hep3Vector momentum = new BasicHep3Vector(track.getTrackStates().get(0).getMomentum());
+                //System.out.print("Enabled alignment cuts with hits cut = ");
                 //Kalman
-                if (TrackType == 1)
-                    nHitsCut = 2*nHitsCut;
+                int actualHitCut = nHitsCut;
+                if (TrackType == 1) {
+                    actualHitCut = 2*nHitsCut;
+                }
+                //System.out.println(actualHitCut);
                 
                 if (momentum.magnitude() < minMom || momentum.magnitude() > maxMom) {
                     continue;
@@ -566,7 +570,7 @@ public class SimpleGBLTrajAliDriver extends Driver {
                 }
                 
                 //Align with tracks with at least 6 hits
-                if ((tanLambda > 0 && track.getTrackerHits().size() < nHitsCut) || (tanLambda < 0 && track.getTrackerHits().size() < nHitsCut))  {
+                if ((tanLambda > 0 && track.getTrackerHits().size() < actualHitCut) || (tanLambda < 0 && track.getTrackerHits().size() < actualHitCut))  {
                     continue;
                 }
                 

--- a/tracking/src/main/java/org/hps/recon/tracking/gbl/SimpleGBLTrajAliDriver.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/gbl/SimpleGBLTrajAliDriver.java
@@ -112,7 +112,6 @@ public class SimpleGBLTrajAliDriver extends Driver {
     private String rawHitCollectionName = "SVTRawTrackerHits";
     private String gblStripClusterDataRelations = "KFGBLStripClusterDataRelations";
     
-    private int nTracksTotal = 0;
     private double bfield;
     private FieldMap bFieldMap;
     private final MultipleScattering _scattering = new MultipleScattering(new MaterialSupervisor());
@@ -578,6 +577,8 @@ public class SimpleGBLTrajAliDriver extends Driver {
                 if (TrackType == 1 && track.getTrackerHits().size() % 2 == 1) {
                     // this is a KF track with an odd number of hits which /cannot/
                     // be equivalent to a GBL track so we are going to skip it
+                    // in a future where KF-based alignment is the standard,
+                    // we probably want to remove this
                     continue;
                 }
                 
@@ -1022,7 +1023,6 @@ public class SimpleGBLTrajAliDriver extends Driver {
                     
                     //System.out.println("Refitted track chi2 " + gblTrk.getChi2());
                     refittedTracks.add(gblTrk);
-                    nTracksTotal += refittedTracks.size();
                     kinkDataCollection.add(newTrack.getSecond());
                     kinkDataRelations.add(new BaseLCRelation(newTrack.getSecond(), gblTrk));
                 }

--- a/tracking/src/main/java/org/hps/recon/tracking/gbl/SimpleGBLTrajAliDriver.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/gbl/SimpleGBLTrajAliDriver.java
@@ -346,6 +346,10 @@ public class SimpleGBLTrajAliDriver extends Driver {
         enableStandardCuts = val;
     }
 
+    public void setNHitsCut(int val) {
+        nHitsCut = val;
+    }
+
     public void setMinMom(double val) {
         minMom = val;
     }

--- a/tracking/src/main/java/org/hps/recon/tracking/gbl/SimpleGBLTrajAliDriver.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/gbl/SimpleGBLTrajAliDriver.java
@@ -571,7 +571,7 @@ public class SimpleGBLTrajAliDriver extends Driver {
                 
                 //Align with tracks with at least 6 hits
                 if ((tanLambda > 0 && track.getTrackerHits().size() < actualHitCut) 
-                    || (tanLambda < 0 && track.getTrackerHits().size() < actualHitCut))  {
+                        || (tanLambda < 0 && track.getTrackerHits().size() < actualHitCut))  {
                     continue;
                 }
 

--- a/tracking/src/main/java/org/hps/recon/tracking/gbl/SimpleGBLTrajAliDriver.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/gbl/SimpleGBLTrajAliDriver.java
@@ -502,6 +502,8 @@ public class SimpleGBLTrajAliDriver extends Driver {
             //System.out.println("PF:: DEBUG :: Found Kalman Tracks in the event");
         }
 
+        //System.out.println("DEBUG::Tom::Deduced a track type of "+TrackType);
+
         //If using Seed Tracker, get the hits from the event
         if (TrackType == 0) {
             hitToStrips = TrackUtils.getHitToStripsTable(event,helicalTrackHitRelationsCollectionName);
@@ -544,7 +546,7 @@ public class SimpleGBLTrajAliDriver extends Driver {
             
 
             if (enableAlignmentCuts) {
-                System.out.println("DEBUG::Tom::alignment cuts enabled...");
+                //System.out.println("DEBUG::Tom::alignment cuts enabled...");
                 //Get the track parameters
                 double[] trk_prms = track.getTrackParameters();
                 double tanLambda = trk_prms[BaseTrack.TANLAMBDA];
@@ -592,7 +594,7 @@ public class SimpleGBLTrajAliDriver extends Driver {
                     else if (trackSide == 1 && !TrackUtils.isHoleTrack(track)) 
                         continue;
                 }
-                System.out.println("DEBUG::Tom::Pass with " + track.getTrackerHits().size() + " hits");
+                //System.out.println("DEBUG::Tom::Pass with " + track.getTrackerHits().size() + " hits");
             }
             
             
@@ -919,8 +921,10 @@ public class SimpleGBLTrajAliDriver extends Driver {
                     continue;
                 
                 if (writeMilleBinary) {
+                    /*
                     System.out.println("DEBUG::Tom::Writing track with "
                         + points_on_traj.size() + " hits to mille binary.");
+                     */
                     trajForMPII.milleOut(mille);
                 }
                 
@@ -937,7 +941,7 @@ public class SimpleGBLTrajAliDriver extends Driver {
                     Pair<Track, GBLKinkData>  newTrack = MakeGblTracks.makeCorrectedTrack(fitTraj, TrackUtils.getHTF(track), allHthList, 0, bfield);
                     Track gblTrk = newTrack.getFirst();
 
-                    System.out.println("DEBUG::Tom::Correct GBL track has "+gblTrk.getTrackerHits().size()+" hits");
+                    //System.out.println("DEBUG::Tom::Correct GBL track has "+gblTrk.getTrackerHits().size()+" hits");
                     
                     if(computeGBLResiduals) {
                         
@@ -1032,6 +1036,14 @@ public class SimpleGBLTrajAliDriver extends Driver {
         
         
         if (correctTrack) {
+            /*
+            System.out.print("Refitted tracks (" + outputCollectionName + ") N hits: ");
+            for (Track trk : refittedTracks) {
+              System.out.print(trk.getTrackerHits().size()+" ");
+            }
+            System.out.println();
+             */
+
             // Put the tracks back into the event and exit
             int flag = 1 << LCIOConstants.TRBIT_HITS;
             event.put(outputCollectionName, refittedTracks, Track.class, flag);

--- a/tracking/src/main/java/org/hps/recon/tracking/gbl/SimpleGBLTrajAliDriver.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/gbl/SimpleGBLTrajAliDriver.java
@@ -111,7 +111,8 @@ public class SimpleGBLTrajAliDriver extends Driver {
     private String trackResidualsRelColName = "TrackResidualsGBLRelations";
     private String rawHitCollectionName = "SVTRawTrackerHits";
     private String gblStripClusterDataRelations = "KFGBLStripClusterDataRelations";
-        
+    
+    private int nTracksTotal = 0;
     private double bfield;
     private FieldMap bFieldMap;
     private final MultipleScattering _scattering = new MultipleScattering(new MaterialSupervisor());
@@ -986,6 +987,7 @@ public class SimpleGBLTrajAliDriver extends Driver {
                             }
                             
                             
+                            gbl_fit_traj_u.delete();
                         } // loop on sensor map
 
 
@@ -1000,13 +1002,15 @@ public class SimpleGBLTrajAliDriver extends Driver {
                     
                     
                     
-                    
-                    
-                    
+                    //System.out.println("Refitted track chi2 " + gblTrk.getChi2());
                     refittedTracks.add(gblTrk);
+                    nTracksTotal += refittedTracks.size();
                     kinkDataCollection.add(newTrack.getSecond());
                     kinkDataRelations.add(new BaseLCRelation(newTrack.getSecond(), gblTrk));
                 }
+                
+                trajForMPII.delete();
+                trajForMPII_unconstrained.delete();
                 
             }// composite Alignment
             


### PR DESCRIPTION
This PR contains a few small but important changes to the KF-based alignment pipeline that are required for it to function properly.

1. @pbutti implemented the `delete` method for GblTrajectoryJna which is necessary to avoid a memory leak causing the alignment pipeline to crash on some systems. This crash was more common with KF-based alignment since KF produced more tracks which therefore created more GBL trajectories which therefore leaked more memory.
2. Since GBL tracker hits consist of two sensors, the "n-hits" cut for GBL is actually half of what it should be for KF. The previous implementation of doubling this cut accidentally doubled the cut _on each track_ which meant the variable holding the cut quickly overflowed and returned to zero, meaning a lot of low-quality KF tracks were being included in the alignment. This patch simply calculates the "actual n hit cut" depending on the type of track on each track, storing the result in a new variable.
3. Some KF tracks are not refit with a GBL trajectory properly and so we need to check that the resulting GBL trajectory is non-null before proceeding.

## To Do
- [x] Make sure code format is proper
- [x] Make sure code still passes current tests
- [x] Update documentation comments
- [x] Cleanup commit history