### PR TITLE
Reduce log level of SVT filter messages.

### DIFF
--- a/recon/src/main/java/org/hps/recon/filtering/EventFlagFilter.java
+++ b/recon/src/main/java/org/hps/recon/filtering/EventFlagFilter.java
@@ -11,7 +11,7 @@ import org.lcsim.event.EventHeader;
 public class EventFlagFilter extends EventReconFilter {
 
     private static Logger LOGGER = Logger.getLogger(EventFlagFilter.class.getPackage().getName());
-    private static Level LEVEL = Level.WARNING;
+    private static Level LEVEL = Level.FINE;
 
     String[] flagNames = {"svt_bias_good", "svt_position_good", "svt_burstmode_noise_good", "svt_event_header_good", "svt_latency_good", "svt_readout_overlap_good"};
 


### PR DESCRIPTION
Change the log level of the SVT filter messages from WARN to FINE to reduce console output when running with the default log settings.