### PR TITLE
remove odd-number-hit cut for Kalman tracks

### DIFF
--- a/tracking/src/main/java/org/hps/recon/tracking/gbl/SimpleGBLTrajAliDriver.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/gbl/SimpleGBLTrajAliDriver.java
@@ -573,14 +573,6 @@ public class SimpleGBLTrajAliDriver extends Driver {
                         || (tanLambda < 0 && track.getTrackerHits().size() < actualHitCut))  {
                     continue;
                 }
-
-                if (TrackType == 1 && track.getTrackerHits().size() % 2 == 1) {
-                    // this is a KF track with an odd number of hits which /cannot/
-                    // be equivalent to a GBL track so we are going to skip it
-                    // in a future where KF-based alignment is the standard,
-                    // we probably want to remove this
-                    continue;
-                }
                 
                 // ask tracks only on a side
                 if (trackSide >= 0) {


### PR DESCRIPTION
This was a relic of a time when we were comparing KF-based and ST-based alignments. It is not needed anymore and we should remove this cut so we can use all tracks found by KF, including ones that may have only one sensor from a given module.

## Still To Do
- [ ] Check that this does not break previous alignment studies
- [ ] Maybe see if it helps?
- [ ] Maybe change the meaning of the nhit cut as described in #944 