### PR TITLE
bug. Should grab track state using TrackUtils AtCalorimeter, not by g…

### DIFF
--- a/recon/src/main/java/org/hps/recon/utils/TrackClusterMatcherMinDistance.java
+++ b/recon/src/main/java/org/hps/recon/utils/TrackClusterMatcherMinDistance.java
@@ -327,7 +327,7 @@ public class TrackClusterMatcherMinDistance extends AbstractTrackClusterMatcher{
         }
         else {
             TrackData trackdata = (TrackData) trackToData.from(track);
-            TrackState ts_ecal = track.getTrackStateAtECal(track);
+            TrackState ts_ecal = TrackUtils.getTrackStateAtECal(track);
             //If trackstate is null, upstream extrapolation error. Skip this
             //Track
             if(ts_ecal == null){

--- a/recon/src/main/java/org/hps/recon/utils/TrackClusterMatcherMinDistance.java
+++ b/recon/src/main/java/org/hps/recon/utils/TrackClusterMatcherMinDistance.java
@@ -327,7 +327,7 @@ public class TrackClusterMatcherMinDistance extends AbstractTrackClusterMatcher{
         }
         else {
             TrackData trackdata = (TrackData) trackToData.from(track);
-            TrackState ts_ecal = track.getTrackStates().get(track.getTrackStates().size()-1);
+            TrackState ts_ecal = track.getTrackStateAtECal(track);
             //If trackstate is null, upstream extrapolation error. Skip this
             //Track
             if(ts_ecal == null){


### PR DESCRIPTION
…rabbing last trackstate in list of track states.

This was my mistake. Techinically, the last track state in the list of trackstates is at Ecal, so nothing was broken up to this point, but clearly this track state was being grabbed incorrectly, and would eventually break if another state was added after.

Whoops