### PR TITLE
Update TrackerHitDriver config in 19/21 steering files

### DIFF
--- a/steering-files/src/main/resources/org/hps/steering/recon/PhysicsRun2019_pass0_recon_evio.lcsim
+++ b/steering-files/src/main/resources/org/hps/steering/recon/PhysicsRun2019_pass0_recon_evio.lcsim
@@ -122,7 +122,7 @@
             <debug>false</debug>
         </driver>
         <driver name="TrackerHitDriver" type="org.hps.recon.tracking.DataTrackerHitDriver">
-            <neighborDeltaT>8.0</neighborDeltaT>
+            <neighborDeltaT>24.0</neighborDeltaT>
             <saveMonsterEvents>false</saveMonsterEvents>
             <thresholdMonsterEvents>400</thresholdMonsterEvents>
             <debug>false</debug>

--- a/steering-files/src/main/resources/org/hps/steering/recon/PhysicsRun2021_pass0_recon_evio.lcsim
+++ b/steering-files/src/main/resources/org/hps/steering/recon/PhysicsRun2021_pass0_recon_evio.lcsim
@@ -104,9 +104,9 @@
             <debug>false</debug>
         </driver>
         <driver name="TrackerHitDriver" type="org.hps.recon.tracking.DataTrackerHitDriver">
-            <neighborDeltaT>8.0</neighborDeltaT>
+            <neighborDeltaT>24.0</neighborDeltaT>
             <saveMonsterEvents>false</saveMonsterEvents>
-            <thresholdMonsterEvents>200</thresholdMonsterEvents>
+            <thresholdMonsterEvents>400</thresholdMonsterEvents>
             <debug>false</debug>
         </driver>
         <driver name="HelicalTrackHitDriver" type="org.hps.recon.tracking.HelicalTrackHitDriver">


### PR DESCRIPTION
Opening up Si cluster hit fit time difference cut from 8 ns to 24 ns.