### PR TITLE
Address simulated ECAL energy resolution

### DIFF
--- a/digi/src/main/java/org/hps/digi/EcalDigitizationWithPulserDataMergingReadoutDriver.java
+++ b/digi/src/main/java/org/hps/digi/EcalDigitizationWithPulserDataMergingReadoutDriver.java
@@ -8,6 +8,7 @@ import org.hps.conditions.database.DatabaseConditionsManager;
 import org.hps.conditions.ecal.EcalChannelConstants;
 import org.hps.conditions.ecal.EcalConditions;
 import org.hps.readout.ReadoutTimestamp;
+import org.hps.recon.ecal.EcalUtils;
 import org.lcsim.event.RawTrackerHit;
 import org.lcsim.geometry.Detector;
 import org.lcsim.geometry.subdetector.HPSEcal3;
@@ -50,7 +51,7 @@ public class EcalDigitizationWithPulserDataMergingReadoutDriver extends Digitiza
         setTriggerPathTruthRelationsCollectionName("TriggerPathTruthRelations");
         setReadoutHitCollectionName("EcalReadoutHits");
         
-        setPhotoelectronsPerMeV(32.8);
+        setPhotoelectronsPerMeV(EcalUtils.photoelectronsPerMeV);
         setPulseTimeParameter(9.6);
     }
     

--- a/ecal-readout-sim/src/main/java/org/hps/readout/ecal/FADCEcalReadoutDriver.java
+++ b/ecal-readout-sim/src/main/java/org/hps/readout/ecal/FADCEcalReadoutDriver.java
@@ -73,7 +73,7 @@ public class FADCEcalReadoutDriver extends EcalReadoutDriver<RawCalorimeterHit> 
     private double fixedGain = -1;
     private boolean constantTriggerWindow = true;
     private boolean addNoise = true;
-    private double pePerMeV = 32.8;
+    private double pePerMeV = EcalUtils.photoelectronsPerMeV;
     private boolean use2014Gain = false;
     private PulseShape pulseShape = PulseShape.ThreePole;
 

--- a/ecal-readout-sim/src/main/java/org/hps/readout/ecal/updated/EcalDigitizationReadoutDriver.java
+++ b/ecal-readout-sim/src/main/java/org/hps/readout/ecal/updated/EcalDigitizationReadoutDriver.java
@@ -10,6 +10,7 @@ import org.hps.conditions.ecal.EcalConditions;
 import org.hps.conditions.ecal.EcalChannel.EcalChannelCollection;
 import org.hps.readout.DigitizationReadoutDriver;
 import org.hps.readout.ReadoutTimestamp;
+import org.hps.recon.ecal.EcalUtils;
 import org.hps.record.daqconfig2019.ConfigurationManager2019;
 import org.hps.record.daqconfig2019.DAQConfig2019;
 import org.hps.record.daqconfig2019.FADCConfigEcal2019;
@@ -48,7 +49,7 @@ public class EcalDigitizationReadoutDriver extends DigitizationReadoutDriver<HPS
         setTriggerPathTruthRelationsCollectionName("TriggerPathTruthRelations");
         setReadoutHitCollectionName("EcalReadoutHits");
         
-        setPhotoelectronsPerMeV(30.8);
+        setPhotoelectronsPerMeV(EcalUtils.photoelectronsPerMeV);
         setPulseTimeParameter(9.6);
     }    
     

--- a/ecal-readout-sim/src/main/java/org/hps/readout/ecal/updated/EcalDigitizationReadoutDriver.java
+++ b/ecal-readout-sim/src/main/java/org/hps/readout/ecal/updated/EcalDigitizationReadoutDriver.java
@@ -48,7 +48,7 @@ public class EcalDigitizationReadoutDriver extends DigitizationReadoutDriver<HPS
         setTriggerPathTruthRelationsCollectionName("TriggerPathTruthRelations");
         setReadoutHitCollectionName("EcalReadoutHits");
         
-        setPhotoelectronsPerMeV(32.8);
+        setPhotoelectronsPerMeV(30.8);
         setPulseTimeParameter(9.6);
     }    
     

--- a/ecal-recon/src/main/java/org/hps/recon/ecal/EcalUtils.java
+++ b/ecal-recon/src/main/java/org/hps/recon/ecal/EcalUtils.java
@@ -23,6 +23,7 @@ public class EcalUtils {
     public static final double readoutGain = Req * lightYield * quantumEff * surfRatio * gainAPD * gainPreAmpl * elemCharge;// = 15.0545 volt-seconds/GeV
     public static final double gainFactor = adcResolution / readoutGain;
     public static final double ecalReadoutPeriod = 4.0; // readout period in ns, it is hardcoded in the public declaration of EcalReadoutDriver. 
+    public static final double photoelectronsPerMeV = 30.8;
 
     /**
      * Returns the quadrant which contains the ECal cluster


### PR DESCRIPTION
For now, just moving to uncorrelated noise on each sample, while still applying the photoelectron/statistical resolution separately on the pulse integral.  Previously the incorrect treatment of the noise effect rendered it zero.  Effect should be largest at lower energies, but no feeling for scale.

Need to get some simulations run to assess.  Can anyone help with this?