### PR TITLE
Update lcsim version to 4.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <dependency.locations.enabled>false</dependency.locations.enabled>
-    <lcsimVersion>4.3</lcsimVersion>
+    <lcsimVersion>4.4.0</lcsimVersion>
     <skipSite>false</skipSite>
     <skipPlugin>false</skipPlugin>
     <additionalparam>-Xdoclint:none</additionalparam>


### PR DESCRIPTION
This updates the lcsim dependency to the latest release which includes the [MC particle endpoint fix](https://github.com/slaclab/lcsim/issues/43).