### PR TITLE
Add new information to Track Data, and add new track collection tracksAtTarget

### DIFF
--- a/steering-files/src/main/resources/org/hps/steering/recon/PhysicsRun2016FullRecon_KF_TrackClusterMatcher.lcsim
+++ b/steering-files/src/main/resources/org/hps/steering/recon/PhysicsRun2016FullRecon_KF_TrackClusterMatcher.lcsim
@@ -7,7 +7,7 @@
       @author <a href="mailto:Norman.Graf@slac.stanford.edu">Norman Graf</a>
     -->
     <execute>
-        <driver name="PreCleanupDriver"/>
+        <!-- <driver name="PreCleanupDriver"/> -->
         <!-- Skip events with known bad conditions -->
         <driver name="EventFlagFilter"/>
         <!--RF driver-->
@@ -126,6 +126,7 @@
             <!-- <addResiduals>true</addResiduals> -->
             <numEvtPlots>40</numEvtPlots>
             <verbose>false</verbose>
+            <beamPositionZ>-4.3</beamPositionZ>
           </driver>
 
         <driver name="LCIOWriter" type="org.lcsim.util.loop.LCIODriver">

--- a/steering-files/src/main/resources/org/hps/steering/recon/PhysicsRun2016FullRecon_KF_TrackClusterMatcher.lcsim
+++ b/steering-files/src/main/resources/org/hps/steering/recon/PhysicsRun2016FullRecon_KF_TrackClusterMatcher.lcsim
@@ -7,7 +7,7 @@
       @author <a href="mailto:Norman.Graf@slac.stanford.edu">Norman Graf</a>
     -->
     <execute>
-        <!-- <driver name="PreCleanupDriver"/>-->
+        <driver name="PreCleanupDriver"/>
         <!-- Skip events with known bad conditions -->
         <driver name="EventFlagFilter"/>
         <!--RF driver-->

--- a/tracking/src/main/java/org/hps/recon/tracking/TrackData.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/TrackData.java
@@ -24,6 +24,13 @@ public class TrackData implements GenericObject {
     public static final int PY_INDEX = 2;
     public static final int PZ_INDEX = 3;
     public static final int TRACK_VOLUME_INDEX = 0;
+    public static final int TRACK_AT_ECAL_X_INDEX = 5; //Tracking coords
+    public static final int TRACK_AT_ECAL_Y_INDEX = 6; //Tracking coords
+    public static final int TRACK_AT_ECAL_Z_INDEX = 7; //Tracking coords
+    public static final int TRACK_AT_TARGET_X_INDEX = 8;//Tracking coords
+    public static final int TRACK_AT_TARGET_Y_INDEX = 9;//Tracking coords
+    public static final int TRACK_AT_TARGET_Z_INDEX = 10;//Tracking coords
+    public static final int TRACK_AT_TARGET_Z0_INDEX = 11;//Tracking coords
     public static final String TRACK_DATA_COLLECTION = "TrackData";
     public static final String TRACK_DATA_RELATION_COLLECTION = "TrackDataRelations";
 
@@ -74,6 +81,27 @@ public class TrackData implements GenericObject {
      * @param isolations : an array of doubles containing isolations for every
      * sensor layer
      * @param momentum   : an array of floats containing track momentum in the form (px,py,pz)
+     * @param trackEcalPos : an array of floats containing track (x,y,z) at ECal *in
+     * tracking coords
+     * @param trackTargPos: an array of floats containing track (x,y,z) at
+     * Target *in tracking coords
+     * @param trackTargz0: a float containing z0 for track at target
+     */
+    public TrackData(int trackVolume, float trackTime, double[] isolations, float[] momentum, float[] trackEcalPos, float[] trackTargPos, float trackTargZ0) {
+
+        this.doubles = isolations;
+        this.floats = new float[]{trackTime,momentum[0],momentum[1],momentum[2],trackEcalPos[0],trackEcalPos[1],trackEcalPos[2],trackTargPos[0],trackTargPos[1],trackTargPos[2],trackTargZ0};
+        this.ints = new int[]{trackVolume};
+    }
+
+    /**
+     * Constructor 
+     *
+     * @param trackVolume : SVT volume associated with the track
+     * @param trackTime : The track time
+     * @param isolations : an array of doubles containing isolations for every
+     * sensor layer
+     * @param momentum   : an array of floats containing track momentum in the form (px,py,pz)
      */
     public TrackData(int trackVolume, float trackTime, double[] isolations, float[] momentum) {
 
@@ -106,6 +134,27 @@ public class TrackData implements GenericObject {
         floats[PX_INDEX] = momentum[0];
         floats[PY_INDEX] = momentum[1];
         floats[PZ_INDEX] = momentum[2];
+    }
+
+    /**
+     * @return track position at Ecal in tracking coords
+     */
+    public float[] getTrackAtEcalPosition(){
+        return new float[]{floats[TRACK_AT_ECAL_X_INDEX],floats[TRACK_AT_ECAL_Y_INDEX],floats[TRACK_AT_ECAL_Z_INDEX]};
+    }
+
+    /**
+     * @return track position at target in tracking coords
+     */
+    public float[] getTrackAtTargetPosition(){
+        return new float[]{floats[TRACK_AT_TARGET_X_INDEX],floats[TRACK_AT_TARGET_Y_INDEX],floats[TRACK_AT_TARGET_Z_INDEX]};
+    }
+
+    /**
+     * @return z0 of track at target
+     */
+    public float getTrackAtTargetZ0(){
+        return floats[TRACK_AT_TARGET_Z0_INDEX];
     }
 
     /**

--- a/tracking/src/main/java/org/hps/recon/tracking/TrackUtils.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/TrackUtils.java
@@ -1732,6 +1732,13 @@ public class TrackUtils {
         return RKint.integrate(startPosition, p0Trans, distance);
     }
 
+    public static BaseTrackState getTrackExtrapAtTarget(Track track, double target_pos, FieldMap fm)
+    {
+        BaseTrackState bts = extrapolateTrackUsingFieldMap(TrackStateUtils.getTrackStateAtIP(track),BeamlineConstants.DIPOLE_EDGE_ENG_RUN, target_pos, 0, fm);
+        bts.setLocation(TrackState.LastLocation);
+        return bts;
+    }
+
     public static BaseTrackState extrapolateTrackUsingFieldMap(TrackState track, double startPositionX, double endPosition, double stepSize, double epsilon, FieldMap fieldMap) {
         // Start by extrapolating the track to the approximate point where the
         // fringe field begins.
@@ -1867,6 +1874,10 @@ public class TrackUtils {
             }
         }
         return null;
+    }
+
+    public static TrackState getTrackStateAtTarget(Track trk){
+        return getTrackStateAtLocation(trk, TrackState.LastLocation);
     }
 
     public static TrackState getTrackStateAtECal(Track trk) {

--- a/tracking/src/main/java/org/hps/recon/tracking/kalman/KalmanPatRecDriver.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/kalman/KalmanPatRecDriver.java
@@ -283,6 +283,10 @@ public class KalmanPatRecDriver extends Driver {
         KI.setRunNumber(runNumber);
                 
         List<Track> outputFullTracks = new ArrayList<Track>();
+        List<Track> outputTracksAtECal = new ArrayList<Track>();
+        List<LCRelation> tracksAtECalRelations = new ArrayList<LCRelation>();
+        List<Track> outputTracksAtTarget = new ArrayList<Track>();
+        List<LCRelation> tracksAtTargetRelations = new ArrayList<LCRelation>();
         
         //For additional track information
         List<TrackData> trackDataCollection = new ArrayList<TrackData>();
@@ -296,10 +300,14 @@ public class KalmanPatRecDriver extends Driver {
         List<TrackResidualsData> trackResiduals = new ArrayList<TrackResidualsData>();
         List<LCRelation> trackResidualsRelations = new ArrayList<LCRelation>();
        
-        ArrayList<KalTrack>[] kPatList = prepareTrackCollections(event, outputFullTracks, trackDataCollection, trackDataRelations, allClstrs, gblStripClusterDataRelations, trackResiduals, trackResidualsRelations);
+        ArrayList<KalTrack>[] kPatList = prepareTrackCollections(event, outputFullTracks, trackDataCollection, trackDataRelations, allClstrs, gblStripClusterDataRelations, trackResiduals, trackResidualsRelations, outputTracksAtECal, tracksAtECalRelations, outputTracksAtTarget, tracksAtTargetRelations);
         
         int flag = 1 << LCIOConstants.TRBIT_HITS;
         event.put(outputFullTrackCollectionName, outputFullTracks, Track.class, flag);
+        event.put(outputFullTrackCollectionName+"AtECal", outputTracksAtECal, Track.class, flag);
+        event.put(outputFullTrackCollectionName+"AtECalRelations", tracksAtECalRelations, LCRelation.class,0);
+        event.put(outputFullTrackCollectionName+"AtTarget", outputTracksAtTarget, Track.class, flag);
+        event.put(outputFullTrackCollectionName+"AtTargetRelations", tracksAtTargetRelations, LCRelation.class,0);
         event.put("KFGBLStripClusterData", allClstrs, GBLStripClusterData.class, flag);
         event.put("KFGBLStripClusterDataRelations", gblStripClusterDataRelations, LCRelation.class, flag);
         event.put("KFTrackData",trackDataCollection, TrackData.class,0);
@@ -339,7 +347,7 @@ public class KalmanPatRecDriver extends Driver {
         }
     }
 
-    private ArrayList<KalTrack>[] prepareTrackCollections(EventHeader event, List<Track> outputFullTracks, List<TrackData> trackDataCollection, List<LCRelation> trackDataRelations, List<GBLStripClusterData> allClstrs, List<LCRelation> gblStripClusterDataRelations, List<TrackResidualsData> trackResiduals, List<LCRelation> trackResidualsRelations) {
+    private ArrayList<KalTrack>[] prepareTrackCollections(EventHeader event, List<Track> outputFullTracks, List<TrackData> trackDataCollection, List<LCRelation> trackDataRelations, List<GBLStripClusterData> allClstrs, List<LCRelation> gblStripClusterDataRelations, List<TrackResidualsData> trackResiduals, List<LCRelation> trackResidualsRelations, List<Track> outputTracksAtECal, List<LCRelation> tracksAtECalRelations, List<Track> outputTracksAtTarget, List<LCRelation> tracksAtTargetRelations) {
         
         int evtNumb = event.getEventNumber();
         String stripHitInputCollectionName = "StripClusterer_SiTrackerHitStrip1D";
@@ -398,6 +406,17 @@ public class KalmanPatRecDriver extends Driver {
                 //double pt = Math.abs(1./ptInv_check);
                 
                 outputFullTracks.add(KalmanTrackHPS);
+
+                //Add track at ECal using track state at ECal
+                Track trackAtECal = KI.createTrackAtECal(kTk, KalmanTrackHPS);
+                outputTracksAtECal.add(trackAtECal);
+                tracksAtECalRelations.add(new BaseLCRelation(trackAtECal,KalmanTrackHPS));
+
+                //Add track at Target using track state at Target
+                Track trackAtTarget = KI.createTrackAtTarget(kTk, KalmanTrackHPS);
+                outputTracksAtTarget.add(trackAtTarget);
+                tracksAtTargetRelations.add(new BaseLCRelation(trackAtTarget,KalmanTrackHPS));
+
                 List<GBLStripClusterData> clstrs = KI.createGBLStripClusterData(kTk);
                 if (verbose) {
                     for (GBLStripClusterData clstr : clstrs) {

--- a/tracking/src/main/java/org/hps/recon/tracking/kalman/KalmanPatRecDriver.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/kalman/KalmanPatRecDriver.java
@@ -16,6 +16,7 @@ import org.hps.recon.tracking.CoordinateTransformations;
 import org.hps.recon.tracking.MaterialSupervisor;
 import org.hps.recon.tracking.TrackData;
 import org.hps.recon.tracking.TrackResidualsData;
+import org.hps.recon.tracking.TrackUtils;
 import org.hps.recon.tracking.MaterialSupervisor.ScatteringDetectorVolume;
 import org.hps.recon.tracking.MaterialSupervisor.SiStripPlane;
 import org.hps.recon.tracking.gbl.GBLStripClusterData;
@@ -56,6 +57,7 @@ public class KalmanPatRecDriver extends Driver {
     private KalmanParams kPar;
     private KalmanPatRecPlots kPlot;
     private static Logger logger;
+    private static double target_pos = -999.9;
     
     // Parameters for the Kalman pattern recognition that can be set by the user in the steering file:
     private ArrayList<String> strategies;     // List of seed strategies for both top and bottom trackers, from steering
@@ -129,6 +131,10 @@ public class KalmanPatRecDriver extends Driver {
 
     public void setAddResiduals(boolean input) {
         addResiduals = input;
+    }
+
+    public void setTargetPosition(double target_pos){
+        this.target_pos = target_pos;
     }
     
     @Override
@@ -268,6 +274,9 @@ public class KalmanPatRecDriver extends Driver {
         kPar.print();
         
         KI = new KalmanInterface(uniformB, kPar, fm);
+        if (target_pos != -999.9) {
+            KI.setTargetPosition(target_pos);
+        }
         KI.setSiHitsLimit(siHitsLimit);
         KI.createSiModules(detPlanes);
         decoder = det.getSubdetector("Tracker").getIDDecoder();
@@ -283,8 +292,6 @@ public class KalmanPatRecDriver extends Driver {
         KI.setRunNumber(runNumber);
                 
         List<Track> outputFullTracks = new ArrayList<Track>();
-        List<Track> outputTracksAtECal = new ArrayList<Track>();
-        List<LCRelation> tracksAtECalRelations = new ArrayList<LCRelation>();
         List<Track> outputTracksAtTarget = new ArrayList<Track>();
         List<LCRelation> tracksAtTargetRelations = new ArrayList<LCRelation>();
         
@@ -300,12 +307,10 @@ public class KalmanPatRecDriver extends Driver {
         List<TrackResidualsData> trackResiduals = new ArrayList<TrackResidualsData>();
         List<LCRelation> trackResidualsRelations = new ArrayList<LCRelation>();
        
-        ArrayList<KalTrack>[] kPatList = prepareTrackCollections(event, outputFullTracks, trackDataCollection, trackDataRelations, allClstrs, gblStripClusterDataRelations, trackResiduals, trackResidualsRelations, outputTracksAtECal, tracksAtECalRelations, outputTracksAtTarget, tracksAtTargetRelations);
+        ArrayList<KalTrack>[] kPatList = prepareTrackCollections(event, outputFullTracks, trackDataCollection, trackDataRelations, allClstrs, gblStripClusterDataRelations, trackResiduals, trackResidualsRelations, outputTracksAtTarget, tracksAtTargetRelations);
         
         int flag = 1 << LCIOConstants.TRBIT_HITS;
         event.put(outputFullTrackCollectionName, outputFullTracks, Track.class, flag);
-        event.put(outputFullTrackCollectionName+"AtECal", outputTracksAtECal, Track.class, flag);
-        event.put(outputFullTrackCollectionName+"AtECalRelations", tracksAtECalRelations, LCRelation.class,0);
         event.put(outputFullTrackCollectionName+"AtTarget", outputTracksAtTarget, Track.class, flag);
         event.put(outputFullTrackCollectionName+"AtTargetRelations", tracksAtTargetRelations, LCRelation.class,0);
         event.put("KFGBLStripClusterData", allClstrs, GBLStripClusterData.class, flag);
@@ -347,7 +352,7 @@ public class KalmanPatRecDriver extends Driver {
         }
     }
 
-    private ArrayList<KalTrack>[] prepareTrackCollections(EventHeader event, List<Track> outputFullTracks, List<TrackData> trackDataCollection, List<LCRelation> trackDataRelations, List<GBLStripClusterData> allClstrs, List<LCRelation> gblStripClusterDataRelations, List<TrackResidualsData> trackResiduals, List<LCRelation> trackResidualsRelations, List<Track> outputTracksAtECal, List<LCRelation> tracksAtECalRelations, List<Track> outputTracksAtTarget, List<LCRelation> tracksAtTargetRelations) {
+    private ArrayList<KalTrack>[] prepareTrackCollections(EventHeader event, List<Track> outputFullTracks, List<TrackData> trackDataCollection, List<LCRelation> trackDataRelations, List<GBLStripClusterData> allClstrs, List<LCRelation> gblStripClusterDataRelations, List<TrackResidualsData> trackResiduals, List<LCRelation> trackResidualsRelations, List<Track> outputTracksAtTarget, List<LCRelation> tracksAtTargetRelations) {
         
         int evtNumb = event.getEventNumber();
         String stripHitInputCollectionName = "StripClusterer_SiTrackerHitStrip1D";
@@ -407,15 +412,12 @@ public class KalmanPatRecDriver extends Driver {
                 
                 outputFullTracks.add(KalmanTrackHPS);
 
-                //Add track at ECal using track state at ECal
-                Track trackAtECal = KI.createTrackAtECal(kTk, KalmanTrackHPS);
-                outputTracksAtECal.add(trackAtECal);
-                tracksAtECalRelations.add(new BaseLCRelation(trackAtECal,KalmanTrackHPS));
-
                 //Add track at Target using track state at Target
                 Track trackAtTarget = KI.createTrackAtTarget(kTk, KalmanTrackHPS);
-                outputTracksAtTarget.add(trackAtTarget);
-                tracksAtTargetRelations.add(new BaseLCRelation(trackAtTarget,KalmanTrackHPS));
+                if (trackAtTarget != null){
+                    outputTracksAtTarget.add(trackAtTarget);
+                    tracksAtTargetRelations.add(new BaseLCRelation(trackAtTarget,KalmanTrackHPS));
+                }
 
                 List<GBLStripClusterData> clstrs = KI.createGBLStripClusterData(kTk);
                 if (verbose) {
@@ -450,9 +452,28 @@ public class KalmanPatRecDriver extends Driver {
                 momentum_f[0] = (float) momentum.x();
                 momentum_f[1] = (float) momentum.y();
                 momentum_f[2] = (float) momentum.z();
+
+                //Get track position at ECal
+                float[] trackECalPos_f = new float[3];
+                if (TrackUtils.getTrackStateAtECal(KalmanTrackHPS) != null){
+                    trackECalPos_f[0] = (float) TrackUtils.getTrackStateAtECal(KalmanTrackHPS).getReferencePoint()[0];
+                    trackECalPos_f[1] = (float) TrackUtils.getTrackStateAtECal(KalmanTrackHPS).getReferencePoint()[1];
+                    trackECalPos_f[2] = (float) TrackUtils.getTrackStateAtECal(KalmanTrackHPS).getReferencePoint()[2];
+                }
+
+                //Get track position at Target
+                float[] trackTargetPos_f = new float[3];
+                float trackTargetZ0_f = (float) -999.9;
+                if (TrackUtils.getTrackStateAtTarget(KalmanTrackHPS) != null){
+                    trackTargetPos_f[0] = (float) TrackUtils.getTrackStateAtTarget(KalmanTrackHPS).getReferencePoint()[0];
+                    trackTargetPos_f[1] = (float) TrackUtils.getTrackStateAtTarget(KalmanTrackHPS).getReferencePoint()[1];
+                    trackTargetPos_f[2] = (float) TrackUtils.getTrackStateAtTarget(KalmanTrackHPS).getReferencePoint()[2];
+                    trackTargetZ0_f = (float) TrackUtils.getTrackStateAtTarget(KalmanTrackHPS).getZ0();
+                }
                 
                 //Add the Track Data 
-                TrackData KFtrackData = new TrackData(trackerVolume, (float) kTk.getTime(), qualityArray, momentum_f);
+                //TrackData KFtrackData = new TrackData(trackerVolume, (float) kTk.getTime(), qualityArray, momentum_f);
+                TrackData KFtrackData = new TrackData(trackerVolume, (float) kTk.getTime(), qualityArray, momentum_f, trackECalPos_f, trackTargetPos_f, trackTargetZ0_f);
                 trackDataCollection.add(KFtrackData);
                 trackDataRelations.add(new BaseLCRelation(KFtrackData, KalmanTrackHPS));
 


### PR DESCRIPTION
FOR KF TRACKS ONLY
I've added 3 float indices to TrackData that contain Track RK extrapolated to ECal XYZ positions.
Also added 3 float indices to TrackData that contain Track RK extrapolated to Target XYZ positions.
Added single float to TrackData that holds Track RK extrapolated to Target Z0 value (this may differ from Z position, depending on the ultimate choice of parameter reference point). 

Add Track RK extrapolation to Target, and create new Track collection for trackAtTarget. The track parameters use (trackX, trackY, 0) as a reference point, therefore d0 = 0 by definition. Instead of d0, trackY becomes variable of interest. If we don't want d0 = 0, we can change the reference point that is used to get the track parameters at the target to (trackX, 0, 0)...need to validate choice.

New trackAtTarget collection is related to original trackAtIP using relations table. 

No TrackData collection exists to hold the track-time and 3-momentum of the new trackAtTarget collection. These values are obtained by using the relation to the original track, and accessing the original track TrackData. 

If we want to store track-time and 3-momentum for trackAtTarget collection, will need to add new TrackData collection and RelationsTable. 