### PR TITLE
Iss952 Fix Z position of ECal Face

### DIFF
--- a/analysis/src/main/java/org/hps/analysis/MC/TrackDataDriverWithTruth.java
+++ b/analysis/src/main/java/org/hps/analysis/MC/TrackDataDriverWithTruth.java
@@ -101,6 +101,21 @@ public final class TrackDataDriverWithTruth extends Driver {
         // doesn't skip the event.
         if (!event.hasCollection(Track.class))
             return;
+        
+        int runNumber = event.getRunNumber();
+        TrackUtils.RunPeriod runPeriod = TrackUtils.RunPeriod.PhysRun2021;
+        if (4441 < runNumber && runNumber < 5967) {
+            runPeriod = TrackUtils.RunPeriod.EngRun2015;
+        }
+        if (7219 < runNumber && runNumber < 8100) {
+            runPeriod = TrackUtils.RunPeriod.EngRun2016;
+        }
+        if (9001 < runNumber && runNumber < 10740) {
+            runPeriod = TrackUtils.RunPeriod.PhysRun2019;
+        }
+        if (14131 < runNumber && runNumber < 14775) {
+            runPeriod = TrackUtils.RunPeriod.PhysRun2021;
+        }
 
         // Get all collections of the type Track from the event. This is
         // required since the event contains a track collection for each of the
@@ -220,7 +235,7 @@ public final class TrackDataDriverWithTruth extends Driver {
 
                 // Extrapolate the track to the face of the Ecal and get the TrackState
                 if (TrackType.isGBL(track.getType())) {
-                    TrackState stateEcal = TrackUtils.getTrackExtrapAtEcalRK(track, bFieldMap);
+                    TrackState stateEcal = TrackUtils.getTrackExtrapAtEcalRK(track, bFieldMap,runPeriod);
                     if (stateEcal != null)
                         track.getTrackStates().add(stateEcal);
                 }

--- a/analysis/src/main/java/org/hps/analysis/dataquality/MollerMonitoring.java
+++ b/analysis/src/main/java/org/hps/analysis/dataquality/MollerMonitoring.java
@@ -366,6 +366,21 @@ public class MollerMonitoring extends DataQualityMonitor {
         if (!matchTrigger(event)) {
             return;
         }
+        
+        int runNumber = event.getRunNumber();
+        TrackUtils.RunPeriod runPeriod = TrackUtils.RunPeriod.PhysRun2021;
+        if (4441 < runNumber && runNumber < 5967) {
+            runPeriod = TrackUtils.RunPeriod.EngRun2015;
+        }
+        if (7219 < runNumber && runNumber < 8100) {
+            runPeriod = TrackUtils.RunPeriod.EngRun2016;
+        }
+        if (9001 < runNumber && runNumber < 10740) {
+            runPeriod = TrackUtils.RunPeriod.PhysRun2019;
+        }
+        if (14131 < runNumber && runNumber < 14775) {
+            runPeriod = TrackUtils.RunPeriod.PhysRun2021;
+        }
 
         List<ReconstructedParticle> unConstrainedV0List = event.get(ReconstructedParticle.class,
                 unconstrainedV0CandidatesColName);
@@ -425,8 +440,8 @@ public class MollerMonitoring extends DataQualityMonitor {
             Hep3Vector pTopRot = VecOp.mult(beamAxisRotation, top.getMomentum());
             Hep3Vector pBotRot = VecOp.mult(beamAxisRotation, bot.getMomentum());
 
-            Hep3Vector topAtEcal = TrackUtils.getTrackPositionAtEcal(top.getTracks().get(0));
-            Hep3Vector botAtEcal = TrackUtils.getTrackPositionAtEcal(bot.getTracks().get(0));
+            Hep3Vector topAtEcal = TrackUtils.getTrackPositionAtEcal(top.getTracks().get(0), runPeriod);
+            Hep3Vector botAtEcal = TrackUtils.getTrackPositionAtEcal(bot.getTracks().get(0), runPeriod);
 
             BilliorVertexer vtxFitter = new BilliorVertexer(TrackUtils.getBField(event.getDetector()).y());
             vtxFitter.setBeamSize(beamSize);

--- a/analysis/src/main/java/org/hps/analysis/dataquality/TrackingMonitoring.java
+++ b/analysis/src/main/java/org/hps/analysis/dataquality/TrackingMonitoring.java
@@ -327,6 +327,21 @@ public class TrackingMonitoring extends DataQualityMonitor {
     @Override
     public void process(EventHeader event) {
 
+        int runNumber = event.getRunNumber();
+        TrackUtils.RunPeriod runPeriod = TrackUtils.RunPeriod.PhysRun2021;
+        if (4441 < runNumber && runNumber < 5967) {
+            runPeriod = TrackUtils.RunPeriod.EngRun2015;
+        }
+        if (7219 < runNumber && runNumber < 8100) {
+            runPeriod = TrackUtils.RunPeriod.EngRun2016;
+        }
+        if (9001 < runNumber && runNumber < 10740) {
+            runPeriod = TrackUtils.RunPeriod.PhysRun2019;
+        }
+        if (14131 < runNumber && runNumber < 14775) {
+            runPeriod = TrackUtils.RunPeriod.PhysRun2021;
+        }
+        
         aida.tree().cd("/");
 
         if (!event.hasCollection(LCRelation.class, helicalTrackHitRelationsCollectionName) || !event.hasCollection(LCRelation.class, rotatedHelicalTrackHitRelationsCollectionName))
@@ -383,7 +398,7 @@ public class TrackingMonitoring extends DataQualityMonitor {
         int cntTop = 0;
         int cntBot = 0;
         for (Track trk : tracks) {
-            Hep3Vector trackPosAtEcalFace = TrackUtils.getTrackPositionAtEcal(trk);
+            Hep3Vector trackPosAtEcalFace = TrackUtils.getTrackPositionAtEcal(trk, runPeriod);
             double xAtECal = trackPosAtEcalFace.x();
             double yAtECal = trackPosAtEcalFace.y();
             if (yAtECal > 0) {

--- a/analysis/src/main/java/org/hps/analysis/ecal/MassCalculator.java
+++ b/analysis/src/main/java/org/hps/analysis/ecal/MassCalculator.java
@@ -139,10 +139,10 @@ public class MassCalculator {
      * 
      * @return combined momentum (GeV)
      */
-    public static double combinedMomentum(Cluster cluster, Track track, double momentum) {
+    public static double combinedMomentum(Cluster cluster, Track track, double momentum,TrackUtils.RunPeriod runPeriod) {
         double energy = cluster.getEnergy();
         TrackState trackState = track.getTrackStates().get(0);
-        Hep3Vector posAtEcal = TrackUtils.getTrackPositionAtEcal(trackState);
+        Hep3Vector posAtEcal = TrackUtils.getTrackPositionAtEcal(trackState, runPeriod);
 
         int ix = ClusterUtilities.findSeedHit(cluster).getIdentifierFieldValue("ix");
         double yraw = posAtEcal.y();
@@ -168,14 +168,14 @@ public class MassCalculator {
      * 
      * @return weighted invariant mass (GeV)
      */
-    public static double combinedMass(Cluster clusterA, Cluster clusterB, ReconstructedParticle v0) {
+    public static double combinedMass(Cluster clusterA, Cluster clusterB, ReconstructedParticle v0, TrackUtils.RunPeriod runPeriod) {
         double momentumA = Math.sqrt(Math.pow(v0.getStartVertex().getParameters().get("p1X"), 2)
                 + Math.pow(v0.getStartVertex().getParameters().get("p1Y"), 2) + Math.pow(v0.getStartVertex().getParameters().get("p1Z"), 2));
         double momentumB = Math.sqrt(Math.pow(v0.getStartVertex().getParameters().get("p2X"), 2)
                 + Math.pow(v0.getStartVertex().getParameters().get("p2Y"), 2) + Math.pow(v0.getStartVertex().getParameters().get("p2Z"), 2));
        
-        double energyA = combinedMomentum(clusterA, v0.getParticles().get(0).getTracks().get(0), momentumA);
-        double energyB = combinedMomentum(clusterB, v0.getParticles().get(1).getTracks().get(0), momentumB);
+        double energyA = combinedMomentum(clusterA, v0.getParticles().get(0).getTracks().get(0), momentumA, runPeriod);
+        double energyB = combinedMomentum(clusterB, v0.getParticles().get(1).getTracks().get(0), momentumB, runPeriod);
 
         double cosT = cosTheta(v0);
         double mass = Math.sqrt(2 * energyA * energyB * (1 - cosT));
@@ -192,13 +192,13 @@ public class MassCalculator {
      * 
      * @return weighted invariant mass (GeV)
      */
-    public static double combinedMass(Track trackA, Cluster clusterB, ReconstructedParticle v0) {
+    public static double combinedMass(Track trackA, Cluster clusterB, ReconstructedParticle v0, TrackUtils.RunPeriod runPeriod) {
         double momentumA = Math.sqrt(Math.pow(v0.getStartVertex().getParameters().get("p1X"), 2)
                 + Math.pow(v0.getStartVertex().getParameters().get("p1Y"), 2) + Math.pow(v0.getStartVertex().getParameters().get("p1Z"), 2));
         double momentumB = Math.sqrt(Math.pow(v0.getStartVertex().getParameters().get("p2X"), 2)
                 + Math.pow(v0.getStartVertex().getParameters().get("p2Y"), 2) + Math.pow(v0.getStartVertex().getParameters().get("p2Z"), 2));
         double energyA = momentumA;
-        double energyB = combinedMomentum(clusterB, v0.getParticles().get(1).getTracks().get(0), momentumB);
+        double energyB = combinedMomentum(clusterB, v0.getParticles().get(1).getTracks().get(0), momentumB, runPeriod);
 
         double cosT = cosTheta(v0);
         double mass = Math.sqrt(2 * energyA * energyB * (1 - cosT));
@@ -214,12 +214,12 @@ public class MassCalculator {
      * 
      * @return weighted invariant mass (GeV)
      */
-    public static double combinedMass(Cluster clusterA, Track trackB, ReconstructedParticle v0) {
+    public static double combinedMass(Cluster clusterA, Track trackB, ReconstructedParticle v0, TrackUtils.RunPeriod runPeriod) {
         double momentumA = Math.sqrt(Math.pow(v0.getStartVertex().getParameters().get("p1X"), 2)
                 + Math.pow(v0.getStartVertex().getParameters().get("p1Y"), 2) + Math.pow(v0.getStartVertex().getParameters().get("p1Z"), 2));
         double momentumB = Math.sqrt(Math.pow(v0.getStartVertex().getParameters().get("p2X"), 2)
                 + Math.pow(v0.getStartVertex().getParameters().get("p2Y"), 2) + Math.pow(v0.getStartVertex().getParameters().get("p2Z"), 2));
-        double energyA = combinedMomentum(clusterA, v0.getParticles().get(0).getTracks().get(0), momentumA);
+        double energyA = combinedMomentum(clusterA, v0.getParticles().get(0).getTracks().get(0), momentumA, runPeriod);
         double energyB = momentumB;
 
         double cosT = cosTheta(v0);

--- a/analysis/src/main/java/org/hps/analysis/tuple/RefitTrackTruthTupleDriver.java
+++ b/analysis/src/main/java/org/hps/analysis/tuple/RefitTrackTruthTupleDriver.java
@@ -11,6 +11,7 @@ import java.util.Map;
 import org.hps.analysis.MC.MCFullDetectorTruth;
 import org.hps.recon.particle.ReconParticleDriver;
 import org.hps.recon.tracking.TrackType;
+import org.hps.recon.tracking.TrackUtils;
 import org.hps.recon.vertexing.BilliorVertex;
 import org.hps.record.triggerbank.TIData;
 import org.lcsim.event.CalorimeterHit;
@@ -28,6 +29,8 @@ import org.lcsim.event.Vertex;
 import org.lcsim.event.base.BaseRelationalTable;
 
 public class RefitTrackTruthTupleDriver extends TupleMaker {
+    
+    TrackUtils.RunPeriod runPeriod = TrackUtils.RunPeriod.PhysRun2021;
     
     private final String trackColName = "GBLTracks";
     private final String badTrackColName = "GBLTracks_bad";
@@ -86,6 +89,20 @@ public class RefitTrackTruthTupleDriver extends TupleMaker {
     @Override
     public void process(EventHeader event) {
         setupCollections(event);
+        int runNumber = event.getRunNumber();
+        
+        if (4441 < runNumber && runNumber < 5967) {
+            runPeriod = TrackUtils.RunPeriod.EngRun2015;
+        }
+        if (7219 < runNumber && runNumber < 8100) {
+            runPeriod = TrackUtils.RunPeriod.EngRun2016;
+        }
+        if (9001 < runNumber && runNumber < 10740) {
+            runPeriod = TrackUtils.RunPeriod.PhysRun2019;
+        }
+        if (14131 < runNumber && runNumber < 14775) {
+            runPeriod = TrackUtils.RunPeriod.PhysRun2021;
+        }
         for (ReconstructedParticle uncV0 : unConstrainedV0List) {
             tupleMap.clear();
             boolean isOK = fillBasicRefitTuple(event, triggerData, uncV0);
@@ -179,7 +196,7 @@ public class RefitTrackTruthTupleDriver extends TupleMaker {
         tupleMap.put("minNegativeIso/D", minNegativeIso);
         tupleMap.put("minIso/D", minIso);
         
-        fillVertexVariables("Badunc", uncV0, false);
+        fillVertexVariables("Badunc", uncV0, false, runPeriod);
         
         List<LCRelation> badMCParticleRelation = event.get(LCRelation.class,badMCParticleRelationsColName);
         MCParticle badEle = null;
@@ -217,18 +234,18 @@ public class RefitTrackTruthTupleDriver extends TupleMaker {
                 
                 fillParticleVariables(event, electronTruth, "eleTruth", true, true, true, "GBLKinkDataRelations_truth");
                 fillParticleVariables(event, positronTruth, "posTruth", true, true, true, "GBLKinkDataRelations_truth");
-                fillVertexVariables("Truthunc", temp, false);
+                fillVertexVariables("Truthunc", temp, false, runPeriod);
             }
             if (unc2bscTruth != null) {
                 ReconstructedParticle temp2 = unc2bscTruth.get(temp);
                 if (temp2 != null){
-                    fillVertexVariables("Truthbsc", temp2, false);
+                    fillVertexVariables("Truthbsc", temp2, false, runPeriod);
                 }
             }
             if (unc2tarTruth != null) {
                 ReconstructedParticle temp2 = unc2tarTruth.get(temp);
                 if (temp2 != null){
-                    fillVertexVariables("Truthtar", temp2, false);
+                    fillVertexVariables("Truthtar", temp2, false, runPeriod);
                 }
             }
         }
@@ -238,14 +255,14 @@ public class RefitTrackTruthTupleDriver extends TupleMaker {
             if (temp == null)
                 isOK = false;
             else{
-                fillVertexVariables("Badbsc", temp, false);
+                fillVertexVariables("Badbsc", temp, false, runPeriod);
             }
         }
         if (unc2tar != null) {
             ReconstructedParticle temp = unc2tar.get(uncV0);
             if (temp == null)
                 isOK = false;
-            fillVertexVariables("Badtar", temp, false);
+            fillVertexVariables("Badtar", temp, false, runPeriod);
         }
 
         return isOK;

--- a/analysis/src/main/java/org/hps/analysis/tuple/TupleMaker.java
+++ b/analysis/src/main/java/org/hps/analysis/tuple/TupleMaker.java
@@ -301,6 +301,20 @@ public abstract class TupleMaker extends Driver {
         if (isGBL != TrackType.isGBL(uncV0.getType())) {
             return false;
         }
+        int runNumber = event.getRunNumber();
+        TrackUtils.RunPeriod runPeriod = TrackUtils.RunPeriod.PhysRun2021;
+        if (4441 < runNumber && runNumber < 5967) {
+            runPeriod = TrackUtils.RunPeriod.EngRun2015;
+        }
+        if (7219 < runNumber && runNumber < 8100) {
+            runPeriod = TrackUtils.RunPeriod.EngRun2016;
+        }
+        if (9001 < runNumber && runNumber < 10740) {
+            runPeriod = TrackUtils.RunPeriod.PhysRun2019;
+        }
+        if (14131 < runNumber && runNumber < 14775) {
+            runPeriod = TrackUtils.RunPeriod.PhysRun2021;
+        }
         
         fillEventVariables(event, triggerData);
 
@@ -334,19 +348,19 @@ public abstract class TupleMaker extends Driver {
         tupleMap.put("minNegativeIso/D", minNegativeIso);
         tupleMap.put("minIso/D", minIso);
 
-        fillVertexVariables("unc", uncV0, false);
+        fillVertexVariables("unc", uncV0, false, runPeriod);
         if (unc2bsc != null) {
             ReconstructedParticle temp = unc2bsc.get(uncV0);
             if (temp == null)
                 isOK = false;
             else
-                fillVertexVariables("bsc", temp, false);
+                fillVertexVariables("bsc", temp, false, runPeriod);
         }
         if (unc2bsc != null) {
             ReconstructedParticle temp = unc2tar.get(uncV0);
             if (temp == null)
                 isOK = false;
-            fillVertexVariables("tar", temp, false);
+            fillVertexVariables("tar", temp, false, runPeriod);
         }
 
         return isOK;
@@ -1196,7 +1210,7 @@ public abstract class TupleMaker extends Driver {
         tupleMap.put(prefix + "CovZZ/D", theCov.e(2, 2));
     }
     
-    protected void fillVertexVariables(String prefix, ReconstructedParticle theV0, boolean isMoller) {
+    protected void fillVertexVariables(String prefix, ReconstructedParticle theV0, boolean isMoller, TrackUtils.RunPeriod runPeriod) {
         String[] mollerParticleNames = {"Top", "Bot"};
         String[] v0ParticleNames = {"Ele", "Pos"};
         
@@ -1280,15 +1294,15 @@ public abstract class TupleMaker extends Driver {
                             particle1.getTracks().get(0),
                             Math.sqrt(Math.pow(theV0.getStartVertex().getParameters().get("p1X"), 2)
                                     + Math.pow(theV0.getStartVertex().getParameters().get("p1Y"), 2)
-                                    + Math.pow(theV0.getStartVertex().getParameters().get("p1Z"), 2))));
+                                    + Math.pow(theV0.getStartVertex().getParameters().get("p1Z"), 2)), runPeriod));
 
             if (nClusters2>0) {
                 tupleMap.put(prefix+particleNames[1] + "WtP/D", MassCalculator.combinedMomentum(particle2.getClusters().get(0), particle2
                         .getTracks().get(0), Math.sqrt(Math.pow(theV0.getStartVertex().getParameters().get("p2X"), 2)
                                 + Math.pow(theV0.getStartVertex().getParameters().get("p2Y"), 2)
-                                + Math.pow(theV0.getStartVertex().getParameters().get("p2Z"), 2))));
+                                + Math.pow(theV0.getStartVertex().getParameters().get("p2Z"), 2)), runPeriod));
                 tupleMap.put(prefix+"WtM/D", MassCalculator.combinedMass(particle1.getClusters().get(0), particle2
-                        .getClusters().get(0), theV0));
+                        .getClusters().get(0), theV0, runPeriod));
             }
             else {
                 tupleMap.put(
@@ -1297,7 +1311,7 @@ public abstract class TupleMaker extends Driver {
                                 + Math.pow(theV0.getStartVertex().getParameters().get("p2Y"), 2)
                                 + Math.pow(theV0.getStartVertex().getParameters().get("p2Z"), 2)));
                 tupleMap.put(prefix+"WtM/D",
-                        MassCalculator.combinedMass(particle1.getClusters().get(0), particle2.getTracks().get(0), theV0));
+                        MassCalculator.combinedMass(particle1.getClusters().get(0), particle2.getTracks().get(0), theV0, runPeriod));
             }
         }
         if (nClusters2 > 0 && nClusters1 == 0) {// e+ has cluster, e- does not
@@ -1309,14 +1323,14 @@ public abstract class TupleMaker extends Driver {
                             particle2.getTracks().get(0),
                             Math.sqrt(Math.pow(theV0.getStartVertex().getParameters().get("p2X"), 2)
                                     + Math.pow(theV0.getStartVertex().getParameters().get("p2Y"), 2)
-                                    + Math.pow(theV0.getStartVertex().getParameters().get("p2Z"), 2))));
+                                    + Math.pow(theV0.getStartVertex().getParameters().get("p2Z"), 2)), runPeriod));
             tupleMap.put(
                     prefix+particleNames[0] + "WtP/D",
                     Math.sqrt(Math.pow(theV0.getStartVertex().getParameters().get("p1X"), 2)
                             + Math.pow(theV0.getStartVertex().getParameters().get("p1Y"), 2)
                             + Math.pow(theV0.getStartVertex().getParameters().get("p1Z"), 2)));
             tupleMap.put(prefix+"WtM/D",
-                    MassCalculator.combinedMass(particle1.getTracks().get(0), particle2.getClusters().get(0), theV0));
+                    MassCalculator.combinedMass(particle1.getTracks().get(0), particle2.getClusters().get(0), theV0, runPeriod));
         }
         if (nClusters2 == 0 && nClusters1 == 0) {
 

--- a/recon/src/main/java/org/hps/recon/filtering/SvtAlignmentFilter.java
+++ b/recon/src/main/java/org/hps/recon/filtering/SvtAlignmentFilter.java
@@ -28,7 +28,21 @@ public class SvtAlignmentFilter extends EventReconFilter {
     
     @Override
     protected void process(EventHeader event) {
-     
+        int runNumber = event.getRunNumber();
+        TrackUtils.RunPeriod runPeriod = TrackUtils.RunPeriod.PhysRun2021;
+        if (4441 < runNumber && runNumber < 5967) {
+            runPeriod = TrackUtils.RunPeriod.EngRun2015;
+        }
+        if (7219 < runNumber && runNumber < 8100) {
+            runPeriod = TrackUtils.RunPeriod.EngRun2016;
+        }
+        if (9001 < runNumber && runNumber < 10740) {
+            runPeriod = TrackUtils.RunPeriod.PhysRun2019;
+        }
+        if (14131 < runNumber && runNumber < 14775) {
+            runPeriod = TrackUtils.RunPeriod.PhysRun2021;
+        }
+        
         incrementEventProcessed();
         
         if(!event.hasCollection(Track.class,"MatchedTracks")) skipEvent();
@@ -42,7 +56,7 @@ public class SvtAlignmentFilter extends EventReconFilter {
         List<Track> selectedTracks = new ArrayList<Track>();
 
         for(Track track : tracks) {
-            Hep3Vector posAtEcal = TrackUtils.getTrackPositionAtEcal(tracks.get(0));
+            Hep3Vector posAtEcal = TrackUtils.getTrackPositionAtEcal(tracks.get(0),runPeriod);
             Cluster cand_clust = findClosestCluster(posAtEcal, clusters);
             if(cand_clust!=null) {
                 if(Math.abs( posAtEcal.x() - cand_clust.getPosition()[0])<30.0 && 

--- a/tracking/src/main/java/org/hps/recon/tracking/BeamlineConstants.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/BeamlineConstants.java
@@ -5,7 +5,8 @@ public final class BeamlineConstants {
     private BeamlineConstants() {
     }
 
-    public static final double ECAL_FACE = 1394.0; // mm Email from Takashi Jan 15th, 2015
+    public static final double ECAL_FACE = 1448.0; // mm Matches z of ECal clusters as returned in reconstruction Norman A. Graf, 3/8/2023
+    public static final double ECAL_FACE_ENGINEERING_RUNS = 1394.0; // mm Email from Takashi Jan 15th, 2015
     public static final double ECAL_FACE_TESTRUN = 1524; // mm
     public static final double DIPOLE_EDGE_TESTRUN = 457.2 + 457.2; // 452.2 +
     // 462.2;

--- a/tracking/src/main/java/org/hps/recon/tracking/TrackDataDriver.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/TrackDataDriver.java
@@ -92,6 +92,20 @@ public final class TrackDataDriver extends Driver {
      */
     @Override
     protected void process(EventHeader event) {
+        int runNumber = event.getRunNumber();
+        TrackUtils.RunPeriod runPeriod = TrackUtils.RunPeriod.PhysRun2021;
+        if (4441 < runNumber && runNumber < 5967) {
+            runPeriod = TrackUtils.RunPeriod.EngRun2015;
+        }
+        if (7219 < runNumber && runNumber < 8100) {
+            runPeriod = TrackUtils.RunPeriod.EngRun2016;
+        }
+        if (9001 < runNumber && runNumber < 10740) {
+            runPeriod = TrackUtils.RunPeriod.PhysRun2019;
+        }
+        if (14131 < runNumber && runNumber < 14775) {
+            runPeriod = TrackUtils.RunPeriod.PhysRun2021;
+        }
 
         // Check if the event contains a collection of the type Track. If it
         // doesn't skip the event.
@@ -213,7 +227,7 @@ public final class TrackDataDriver extends Driver {
 
                 // Extrapolate the track to the face of the Ecal and get the TrackState
                 if (TrackType.isGBL(track.getType())) {
-                    TrackState stateEcal = TrackUtils.getTrackExtrapAtEcalRK(track, bFieldMap);
+                    TrackState stateEcal = TrackUtils.getTrackExtrapAtEcalRK(track, bFieldMap,runPeriod);
                     if (stateEcal != null)
                         track.getTrackStates().add(stateEcal);
                 }

--- a/tracking/src/main/java/org/hps/recon/tracking/TrackDataDriver.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/TrackDataDriver.java
@@ -227,6 +227,7 @@ public final class TrackDataDriver extends Driver {
 
                 // Extrapolate the track to the face of the Ecal and get the TrackState
                 if (TrackType.isGBL(track.getType())) {
+                    
                     TrackState stateEcal = TrackUtils.getTrackExtrapAtEcalRK(track, bFieldMap,runPeriod);
                     if (stateEcal != null)
                         track.getTrackStates().add(stateEcal);

--- a/tracking/src/main/java/org/hps/recon/tracking/TrackUtils.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/TrackUtils.java
@@ -644,17 +644,16 @@ public class TrackUtils {
 
     public static BaseTrackState getTrackExtrapAtEcal(TrackState track, FieldMap fieldMap, TrackUtils.RunPeriod runPeriod) {
         // extrapolateTrackUsingFieldMap(TrackState track, double startPositionX, double endPosition, double stepSize, FieldMap fieldMap)
-        double zAtEcal = 0.;
-        switch (runPeriod) {
-            case EngRun2015:
-                zAtEcal = BeamlineConstants.ECAL_FACE_ENGINEERING_RUNS;
-            case EngRun2016:
-                zAtEcal = BeamlineConstants.ECAL_FACE_ENGINEERING_RUNS;
-            case PhysRun2019:
-                zAtEcal = BeamlineConstants.ECAL_FACE;
-            case PhysRun2021:
-                zAtEcal = BeamlineConstants.ECAL_FACE;
-        }
+        double zAtEcal = BeamlineConstants.ECAL_FACE;
+        if (runPeriod == RunPeriod.EngRun2015)
+            zAtEcal = BeamlineConstants.ECAL_FACE_ENGINEERING_RUNS;
+        else if (runPeriod == RunPeriod.EngRun2016)
+            zAtEcal = BeamlineConstants.ECAL_FACE_ENGINEERING_RUNS;
+        else if (runPeriod == RunPeriod.PhysRun2019)
+            zAtEcal = BeamlineConstants.ECAL_FACE;
+        else if (runPeriod == RunPeriod.PhysRun2021)
+            zAtEcal = BeamlineConstants.ECAL_FACE;
+        
         BaseTrackState bts = extrapolateTrackUsingFieldMap(track, BeamlineConstants.DIPOLE_EDGE_ENG_RUN, zAtEcal, 5.0, fieldMap);
         bts.setLocation(TrackState.AtCalorimeter);
         return bts;
@@ -666,18 +665,16 @@ public class TrackUtils {
 
     public static BaseTrackState getTrackExtrapAtEcalRK(TrackState ts, FieldMap fM, double stepSize, TrackUtils.RunPeriod runPeriod) {
 
-        double zAtEcal = 0.;
-        switch (runPeriod) {
-            case EngRun2015:
-                zAtEcal = BeamlineConstants.ECAL_FACE_ENGINEERING_RUNS;
-            case EngRun2016:
-                zAtEcal = BeamlineConstants.ECAL_FACE_ENGINEERING_RUNS;
-            case PhysRun2019:
-                zAtEcal = BeamlineConstants.ECAL_FACE;
-            case PhysRun2021:
-                zAtEcal = BeamlineConstants.ECAL_FACE;
-        }
-
+        double zAtEcal = BeamlineConstants.ECAL_FACE;
+        if (runPeriod == RunPeriod.EngRun2015)
+            zAtEcal = BeamlineConstants.ECAL_FACE_ENGINEERING_RUNS;
+        else if (runPeriod == RunPeriod.EngRun2016)
+            zAtEcal = BeamlineConstants.ECAL_FACE_ENGINEERING_RUNS;
+        else if (runPeriod == RunPeriod.PhysRun2019)
+            zAtEcal = BeamlineConstants.ECAL_FACE;
+        else if (runPeriod == RunPeriod.PhysRun2021)
+            zAtEcal = BeamlineConstants.ECAL_FACE;
+ 
         Hep3Vector startPos = extrapolateHelixToXPlane(ts, BeamlineConstants.DIPOLE_EDGE_ENG_RUN);
         Hep3Vector startPosTrans = CoordinateTransformations.transformVectorToDetector(startPos);
         double distanceZ = zAtEcal - BeamlineConstants.DIPOLE_EDGE_ENG_RUN;
@@ -783,13 +780,37 @@ public class TrackUtils {
     }
 
     @Deprecated
-    public static Hep3Vector getTrackPositionAtEcal(Track track) {
-        return extrapolateTrack(track, BeamlineConstants.ECAL_FACE);
+    public static Hep3Vector getTrackPositionAtEcal(Track track, TrackUtils.RunPeriod runPeriod) {
+        double zAtEcal = BeamlineConstants.ECAL_FACE;
+        switch (runPeriod) {
+            case EngRun2015:
+                zAtEcal = BeamlineConstants.ECAL_FACE_ENGINEERING_RUNS;
+            case EngRun2016:
+                zAtEcal = BeamlineConstants.ECAL_FACE_ENGINEERING_RUNS;
+            case PhysRun2019:
+                zAtEcal = BeamlineConstants.ECAL_FACE;
+            case PhysRun2021:
+                zAtEcal = BeamlineConstants.ECAL_FACE;
+        }
+        
+        return extrapolateTrack(track, zAtEcal);
     }
 
     @Deprecated
-    public static Hep3Vector getTrackPositionAtEcal(TrackState track) {
-        return extrapolateTrack(track, BeamlineConstants.ECAL_FACE);
+    public static Hep3Vector getTrackPositionAtEcal(TrackState track, TrackUtils.RunPeriod runPeriod) {
+        double zAtEcal = BeamlineConstants.ECAL_FACE;
+        switch (runPeriod) {
+            case EngRun2015:
+                zAtEcal = BeamlineConstants.ECAL_FACE_ENGINEERING_RUNS;
+            case EngRun2016:
+                zAtEcal = BeamlineConstants.ECAL_FACE_ENGINEERING_RUNS;
+            case PhysRun2019:
+                zAtEcal = BeamlineConstants.ECAL_FACE;
+            case PhysRun2021:
+                zAtEcal = BeamlineConstants.ECAL_FACE;
+        }
+        
+        return extrapolateTrack(track, zAtEcal);
     }
 
     /**

--- a/tracking/src/main/java/org/hps/recon/tracking/TrackUtils.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/TrackUtils.java
@@ -77,6 +77,13 @@ import org.ejml.data.DMatrix3;
  */
 public class TrackUtils {
 
+    public enum RunPeriod {
+        EngRun2015,
+        EngRun2016,
+        PhysRun2019,
+        PhysRun2021;
+    }
+
     /**
      * Private constructor to make class static only
      */
@@ -90,11 +97,13 @@ public class TrackUtils {
             // no TrackState at this sensor available
             // try to get last available TrackState-at-sensor
             TrackState tmp = TrackStateUtils.getPreviousTrackStateAtSensor(track, sensors, i + 1);
-            if (tmp != null)
+            if (tmp != null) {
                 extrapPos = TrackStateUtils.getLocationAtSensor(tmp, sensor, bfield);
-            if (extrapPos == null)
-                // now try using TrackState at IP
+            }
+            if (extrapPos == null) // now try using TrackState at IP
+            {
                 extrapPos = TrackStateUtils.getLocationAtSensor(TrackStateUtils.getTrackStateAtIP(track), sensor, bfield);
+            }
         }
         return extrapPos;
     }
@@ -141,15 +150,13 @@ public class TrackUtils {
         double px = momentum.x();
         double py = momentum.y();
         double pz = momentum.z();
-        
+
         //wrong =
         double R = charge * momentum.magnitude() / (Constants.fieldConversion * BField);
-        
+
         //correct
         //double pt = Math.sqrt(px*px + py*py);
         //double R = charge * pt / (Constants.fieldConversion * BField);
-        
-
         double tanL = calculateTanLambda(pz, momentum.magnitude());
         double phi = calculatePhi(px, py);
         //reference position is at x=pointX, y=pointY, z=0
@@ -176,8 +183,9 @@ public class TrackUtils {
     public static double[] getParametersFromPointAndMomentum(Hep3Vector point, Hep3Vector momentum, int charge, double BField, boolean writeIt) throws FileNotFoundException {
 
         //print out the original trajectory
-        if (writeIt)
+        if (writeIt) {
             writeTrajectory(momentum, point, charge, BField, "orig-point-and-mom.txt");
+        }
         //first, get the curvature
         //Calculate theta, the of the helix projected into an SZ plane, from the z axis
         double px = momentum.x();
@@ -195,9 +203,9 @@ public class TrackUtils {
         double tanL = pz / pt;
         //  Azimuthal direction at point
         //double phi = Math.atan2(py, px);
-        
-        double phi = FastMath.atan2(py,px);
-                
+
+        double phi = FastMath.atan2(py, px);
+
         //reference position is at x=pointX, y=pointY, z=0
         //so dca=0, z0=pointZ
         double dca = 0;
@@ -219,8 +227,9 @@ public class TrackUtils {
         double[] newParameters = getParametersAtNewRefPoint(newReferencePoint, oldReferencePoint, params);
         //System.out.println("New  :  d0 = " + newParameters[HelicalTrackFit.dcaIndex] + "; phi0 = " + newParameters[HelicalTrackFit.phi0Index] + "; curvature = " + newParameters[HelicalTrackFit.curvatureIndex] + "; z0 = " + newParameters[HelicalTrackFit.z0Index] + "; slope = " + newParameters[HelicalTrackFit.slopeIndex]);
         //print the trajectory after shift.  Should be the same!!!        
-        if (writeIt)
+        if (writeIt) {
             writeTrajectory(getMomentum(newParameters[HelicalTrackFit.curvatureIndex], newParameters[HelicalTrackFit.phi0Index], newParameters[HelicalTrackFit.slopeIndex], BField), getPoint(newParameters[HelicalTrackFit.dcaIndex], newParameters[HelicalTrackFit.phi0Index], newParameters[HelicalTrackFit.z0Index]), charge, BField, "final-point-and-mom.txt");
+        }
 
         return newParameters;
     }
@@ -228,8 +237,7 @@ public class TrackUtils {
     /**
      * Change reference point of helix (following L3 Internal Note 1666.)
      *
-     * @param newRefPoint
-     * - The new reference point in XY
+     * @param newRefPoint - The new reference point in XY
      */
     public static double[] getParametersAtNewRefPoint(double[] newRefPoint, TrackState trkState) {
         return getParametersAtNewRefPoint(newRefPoint, trkState.getReferencePoint(), trkState.getParameters());
@@ -238,8 +246,7 @@ public class TrackUtils {
     /**
      * Change reference point of helix (following L3 Internal Note 1666.)
      *
-     * @param newRefPoint
-     * - The new reference point in XY
+     * @param newRefPoint - The new reference point in XY
      */
     public static double[] getParametersAtNewRefPoint(double[] newRefPoint, HpsHelicalTrackFit helicalTrackFit) {
         return getParametersAtNewRefPoint(newRefPoint, helicalTrackFit.getRefPoint(), helicalTrackFit.parameters());
@@ -248,8 +255,7 @@ public class TrackUtils {
     /**
      * Change reference point of helix (following L3 Internal Note 1666.)
      *
-     * @param newRefPoint
-     * - The new reference point in XY
+     * @param newRefPoint - The new reference point in XY
      */
     public static double[] getParametersAtNewRefPoint(double[] newRefPoint, double[] __refPoint, double[] parameters) {
 
@@ -284,22 +290,23 @@ public class TrackUtils {
             //phinew = Math.atan2(sinphi - dx / (R - dca), cosphi + dy / (R - dca));
             //System.out.println("PF::DEBUG::phinew:="+phinew);
             phinew = FastMath.atan2(sinphi - dx / (R - dca), cosphi + dy / (R - dca));
-            
 
             // difference in phi
             // watch out for ambiguity        
             double dphi = phinew - phi0;
-            if (Math.abs(dphi) > Math.PI)
+            if (Math.abs(dphi) > Math.PI) {
                 System.out.println("TrackUtils::WARNING::dphi is large " + dphi + " from phi0 " + phi0 + " and phinew " + phinew + " take care of the ambiguity!!??");
+            }
 
             // calculate new dca
             dcanew += dx * sinphi - dy * cosphi + (dx * cosphi + dy * sinphi) * Math.tan(dphi / 2.);
-            
+
             // path length from old to new point
             double s = -1.0 * dphi / curvature;
-            double dz = 0.; 
-            if (newRefPoint.length == 3)
+            double dz = 0.;
+            if (newRefPoint.length == 3) {
                 dz = newRefPoint[2] - __refPoint[2];
+            }
             // new z0
             z0new += s * slope - dz;
             //z0new += s * slope;
@@ -499,14 +506,10 @@ public class TrackUtils {
      * space. Uses an iterative procedure. This function makes assumptions on
      * the sign and convecntion of the B-field. Be careful.
      *
-     * @param helfit
-     * - helix
-     * @param unit_vec_normal_to_plane
-     * - unit vector normal to the plane
-     * @param point_on_plane
-     * - point on the plane
-     * @param bfield
-     * - magnetic field value
+     * @param helfit - helix
+     * @param unit_vec_normal_to_plane - unit vector normal to the plane
+     * @param point_on_plane - point on the plane
+     * @param bfield - magnetic field value
      * @return point at intercept
      */
     public static Hep3Vector getHelixPlaneIntercept(HelicalTrackFit helfit, Hep3Vector unit_vec_normal_to_plane, Hep3Vector point_on_plane, double bfield) {
@@ -517,24 +520,28 @@ public class TrackUtils {
         boolean debug = false;
         // Hep3Vector B = new BasicHep3Vector(0, 0, -1);
         // WTrack wtrack = new WTrack(helfit, -1.0*bfield); //
-        if (Math.abs(point_on_plane.x() - helfit.xc()) > Math.abs(helfit.R()))
+        if (Math.abs(point_on_plane.x() - helfit.xc()) > Math.abs(helfit.R())) {
             return null;
+        }
         Hep3Vector B = new BasicHep3Vector(0, 0, 1);
-        DMatrix3 B_ejml = new DMatrix3(B.x(),B.y(),B.z());
+        DMatrix3 B_ejml = new DMatrix3(B.x(), B.y(), B.z());
         DMatrix3 unit_vec_normal_to_plane_ejml = new DMatrix3(unit_vec_normal_to_plane.x(), unit_vec_normal_to_plane.y(), unit_vec_normal_to_plane.z());
         DMatrix3 point_on_plane_ejml = new DMatrix3(point_on_plane.x(), point_on_plane.y(), point_on_plane.z());
-        
+
         WTrack wtrack = new WTrack(helfit, bfield); //
-        if (initial_s != 0 && initial_s != Double.NaN)
-            //wtrack.setTrackParameters(wtrack.getHelixParametersAtPathLength(initial_s, B));
+        if (initial_s != 0 && initial_s != Double.NaN) //wtrack.setTrackParameters(wtrack.getHelixParametersAtPathLength(initial_s, B));
+        {
             wtrack.setTrackParameters(wtrack.getHelixParametersAtPathLength_ejml(initial_s, B_ejml));
-        if (debug)
+        }
+        if (debug) {
             System.out.printf("getHelixPlaneIntercept:find intercept between plane defined by point on plane %s, unit vec %s, bfield %.3f, h=%s and WTrack \n%s \n", point_on_plane.toString(), unit_vec_normal_to_plane.toString(), bfield, B.toString(), wtrack.toString());
+        }
         try {
             //Hep3Vector intercept_point = wtrack.getHelixAndPlaneIntercept(point_on_plane, unit_vec_normal_to_plane, B);
             Hep3Vector intercept_point = wtrack.getHelixAndPlaneIntercept_ejml(point_on_plane_ejml, unit_vec_normal_to_plane_ejml, B_ejml);
-            if (debug)
+            if (debug) {
                 System.out.printf("getHelixPlaneIntercept: found intercept point at %s\n", intercept_point.toString());
+            }
             return intercept_point;
         } catch (RuntimeException e) {
             return null;
@@ -545,18 +552,16 @@ public class TrackUtils {
      * Calculate the point of interception between the helix and a plane in
      * space. Uses an iterative procedure.
      *
-     * @param helfit
-     * - helix
-     * @param strip
-     * - strip cluster that will define the plane
-     * @param bfield
-     * - magnetic field value
+     * @param helfit - helix
+     * @param strip - strip cluster that will define the plane
+     * @param bfield - magnetic field value
      * @return point at intercept
      */
     public static Hep3Vector getHelixPlaneIntercept(HelicalTrackFit helfit, HelicalTrackStripGbl strip, double bfield) {
         Hep3Vector point_on_plane = strip.origin();
-        if (Math.abs(point_on_plane.x() - helfit.xc()) > Math.abs(helfit.R()))
+        if (Math.abs(point_on_plane.x() - helfit.xc()) > Math.abs(helfit.R())) {
             return null;
+        }
         Hep3Vector unit_vec_normal_to_plane = VecOp.cross(strip.u(), strip.v());// strip.w();
         double s_origin = HelixUtils.PathToXPlane(helfit, point_on_plane.x(), 0., 0).get(0);
         Hep3Vector intercept_point = getHelixPlaneIntercept(helfit, unit_vec_normal_to_plane, point_on_plane, bfield, s_origin);
@@ -573,43 +578,41 @@ public class TrackUtils {
     public static Hep3Vector getTrackPositionAtHarp(Track track) {
         return extrapolateTrack(track, BeamlineConstants.HARP_POSITION_TESTRUN);
     }
-    
 
     //******* This block can be generalized! *******//
-    
     //Default step size
     public static BaseTrackState getTrackExtrapAtVtxSurfRK(Track trk, FieldMap fM, double distanceZ) {
         return getTrackExtrapAtVtxSurfRK(trk, fM, 0, distanceZ);
     }
-    
+
     //For the moment I use IP, but I should use first sensor!!
     public static BaseTrackState getTrackExtrapAtVtxSurfRK(Track trk, FieldMap fM, double stepSize, double distanceZ) {
         BaseTrackState ts = (BaseTrackState) TrackStateUtils.getTrackStateAtFirst(trk);
-        if (ts != null)
-            return getTrackExtrapAtVtxSurfRK(ts, fM, stepSize,distanceZ);
+        if (ts != null) {
+            return getTrackExtrapAtVtxSurfRK(ts, fM, stepSize, distanceZ);
+        }
         return null;
     }
-    
-    
+
     public static BaseTrackState getTrackExtrapAtVtxSurfRK(TrackState ts, FieldMap fM, double stepSize, double distanceZ) {
         //Change of charge
         Hep3Vector startPos = extrapolateHelixToXPlane(ts, 0.);
         Hep3Vector startPosTrans = CoordinateTransformations.transformVectorToDetector(startPos);
         double charge = -1.0 * Math.signum(getR(ts));
-        
+
         //Extrapolate
         org.hps.util.Pair<Hep3Vector, Hep3Vector> RKresults = extrapolateTrackUsingFieldMapRK(ts, startPosTrans, distanceZ, stepSize, fM);
         //Position
         Hep3Vector posTrans = CoordinateTransformations.transformVectorToTracking(RKresults.getFirstElement());
         //Momentum
-        Hep3Vector momTrans = CoordinateTransformations.transformVectorToTracking(RKresults.getSecondElement()); 
-        
+        Hep3Vector momTrans = CoordinateTransformations.transformVectorToTracking(RKresults.getSecondElement());
+
         double bFieldY = fM.getField(RKresults.getFirstElement()).y();
-        
+
         //Correct if it didn't arrive to it
         Hep3Vector finalPos = posTrans;
         if (RKresults.getFirstElement().z() != distanceZ) {
-            Hep3Vector mom = RKresults.getSecondElement();  
+            Hep3Vector mom = RKresults.getSecondElement();
             double dz = distanceZ - RKresults.getFirstElement().z();
             double dy = dz * mom.y() / mom.z();
             double dx = dz * mom.x() / mom.z();
@@ -623,7 +626,6 @@ public class TrackUtils {
         bts.setLocation(TrackState.AtVertex);
         return bts;
     }
-    
 
     /**
      * Get position of a track extrapolated to the ECAL face in the HPS test run
@@ -632,28 +634,53 @@ public class TrackUtils {
      * @param track
      * @return position at ECAL
      */
-    public static BaseTrackState getTrackExtrapAtEcal(Track track, FieldMap fieldMap) {
+    public static BaseTrackState getTrackExtrapAtEcal(Track track, FieldMap fieldMap, TrackUtils.RunPeriod runPeriod) {
         TrackState stateAtLast = TrackUtils.getTrackStateAtLocation(track, TrackState.AtLastHit);
-        if (stateAtLast == null)
+        if (stateAtLast == null) {
             return null;
-        return getTrackExtrapAtEcal(stateAtLast, fieldMap);
+        }
+        return getTrackExtrapAtEcal(stateAtLast, fieldMap, runPeriod);
     }
 
-    public static BaseTrackState getTrackExtrapAtEcal(TrackState track, FieldMap fieldMap) {
+    public static BaseTrackState getTrackExtrapAtEcal(TrackState track, FieldMap fieldMap, TrackUtils.RunPeriod runPeriod) {
         // extrapolateTrackUsingFieldMap(TrackState track, double startPositionX, double endPosition, double stepSize, FieldMap fieldMap)
-        BaseTrackState bts = extrapolateTrackUsingFieldMap(track, BeamlineConstants.DIPOLE_EDGE_ENG_RUN, BeamlineConstants.ECAL_FACE, 5.0, fieldMap);
+        double zAtEcal = 0.;
+        switch (runPeriod) {
+            case EngRun2015:
+                zAtEcal = BeamlineConstants.ECAL_FACE_ENGINEERING_RUNS;
+            case EngRun2016:
+                zAtEcal = BeamlineConstants.ECAL_FACE_ENGINEERING_RUNS;
+            case PhysRun2019:
+                zAtEcal = BeamlineConstants.ECAL_FACE;
+            case PhysRun2021:
+                zAtEcal = BeamlineConstants.ECAL_FACE;
+        }
+        BaseTrackState bts = extrapolateTrackUsingFieldMap(track, BeamlineConstants.DIPOLE_EDGE_ENG_RUN, zAtEcal, 5.0, fieldMap);
         bts.setLocation(TrackState.AtCalorimeter);
         return bts;
     }
 
-    public static BaseTrackState getTrackExtrapAtEcalRK(TrackState ts, FieldMap fM) {
-        return getTrackExtrapAtEcalRK(ts, fM, 0);
+    public static BaseTrackState getTrackExtrapAtEcalRK(TrackState ts, FieldMap fM, TrackUtils.RunPeriod runPeriod) {
+        return getTrackExtrapAtEcalRK(ts, fM, 0, runPeriod);
     }
 
-    public static BaseTrackState getTrackExtrapAtEcalRK(TrackState ts, FieldMap fM, double stepSize) {
+    public static BaseTrackState getTrackExtrapAtEcalRK(TrackState ts, FieldMap fM, double stepSize, TrackUtils.RunPeriod runPeriod) {
+
+        double zAtEcal = 0.;
+        switch (runPeriod) {
+            case EngRun2015:
+                zAtEcal = BeamlineConstants.ECAL_FACE_ENGINEERING_RUNS;
+            case EngRun2016:
+                zAtEcal = BeamlineConstants.ECAL_FACE_ENGINEERING_RUNS;
+            case PhysRun2019:
+                zAtEcal = BeamlineConstants.ECAL_FACE;
+            case PhysRun2021:
+                zAtEcal = BeamlineConstants.ECAL_FACE;
+        }
+
         Hep3Vector startPos = extrapolateHelixToXPlane(ts, BeamlineConstants.DIPOLE_EDGE_ENG_RUN);
         Hep3Vector startPosTrans = CoordinateTransformations.transformVectorToDetector(startPos);
-        double distanceZ = BeamlineConstants.ECAL_FACE - BeamlineConstants.DIPOLE_EDGE_ENG_RUN;
+        double distanceZ = zAtEcal - BeamlineConstants.DIPOLE_EDGE_ENG_RUN;
         double charge = -1.0 * Math.signum(getR(ts));
 
         org.hps.util.Pair<Hep3Vector, Hep3Vector> RKresults = extrapolateTrackUsingFieldMapRK(ts, startPosTrans, distanceZ, stepSize, fM);
@@ -662,9 +689,9 @@ public class TrackUtils {
         Hep3Vector momTrans = CoordinateTransformations.transformVectorToTracking(RKresults.getSecondElement());
 
         Hep3Vector finalPos = posTrans;
-        if (RKresults.getFirstElement().z() != BeamlineConstants.ECAL_FACE) {
+        if (RKresults.getFirstElement().z() != zAtEcal) {
             Hep3Vector mom = RKresults.getSecondElement();
-            double dz = BeamlineConstants.ECAL_FACE - RKresults.getFirstElement().z();
+            double dz = zAtEcal - RKresults.getFirstElement().z();
             double dy = dz * mom.y() / mom.z();
             double dx = dz * mom.x() / mom.z();
             Hep3Vector dPos = new BasicHep3Vector(dx, dy, dz);
@@ -678,15 +705,16 @@ public class TrackUtils {
         return bts;
     }
 
-    public static BaseTrackState getTrackExtrapAtEcalRK(Track trk, FieldMap fM, double stepSize) {
+    public static BaseTrackState getTrackExtrapAtEcalRK(Track trk, FieldMap fM, double stepSize, TrackUtils.RunPeriod runPeriod) {
         BaseTrackState ts = (BaseTrackState) TrackStateUtils.getTrackStateAtLast(trk);
-        if (ts != null)
-            return getTrackExtrapAtEcalRK(ts, fM, stepSize);
+        if (ts != null) {
+            return getTrackExtrapAtEcalRK(ts, fM, stepSize, runPeriod);
+        }
         return null;
     }
 
-    public static BaseTrackState getTrackExtrapAtEcalRK(Track trk, FieldMap fM) {
-        return getTrackExtrapAtEcalRK(trk, fM, 0);
+    public static BaseTrackState getTrackExtrapAtEcalRK(Track trk, FieldMap fM, TrackUtils.RunPeriod runPeriod) {
+        return getTrackExtrapAtEcalRK(trk, fM, 0, runPeriod);
     }
 
     /**
@@ -702,8 +730,9 @@ public class TrackUtils {
         Hep3Vector startPosTrans = CoordinateTransformations.transformVectorToDetector(startPos);
         double distZHodo = BeamlineConstants.HODO_L1_ZPOS;
         int hodoTrackStateIndex = 0;
-        if (hodoLayer == 2)
+        if (hodoLayer == 2) {
             distZHodo = BeamlineConstants.HODO_L2_ZPOS; //            hodoTrackStateIndex = 7;
+        }
         double distanceZ = distZHodo - BeamlineConstants.DIPOLE_EDGE_ENG_RUN;
         double charge = -1.0 * Math.signum(getR(ts));
 
@@ -731,8 +760,9 @@ public class TrackUtils {
 
     public static BaseTrackState getTrackExtrapAtHodoRK(Track trk, FieldMap fM, double stepSize, int hodoLayer) {
         BaseTrackState ts = (BaseTrackState) TrackStateUtils.getTrackStateAtLast(trk);
-        if (ts != null)
+        if (ts != null) {
             return getTrackExtrapAtHodoRK(ts, fM, stepSize, hodoLayer);
+        }
         return null;
     }
 
@@ -743,8 +773,7 @@ public class TrackUtils {
     /**
      * Extrapolate track to given position. For backwards compatibility.
      *
-     * @param track
-     * - to be extrapolated
+     * @param track - to be extrapolated
      * @param z
      * @return extrapolated position
      */
@@ -766,8 +795,7 @@ public class TrackUtils {
     /**
      * Extrapolate track to given position.
      *
-     * @param track
-     * - to be extrapolated
+     * @param track - to be extrapolated
      * @param z
      * @return extrapolated position
      */
@@ -806,8 +834,8 @@ public class TrackUtils {
     /**
      * Extrapolate track to given position, using dipole position from geometry.
      *
-     * @param track
-     * - position along the x-axis of the helix in lcsim coordinates
+     * @param track - position along the x-axis of the helix in lcsim
+     * coordinates
      * @return extrapolated position
      */
     public static Hep3Vector extrapolateTrack(Track track, double z, Detector detector) {
@@ -820,11 +848,11 @@ public class TrackUtils {
         double magnetZ = detector.getConstants().get("dipoleMagnetPositionZ").getValue();
         double magnetDownstreamEdge = magnetZ + magnetLength / 2;
         double magnetUpstreamEdge = magnetZ - magnetLength / 2;
-        if (z >= magnetDownstreamEdge)
+        if (z >= magnetDownstreamEdge) {
             trackPosition = extrapolateHelixToXPlane(track, magnetDownstreamEdge);
-        else if (z <= magnetUpstreamEdge)
+        } else if (z <= magnetUpstreamEdge) {
             trackPosition = extrapolateHelixToXPlane(track, magnetUpstreamEdge);
-        else {
+        } else {
             Hep3Vector detVecTracking = extrapolateHelixToXPlane(track, z);
             // System.out.printf("detVec %s\n", detVecTracking.toString());
             return new BasicHep3Vector(detVecTracking.y(), detVecTracking.z(), detVecTracking.x());
@@ -849,10 +877,8 @@ public class TrackUtils {
     /**
      * Extrapolate helix to given position
      *
-     * @param helix
-     * - to be extrapolated
-     * @param z
-     * - position along the x-axis of the helix in lcsim coordiantes
+     * @param helix - to be extrapolated
+     * @param z - position along the x-axis of the helix in lcsim coordiantes
      * @return the extrapolated position
      */
     @Deprecated
@@ -873,14 +899,10 @@ public class TrackUtils {
     }
 
     /**
-     * @param helix
-     * input helix object
-     * @param origin
-     * of the plane to intercept
-     * @param normal
-     * of the plane to intercept
-     * @param eps
-     * criteria on the distance to the plane before stopping
+     * @param helix input helix object
+     * @param origin of the plane to intercept
+     * @param normal of the plane to intercept
+     * @param eps criteria on the distance to the plane before stopping
      * iteration
      * @return position in space at the intercept of the plane
      */
@@ -904,8 +926,9 @@ public class TrackUtils {
             // Check if we are on the plane
             d = VecOp.dot(VecOp.sub(pos, origin), normal);
             dx += -1.0 * d / 2.0;
-            if (debug)
+            if (debug) {
                 System.out.printf("%d d %.10f pos [%.10f %.10f %.10f] dx %.10f\n", nIter, d, pos.x(), pos.y(), pos.z(), dx);
+            }
             nIter += 1;
         }
         return pos;
@@ -936,10 +959,12 @@ public class TrackUtils {
         double sinPhi = (xc - x) / R;
         double phi_at_x = Math.asin(sinPhi);
         double dphi_at_x = phi_at_x - phi0;
-        if (dphi_at_x > Math.PI)
+        if (dphi_at_x > Math.PI) {
             dphi_at_x -= 2.0 * Math.PI;
-        if (dphi_at_x < -Math.PI)
+        }
+        if (dphi_at_x < -Math.PI) {
             dphi_at_x += 2.0 * Math.PI;
+        }
         double s_at_x = -1.0 * dphi_at_x * R;
         double y = dca * Math.cos(phi0) - R * Math.cos(phi0) + R * Math.cos(phi_at_x);
         double z = z0 + s_at_x * slope;
@@ -947,8 +972,9 @@ public class TrackUtils {
         // System.out.printf("pos %s xc %f phi_at_x %f dphi_at_x %f s_at_x %f\n",
         // pos.toString(),xc,phi_at_x,dphi_at_x,s_at_x);
         Hep3Vector posXCheck = TrackUtils.extrapolateHelixToXPlane(helix, x);
-        if (VecOp.sub(pos, posXCheck).magnitude() > 0.0000001)
+        if (VecOp.sub(pos, posXCheck).magnitude() > 0.0000001) {
             throw new RuntimeException(String.format("ERROR the helix propagation equations do not agree? (%f,%f,%f) vs (%f,%f,%f) in HelixUtils", pos.x(), pos.y(), pos.z(), posXCheck.x(), posXCheck.y(), posXCheck.z()));
+        }
         return pos;
     }
 
@@ -1008,10 +1034,11 @@ public class TrackUtils {
             // ((RawTrackerHit) hth.getRawHits().get(0)).getDetectorElement()))
             // {
             HpsSiSensor sensor = ((HpsSiSensor) ((RawTrackerHit) hth.getRawHits().get(0)).getDetectorElement());
-            if (sensor.isTopLayer())
+            if (sensor.isTopLayer()) {
                 n[0] = n[0] + 1;
-            else
+            } else {
                 n[1] = n[1] + 1;
+            }
         }
         return n;
     }
@@ -1026,12 +1053,13 @@ public class TrackUtils {
 
     public static int isTopOrBottomTrack(Track track, int minhits) {
         int nhits[] = getHitsInTopBottom(track);
-        if (nhits[0] >= minhits && nhits[1] == 0)
+        if (nhits[0] >= minhits && nhits[1] == 0) {
             return 1;
-        else if (nhits[1] >= minhits && nhits[0] == 0)
+        } else if (nhits[1] >= minhits && nhits[0] == 0) {
             return 0;
-        else
+        } else {
             return -1;
+        }
     }
 
     public static boolean hasTopBotHit(Track track) {
@@ -1049,8 +1077,9 @@ public class TrackUtils {
                 // HelicalTrackHit loop_hth = (HelicalTrackHit) loop_hit;
                 TrackerHit loop_hth = loop_hit;
                 if (hth.equals(loop_hth)) // System.out.printf("share hit at layer %d at %s (%s) with track w/ chi2=%f\n",hth.Layer(),hth.getCorrectedPosition().toString(),loop_hth.getCorrectedPosition().toString(),track.getChi2());
-
+                {
                     return true;
+                }
             }
         }
         return false;
@@ -1065,7 +1094,9 @@ public class TrackUtils {
             // HelicalTrackHit loop_hth = (HelicalTrackHit) loop_hit;
             TrackerHit loop_hth = loop_hit;
             if (hth.equals(loop_hth)) // System.out.printf("share hit at layer %d at %s (%s) with track w/ chi2=%f\n",hth.Layer(),hth.getCorrectedPosition().toString(),loop_hth.getCorrectedPosition().toString(),track.getChi2());
+            {
                 return true;
+            }
         }
         return false;
     }
@@ -1084,16 +1115,19 @@ public class TrackUtils {
         for (Track t : tracklist) {
             // System.out.printf("add track with chi2=%f and px=%f ?\n",t.getChi2(),t.getTrackStates().get(0).getMomentum()[0]);
             if (t.equals(track)) // System.out.printf("NOPE\n");
-
+            {
                 continue;
+            }
             // System.out.printf("YEPP\n");
             tracks.add(t);
         }
         List<TrackerHit> hitsOnTrack = track.getTrackerHits();
         int n_shared = 0;
-        for (TrackerHit hit : hitsOnTrack)
-            if (isSharedHit(hit, tracks))
+        for (TrackerHit hit : hitsOnTrack) {
+            if (isSharedHit(hit, tracks)) {
                 ++n_shared;
+            }
+        }
         return n_shared;
     }
 
@@ -1105,14 +1139,16 @@ public class TrackUtils {
      * @return number of 3D hits shared between two tracks
      */
     public static int numberOfSharedHits(Track track1, Track track2) {
-        if (track1.equals(track2))
+        if (track1.equals(track2)) {
             return 0;
-        else {
+        } else {
             List<TrackerHit> hitsOnTrack = track1.getTrackerHits();
             int n_shared = 0;
-            for (TrackerHit hit : hitsOnTrack)
-                if (isSharedHit(hit, track2))
+            for (TrackerHit hit : hitsOnTrack) {
+                if (isSharedHit(hit, track2)) {
                     ++n_shared;
+                }
+            }
             return n_shared;
         }
     }
@@ -1131,8 +1167,9 @@ public class TrackUtils {
         for (Track t : tracklist) {
             // System.out.printf("add track with chi2=%f and px=%f ?\n",t.getChi2(),t.getTrackStates().get(0).getMomentum()[0]);
             if (t.equals(track)) // System.out.printf("NOPE\n");
-
+            {
                 continue;
+            }
             // System.out.printf("YEPP\n");
             tracks.add(t);
         }
@@ -1140,11 +1177,12 @@ public class TrackUtils {
         // track
         int mostShared = 0;
         Track sharedTrk = track;
-        for (Track tt : tracks)
+        for (Track tt : tracks) {
             if (mostShared < numberOfSharedHits(track, tt)) {
                 mostShared = numberOfSharedHits(track, tt);
                 sharedTrk = tt;
             }
+        }
 
         return sharedTrk;
     }
@@ -1165,16 +1203,21 @@ public class TrackUtils {
     public static int passTrackSelections(Track track, List<Track> tracklist, EventQuality.Quality trk_quality) {
         int cuts[] = {0};
         if (trk_quality.compareTo(Quality.NONE) != 0) {
-            if (track.getTrackStates().get(0).getMomentum()[0] < EventQuality.instance().getCutValue(EventQuality.Cut.PZ, trk_quality))
+            if (track.getTrackStates().get(0).getMomentum()[0] < EventQuality.instance().getCutValue(EventQuality.Cut.PZ, trk_quality)) {
                 cut(cuts, EventQuality.Cut.PZ);
-            if (track.getChi2() >= EventQuality.instance().getCutValue(EventQuality.Cut.CHI2, trk_quality))
+            }
+            if (track.getChi2() >= EventQuality.instance().getCutValue(EventQuality.Cut.CHI2, trk_quality)) {
                 cut(cuts, EventQuality.Cut.CHI2);
-            if (numberOfSharedHits(track, tracklist) > ((int) Math.round(EventQuality.instance().getCutValue(EventQuality.Cut.SHAREDHIT, trk_quality))))
+            }
+            if (numberOfSharedHits(track, tracklist) > ((int) Math.round(EventQuality.instance().getCutValue(EventQuality.Cut.SHAREDHIT, trk_quality)))) {
                 cut(cuts, EventQuality.Cut.SHAREDHIT);
-            if (hasTopBotHit(track))
+            }
+            if (hasTopBotHit(track)) {
                 cut(cuts, EventQuality.Cut.TOPBOTHIT);
-            if (track.getTrackerHits().size() < ((int) Math.round(EventQuality.instance().getCutValue(EventQuality.Cut.NHITS, trk_quality))))
+            }
+            if (track.getTrackerHits().size() < ((int) Math.round(EventQuality.instance().getCutValue(EventQuality.Cut.NHITS, trk_quality)))) {
                 cut(cuts, EventQuality.Cut.NHITS);
+            }
         }
         return cuts[0];
     }
@@ -1191,8 +1234,7 @@ public class TrackUtils {
      * Transform MCParticle into a Helix object. Note that it produces the helix
      * parameters at nominal x=0 and assumes that there is no field at x<0
      *
-     * @param mcp
-     * MC particle to be transformed
+     * @param mcp MC particle to be transformed
      * @return {@link HelicalTrackFit} object based on the MC particle
      */
     public static HelicalTrackFit getHTF(MCParticle mcp, double Bz) {
@@ -1204,23 +1246,23 @@ public class TrackUtils {
      * produces the {@link HelicalTrackFit} parameters at nominal reference
      * point at origin and assumes that there is no field at x<0
      *
-     * @param mcp
-     * - MC particle to be transformed
-     * @param origin
-     * - origin to be used for the track
+     * @param mcp - MC particle to be transformed
+     * @param origin - origin to be used for the track
      * @return {@link HelicalTrackFit} object based on the MC particle
      */
     public static HelicalTrackFit getHTF(MCParticle mcp, Hep3Vector origin, double Bz) {
         boolean debug = false;
 
-        if (debug)
+        if (debug) {
             System.out.printf("getHTF\nmcp org %s origin used %s mc p %s\n", mcp.getOrigin().toString(), origin.toString(), mcp.getMomentum().toString());
+        }
 
         Hep3Vector org = CoordinateTransformations.transformVectorToTracking(origin);
         Hep3Vector p = CoordinateTransformations.transformVectorToTracking(mcp.getMomentum());
 
-        if (debug)
+        if (debug) {
             System.out.printf("mcp org %s mc p %s (trans)\n", org.toString(), p.toString());
+        }
 
         // Move to x=0 if needed
         double targetX = BeamlineConstants.DIPOLE_EDGELOW_TESTRUN;
@@ -1231,15 +1273,17 @@ public class TrackUtils {
             double y = delta_x * dydx + org.y();
             double z = delta_x * dzdx + org.z();
             double x = org.x() + delta_x;
-            if (Math.abs(x - targetX) > 1e-8)
+            if (Math.abs(x - targetX) > 1e-8) {
                 throw new RuntimeException("Error: origin is not zero!");
+            }
             org = new BasicHep3Vector(x, y, z);
             // System.out.printf("org %s p %s -> org %s\n",
             // old.toString(),p.toString(),org.toString());
         }
 
-        if (debug)
+        if (debug) {
             System.out.printf("mcp org %s mc p %s (trans2)\n", org.toString(), p.toString());
+        }
 
         HelixParamCalculator helixParamCalculator = new HelixParamCalculator(p, org, -1 * ((int) mcp.getCharge()), Bz);
         double par[] = new double[5];
@@ -1249,15 +1293,16 @@ public class TrackUtils {
         par[HelicalTrackFit.curvatureIndex] = 1.0 / helixParamCalculator.getRadius();
         par[HelicalTrackFit.z0Index] = helixParamCalculator.getZ0();
         HelicalTrackFit htf = getHTF(par);
-        if (debug)
+        if (debug) {
             System.out.printf("d0 %f z0 %f R %f phi %f lambda %s\n", htf.dca(), htf.z0(), htf.R(), htf.phi0(), htf.slope());
+        }
         return htf;
     }
 
     public static HelicalTrackFit getHTF(Track track) {
-        if (track.getClass().isInstance(SeedTrack.class))
+        if (track.getClass().isInstance(SeedTrack.class)) {
             return ((SeedTrack) track).getSeedCandidate().getHelix();
-        else {
+        } else {
             double[] chisq = {track.getChi2(), 0};
             int[] ndf = {track.getNDF(), 0};
             TrackState ts = track.getTrackStates().get(0);
@@ -1271,8 +1316,9 @@ public class TrackUtils {
     public static HelicalTrackFit getHTF(double par[]) {
         // need to have matrix that makes sense? Really?
         SymmetricMatrix cov = new SymmetricMatrix(5);
-        for (int i = 0; i < cov.getNRows(); ++i)
+        for (int i = 0; i < cov.getNRows(); ++i) {
             cov.setElement(i, i, 1.);
+        }
         HelicalTrackFit htf = new HelicalTrackFit(par, cov, new double[2], new int[2], null, null);
         return htf;
     }
@@ -1289,19 +1335,22 @@ public class TrackUtils {
 
         Map<MCParticle, Integer> particlesOnTrack = new LinkedHashMap<MCParticle, Integer>();
 
-        if (debug)
+        if (debug) {
             System.out.printf("getMatchedTruthParticle: getmatched mc particle from %d tracker hits on the track \n", track.getTrackerHits().size());
+        }
 
         for (TrackerHit hit : track.getTrackerHits()) {
             List<MCParticle> mcps = ((HelicalTrackHit) hit).getMCParticles();
-            if (mcps == null)
+            if (mcps == null) {
                 System.out.printf("getMatchedTruthParticle: warning, this hit (layer %d pos=%s) has no mc particles.\n", ((HelicalTrackHit) hit).Layer(), ((HelicalTrackHit) hit).getCorrectedPosition().toString());
-            else {
-                if (debug)
+            } else {
+                if (debug) {
                     System.out.printf("getMatchedTruthParticle: this hit (layer %d pos=%s) has %d mc particles.\n", ((HelicalTrackHit) hit).Layer(), ((HelicalTrackHit) hit).getCorrectedPosition().toString(), mcps.size());
+                }
                 for (MCParticle mcp : mcps) {
-                    if (!particlesOnTrack.containsKey(mcp))
+                    if (!particlesOnTrack.containsKey(mcp)) {
                         particlesOnTrack.put(mcp, 0);
+                    }
                     int c = particlesOnTrack.get(mcp);
                     particlesOnTrack.put(mcp, c + 1);
                 }
@@ -1310,21 +1359,24 @@ public class TrackUtils {
         if (debug) {
             System.out.printf("Track p=[ %f, %f, %f] \n", track.getTrackStates().get(0).getMomentum()[0], track.getTrackStates().get(0).getMomentum()[1], track.getTrackStates().get(0).getMomentum()[1]);
             System.out.printf("Found %d particles\n", particlesOnTrack.size());
-            for (Map.Entry<MCParticle, Integer> entry : particlesOnTrack.entrySet())
+            for (Map.Entry<MCParticle, Integer> entry : particlesOnTrack.entrySet()) {
                 System.out.printf("%d hits assigned to %d p=%s \n", entry.getValue(), entry.getKey().getPDGID(), entry.getKey().getMomentum().toString());
+            }
         }
         Map.Entry<MCParticle, Integer> maxEntry = null;
-        for (Map.Entry<MCParticle, Integer> entry : particlesOnTrack.entrySet())
-            if (maxEntry == null || entry.getValue().compareTo(maxEntry.getValue()) > 0)
+        for (Map.Entry<MCParticle, Integer> entry : particlesOnTrack.entrySet()) {
+            if (maxEntry == null || entry.getValue().compareTo(maxEntry.getValue()) > 0) {
                 maxEntry = entry; // if ( maxEntry != null ) { //
-        // if(entry.getValue().compareTo(maxEntry.getValue())
-        // < 0) continue; //}
+            }        // if(entry.getValue().compareTo(maxEntry.getValue())
+        }        // < 0) continue; //}
         // maxEntry = entry;
-        if (debug)
-            if (maxEntry != null)
+        if (debug) {
+            if (maxEntry != null) {
                 System.out.printf("Matched particle with pdgId=%d and mom %s to track with charge %d and momentum [%f %f %f]\n", maxEntry.getKey().getPDGID(), maxEntry.getKey().getMomentum().toString(), track.getCharge(), track.getTrackStates().get(0).getMomentum()[0], track.getTrackStates().get(0).getMomentum()[1], track.getTrackStates().get(0).getMomentum()[2]);
-            else
+            } else {
                 System.out.printf("No truth particle found on this track\n");
+            }
+        }
         return maxEntry == null ? null : maxEntry.getKey();
     }
 
@@ -1352,8 +1404,9 @@ public class TrackUtils {
         // now get the hits and make them helicaltrackhits
         List<TrackerHit> rth = track.getTrackerHits();
         List<HelicalTrackHit> hth = new ArrayList<>();
-        for (TrackerHit hit : rth)
+        for (TrackerHit hit : rth) {
             hth.add(makeHelicalTrackHitFromTrackerHit(hit));
+        }
         // SeedCandidate(List<HelicalTrackHit> , SeedStrategy strategy,
         // HelicalTrackFit helix, double bfield) ;
         SeedCandidate scand = new SeedCandidate(hth, null, htf, 0.24);
@@ -1383,23 +1436,26 @@ public class TrackUtils {
 
     private static Pair<EventHeader, RelationalTable> hitToStripsCache = null;
 
-    public static RelationalTable getHitToStripsTable(EventHeader event,String HelicalTrackHitRelationsCollectionName) {
+    public static RelationalTable getHitToStripsTable(EventHeader event, String HelicalTrackHitRelationsCollectionName) {
         if (hitToStripsCache == null || hitToStripsCache.getFirst() != event) {
             RelationalTable hitToStrips = new BaseRelationalTable(RelationalTable.Mode.MANY_TO_MANY, RelationalTable.Weighting.UNWEIGHTED);
             //List<LCRelation> hitrelations = event.get(LCRelation.class, "HelicalTrackHitRelations");
-            if (!event.hasCollection(LCRelation.class,HelicalTrackHitRelationsCollectionName))
+            if (!event.hasCollection(LCRelation.class, HelicalTrackHitRelationsCollectionName)) {
                 return null;
+            }
             List<LCRelation> hitrelations = event.get(LCRelation.class, HelicalTrackHitRelationsCollectionName);
-            for (LCRelation relation : hitrelations)
-                if (relation != null && relation.getFrom() != null && relation.getTo() != null)
+            for (LCRelation relation : hitrelations) {
+                if (relation != null && relation.getFrom() != null && relation.getTo() != null) {
                     hitToStrips.add(relation.getFrom(), relation.getTo());
+                }
+            }
             hitToStripsCache = new Pair<EventHeader, RelationalTable>(event, hitToStrips);
         }
         return hitToStripsCache.getSecond();
     }
-    
+
     public static RelationalTable getHitToStripsTable(EventHeader event) {
-        return getHitToStripsTable(event,"HelicalTrackHitRelations");
+        return getHitToStripsTable(event, "HelicalTrackHitRelations");
     }
 
     private static Pair<EventHeader, RelationalTable> hitToRotatedCache = null;
@@ -1414,19 +1470,22 @@ public class TrackUtils {
             //          System.out.println("getHitToRotatedTable:  making new table");
             RelationalTable hitToRotated = new BaseRelationalTable(RelationalTable.Mode.ONE_TO_ONE, RelationalTable.Weighting.UNWEIGHTED);
             //List<LCRelation> rotaterelations = event.get(LCRelation.class, "RotatedHelicalTrackHitRelations");
-            if (!event.hasCollection(LCRelation.class, RotatedHelicalTrackHitRelationsCollectionName))
+            if (!event.hasCollection(LCRelation.class, RotatedHelicalTrackHitRelationsCollectionName)) {
                 return null;
+            }
             List<LCRelation> rotaterelations = event.get(LCRelation.class, RotatedHelicalTrackHitRelationsCollectionName);
-            for (LCRelation relation : rotaterelations)
-                if (relation != null && relation.getFrom() != null && relation.getTo() != null)
-                    //                   System.out.println("getHitToRotatedTable:  adding a relation to hitToRotated");
+            for (LCRelation relation : rotaterelations) {
+                if (relation != null && relation.getFrom() != null && relation.getTo() != null) //                   System.out.println("getHitToRotatedTable:  adding a relation to hitToRotated");
+                {
                     hitToRotated.add(relation.getFrom(), relation.getTo());
+                }
+            }
             hitToRotatedCache = new Pair<EventHeader, RelationalTable>(event, hitToRotated);
         }
         //       System.out.println("getHitToRotatedTable: returning hitToRotatedCache with size = " + hitToRotatedCache.getSecond().size());
         return hitToRotatedCache.getSecond();
     }
-    
+
     public static RelationalTable getHitToRotatedTable(EventHeader event) {
         return getHitToRotatedTable(event, "RotatedHelicalTrackHitRelations");
     }
@@ -1434,8 +1493,9 @@ public class TrackUtils {
     public static double getTrackTime(Track track, RelationalTable hitToStrips, RelationalTable hitToRotated) {
         double meanTime = 0;
         List<TrackerHit> stripHits = getStripHits(track, hitToStrips, hitToRotated);
-        for (TrackerHit hit : stripHits)
+        for (TrackerHit hit : stripHits) {
             meanTime += hit.getTime();
+        }
         meanTime /= stripHits.size();
         return meanTime;
     }
@@ -1445,8 +1505,9 @@ public class TrackUtils {
         List<TrackerHit> stripHits = getStripHits(track, hitToStrips, hitToRotated);
 
         double sdTime = 0;
-        for (TrackerHit hit : stripHits)
+        for (TrackerHit hit : stripHits) {
             sdTime += Math.pow(meanTime - hit.getTime(), 2);
+        }
         sdTime = Math.sqrt(sdTime / stripHits.size());
 
         return sdTime;
@@ -1454,8 +1515,9 @@ public class TrackUtils {
 
     public static List<TrackerHit> getStripHits(Track track, RelationalTable hitToStrips, RelationalTable hitToRotated) {
         List<TrackerHit> hits = new ArrayList<TrackerHit>();
-        for (TrackerHit hit : track.getTrackerHits())
+        for (TrackerHit hit : track.getTrackerHits()) {
             hits.addAll(hitToStrips.allFrom(hitToRotated.from(hit)));
+        }
 
         return hits;
     }
@@ -1486,10 +1548,13 @@ public class TrackUtils {
     public static int numberOfSharedStrips(Track track1, Track track2, RelationalTable hitToStrips, RelationalTable hitToRotated) {
         Set<TrackerHit> track1hits = new HashSet<TrackerHit>(getStripHits(track1, hitToStrips, hitToRotated));
         int nShared = 0;
-        for (TrackerHit hit : track2.getTrackerHits())
-            for (TrackerHit hts : (Set<TrackerHit>) hitToStrips.allFrom(hitToRotated.from(hit)))
-                if (track1hits.contains(hts))
+        for (TrackerHit hit : track2.getTrackerHits()) {
+            for (TrackerHit hts : (Set<TrackerHit>) hitToStrips.allFrom(hitToRotated.from(hit))) {
+                if (track1hits.contains(hts)) {
                     nShared++;
+                }
+            }
+        }
         return nShared;
     }
 
@@ -1504,17 +1569,20 @@ public class TrackUtils {
      */
     public static boolean hasSharedStrips(Track track1, Track track2, RelationalTable hitToStrips, RelationalTable hitToRotated) {
         int nShared = numberOfSharedStrips(track1, track2, hitToStrips, hitToRotated);
-        if (nShared == 0)
+        if (nShared == 0) {
             return false;
-        else
+        } else {
             return true;
+        }
     }
 
     public static int getLayer(TrackerHit strip) {
-        if (strip == null)
+        if (strip == null) {
             System.out.println("Strip is null?????");
-        if (strip.getRawHits() == null)
+        }
+        if (strip.getRawHits() == null) {
             System.out.println("No raw hits associated with this strip????");
+        }
 
         return ((RawTrackerHit) strip.getRawHits().get(0)).getLayerNumber();
     }
@@ -1524,18 +1592,16 @@ public class TrackUtils {
      * in the same sensor. Strips are only checked if they formed valid crosses
      * with the other strip in the cross (passing time and tolerance cuts).
      *
-     * @param strip
-     * The strip whose isolation is being calculated.
-     * @param otherStrip
-     * The other strip in the stereo hit.
+     * @param strip The strip whose isolation is being calculated.
+     * @param otherStrip The other strip in the stereo hit.
      * @param hitToStrips
      * @param hitToRotated
      * @return Double_MAX_VALUE if no other strips found.
      */
     public static double getIsolation(TrackerHit strip, TrackerHit otherStrip, RelationalTable hitToStrips, RelationalTable hitToRotated) {
         double nearestDistance = 99999999.0;
-        for (TrackerHit cross : (Set<TrackerHit>) hitToStrips.allTo(otherStrip))
-            for (TrackerHit crossStrip : (Set<TrackerHit>) hitToStrips.allFrom(cross))
+        for (TrackerHit cross : (Set<TrackerHit>) hitToStrips.allTo(otherStrip)) {
+            for (TrackerHit crossStrip : (Set<TrackerHit>) hitToStrips.allFrom(cross)) {
                 if (crossStrip != strip && crossStrip != otherStrip) {
                     int stripMin = Integer.MAX_VALUE;
                     int stripMax = Integer.MIN_VALUE;
@@ -1551,13 +1617,15 @@ public class TrackUtils {
                         crossMin = Math.min(crossMin, hitStrip);
                         crossMax = Math.max(crossMax, hitStrip);
                     }
-                    if (stripMin - crossMax <= 1 && crossMin - stripMax <= 1)
+                    if (stripMin - crossMax <= 1 && crossMin - stripMax <= 1) {
                         continue; // adjacent strips don't count
+                    }
                     Hep3Vector stripPosition = new BasicHep3Vector(strip.getPosition());
                     Hep3Vector crossStripPosition = new BasicHep3Vector(crossStrip.getPosition());
                     double distance = VecOp.sub(stripPosition, crossStripPosition).magnitude();
-                    if (Math.abs(stripPosition.y()) > Math.abs(crossStripPosition.y()))
+                    if (Math.abs(stripPosition.y()) > Math.abs(crossStripPosition.y())) {
                         distance = -distance;
+                    }
                     // System.out.format("%s, %s, %s, %f\n", stripPosition,
                     // crossStripPosition, VecOp.sub(stripPosition,
                     // crossStripPosition), distance);
@@ -1571,9 +1639,12 @@ public class TrackUtils {
                     // crossStripPosition, VecOp.sub(stripPosition,
                     // crossStripPosition), distance);
                     // }
-                    if (Math.abs(distance) < Math.abs(nearestDistance))
+                    if (Math.abs(distance) < Math.abs(nearestDistance)) {
                         nearestDistance = distance;
+                    }
                 }
+            }
+        }
         return nearestDistance;
     }
 
@@ -1593,11 +1664,13 @@ public class TrackUtils {
             Set<TrackerHit> htsList = hitToStrips.allFrom(hitToRotated.from(hit));
             TrackerHit[] strips = new TrackerHit[2];
             htsList.toArray(strips);
-            if (strips[0] == null)
+            if (strips[0] == null) {
                 continue;
+            }
             isolations[TrackUtils.getLayer(strips[0]) - 1] = TrackUtils.getIsolation(strips[0], strips[1], hitToStrips, hitToRotated);
-            if (strips[1] == null)
+            if (strips[1] == null) {
                 continue;
+            }
             isolations[TrackUtils.getLayer(strips[1]) - 1] = TrackUtils.getIsolation(strips[1], strips[0], hitToStrips, hitToRotated);
         }
         return isolations;
@@ -1613,11 +1686,14 @@ public class TrackUtils {
      */
     public static BaseTrackState extrapolateTrackUsingFieldMap(Track track, double startPositionX, double endPositionX, double stepSize, FieldMap fieldMap) {
         TrackState stateAtIP = null;
-        for (TrackState state : track.getTrackStates())
-            if (state.getLocation() == TrackState.AtIP)
+        for (TrackState state : track.getTrackStates()) {
+            if (state.getLocation() == TrackState.AtIP) {
                 stateAtIP = state;
-        if (stateAtIP == null)
+            }
+        }
+        if (stateAtIP == null) {
             throw new RuntimeException("No track state at IP was found so this function shouldn't be used.");
+        }
 
         // Extrapolate this track state
         return extrapolateTrackUsingFieldMap(stateAtIP, startPositionX, endPositionX, stepSize, fieldMap);
@@ -1627,22 +1703,16 @@ public class TrackUtils {
      * Iteratively extrapolates a track to a specified value of x (z in detector
      * frame) using the full 3D field map.
      *
-     * @param track
-     * The {@link Track} object to extrapolate.
-     * @param startPositionX
-     * The position from which to start the extrapolation from. The
-     * track will be extrapolated to this point using a constant
+     * @param track The {@link Track} object to extrapolate.
+     * @param startPositionX The position from which to start the extrapolation
+     * from. The track will be extrapolated to this point using a constant
      * field.
-     * @param endPositionX
-     * The position to extrapolate the track to.
-     * @param stepSize
-     * The step size determining how far a track will be extrapolated
-     * after every iteration.
-     * @param fieldMap
-     * The 3D field map
+     * @param endPositionX The position to extrapolate the track to.
+     * @param stepSize The step size determining how far a track will be
+     * extrapolated after every iteration.
+     * @param fieldMap The 3D field map
      * @return A {@link TrackState} at the final extrapolation point. Note that
-     * the "Tracking" frame is used for the reference point coordinate
-     * system.
+     * the "Tracking" frame is used for the reference point coordinate system.
      */
     public static BaseTrackState extrapolateTrackUsingFieldMap(TrackState track, double startPositionX, double endPosition, double stepSize, FieldMap fieldMap) {
         return extrapolateTrackUsingFieldMap(track, startPositionX, endPosition, stepSize, 0.005, fieldMap);
@@ -1659,8 +1729,9 @@ public class TrackUtils {
         Hep3Vector p0Trans = CoordinateTransformations.transformVectorToDetector(VecOp.mult(p, helixDirection));
 
         double distance = distanceZ / VecOp.cosTheta(p0Trans);
-        if (stepSize == 0)
+        if (stepSize == 0) {
             stepSize = distance / 100.0;
+        }
 
         double charge = -1.0 * Math.signum(getR(ts));
         RK4integrator RKint = new RK4integrator(charge, stepSize, fM);
@@ -1691,15 +1762,17 @@ public class TrackUtils {
         // turned to positive for tracking purposes. As a result,
         // the charge calculated using the B-field, will be wrong
         // when the field is negative and needs to be flipped.
-        if (bFieldY < 0)
+        if (bFieldY < 0) {
             q = q * (-1);
+        }
 
         // Swim the track through the B-field until the end point is reached
         Hep3Vector currentPositionDet = null;
 
         double distance = endPosition - currentPosition.x();
-        if (stepSize == 0)
+        if (stepSize == 0) {
             stepSize = distance / 100.0;
+        }
         double sign = Math.signum(distance);
         distance = Math.abs(distance);
 
@@ -1720,13 +1793,15 @@ public class TrackUtils {
             // update the extrapolated position.
             Hep3Vector currentPositionTry = trajectory.getPointAtDistance(stepSize);
 
-            if ((Math.abs(endPosition - currentPositionTry.x()) > epsilon) && (Math.signum(endPosition - currentPositionTry.x()) != sign))
-                // went too far, try again with smaller step-size
+            if ((Math.abs(endPosition - currentPositionTry.x()) > epsilon) && (Math.signum(endPosition - currentPositionTry.x()) != sign)) // went too far, try again with smaller step-size
+            {
                 if (Math.abs(stepSize) > 0.001) {
                     stepSize /= 2.0;
                     continue;
-                } else
+                } else {
                     break;
+                }
+            }
             currentPosition = currentPositionTry;
 
             distance = Math.abs(endPosition - currentPosition.x());
@@ -1780,23 +1855,24 @@ public class TrackUtils {
             // System.out.println("[GetTrajectory] : Current Radius: " +
             // radius);
             return new Helix(r0, radius, phi, lambda);
-        } else
+        } else {
             return new Line(r0, phi, lambda);
+        }
     }
 
     /**
      * Port of Track.getTrackState(int location) from the C++ LCIO API.
      *
-     * @param trk
-     * A track.
-     * @param location
-     * A TrackState location constant
+     * @param trk A track.
+     * @param location A TrackState location constant
      * @return The first matching TrackState; null if none is found.
      */
     public static TrackState getTrackStateAtLocation(Track trk, int location) {
-        for (TrackState state : trk.getTrackStates())
-            if (state.getLocation() == location)
+        for (TrackState state : trk.getTrackStates()) {
+            if (state.getLocation() == location) {
                 return state;
+            }
+        }
         return null;
     }
 
@@ -1805,16 +1881,20 @@ public class TrackUtils {
     }
 
     public static TrackState getTrackStateAtHodoL1(Track trk) {
-        for (TrackState state : trk.getTrackStates())
-            if (state.getReferencePoint()[0] == BeamlineConstants.HODO_L1_ZPOS)
+        for (TrackState state : trk.getTrackStates()) {
+            if (state.getReferencePoint()[0] == BeamlineConstants.HODO_L1_ZPOS) {
                 return state;
+            }
+        }
         return null;
     }
 
     public static TrackState getTrackStateAtHodoL2(Track trk) {
-        for (TrackState state : trk.getTrackStates())
-            if (state.getReferencePoint()[0] == BeamlineConstants.HODO_L2_ZPOS)
+        for (TrackState state : trk.getTrackStates()) {
+            if (state.getReferencePoint()[0] == BeamlineConstants.HODO_L2_ZPOS) {
                 return state;
+            }
+        }
         return null;
     }
 
@@ -1825,10 +1905,11 @@ public class TrackUtils {
     //the methods below take Mathematica methods and convert to Java.
     //this removes errors introduced by doing copy-paste-convert-to-Java 
     public static double Sec(double arg) {
-        if (Math.cos(arg) != 0.0)
+        if (Math.cos(arg) != 0.0) {
             return 1 / Math.cos(arg);
-        else
+        } else {
             return 0;
+        }
     }
 
     public static double Power(double arg, double pow) {
@@ -1852,8 +1933,9 @@ public class TrackUtils {
     }
 
     public static Hep3Vector getMomentum(double omega, double phi0, double tanL, double magneticField) {
-        if (abs(omega) < 0.0000001)
+        if (abs(omega) < 0.0000001) {
             omega = 0.0000001;
+        }
         double Pt = abs((1. / omega) * magneticField * Constants.fieldConversion);
         double px = Pt * Math.cos(phi0);
         double py = Pt * Math.sin(phi0);
@@ -1888,13 +1970,13 @@ public class TrackUtils {
         }
         return electrodes.getGlobalToLocal().transformed(trkpos);
     }
-    
-     /**
+
+    /**
      *
      */
-    public static boolean detectorElementContainsPoint(Hep3Vector trackPosition, DetectorElement sensor,double tolerance) {
+    public static boolean detectorElementContainsPoint(Hep3Vector trackPosition, DetectorElement sensor, double tolerance) {
         boolean debug = false;
-        
+
         ITransform3D localToGlobal = sensor.getGeometry().getLocalToGlobal();
 
         Box sensorSolid = (Box) sensor.getGeometry().getLogicalVolume().getSolid();
@@ -1923,131 +2005,120 @@ public class TrackUtils {
 
             System.out.printf("Track-to-vertex Position: %f \n", GeomOp3D.distanceBetween(trackPositionPoint, transformedSensorFace));
         }
-        double distance=GeomOp3D.distanceBetween(trackPositionPoint, transformedSensorFace);
+        double distance = GeomOp3D.distanceBetween(trackPositionPoint, transformedSensorFace);
         return (Math.abs(distance) < tolerance);
         //return GeomOp3D.intersects(trackPositionPoint, transformedSensorFace);
     }
-    
-    public static boolean detectorElementContainsPoint(Hep3Vector trackPosition, DetectorElement sensor){
-        return detectorElementContainsPoint( trackPosition,  sensor,0.0);
+
+    public static boolean detectorElementContainsPoint(Hep3Vector trackPosition, DetectorElement sensor) {
+        return detectorElementContainsPoint(trackPosition, sensor, 0.0);
     }
-    
 
     //This method return the layer number and the module number of a sensor given the volume and the millepedeID 
-    public static Pair<Integer,Integer> getLayerSide(int volume, int millepedeID) {
-        
-        Integer retLy=null;
-        Integer retMod=null;
+    public static Pair<Integer, Integer> getLayerSide(int volume, int millepedeID) {
+
+        Integer retLy = null;
+        Integer retMod = null;
         //top
         if (volume == 1) {
             if (millepedeID < 9) {
-                retLy=millepedeID;
-                retMod=0;
-            }
-            else {
+                retLy = millepedeID;
+                retMod = 0;
+            } else {
                 if (millepedeID == 9 || millepedeID == 10) {
-                    retLy=millepedeID;
-                    retMod=0;
-                }
-                else if (millepedeID == 11 | millepedeID== 12) {
+                    retLy = millepedeID;
+                    retMod = 0;
+                } else if (millepedeID == 11 | millepedeID == 12) {
                     retLy = millepedeID - 2;
                     retMod = 2;
-                }
-                else if (millepedeID == 13 | millepedeID == 14) {
+                } else if (millepedeID == 13 | millepedeID == 14) {
                     retLy = millepedeID - 2;
                     retMod = 0;
-                }
-                else if (millepedeID == 15 | millepedeID == 16) {
+                } else if (millepedeID == 15 | millepedeID == 16) {
                     retLy = millepedeID - 4;
                     retMod = 2;
-                }
-                else if (millepedeID == 17 | millepedeID == 18 ) {
+                } else if (millepedeID == 17 | millepedeID == 18) {
                     retLy = millepedeID - 4;
                     retMod = 0;
-                }
-                else if (millepedeID == 19 | millepedeID == 20 ) {
+                } else if (millepedeID == 19 | millepedeID == 20) {
                     retLy = millepedeID - 6;
                     retMod = 2;
                 }
             }
-        }
-        //bottom
+        } //bottom
         else {
             if (millepedeID < 9) {
-                retLy=millepedeID;
-                retMod=1;
-            }
-            else {
+                retLy = millepedeID;
+                retMod = 1;
+            } else {
                 if (millepedeID == 9 || millepedeID == 10) {
-                    retLy=millepedeID;
-                    retMod=1;
-                }
-                else if (millepedeID == 11 | millepedeID== 12) {
+                    retLy = millepedeID;
+                    retMod = 1;
+                } else if (millepedeID == 11 | millepedeID == 12) {
                     retLy = millepedeID - 2;
                     retMod = 3;
-                }
-                else if (millepedeID == 13 | millepedeID == 14) {
+                } else if (millepedeID == 13 | millepedeID == 14) {
                     retLy = millepedeID - 2;
                     retMod = 1;
-                }
-                else if (millepedeID == 15 | millepedeID == 16) {
+                } else if (millepedeID == 15 | millepedeID == 16) {
                     retLy = millepedeID - 4;
                     retMod = 3;
-                }
-                else if (millepedeID == 17 | millepedeID == 18 ) {
+                } else if (millepedeID == 17 | millepedeID == 18) {
                     retLy = millepedeID - 4;
                     retMod = 1;
-                }
-                else if (millepedeID == 19 | millepedeID == 20 ) {
+                } else if (millepedeID == 19 | millepedeID == 20) {
                     retLy = millepedeID - 6;
                     retMod = 3;
                 }
             }
         }
-        
-        return new Pair<Integer,Integer>(retLy,retMod);
-    }            
+
+        return new Pair<Integer, Integer>(retLy, retMod);
+    }
     //This methods checks if a track has only hole hits in the back of the detector
     //return true if all back layers have hole hits, false if all back layers have slot hits
-    
+
     public static boolean isHoleTrack(Track trk) {
-        
+
         boolean holeTrack = false;
-        
+
         TrackState trackState = trk.getTrackStates().get(0);
         boolean isTop = true;
-        if (trackState.getTanLambda()<0)
-            isTop=false;                        
-        
+        if (trackState.getTanLambda() < 0) {
+            isTop = false;
+        }
+
         //System.out.println("--------------");
         for (TrackerHit hit : trk.getTrackerHits()) {
-            
-            int stripLayer   = ((HpsSiSensor) ((RawTrackerHit) hit.getRawHits().get(0)).getDetectorElement()).getLayerNumber();
-            int hpslayer     = (stripLayer + 1 ) / 2;
-            String side      = ((HpsSiSensor) ((RawTrackerHit) hit.getRawHits().get(0)).getDetectorElement()).getSide();
-            
+
+            int stripLayer = ((HpsSiSensor) ((RawTrackerHit) hit.getRawHits().get(0)).getDetectorElement()).getLayerNumber();
+            int hpslayer = (stripLayer + 1) / 2;
+            String side = ((HpsSiSensor) ((RawTrackerHit) hit.getRawHits().get(0)).getDetectorElement()).getSide();
+
             if (isTop) {
-                if (hpslayer == 5 || hpslayer ==6 || hpslayer==7) 
-                    if (side=="ELECTRON")
-                        holeTrack=true;
+                if (hpslayer == 5 || hpslayer == 6 || hpslayer == 7) {
+                    if (side == "ELECTRON") {
+                        holeTrack = true;
+                    }
+                }
+            } else {
+                if (hpslayer == 5 || hpslayer == 6 || hpslayer == 7) {
+                    if (side == "ELECTRON") {
+                        holeTrack = true;
+                    }
+                }
             }
-            else {
-                if (hpslayer == 5 || hpslayer ==6 || hpslayer==7)
-                    if (side=="ELECTRON")
-                        holeTrack=true;
-            }
-            
+
             String moduleName = ((HpsSiSensor) ((RawTrackerHit) hit.getRawHits().get(0)).getDetectorElement()).getName();
-            int hpsmodule    = ((HpsSiSensor) ((RawTrackerHit) hit.getRawHits().get(0)).getDetectorElement()).getModuleNumber();
-            int MPID         = ((HpsSiSensor) ((RawTrackerHit) hit.getRawHits().get(0)).getDetectorElement()).getMillepedeId();
-            
+            int hpsmodule = ((HpsSiSensor) ((RawTrackerHit) hit.getRawHits().get(0)).getDetectorElement()).getModuleNumber();
+            int MPID = ((HpsSiSensor) ((RawTrackerHit) hit.getRawHits().get(0)).getDetectorElement()).getMillepedeId();
+
             //System.out.println("Hit on track :: " + moduleName);
             //System.out.println("Layer="+hpslayer+" Module=" + hpsmodule +" MPID=" + MPID+" side="+side +" top=" +isTop);
-            
         }
         //System.out.println("Track is hole=" + holeTrack);
         //System.out.println("==========");
-        
+
         return holeTrack;
     }
 }

--- a/tracking/src/main/java/org/hps/recon/tracking/TrackingReconstructionPlots.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/TrackingReconstructionPlots.java
@@ -355,8 +355,8 @@ public class TrackingReconstructionPlots extends Driver {
         }
     }
 
-    private void doClustersOnTrack(Track trk, List<Cluster> clusters) {
-        Hep3Vector posAtEcal = TrackUtils.getTrackPositionAtEcal(trk);
+    private void doClustersOnTrack(Track trk, List<Cluster> clusters,TrackUtils.RunPeriod runPeriod) {
+        Hep3Vector posAtEcal = TrackUtils.getTrackPositionAtEcal(trk,runPeriod);
         Cluster clust = findClosestCluster(posAtEcal, clusters);
         if (clust == null)
             return;
@@ -445,6 +445,20 @@ public class TrackingReconstructionPlots extends Driver {
 
     @Override
     public void process(EventHeader event) {
+        int runNumber = event.getRunNumber();
+        TrackUtils.RunPeriod runPeriod = TrackUtils.RunPeriod.PhysRun2021;
+        if (4441 < runNumber && runNumber < 5967) {
+            runPeriod = TrackUtils.RunPeriod.EngRun2015;
+        }
+        if (7219 < runNumber && runNumber < 8100) {
+            runPeriod = TrackUtils.RunPeriod.EngRun2016;
+        }
+        if (9001 < runNumber && runNumber < 10740) {
+            runPeriod = TrackUtils.RunPeriod.PhysRun2019;
+        }
+        if (14131 < runNumber && runNumber < 14775) {
+            runPeriod = TrackUtils.RunPeriod.PhysRun2021;
+        }
         aida.tree().cd("/");
         if (!event.hasCollection(TrackerHit.class, helicalTrackHitCollectionName)) {
             System.out.println(helicalTrackHitCollectionName + " does not exist; skipping event");
@@ -531,7 +545,7 @@ public class TrackingReconstructionPlots extends Driver {
                 doAmplitude(fittedHits, trk);
 
             if (doMatchedClusterPlots)
-                doClustersOnTrack(trk, clusters);
+                doClustersOnTrack(trk, clusters,runPeriod);
         }
 
         if (doElectronPositronPlots)

--- a/tracking/src/main/java/org/hps/recon/tracking/kalman/KalmanDriverHPS.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/kalman/KalmanDriverHPS.java
@@ -193,6 +193,21 @@ public class KalmanDriverHPS extends Driver {
             System.out.println(trackCollectionName + " does not exist; skipping event");
             return;
         }
+        int runNumber = event.getRunNumber();
+        TrackUtils.RunPeriod runPeriod = TrackUtils.RunPeriod.PhysRun2021;
+        if (4441 < runNumber && runNumber < 5967) {
+            runPeriod = TrackUtils.RunPeriod.EngRun2015;
+        }
+        if (7219 < runNumber && runNumber < 8100) {
+            runPeriod = TrackUtils.RunPeriod.EngRun2016;
+        }
+        if (9001 < runNumber && runNumber < 10740) {
+            runPeriod = TrackUtils.RunPeriod.PhysRun2019;
+        }
+        if (14131 < runNumber && runNumber < 14775) {
+            runPeriod = TrackUtils.RunPeriod.PhysRun2021;
+        }
+        KI.setRunPeriod(runPeriod);
         int evtNumb = event.getEventNumber();
         List<Track> tracks = event.get(Track.class, trackCollectionName);
         List<Track> outputSeedTracks = new ArrayList<Track>();

--- a/tracking/src/main/java/org/hps/recon/tracking/kalman/KalmanDriverHPS.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/kalman/KalmanDriverHPS.java
@@ -207,6 +207,7 @@ public class KalmanDriverHPS extends Driver {
         if (14131 < runNumber && runNumber < 14775) {
             runPeriod = TrackUtils.RunPeriod.PhysRun2021;
         }
+       
         KI.setRunPeriod(runPeriod);
         int evtNumb = event.getEventNumber();
         List<Track> tracks = event.get(Track.class, trackCollectionName);

--- a/tracking/src/main/java/org/hps/recon/tracking/kalman/KalmanInterface.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/kalman/KalmanInterface.java
@@ -596,6 +596,7 @@ public class KalmanInterface {
         }
         
         // Extrapolate to the ECAL and make a new trackState there.
+       
         BaseTrackState ts_ecal = TrackUtils.getTrackExtrapAtEcalRK(newTrack, fM, runPeriod);
         newTrack.getTrackStates().add(ts_ecal);
         

--- a/tracking/src/main/java/org/hps/recon/tracking/kalman/KalmanInterface.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/kalman/KalmanInterface.java
@@ -84,6 +84,12 @@ public class KalmanInterface {
     private static final double SVTcenter = 505.57;
     private static final double c = 2.99793e8; // Speed of light in m/s
     
+    private TrackUtils.RunPeriod runPeriod = TrackUtils.RunPeriod.PhysRun2021;
+    
+    public void setRunPeriod(TrackUtils.RunPeriod runPeriod){
+        this.runPeriod = runPeriod;
+    }
+    
     public void setSiHitsLimit(int limit) {
         _siHitsLimit = limit;
     }
@@ -590,7 +596,7 @@ public class KalmanInterface {
         }
         
         // Extrapolate to the ECAL and make a new trackState there.
-        BaseTrackState ts_ecal = TrackUtils.getTrackExtrapAtEcalRK(newTrack, fM);
+        BaseTrackState ts_ecal = TrackUtils.getTrackExtrapAtEcalRK(newTrack, fM, runPeriod);
         newTrack.getTrackStates().add(ts_ecal);
         
         // other track properties

--- a/tracking/src/main/java/org/hps/recon/tracking/kalman/KalmanPatRecDriver.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/kalman/KalmanPatRecDriver.java
@@ -18,6 +18,7 @@ import org.hps.recon.tracking.TrackData;
 import org.hps.recon.tracking.TrackResidualsData;
 import org.hps.recon.tracking.MaterialSupervisor.ScatteringDetectorVolume;
 import org.hps.recon.tracking.MaterialSupervisor.SiStripPlane;
+import org.hps.recon.tracking.TrackUtils;
 import org.hps.recon.tracking.gbl.GBLStripClusterData;
 import org.hps.util.Pair;
 import org.lcsim.detector.tracker.silicon.HpsSiSensor;
@@ -278,6 +279,22 @@ public class KalmanPatRecDriver extends Driver {
 
     @Override
     public void process(EventHeader event) {
+        int runNumber = event.getRunNumber();
+        TrackUtils.RunPeriod runPeriod = TrackUtils.RunPeriod.PhysRun2021;
+        if (4441 < runNumber && runNumber < 5967) {
+            runPeriod = TrackUtils.RunPeriod.EngRun2015;
+        }
+        if (7219 < runNumber && runNumber < 8100) {
+            runPeriod = TrackUtils.RunPeriod.EngRun2016;
+        }
+        if (9001 < runNumber && runNumber < 10740) {
+            runPeriod = TrackUtils.RunPeriod.PhysRun2019;
+        }
+        if (14131 < runNumber && runNumber < 14775) {
+            runPeriod = TrackUtils.RunPeriod.PhysRun2021;
+        }
+       
+        KI.setRunPeriod(runPeriod);
                 
         List<Track> outputFullTracks = new ArrayList<Track>();
         


### PR DESCRIPTION
There were a lot of instances in our code base of the static methods used to propagate a track to the face of the Ecal. I have tested the code and verified that it works correctly when reconstructing data from 2016, 2019 and 2021. It could use a thorough review to make sure that I did not introduce any bugs.