### PR TITLE
restore relevant detectors to old version

### DIFF
--- a/detector-data/detectors/HPS_PhysicsRun2019_Pass2/HPS_PhysicsRun2019_Pass2.lcdd
+++ b/detector-data/detectors/HPS_PhysicsRun2019_Pass2/HPS_PhysicsRun2019_Pass2.lcdd
@@ -2,7 +2,7 @@
 <lcdd xmlns:lcdd="http://www.lcsim.org/schemas/lcdd/1.0" xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/lcdd/1.0/lcdd.xsd">
   <header>
     <detector name="HPS_PhysicsRun2019_Pass2" />
-    <generator name="lcsim" version="1.0" file="/sdf/group/hps/users/sgaiser/src/hps-java/detector-data/detectors/HPS_PhysicsRun2019_Pass2/compact.xml" checksum="3526012259" />
+    <generator name="lcsim" version="1.0" file="/sdf/group/hps/users/sgaiser/src/hps-java/detector-data/detectors/HPS_PhysicsRun2019_Pass2/compact.xml" checksum="1490788426" />
     <author name="NONE" />
     <comment>HPS detector for 2019 run with fieldmap, Tracker at nominal opening angle. SVT Survey for back of the detector from 2016. SVT Survey for front of the detector from 2019 measurements only Ty corrections. This detector uses the corrected fieldmap scaled to -1.022T for 4.5 GeV. Includes L0 and Hodoscope. ECAL with survey alignment for HPSEcal3 (global y/z translations). This detector has the full hierarchical alignment structure. SVT Alignment is done using FEEs, momentum constraint and beamspot constraint. Alignment of the back of the detector to be performed. All iterations included in the constants for debugging purposes. [PF]</comment>
   </header>
@@ -224,8 +224,8 @@
       <rotation name="support_plate_top_L14_rotation" x="-3.141018539088844" y="-6.078450108025306E-5" z="0.03113685437897771" unit="radian" />
       <position name="support_plate_bottom_L46_position" x="-1.4933850161612972" y="-354.61600510060094" z="-65.71764993705746" unit="mm" />
       <rotation name="support_plate_bottom_L46_rotation" x="3.094476993563374E-5" y="-7.645252288032373E-5" z="3.1115061896334066" unit="radian" />
-      <position name="support_plate_top_L46_position" x="-0.14729758292224293" y="-354.6032717303616" z="65.55564309931233" unit="mm" />
-      <rotation name="support_plate_top_L46_rotation" x="3.1415587079322944" y="-7.269497515093535E-5" z="0.030213707871632037" unit="radian" />
+      <position name="support_plate_top_L46_position" x="-0.11622205232588367" y="-354.5430631053185" z="65.523413" unit="mm" />
+      <rotation name="support_plate_top_L46_rotation" x="3.141592653589793" y="-0.0" z="0.030483299558163937" unit="radian" />
       <position name="module_L1b_halfmodule_axial_position" x="-18.774339359019493" y="288.67258183111045" z="-7.748191939449569" unit="mm" />
       <rotation name="module_L1b_halfmodule_axial_rotation" x="-1.5714074031976124" y="-0.03035471737017249" z="1.5756096030656122" unit="radian" />
       <position name="module_L1b_halfmodule_axial_sensor_position" x="0.0" y="0.0" z="0.0" unit="mm" />
@@ -274,7 +274,7 @@
       <rotation name="module_L2t_halfmodule_stereo_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
       <position name="module_L2t_halfmodule_stereo_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
       <rotation name="module_L2t_halfmodule_stereo_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
-      <position name="module_L3b_halfmodule_axial_position" x="-44.193119863692615" y="137.33499539583744" z="-25.54428901468013" unit="mm" />
+      <position name="module_L3b_halfmodule_axial_position" x="-44.19320083298571" y="137.3345651838303" z="-24.844289151564713" unit="mm" />
       <rotation name="module_L3b_halfmodule_axial_rotation" x="-1.5714074031976124" y="-0.03035471737017238" z="1.5714306030656124" unit="radian" />
       <position name="module_L3b_halfmodule_axial_sensor_position" x="-3.414999999999999" y="30.0" z="-0.50725" unit="mm" />
       <rotation name="module_L3b_halfmodule_axial_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
@@ -286,7 +286,7 @@
       <rotation name="module_L3b_halfmodule_axial_cf_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
       <position name="module_L3b_halfmodule_axial_hybrid_position" x="-3.414999999999999" y="-55.0" z="0.12649999999999995" unit="mm" />
       <rotation name="module_L3b_halfmodule_axial_hybrid_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
-      <position name="module_L3b_halfmodule_stereo_position" x="-44.635077546333264" y="145.70360743174547" z="-21.727547598517496" unit="mm" />
+      <position name="module_L3b_halfmodule_stereo_position" x="-44.63515851562636" y="145.70317721973834" z="-21.02754773540208" unit="mm" />
       <rotation name="module_L3b_halfmodule_stereo_rotation" x="1.570185250392181" y="0.03035471737017249" z="1.669987050524181" unit="radian" />
       <position name="module_L3b_halfmodule_stereo_sensor_position" x="-3.414999999999999" y="30.0" z="-0.50725" unit="mm" />
       <rotation name="module_L3b_halfmodule_stereo_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
@@ -298,7 +298,7 @@
       <rotation name="module_L3b_halfmodule_stereo_cf_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
       <position name="module_L3b_halfmodule_stereo_hybrid_position" x="-3.414999999999999" y="-55.0" z="0.12649999999999995" unit="mm" />
       <rotation name="module_L3b_halfmodule_stereo_hybrid_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
-      <position name="module_L3t_halfmodule_axial_position" x="-46.632131995052205" y="162.13693957278366" z="25.545864871389206" unit="mm" />
+      <position name="module_L3t_halfmodule_axial_position" x="-46.63208944590146" y="162.13653769265582" z="24.845864988044973" unit="mm" />
       <rotation name="module_L3t_halfmodule_axial_rotation" x="1.5716724800294697" y="0.031136834675633055" z="1.570866484846581" unit="radian" />
       <position name="module_L3t_halfmodule_axial_sensor_position" x="-3.414999999999999" y="30.0" z="-0.50725" unit="mm" />
       <rotation name="module_L3t_halfmodule_axial_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
@@ -310,7 +310,7 @@
       <rotation name="module_L3t_halfmodule_axial_cf_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
       <position name="module_L3t_halfmodule_axial_hybrid_position" x="-3.414999999999999" y="-55.0" z="0.12649999999999995" unit="mm" />
       <rotation name="module_L3t_halfmodule_axial_hybrid_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
-      <position name="module_L3t_halfmodule_stereo_position" x="-46.56014482186261" y="153.7503882806926" z="21.76461856781115" unit="mm" />
+      <position name="module_L3t_halfmodule_stereo_position" x="-46.56010227271186" y="153.74998640056475" z="21.064618684466918" unit="mm" />
       <rotation name="module_L3t_halfmodule_stereo_rotation" x="-1.5699216709366044" y="-0.031166784805223023" z="1.6707262108891452" unit="radian" />
       <position name="module_L3t_halfmodule_stereo_sensor_position" x="-3.414999999999999" y="30.0" z="-0.50725" unit="mm" />
       <rotation name="module_L3t_halfmodule_stereo_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
@@ -322,7 +322,7 @@
       <rotation name="module_L3t_halfmodule_stereo_cf_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
       <position name="module_L3t_halfmodule_stereo_hybrid_position" x="-3.414999999999999" y="-55.0" z="0.12649999999999995" unit="mm" />
       <rotation name="module_L3t_halfmodule_stereo_hybrid_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
-      <position name="module_L4b_halfmodule_axial_position" x="-41.15539272806291" y="37.38206112789007" z="-27.07413282912855" unit="mm" />
+      <position name="module_L4b_halfmodule_axial_position" x="-41.155473697356" y="37.381630915882944" z="-26.374132966013136" unit="mm" />
       <rotation name="module_L4b_halfmodule_axial_rotation" x="-1.5714074031976122" y="-0.03035471737017238" z="1.5706806030656122" unit="radian" />
       <position name="module_L4b_halfmodule_axial_sensor_position" x="-3.414999999999999" y="30.0" z="-0.50725" unit="mm" />
       <rotation name="module_L4b_halfmodule_axial_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
@@ -334,7 +334,7 @@
       <rotation name="module_L4b_halfmodule_axial_cf_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
       <position name="module_L4b_halfmodule_axial_hybrid_position" x="-3.414999999999999" y="-55.0" z="0.12649999999999995" unit="mm" />
       <rotation name="module_L4b_halfmodule_axial_hybrid_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
-      <position name="module_L4b_halfmodule_stereo_position" x="-41.60019738566119" y="45.75059251703685" z="-23.2668811045824" unit="mm" />
+      <position name="module_L4b_halfmodule_stereo_position" x="-41.600278354954284" y="45.75016230502973" z="-22.566881241466984" unit="mm" />
       <rotation name="module_L4b_halfmodule_stereo_rotation" x="1.5701852503921807" y="0.030354717370172268" z="1.6709120505241806" unit="radian" />
       <position name="module_L4b_halfmodule_stereo_sensor_position" x="-3.414999999999999" y="30.0" z="-0.50725" unit="mm" />
       <rotation name="module_L4b_halfmodule_stereo_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
@@ -346,7 +346,7 @@
       <rotation name="module_L4b_halfmodule_stereo_cf_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
       <position name="module_L4b_halfmodule_stereo_hybrid_position" x="-3.414999999999999" y="-55.0" z="0.12649999999999995" unit="mm" />
       <rotation name="module_L4b_halfmodule_stereo_hybrid_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
-      <position name="module_L4t_halfmodule_axial_position" x="-43.51902684081348" y="62.1858742114486" z="27.078047708023554" unit="mm" />
+      <position name="module_L4t_halfmodule_axial_position" x="-43.51898429166276" y="62.18547233132076" z="26.378047824679328" unit="mm" />
       <rotation name="module_L4t_halfmodule_axial_rotation" x="1.5716724800294697" y="0.031136834675633055" z="1.570866484846581" unit="radian" />
       <position name="module_L4t_halfmodule_axial_sensor_position" x="-3.414999999999999" y="30.0" z="-0.50725" unit="mm" />
       <rotation name="module_L4t_halfmodule_axial_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
@@ -358,7 +358,7 @@
       <rotation name="module_L4t_halfmodule_axial_cf_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
       <position name="module_L4t_halfmodule_axial_hybrid_position" x="-3.414999999999999" y="-55.0" z="0.12649999999999995" unit="mm" />
       <rotation name="module_L4t_halfmodule_axial_hybrid_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
-      <position name="module_L4t_halfmodule_stereo_position" x="-43.44889371072665" y="53.79924422264598" z="23.260432160811167" unit="mm" />
+      <position name="module_L4t_halfmodule_stereo_position" x="-43.44885116157593" y="53.79884234251814" z="22.56043227746694" unit="mm" />
       <rotation name="module_L4t_halfmodule_stereo_rotation" x="-1.5699216709366044" y="-0.031166784805223023" z="1.6707262108891452" unit="radian" />
       <position name="module_L4t_halfmodule_stereo_sensor_position" x="-3.414999999999999" y="30.0" z="-0.50725" unit="mm" />
       <rotation name="module_L4t_halfmodule_stereo_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
@@ -402,32 +402,32 @@
       <rotation name="module_L5b_halfmodule_stereo_slot_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
       <position name="module_L5b_halfmodule_stereo_slot_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
       <rotation name="module_L5b_halfmodule_stereo_slot_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
-      <position name="module_L5t_halfmodule_axial_hole_position" x="-57.057521196380115" y="-139.74786960134318" z="26.667258948001823" unit="mm" />
-      <rotation name="module_L5t_halfmodule_axial_hole_rotation" x="1.5711554044823286" y="0.03108188104825312" z="1.5703398086318114" unit="radian" />
+      <position name="module_L5t_halfmodule_axial_hole_position" x="-57.087193841109176" y="-139.70433228483577" z="26.63187265326517" unit="mm" />
+      <rotation name="module_L5t_halfmodule_axial_hole_rotation" x="1.5711870932041438" y="0.03135150120287022" z="1.5702671839316498" unit="radian" />
       <position name="module_L5t_halfmodule_axial_hole_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
       <rotation name="module_L5t_halfmodule_axial_hole_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
       <position name="module_L5t_halfmodule_axial_hole_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
       <rotation name="module_L5t_halfmodule_axial_hole_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
       <position name="module_L5t_halfmodule_axial_hole_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
       <rotation name="module_L5t_halfmodule_axial_hole_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
-      <position name="module_L5t_halfmodule_axial_slot_position" x="43.819693284575784" y="-136.6058248346396" z="26.659717834128806" unit="mm" />
-      <rotation name="module_L5t_halfmodule_axial_slot_rotation" x="1.5698852994698227" y="0.030544284820477878" z="-1.5698873427014406" unit="radian" />
+      <position name="module_L5t_halfmodule_axial_slot_position" x="43.7891690824166" y="-136.53509223227852" z="26.6168916140477" unit="mm" />
+      <rotation name="module_L5t_halfmodule_axial_slot_rotation" x="1.5699170167488445" y="0.030813812562634938" z="-1.5699603087374405" unit="radian" />
       <position name="module_L5t_halfmodule_axial_slot_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
       <rotation name="module_L5t_halfmodule_axial_slot_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
       <position name="module_L5t_halfmodule_axial_slot_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
       <rotation name="module_L5t_halfmodule_axial_slot_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
       <position name="module_L5t_halfmodule_axial_slot_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
       <rotation name="module_L5t_halfmodule_axial_slot_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
-      <position name="module_L5t_halfmodule_stereo_hole_position" x="-56.7666052532032" y="-147.16273493092876" z="29.171898708644306" unit="mm" />
-      <rotation name="module_L5t_halfmodule_stereo_hole_rotation" x="-1.5704295366748464" y="-0.031106279723979956" z="1.620644656209409" unit="radian" />
+      <position name="module_L5t_halfmodule_stereo_hole_position" x="-56.79409685315387" y="-147.1190338414445" z="29.136742960197566" unit="mm" />
+      <rotation name="module_L5t_halfmodule_stereo_hole_rotation" x="-1.5703978496608857" y="-0.03137590043836716" z="1.6207172788847106" unit="radian" />
       <position name="module_L5t_halfmodule_stereo_hole_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
       <rotation name="module_L5t_halfmodule_stereo_hole_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
       <position name="module_L5t_halfmodule_stereo_hole_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
       <rotation name="module_L5t_halfmodule_stereo_hole_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
       <position name="module_L5t_halfmodule_stereo_hole_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
       <rotation name="module_L5t_halfmodule_stereo_hole_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
-      <position name="module_L5t_halfmodule_stereo_slot_position" x="43.98407068954166" y="-144.03913762721587" z="24.186622508073516" unit="mm" />
-      <rotation name="module_L5t_halfmodule_stereo_slot_rotation" x="-1.57214881821343" y="-0.030353404813695483" z="-1.5210104578328432" unit="radian" />
+      <position name="module_L5t_halfmodule_stereo_slot_position" x="43.95537069966054" y="-143.968444434972" z="24.144036675229962" unit="mm" />
+      <rotation name="module_L5t_halfmodule_stereo_slot_rotation" x="-1.572117090627552" y="-0.030622900333239313" z="-1.5209373731893334" unit="radian" />
       <position name="module_L5t_halfmodule_stereo_slot_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
       <rotation name="module_L5t_halfmodule_stereo_slot_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
       <position name="module_L5t_halfmodule_stereo_slot_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
@@ -466,32 +466,32 @@
       <rotation name="module_L6b_halfmodule_stereo_slot_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
       <position name="module_L6b_halfmodule_stereo_slot_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
       <rotation name="module_L6b_halfmodule_stereo_slot_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
-      <position name="module_L6t_halfmodule_axial_hole_position" x="-51.01100173597741" y="-339.5809031444822" z="29.74464593384373" unit="mm" />
-      <rotation name="module_L6t_halfmodule_axial_hole_rotation" x="1.5710330567776416" y="0.03243189279387863" z="1.5702224656848973" unit="radian" />
+      <position name="module_L6t_halfmodule_axial_hole_position" x="-50.98657711703537" y="-339.53562383522086" z="29.71560354131555" unit="mm" />
+      <rotation name="module_L6t_halfmodule_axial_hole_rotation" x="1.5710646463285063" y="0.032701504061740265" z="1.5701498048390818" unit="radian" />
       <position name="module_L6t_halfmodule_axial_hole_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
       <rotation name="module_L6t_halfmodule_axial_hole_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
       <position name="module_L6t_halfmodule_axial_hole_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
       <rotation name="module_L6t_halfmodule_axial_hole_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
       <position name="module_L6t_halfmodule_axial_hole_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
       <rotation name="module_L6t_halfmodule_axial_hole_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
-      <position name="module_L6t_halfmodule_axial_slot_position" x="49.82469885836299" y="-336.46752876829333" z="29.76396928356165" unit="mm" />
-      <rotation name="module_L6t_halfmodule_axial_slot_rotation" x="1.5701766707431712" y="0.029419161319946183" z="-1.5693003568486898" unit="radian" />
+      <position name="module_L6t_halfmodule_axial_slot_position" x="49.84828160352837" y="-336.3950644514602" z="29.727490956688765" unit="mm" />
+      <rotation name="module_L6t_halfmodule_axial_slot_rotation" x="1.570208472475122" y="0.029688710303940213" z="-1.569373241830136" unit="radian" />
       <position name="module_L6t_halfmodule_axial_slot_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
       <rotation name="module_L6t_halfmodule_axial_slot_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
       <position name="module_L6t_halfmodule_axial_slot_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
       <rotation name="module_L6t_halfmodule_axial_slot_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
       <position name="module_L6t_halfmodule_axial_slot_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
       <rotation name="module_L6t_halfmodule_axial_slot_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
-      <position name="module_L6t_halfmodule_stereo_hole_position" x="-50.65962388277971" y="-347.1395050167246" z="32.22465616548353" unit="mm" />
-      <rotation name="module_L6t_halfmodule_stereo_hole_rotation" x="-1.5705647916465628" y="-0.030864711332819386" z="1.6203579453908934" unit="radian" />
+      <position name="module_L6t_halfmodule_stereo_hole_position" x="-50.63298126110263" y="-347.09404646570033" z="32.1958448032789" unit="mm" />
+      <rotation name="module_L6t_halfmodule_stereo_hole_rotation" x="-1.5705330882112192" y="-0.031134322227552125" z="1.6204306040022474" unit="radian" />
       <position name="module_L6t_halfmodule_stereo_hole_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
       <rotation name="module_L6t_halfmodule_stereo_hole_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
       <position name="module_L6t_halfmodule_stereo_hole_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
       <rotation name="module_L6t_halfmodule_stereo_hole_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
       <position name="module_L6t_halfmodule_stereo_hole_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
       <rotation name="module_L6t_halfmodule_stereo_hole_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
-      <position name="module_L6t_halfmodule_stereo_slot_position" x="50.10992411924468" y="-343.9866960994214" z="27.265875042631098" unit="mm" />
-      <rotation name="module_L6t_halfmodule_stereo_slot_rotation" x="-1.5719308839924733" y="-0.030544008302550243" z="-1.521817102649792" unit="radian" />
+      <position name="module_L6t_halfmodule_stereo_slot_position" x="50.135352400791945" y="-343.91423945905376" z="27.2296312324331" unit="mm" />
+      <rotation name="module_L6t_halfmodule_stereo_slot_rotation" x="-1.5718991685415205" y="-0.030813519735493712" z="-1.521744076340142" unit="radian" />
       <position name="module_L6t_halfmodule_stereo_slot_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
       <rotation name="module_L6t_halfmodule_stereo_slot_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
       <position name="module_L6t_halfmodule_stereo_slot_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
@@ -530,32 +530,32 @@
       <rotation name="module_L7b_halfmodule_stereo_slot_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
       <position name="module_L7b_halfmodule_stereo_slot_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
       <rotation name="module_L7b_halfmodule_stereo_slot_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
-      <position name="module_L7t_halfmodule_axial_hole_position" x="-45.070159208168896" y="-539.6607698245851" z="32.725346428913454" unit="mm" />
-      <rotation name="module_L7t_halfmodule_axial_hole_rotation" x="1.5707645781907194" y="0.030213707791774652" z="1.5708690549631361" unit="radian" />
+      <position name="module_L7t_halfmodule_axial_hole_position" x="-44.991577804403356" y="-539.613780287061" z="32.702664000000006" unit="mm" />
+      <rotation name="module_L7t_halfmodule_axial_hole_rotation" x="1.5707963267948966" y="0.030483299558163958" z="1.5707963267948963" unit="radian" />
       <position name="module_L7t_halfmodule_axial_hole_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
       <rotation name="module_L7t_halfmodule_axial_hole_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
       <position name="module_L7t_halfmodule_axial_hole_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
       <rotation name="module_L7t_halfmodule_axial_hole_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
       <position name="module_L7t_halfmodule_axial_hole_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
       <rotation name="module_L7t_halfmodule_axial_hole_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
-      <position name="module_L7t_halfmodule_axial_slot_position" x="55.874148572118806" y="-536.6099398490617" z="32.732788135305796" unit="mm" />
-      <rotation name="module_L7t_halfmodule_axial_slot_rotation" x="1.5707645781907191" y="0.03021370779177482" z="-1.5707235986266568" unit="radian" />
+      <position name="module_L7t_halfmodule_axial_slot_position" x="55.95190409585151" y="-536.5357364256258" z="32.702664000000006" unit="mm" />
+      <rotation name="module_L7t_halfmodule_axial_slot_rotation" x="1.5707963267948968" y="0.030483299558164013" z="-1.5707963267948963" unit="radian" />
       <position name="module_L7t_halfmodule_axial_slot_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
       <rotation name="module_L7t_halfmodule_axial_slot_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
       <position name="module_L7t_halfmodule_axial_slot_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
       <rotation name="module_L7t_halfmodule_axial_slot_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
       <position name="module_L7t_halfmodule_axial_slot_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
       <rotation name="module_L7t_halfmodule_axial_slot_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
-      <position name="module_L7t_halfmodule_stereo_hole_position" x="-44.79427850041312" y="-546.9718549056541" z="35.322358680456006" unit="mm" />
-      <rotation name="module_L7t_halfmodule_stereo_hole_rotation" x="-1.5708280753990735" y="-0.030213707791774652" z="1.620723598626657" unit="radian" />
+      <position name="module_L7t_halfmodule_stereo_hole_position" x="-44.71353731566072" y="-546.9247025149035" z="35.29990436763247" unit="mm" />
+      <rotation name="module_L7t_halfmodule_stereo_hole_rotation" x="-1.5707963267948963" y="-0.030483299558163958" z="1.6207963267948968" unit="radian" />
       <position name="module_L7t_halfmodule_stereo_hole_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
       <rotation name="module_L7t_halfmodule_stereo_hole_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
       <position name="module_L7t_halfmodule_stereo_hole_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
       <rotation name="module_L7t_halfmodule_stereo_hole_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
       <position name="module_L7t_halfmodule_stereo_hole_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
       <rotation name="module_L7t_halfmodule_stereo_hole_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
-      <position name="module_L7t_halfmodule_stereo_slot_position" x="56.04884309433802" y="-543.923922593859" z="30.27519291649009" unit="mm" />
-      <rotation name="module_L7t_halfmodule_stereo_slot_rotation" x="-1.5708280753990738" y="-0.03021370779177443" z="-1.5208690549631367" unit="radian" />
+      <position name="module_L7t_halfmodule_stereo_slot_position" x="56.128391785901734" y="-543.8497552770714" z="30.245304367632464" unit="mm" />
+      <rotation name="module_L7t_halfmodule_stereo_slot_rotation" x="-1.5707963267948966" y="-0.030483299558163847" z="-1.520796326794897" unit="radian" />
       <position name="module_L7t_halfmodule_stereo_slot_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
       <rotation name="module_L7t_halfmodule_stereo_slot_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
       <position name="module_L7t_halfmodule_stereo_slot_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />

--- a/detector-data/detectors/HPS_PhysicsRun2019_Pass2_fixed/HPS_PhysicsRun2019_Pass2_fixed.lcdd
+++ b/detector-data/detectors/HPS_PhysicsRun2019_Pass2_fixed/HPS_PhysicsRun2019_Pass2_fixed.lcdd
@@ -1,0 +1,10070 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lcdd xmlns:lcdd="http://www.lcsim.org/schemas/lcdd/1.0" xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/lcdd/1.0/lcdd.xsd">
+  <header>
+    <detector name="HPS_PhysicsRun2019_Pass2_fixed" />
+    <generator name="lcsim" version="1.0" file="/sdf/group/hps/users/sgaiser/src/hps-java/detector-data/detectors/HPS_PhysicsRun2019_Pass2/compact.xml" checksum="3526012259" />
+    <author name="NONE" />
+    <comment>HPS detector for 2019 run with fieldmap, Tracker at nominal opening angle. SVT Survey for back of the detector from 2016. SVT Survey for front of the detector from 2019 measurements only Ty corrections. This detector uses the corrected fieldmap scaled to -1.022T for 4.5 GeV. Includes L0 and Hodoscope. ECAL with survey alignment for HPSEcal3 (global y/z translations). This detector has the full hierarchical alignment structure. SVT Alignment is done using FEEs, momentum constraint and beamspot constraint. Alignment of the back of the detector to be performed. All iterations included in the constants for debugging purposes. [PF]</comment>
+  </header>
+  <iddict>
+    <idspec name="HodoscopeForeHits" length="46">
+      <idfield signed="false" label="system" length="6" start="0" />
+      <idfield signed="false" label="barrel" length="3" start="6" />
+      <idfield signed="false" label="layer" length="4" start="9" />
+      <idfield signed="false" label="module" length="12" start="13" />
+      <idfield signed="false" label="sensor" length="1" start="25" />
+      <idfield signed="true" label="side" length="2" start="32" />
+      <idfield signed="false" label="strip" length="12" start="34" />
+    </idspec>
+    <idspec name="TrackerHitsFieldDef" length="46">
+      <idfield signed="false" label="system" length="6" start="0" />
+      <idfield signed="false" label="barrel" length="3" start="6" />
+      <idfield signed="false" label="layer" length="4" start="9" />
+      <idfield signed="false" label="module" length="12" start="13" />
+      <idfield signed="false" label="sensor" length="1" start="25" />
+      <idfield signed="true" label="side" length="2" start="32" />
+      <idfield signed="false" label="strip" length="12" start="34" />
+    </idspec>
+    <idspec name="TrackerHits" length="46">
+      <idfield signed="false" label="system" length="6" start="0" />
+      <idfield signed="false" label="barrel" length="3" start="6" />
+      <idfield signed="false" label="layer" length="4" start="9" />
+      <idfield signed="false" label="module" length="12" start="13" />
+      <idfield signed="false" label="sensor" length="1" start="25" />
+      <idfield signed="true" label="side" length="2" start="32" />
+      <idfield signed="false" label="strip" length="12" start="34" />
+    </idspec>
+    <idspec name="HodoscopeHits" length="23">
+      <idfield signed="false" label="system" length="6" start="0" />
+      <idfield signed="false" label="barrel" length="3" start="6" />
+      <idfield signed="false" label="layer" length="4" start="9" />
+      <idfield signed="false" label="ix" length="4" start="13" />
+      <idfield signed="true" label="iy" length="3" start="17" />
+      <idfield signed="true" label="hole" length="3" start="20" />
+    </idspec>
+    <idspec name="EcalHits" length="22">
+      <idfield signed="false" label="system" length="6" start="0" />
+      <idfield signed="false" label="layer" length="2" start="6" />
+      <idfield signed="true" label="ix" length="8" start="8" />
+      <idfield signed="true" label="iy" length="6" start="16" />
+    </idspec>
+    <idspec name="TrackerHitsECal" length="46">
+      <idfield signed="false" label="system" length="6" start="0" />
+      <idfield signed="false" label="barrel" length="3" start="6" />
+      <idfield signed="false" label="layer" length="4" start="9" />
+      <idfield signed="false" label="module" length="12" start="13" />
+      <idfield signed="false" label="sensor" length="1" start="25" />
+      <idfield signed="true" label="side" length="2" start="32" />
+      <idfield signed="false" label="strip" length="12" start="34" />
+    </idspec>
+  </iddict>
+  <sensitive_detectors>
+    <tracker name="Tracker" ecut="0.0" eunit="MeV" verbose="0" hits_collection="TrackerHits">
+      <idspecref ref="TrackerHits" />
+    </tracker>
+    <tracker name="ECalScoring" ecut="0.0" eunit="MeV" verbose="0" hits_collection="TrackerHitsECal">
+      <idspecref ref="TrackerHitsECal" />
+      <hit_processor type="ScoringTrackerHitProcessor" />
+    </tracker>
+    <calorimeter name="Ecal" ecut="0.0" eunit="MeV" verbose="0" hits_collection="EcalHits">
+      <idspecref ref="EcalHits" />
+      <grid_xyz grid_size_x="0.0" grid_size_y="0.0" grid_size_z="0.0" />
+    </calorimeter>
+    <tracker name="Hodoscope" ecut="0.0" eunit="MeV" verbose="0" hits_collection="HodoscopeHits">
+      <idspecref ref="HodoscopeHits" />
+    </tracker>
+  </sensitive_detectors>
+  <limits />
+  <regions>
+    <region name="TrackingRegion" store_secondaries="true" kill_tracks="false" cut="10.0" lunit="mm" threshold="1.0" eunit="MeV" />
+  </regions>
+  <display>
+    <vis name="InvisibleWithDaughters" line_style="unbroken" drawing_style="wireframe" show_daughters="true" visible="false">
+      <color R="0.0" G="0.0" B="0.0" alpha="0.0" />
+    </vis>
+    <vis name="SensorVis" line_style="unbroken" drawing_style="wireframe" show_daughters="true" visible="true">
+      <color R="1.0" G="0.0" B="0.0" alpha="1.0" />
+    </vis>
+    <vis name="SvtBoxVis" line_style="unbroken" drawing_style="wireframe" show_daughters="true" visible="true">
+      <color R="1.0" G="1.0" B="0.0" alpha="1.0" />
+    </vis>
+    <vis name="ComponentVis" line_style="unbroken" drawing_style="solid" show_daughters="false" visible="false">
+      <color R="0.0" G="0.2" B="0.4" alpha="0.0" />
+    </vis>
+    <vis name="HybridVis" line_style="unbroken" drawing_style="solid" show_daughters="true" visible="true">
+      <color R="0.0" G="1.0" B="0.0" alpha="1.0" />
+    </vis>
+    <vis name="ColdBlockVis" line_style="dashed" drawing_style="solid" show_daughters="true" visible="true">
+      <color R="0.75" G="0.73" B="0.75" alpha="1.0" />
+    </vis>
+    <vis name="ECALVis" line_style="unbroken" drawing_style="wireframe" show_daughters="true" visible="true">
+      <color R="0.8" G="0.5" B="0.1" alpha="1.0" />
+    </vis>
+    <vis name="HodoscopeVis" line_style="unbroken" drawing_style="solid" show_daughters="true" visible="true">
+      <color R="0.0" G="0.3372549" B="0.50980395" alpha="1.0" />
+    </vis>
+    <vis name="BasePlateVis" line_style="dashed" drawing_style="solid" show_daughters="true" visible="true">
+      <color R="0.35" G="0.35" B="0.35" alpha="1.0" />
+    </vis>
+    <vis name="BeamPlaneVis" line_style="unbroken" drawing_style="solid" show_daughters="false" visible="true">
+      <color R="1.0" G="1.0" B="1.0" alpha="1.0" />
+    </vis>
+    <vis name="HalfModuleVis" line_style="dashed" drawing_style="wireframe" show_daughters="true" visible="true">
+      <color R="1.0" G="1.0" B="1.0" alpha="1.0" />
+    </vis>
+    <vis name="CarbonFiberVis" line_style="unbroken" drawing_style="solid" show_daughters="true" visible="true">
+      <color R="0.88" G="0.88" B="0.88" alpha="1.0" />
+    </vis>
+    <vis name="ModuleVis" line_style="dotted" drawing_style="wireframe" show_daughters="true" visible="true">
+      <color R="1.0" G="1.0" B="1.0" alpha="1.0" />
+    </vis>
+    <vis name="SupportPlateVis" line_style="dashed" drawing_style="solid" show_daughters="true" visible="true">
+      <color R="0.45" G="0.45" B="0.45" alpha="1.0" />
+    </vis>
+    <vis name="LayerVis" line_style="unbroken" drawing_style="wireframe" show_daughters="true" visible="false">
+      <color R="0.0" G="0.0" B="1.0" alpha="0.0" />
+    </vis>
+    <vis name="ChamberVis" line_style="unbroken" drawing_style="wireframe" show_daughters="true" visible="true">
+      <color R="1.0" G="0.0" B="1.0" alpha="1.0" />
+    </vis>
+    <vis name="InvisibleNoDaughters" line_style="unbroken" drawing_style="wireframe" show_daughters="false" visible="false">
+      <color R="0.0" G="0.0" B="0.0" alpha="0.0" />
+    </vis>
+    <vis name="ActiveSensorVis" line_style="unbroken" drawing_style="solid" show_daughters="true" visible="true">
+      <color R="1.0" G="0.0" B="0.0" alpha="1.0" />
+    </vis>
+    <vis name="KaptonVis" line_style="unbroken" drawing_style="solid" show_daughters="true" visible="true">
+      <color R="0.91" G="0.77" B="0.06" alpha="1.0" />
+    </vis>
+    <vis name="SupportVolumeVis" line_style="dashed" drawing_style="wireframe" show_daughters="true" visible="true">
+      <color R="0.75" G="0.73" B="0.75" alpha="1.0" />
+    </vis>
+    <vis name="WorldVis" line_style="unbroken" drawing_style="wireframe" show_daughters="true" visible="false">
+      <color R="1.0" G="1.0" B="1.0" alpha="1.0" />
+    </vis>
+    <vis name="TrackingVis" line_style="unbroken" drawing_style="wireframe" show_daughters="true" visible="false">
+      <color R="1.0" G="1.0" B="1.0" alpha="1.0" />
+    </vis>
+  </display>
+  <gdml>
+    <define>
+      <rotation name="identity_rot" x="0.0" y="0.0" z="0.0" unit="radian" />
+      <rotation name="reflect_rot" x="3.141592653589793" y="0.0" z="0.0" unit="radian" />
+      <position name="identity_pos" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <constant name="bot_tr_x" value="-0.405" />
+      <constant name="x_rot_top" value="0.0" />
+      <constant name="hodoscopeXMin2" value="48.0" />
+      <constant name="hodoscopeXMin1" value="43.548" />
+      <constant name="scoringThickness" value="0.001" />
+      <constant name="ecal_back" value="8.0" />
+      <constant name="pivot" value="791.0" />
+      <constant name="bot_tr_y" value="-0.9125" />
+      <constant name="hodoscopeThickness" value="10.0" />
+      <constant name="bot_tr_z" value="2.6225" />
+      <constant name="bot_rot_beta" value="0.0" />
+      <constant name="dipoleMagnetWidth" value="1000.0" />
+      <constant name="top_rot_beta" value="0.0" />
+      <constant name="SA1" value="0.1" />
+      <constant name="x_rot_top_add" value="0.0" />
+      <constant name="SA2" value="0.05" />
+      <constant name="tracking_region_min" value="50.0" />
+      <constant name="y02t" value="21.419865625949214" />
+      <constant name="world_side" value="5000.0" />
+      <constant name="sensorLength" value="98.33" />
+      <constant name="sensorWidth" value="38.3399" />
+      <constant name="y02b" value="-21.419865625949214" />
+      <constant name="bot_rot_gamma" value="0.0013469727279283583" />
+      <constant name="x_rot_bot" value="0.0" />
+      <constant name="dipoleMagnetHeight" value="1000.0" />
+      <constant name="z02t" value="146.185" />
+      <constant name="top_rot_alpha" value="6.4964212772E-4" />
+      <constant name="y_rot" value="0.03052" />
+      <constant name="tracking_region_zmax" value="1368.0" />
+      <constant name="constBFieldY" value="-1.08" />
+      <constant name="top_tr_z" value="4.9375" />
+      <constant name="top_tr_y" value="2.725" />
+      <constant name="top_tr_x" value="-0.71" />
+      <constant name="dipoleMagnetLength" value="1080.0" />
+      <constant name="top_rot_gamma" value="-4.6882347412E-4" />
+      <constant name="y01t" value="21.419865625949214" />
+      <constant name="x_rot_bot_add" value="0.0" />
+      <constant name="zst" value="1.0" />
+      <constant name="bot_rot_alpha" value="5.150274940439E-4" />
+      <constant name="hodoscopePixelHeight" value="59.225" />
+      <constant name="beam_angle" value="0.03052" />
+      <constant name="z02b" value="161.185" />
+      <constant name="y01b" value="-21.419865625949214" />
+      <constant name="electronGapLeftEdge" value="382.492" />
+      <constant name="ecal_front" value="6.65" />
+      <constant name="z01t" value="138.815" />
+      <constant name="world_x" value="5000.0" />
+      <constant name="hodoscopeScoreDisplacement" value="1.0" />
+      <constant name="world_y" value="5000.0" />
+      <constant name="dipoleMagnetPositionX" value="21.17" />
+      <constant name="world_z" value="5000.0" />
+      <constant name="dipoleMagnetPositionZ" value="457.2" />
+      <constant name="tracking_region_radius" value="2000.0" />
+      <constant name="moduleWidth" value="40.34" />
+      <constant name="x_off" value="0.0" />
+      <constant name="electronGapRightEdge" value="474.962" />
+      <constant name="hodoscopeZ" value="1098.5" />
+      <constant name="moduleLength" value="100.0" />
+      <constant name="PI" value="3.14159265359" />
+      <constant name="ecal_dface" value="1448.0" />
+      <constant name="ecal_z" value="80.0" />
+      <constant name="z01b" value="153.815" />
+      <position name="tracking_region_pos" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <position name="base_position" x="21.336" y="0.0" z="349.9358" unit="mm" />
+      <rotation name="base_rotation" x="1.5707963267948963" y="-0.0" z="0.0" unit="radian" />
+      <position name="base_plate_position" x="0.0" y="0.0" z="-82.423" unit="mm" />
+      <rotation name="base_plate_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="support_plate_bottom_L14_position" x="-43.228706532832426" y="158.6377851771212" z="-63.940602475966074" unit="mm" />
+      <rotation name="support_plate_bottom_L14_rotation" x="-6.145886244036026E-4" y="1.156704189424989E-4" z="3.1112379360164906" unit="radian" />
+      <position name="support_plate_top_L14_position" x="-44.93860812433106" y="159.19611767274353" z="64.02933692178013" unit="mm" />
+      <rotation name="support_plate_top_L14_rotation" x="-3.141018539088844" y="-6.078450108025306E-5" z="0.03113685437897771" unit="radian" />
+      <position name="support_plate_bottom_L46_position" x="-1.4933850161612972" y="-354.61600510060094" z="-65.71764993705746" unit="mm" />
+      <rotation name="support_plate_bottom_L46_rotation" x="3.094476993563374E-5" y="-7.645252288032373E-5" z="3.1115061896334066" unit="radian" />
+      <position name="support_plate_top_L46_position" x="-0.14729758292224293" y="-354.6032717303616" z="65.55564309931233" unit="mm" />
+      <rotation name="support_plate_top_L46_rotation" x="3.1415587079322944" y="-7.269497515093535E-5" z="0.030213707871632037" unit="radian" />
+      <position name="module_L1b_halfmodule_axial_position" x="-18.774339359019493" y="288.67258183111045" z="-7.748191939449569" unit="mm" />
+      <rotation name="module_L1b_halfmodule_axial_rotation" x="-1.5714074031976124" y="-0.03035471737017249" z="1.5756096030656122" unit="radian" />
+      <position name="module_L1b_halfmodule_axial_sensor_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L1b_halfmodule_axial_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L1b_halfmodule_axial_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L1b_halfmodule_axial_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L1b_halfmodule_stereo_position" x="-18.228138348167576" y="296.2871897749729" z="-7.6196336066366825" unit="mm" />
+      <rotation name="module_L1b_halfmodule_stereo_rotation" x="1.5701852503921805" y="0.0303547173701726" z="-1.4804926030656123" unit="radian" />
+      <position name="module_L1b_halfmodule_stereo_sensor_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L1b_halfmodule_stereo_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L1b_halfmodule_stereo_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L1b_halfmodule_stereo_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L1t_halfmodule_axial_position" x="-21.299680771100682" y="312.48426548363204" z="7.750682479799885" unit="mm" />
+      <rotation name="module_L1t_halfmodule_axial_rotation" x="1.571672477470632" y="0.03113809467209238" z="1.566666484955918" unit="radian" />
+      <position name="module_L1t_halfmodule_axial_sensor_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L1t_halfmodule_axial_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L1t_halfmodule_axial_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L1t_halfmodule_axial_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L1t_halfmodule_stereo_position" x="-20.293885079139073" y="304.9173269428975" z="7.782383619100628" unit="mm" />
+      <rotation name="module_L1t_halfmodule_stereo_rotation" x="-1.5699214882196084" y="-0.031164903652651954" z="-1.4771664481107574" unit="radian" />
+      <position name="module_L1t_halfmodule_stereo_sensor_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L1t_halfmodule_stereo_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L1t_halfmodule_stereo_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L1t_halfmodule_stereo_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L2b_halfmodule_axial_position" x="-17.506669703090992" y="238.68831172952116" z="-8.225583162587412" unit="mm" />
+      <rotation name="module_L2b_halfmodule_axial_rotation" x="-1.5714074031976124" y="-0.03035471737017238" z="1.5776136030656123" unit="radian" />
+      <position name="module_L2b_halfmodule_axial_sensor_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L2b_halfmodule_axial_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L2b_halfmodule_axial_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L2b_halfmodule_axial_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L2b_halfmodule_stereo_position" x="-16.963289817866595" y="246.30283276053223" z="-8.094975899465702" unit="mm" />
+      <rotation name="module_L2b_halfmodule_stereo_rotation" x="1.5701852503921805" y="0.030354717370172545" z="-1.4831716030656121" unit="radian" />
+      <position name="module_L2b_halfmodule_stereo_sensor_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L2b_halfmodule_stereo_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L2b_halfmodule_stereo_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L2b_halfmodule_stereo_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L2t_halfmodule_axial_position" x="-19.99298837874153" y="262.5008443626967" z="8.158945179725542" unit="mm" />
+      <rotation name="module_L2t_halfmodule_axial_rotation" x="1.5716724701113056" y="0.031139294648729523" z="1.5626664849067944" unit="radian" />
+      <position name="module_L2t_halfmodule_axial_sensor_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L2t_halfmodule_axial_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L2t_halfmodule_axial_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L2t_halfmodule_axial_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L2t_halfmodule_stereo_position" x="-18.993334255363024" y="254.9336739707053" z="8.120230129061774" unit="mm" />
+      <rotation name="module_L2t_halfmodule_stereo_rotation" x="-1.5699214162696666" y="-0.03116412697519578" z="-1.4797664502356798" unit="radian" />
+      <position name="module_L2t_halfmodule_stereo_sensor_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L2t_halfmodule_stereo_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L2t_halfmodule_stereo_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L2t_halfmodule_stereo_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3b_halfmodule_axial_position" x="-44.193119863692615" y="137.33499539583744" z="-25.54428901468013" unit="mm" />
+      <rotation name="module_L3b_halfmodule_axial_rotation" x="-1.5714074031976124" y="-0.03035471737017238" z="1.5714306030656124" unit="radian" />
+      <position name="module_L3b_halfmodule_axial_sensor_position" x="-3.414999999999999" y="30.0" z="-0.50725" unit="mm" />
+      <rotation name="module_L3b_halfmodule_axial_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3b_halfmodule_axial_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L3b_halfmodule_axial_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3b_halfmodule_axial_lamination_position" x="-3.414999999999999" y="30.0" z="-0.69225" unit="mm" />
+      <rotation name="module_L3b_halfmodule_axial_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3b_halfmodule_axial_cf_position" x="-3.414999999999999" y="30.0" z="-0.81875" unit="mm" />
+      <rotation name="module_L3b_halfmodule_axial_cf_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3b_halfmodule_axial_hybrid_position" x="-3.414999999999999" y="-55.0" z="0.12649999999999995" unit="mm" />
+      <rotation name="module_L3b_halfmodule_axial_hybrid_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3b_halfmodule_stereo_position" x="-44.635077546333264" y="145.70360743174547" z="-21.727547598517496" unit="mm" />
+      <rotation name="module_L3b_halfmodule_stereo_rotation" x="1.570185250392181" y="0.03035471737017249" z="1.669987050524181" unit="radian" />
+      <position name="module_L3b_halfmodule_stereo_sensor_position" x="-3.414999999999999" y="30.0" z="-0.50725" unit="mm" />
+      <rotation name="module_L3b_halfmodule_stereo_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3b_halfmodule_stereo_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L3b_halfmodule_stereo_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3b_halfmodule_stereo_lamination_position" x="-3.414999999999999" y="30.0" z="-0.69225" unit="mm" />
+      <rotation name="module_L3b_halfmodule_stereo_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3b_halfmodule_stereo_cf_position" x="-3.414999999999999" y="30.0" z="-0.81875" unit="mm" />
+      <rotation name="module_L3b_halfmodule_stereo_cf_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3b_halfmodule_stereo_hybrid_position" x="-3.414999999999999" y="-55.0" z="0.12649999999999995" unit="mm" />
+      <rotation name="module_L3b_halfmodule_stereo_hybrid_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3t_halfmodule_axial_position" x="-46.632131995052205" y="162.13693957278366" z="25.545864871389206" unit="mm" />
+      <rotation name="module_L3t_halfmodule_axial_rotation" x="1.5716724800294697" y="0.031136834675633055" z="1.570866484846581" unit="radian" />
+      <position name="module_L3t_halfmodule_axial_sensor_position" x="-3.414999999999999" y="30.0" z="-0.50725" unit="mm" />
+      <rotation name="module_L3t_halfmodule_axial_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3t_halfmodule_axial_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L3t_halfmodule_axial_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3t_halfmodule_axial_lamination_position" x="-3.414999999999999" y="30.0" z="-0.69225" unit="mm" />
+      <rotation name="module_L3t_halfmodule_axial_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3t_halfmodule_axial_cf_position" x="-3.414999999999999" y="30.0" z="-0.81875" unit="mm" />
+      <rotation name="module_L3t_halfmodule_axial_cf_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3t_halfmodule_axial_hybrid_position" x="-3.414999999999999" y="-55.0" z="0.12649999999999995" unit="mm" />
+      <rotation name="module_L3t_halfmodule_axial_hybrid_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3t_halfmodule_stereo_position" x="-46.56014482186261" y="153.7503882806926" z="21.76461856781115" unit="mm" />
+      <rotation name="module_L3t_halfmodule_stereo_rotation" x="-1.5699216709366044" y="-0.031166784805223023" z="1.6707262108891452" unit="radian" />
+      <position name="module_L3t_halfmodule_stereo_sensor_position" x="-3.414999999999999" y="30.0" z="-0.50725" unit="mm" />
+      <rotation name="module_L3t_halfmodule_stereo_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3t_halfmodule_stereo_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L3t_halfmodule_stereo_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3t_halfmodule_stereo_lamination_position" x="-3.414999999999999" y="30.0" z="-0.69225" unit="mm" />
+      <rotation name="module_L3t_halfmodule_stereo_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3t_halfmodule_stereo_cf_position" x="-3.414999999999999" y="30.0" z="-0.81875" unit="mm" />
+      <rotation name="module_L3t_halfmodule_stereo_cf_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3t_halfmodule_stereo_hybrid_position" x="-3.414999999999999" y="-55.0" z="0.12649999999999995" unit="mm" />
+      <rotation name="module_L3t_halfmodule_stereo_hybrid_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4b_halfmodule_axial_position" x="-41.15539272806291" y="37.38206112789007" z="-27.07413282912855" unit="mm" />
+      <rotation name="module_L4b_halfmodule_axial_rotation" x="-1.5714074031976122" y="-0.03035471737017238" z="1.5706806030656122" unit="radian" />
+      <position name="module_L4b_halfmodule_axial_sensor_position" x="-3.414999999999999" y="30.0" z="-0.50725" unit="mm" />
+      <rotation name="module_L4b_halfmodule_axial_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4b_halfmodule_axial_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L4b_halfmodule_axial_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4b_halfmodule_axial_lamination_position" x="-3.414999999999999" y="30.0" z="-0.69225" unit="mm" />
+      <rotation name="module_L4b_halfmodule_axial_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4b_halfmodule_axial_cf_position" x="-3.414999999999999" y="30.0" z="-0.81875" unit="mm" />
+      <rotation name="module_L4b_halfmodule_axial_cf_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4b_halfmodule_axial_hybrid_position" x="-3.414999999999999" y="-55.0" z="0.12649999999999995" unit="mm" />
+      <rotation name="module_L4b_halfmodule_axial_hybrid_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4b_halfmodule_stereo_position" x="-41.60019738566119" y="45.75059251703685" z="-23.2668811045824" unit="mm" />
+      <rotation name="module_L4b_halfmodule_stereo_rotation" x="1.5701852503921807" y="0.030354717370172268" z="1.6709120505241806" unit="radian" />
+      <position name="module_L4b_halfmodule_stereo_sensor_position" x="-3.414999999999999" y="30.0" z="-0.50725" unit="mm" />
+      <rotation name="module_L4b_halfmodule_stereo_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4b_halfmodule_stereo_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L4b_halfmodule_stereo_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4b_halfmodule_stereo_lamination_position" x="-3.414999999999999" y="30.0" z="-0.69225" unit="mm" />
+      <rotation name="module_L4b_halfmodule_stereo_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4b_halfmodule_stereo_cf_position" x="-3.414999999999999" y="30.0" z="-0.81875" unit="mm" />
+      <rotation name="module_L4b_halfmodule_stereo_cf_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4b_halfmodule_stereo_hybrid_position" x="-3.414999999999999" y="-55.0" z="0.12649999999999995" unit="mm" />
+      <rotation name="module_L4b_halfmodule_stereo_hybrid_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4t_halfmodule_axial_position" x="-43.51902684081348" y="62.1858742114486" z="27.078047708023554" unit="mm" />
+      <rotation name="module_L4t_halfmodule_axial_rotation" x="1.5716724800294697" y="0.031136834675633055" z="1.570866484846581" unit="radian" />
+      <position name="module_L4t_halfmodule_axial_sensor_position" x="-3.414999999999999" y="30.0" z="-0.50725" unit="mm" />
+      <rotation name="module_L4t_halfmodule_axial_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4t_halfmodule_axial_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L4t_halfmodule_axial_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4t_halfmodule_axial_lamination_position" x="-3.414999999999999" y="30.0" z="-0.69225" unit="mm" />
+      <rotation name="module_L4t_halfmodule_axial_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4t_halfmodule_axial_cf_position" x="-3.414999999999999" y="30.0" z="-0.81875" unit="mm" />
+      <rotation name="module_L4t_halfmodule_axial_cf_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4t_halfmodule_axial_hybrid_position" x="-3.414999999999999" y="-55.0" z="0.12649999999999995" unit="mm" />
+      <rotation name="module_L4t_halfmodule_axial_hybrid_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4t_halfmodule_stereo_position" x="-43.44889371072665" y="53.79924422264598" z="23.260432160811167" unit="mm" />
+      <rotation name="module_L4t_halfmodule_stereo_rotation" x="-1.5699216709366044" y="-0.031166784805223023" z="1.6707262108891452" unit="radian" />
+      <position name="module_L4t_halfmodule_stereo_sensor_position" x="-3.414999999999999" y="30.0" z="-0.50725" unit="mm" />
+      <rotation name="module_L4t_halfmodule_stereo_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4t_halfmodule_stereo_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L4t_halfmodule_stereo_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4t_halfmodule_stereo_lamination_position" x="-3.414999999999999" y="30.0" z="-0.69225" unit="mm" />
+      <rotation name="module_L4t_halfmodule_stereo_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4t_halfmodule_stereo_cf_position" x="-3.414999999999999" y="30.0" z="-0.81875" unit="mm" />
+      <rotation name="module_L4t_halfmodule_stereo_cf_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4t_halfmodule_stereo_hybrid_position" x="-3.414999999999999" y="-55.0" z="0.12649999999999995" unit="mm" />
+      <rotation name="module_L4t_halfmodule_stereo_hybrid_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5b_halfmodule_axial_hole_position" x="-57.617202125278176" y="-163.15968227852312" z="-26.819827255266134" unit="mm" />
+      <rotation name="module_L5b_halfmodule_axial_hole_rotation" x="-1.5686288961869366" y="-0.0300902636040092" z="1.570985478651439" unit="radian" />
+      <position name="module_L5b_halfmodule_axial_hole_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L5b_halfmodule_axial_hole_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5b_halfmodule_axial_hole_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L5b_halfmodule_axial_hole_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5b_halfmodule_axial_hole_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L5b_halfmodule_axial_hole_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5b_halfmodule_axial_slot_position" x="43.18874946504184" y="-160.10823771558583" z="-26.784047485440663" unit="mm" />
+      <rotation name="module_L5b_halfmodule_axial_slot_rotation" x="-1.5701922218260902" y="-0.030456362320513977" z="-1.5708075295369168" unit="radian" />
+      <position name="module_L5b_halfmodule_axial_slot_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L5b_halfmodule_axial_slot_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5b_halfmodule_axial_slot_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L5b_halfmodule_axial_slot_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5b_halfmodule_axial_slot_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L5b_halfmodule_axial_slot_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5b_halfmodule_stereo_hole_position" x="-57.85240934757451" y="-155.70582086603895" z="-29.34792552119249" unit="mm" />
+      <rotation name="module_L5b_halfmodule_stereo_hole_rotation" x="1.5730758382002616" y="0.029047966673090862" z="1.6204647814657878" unit="radian" />
+      <position name="module_L5b_halfmodule_stereo_hole_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L5b_halfmodule_stereo_hole_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5b_halfmodule_stereo_hole_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L5b_halfmodule_stereo_hole_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5b_halfmodule_stereo_hole_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L5b_halfmodule_stereo_hole_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5b_halfmodule_stereo_slot_position" x="43.0270238661884" y="-152.6550136432873" z="-24.338045150604408" unit="mm" />
+      <rotation name="module_L5b_halfmodule_stereo_slot_rotation" x="1.5720656338438532" y="0.030407012479740474" z="-1.519788397839531" unit="radian" />
+      <position name="module_L5b_halfmodule_stereo_slot_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L5b_halfmodule_stereo_slot_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5b_halfmodule_stereo_slot_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L5b_halfmodule_stereo_slot_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5b_halfmodule_stereo_slot_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L5b_halfmodule_stereo_slot_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5t_halfmodule_axial_hole_position" x="-57.057521196380115" y="-139.74786960134318" z="26.667258948001823" unit="mm" />
+      <rotation name="module_L5t_halfmodule_axial_hole_rotation" x="1.5711554044823286" y="0.03108188104825312" z="1.5703398086318114" unit="radian" />
+      <position name="module_L5t_halfmodule_axial_hole_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L5t_halfmodule_axial_hole_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5t_halfmodule_axial_hole_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L5t_halfmodule_axial_hole_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5t_halfmodule_axial_hole_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L5t_halfmodule_axial_hole_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5t_halfmodule_axial_slot_position" x="43.819693284575784" y="-136.6058248346396" z="26.659717834128806" unit="mm" />
+      <rotation name="module_L5t_halfmodule_axial_slot_rotation" x="1.5698852994698227" y="0.030544284820477878" z="-1.5698873427014406" unit="radian" />
+      <position name="module_L5t_halfmodule_axial_slot_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L5t_halfmodule_axial_slot_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5t_halfmodule_axial_slot_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L5t_halfmodule_axial_slot_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5t_halfmodule_axial_slot_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L5t_halfmodule_axial_slot_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5t_halfmodule_stereo_hole_position" x="-56.7666052532032" y="-147.16273493092876" z="29.171898708644306" unit="mm" />
+      <rotation name="module_L5t_halfmodule_stereo_hole_rotation" x="-1.5704295366748464" y="-0.031106279723979956" z="1.620644656209409" unit="radian" />
+      <position name="module_L5t_halfmodule_stereo_hole_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L5t_halfmodule_stereo_hole_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5t_halfmodule_stereo_hole_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L5t_halfmodule_stereo_hole_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5t_halfmodule_stereo_hole_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L5t_halfmodule_stereo_hole_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5t_halfmodule_stereo_slot_position" x="43.98407068954166" y="-144.03913762721587" z="24.186622508073516" unit="mm" />
+      <rotation name="module_L5t_halfmodule_stereo_slot_rotation" x="-1.57214881821343" y="-0.030353404813695483" z="-1.5210104578328432" unit="radian" />
+      <position name="module_L5t_halfmodule_stereo_slot_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L5t_halfmodule_stereo_slot_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5t_halfmodule_stereo_slot_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L5t_halfmodule_stereo_slot_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5t_halfmodule_stereo_slot_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L5t_halfmodule_stereo_slot_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6b_halfmodule_axial_hole_position" x="-51.615491750493796" y="-363.1487923644609" z="-29.807156413874843" unit="mm" />
+      <rotation name="module_L6b_halfmodule_axial_hole_rotation" x="-1.56994961701748" y="-0.02981430463722882" z="1.5707991078442727" unit="radian" />
+      <position name="module_L6b_halfmodule_axial_hole_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L6b_halfmodule_axial_hole_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6b_halfmodule_axial_hole_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L6b_halfmodule_axial_hole_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6b_halfmodule_axial_hole_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L6b_halfmodule_axial_hole_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6b_halfmodule_axial_slot_position" x="49.264057603884524" y="-360.1134695427753" z="-29.832790921013746" unit="mm" />
+      <rotation name="module_L6b_halfmodule_axial_slot_rotation" x="-1.570957320204281" y="-0.030896302486583" z="-1.5708961840930562" unit="radian" />
+      <position name="module_L6b_halfmodule_axial_slot_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L6b_halfmodule_axial_slot_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6b_halfmodule_axial_slot_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L6b_halfmodule_axial_slot_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6b_halfmodule_axial_slot_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L6b_halfmodule_axial_slot_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6b_halfmodule_stereo_hole_position" x="-51.775905531361786" y="-355.59926508325015" z="-32.344018517295716" unit="mm" />
+      <rotation name="module_L6b_halfmodule_stereo_hole_rotation" x="1.570307728074013" y="0.030512296774570718" z="1.6216160875939192" unit="radian" />
+      <position name="module_L6b_halfmodule_stereo_hole_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L6b_halfmodule_stereo_hole_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6b_halfmodule_stereo_hole_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L6b_halfmodule_stereo_hole_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6b_halfmodule_stereo_hole_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L6b_halfmodule_stereo_hole_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6b_halfmodule_stereo_slot_position" x="49.012733346014585" y="-352.5603564881353" z="-27.334075581647113" unit="mm" />
+      <rotation name="module_L6b_halfmodule_stereo_slot_rotation" x="1.569241478148846" y="0.029630855149868712" z="-1.5215403647859276" unit="radian" />
+      <position name="module_L6b_halfmodule_stereo_slot_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L6b_halfmodule_stereo_slot_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6b_halfmodule_stereo_slot_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L6b_halfmodule_stereo_slot_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6b_halfmodule_stereo_slot_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L6b_halfmodule_stereo_slot_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6t_halfmodule_axial_hole_position" x="-51.01100173597741" y="-339.5809031444822" z="29.74464593384373" unit="mm" />
+      <rotation name="module_L6t_halfmodule_axial_hole_rotation" x="1.5710330567776416" y="0.03243189279387863" z="1.5702224656848973" unit="radian" />
+      <position name="module_L6t_halfmodule_axial_hole_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L6t_halfmodule_axial_hole_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6t_halfmodule_axial_hole_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L6t_halfmodule_axial_hole_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6t_halfmodule_axial_hole_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L6t_halfmodule_axial_hole_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6t_halfmodule_axial_slot_position" x="49.82469885836299" y="-336.46752876829333" z="29.76396928356165" unit="mm" />
+      <rotation name="module_L6t_halfmodule_axial_slot_rotation" x="1.5701766707431712" y="0.029419161319946183" z="-1.5693003568486898" unit="radian" />
+      <position name="module_L6t_halfmodule_axial_slot_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L6t_halfmodule_axial_slot_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6t_halfmodule_axial_slot_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L6t_halfmodule_axial_slot_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6t_halfmodule_axial_slot_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L6t_halfmodule_axial_slot_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6t_halfmodule_stereo_hole_position" x="-50.65962388277971" y="-347.1395050167246" z="32.22465616548353" unit="mm" />
+      <rotation name="module_L6t_halfmodule_stereo_hole_rotation" x="-1.5705647916465628" y="-0.030864711332819386" z="1.6203579453908934" unit="radian" />
+      <position name="module_L6t_halfmodule_stereo_hole_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L6t_halfmodule_stereo_hole_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6t_halfmodule_stereo_hole_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L6t_halfmodule_stereo_hole_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6t_halfmodule_stereo_hole_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L6t_halfmodule_stereo_hole_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6t_halfmodule_stereo_slot_position" x="50.10992411924468" y="-343.9866960994214" z="27.265875042631098" unit="mm" />
+      <rotation name="module_L6t_halfmodule_stereo_slot_rotation" x="-1.5719308839924733" y="-0.030544008302550243" z="-1.521817102649792" unit="radian" />
+      <position name="module_L6t_halfmodule_stereo_slot_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L6t_halfmodule_stereo_slot_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6t_halfmodule_stereo_slot_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L6t_halfmodule_stereo_slot_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6t_halfmodule_stereo_slot_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L6t_halfmodule_stereo_slot_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7b_halfmodule_axial_hole_position" x="-45.742030229084996" y="-562.8483841393576" z="-32.75144920133018" unit="mm" />
+      <rotation name="module_L7b_halfmodule_axial_hole_rotation" x="-1.5707676829053234" y="-0.03008646386843271" z="1.570472813933065" unit="radian" />
+      <position name="module_L7b_halfmodule_axial_hole_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L7b_halfmodule_axial_hole_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7b_halfmodule_axial_hole_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L7b_halfmodule_axial_hole_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7b_halfmodule_axial_hole_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L7b_halfmodule_axial_hole_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7b_halfmodule_axial_slot_position" x="55.20266711477981" y="-559.8103978325854" z="-32.7303606878213" unit="mm" />
+      <rotation name="module_L7b_halfmodule_axial_slot_rotation" x="-1.5707676829053236" y="-0.03008646386843243" z="-1.5704198396567282" unit="radian" />
+      <position name="module_L7b_halfmodule_axial_slot_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L7b_halfmodule_axial_slot_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7b_halfmodule_axial_slot_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L7b_halfmodule_axial_slot_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7b_halfmodule_axial_slot_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L7b_halfmodule_axial_slot_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7b_halfmodule_stereo_hole_position" x="-45.91032040910272" y="-555.5342088870343" z="-35.27972750110794" unit="mm" />
+      <rotation name="module_L7b_halfmodule_stereo_hole_rotation" x="1.57082497068447" y="0.030086463868432486" z="1.6213198396567283" unit="radian" />
+      <position name="module_L7b_halfmodule_stereo_hole_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L7b_halfmodule_stereo_hole_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7b_halfmodule_stereo_hole_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L7b_halfmodule_stereo_hole_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7b_halfmodule_stereo_hole_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L7b_halfmodule_stereo_hole_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7b_halfmodule_stereo_slot_position" x="54.93551160789105" y="-552.4990553520553" z="-30.27907358652926" unit="mm" />
+      <rotation name="module_L7b_halfmodule_stereo_slot_rotation" x="1.57082497068447" y="0.03008646386843282" z="-1.5216728139330649" unit="radian" />
+      <position name="module_L7b_halfmodule_stereo_slot_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L7b_halfmodule_stereo_slot_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7b_halfmodule_stereo_slot_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L7b_halfmodule_stereo_slot_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7b_halfmodule_stereo_slot_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L7b_halfmodule_stereo_slot_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7t_halfmodule_axial_hole_position" x="-45.070159208168896" y="-539.6607698245851" z="32.725346428913454" unit="mm" />
+      <rotation name="module_L7t_halfmodule_axial_hole_rotation" x="1.5707645781907194" y="0.030213707791774652" z="1.5708690549631361" unit="radian" />
+      <position name="module_L7t_halfmodule_axial_hole_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L7t_halfmodule_axial_hole_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7t_halfmodule_axial_hole_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L7t_halfmodule_axial_hole_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7t_halfmodule_axial_hole_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L7t_halfmodule_axial_hole_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7t_halfmodule_axial_slot_position" x="55.874148572118806" y="-536.6099398490617" z="32.732788135305796" unit="mm" />
+      <rotation name="module_L7t_halfmodule_axial_slot_rotation" x="1.5707645781907191" y="0.03021370779177482" z="-1.5707235986266568" unit="radian" />
+      <position name="module_L7t_halfmodule_axial_slot_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L7t_halfmodule_axial_slot_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7t_halfmodule_axial_slot_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L7t_halfmodule_axial_slot_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7t_halfmodule_axial_slot_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L7t_halfmodule_axial_slot_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7t_halfmodule_stereo_hole_position" x="-44.79427850041312" y="-546.9718549056541" z="35.322358680456006" unit="mm" />
+      <rotation name="module_L7t_halfmodule_stereo_hole_rotation" x="-1.5708280753990735" y="-0.030213707791774652" z="1.620723598626657" unit="radian" />
+      <position name="module_L7t_halfmodule_stereo_hole_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L7t_halfmodule_stereo_hole_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7t_halfmodule_stereo_hole_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L7t_halfmodule_stereo_hole_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7t_halfmodule_stereo_hole_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L7t_halfmodule_stereo_hole_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7t_halfmodule_stereo_slot_position" x="56.04884309433802" y="-543.923922593859" z="30.27519291649009" unit="mm" />
+      <rotation name="module_L7t_halfmodule_stereo_slot_rotation" x="-1.5708280753990738" y="-0.03021370779177443" z="-1.5208690549631367" unit="radian" />
+      <position name="module_L7t_halfmodule_stereo_slot_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L7t_halfmodule_stereo_slot_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7t_halfmodule_stereo_slot_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L7t_halfmodule_stereo_slot_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7t_halfmodule_stereo_slot_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L7t_halfmodule_stereo_slot_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="BeamLeftVolume_component0_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="BeamLeftVolume_component0_rotation" x="0.0" y="0.0" z="0.0" unit="radian" />
+      <position name="BeamLeftVolume_component0Sensor0Position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="BeamLeftVolume_component0Sensor0Rotation" x="0.0" y="0.0" z="0.0" unit="radian" />
+      <position name="ElectronGapVolume_component0_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="ElectronGapVolume_component0_rotation" x="0.0" y="0.0" z="0.0" unit="radian" />
+      <position name="ElectronGapVolume_component0Sensor0Position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="ElectronGapVolume_component0Sensor0Rotation" x="0.0" y="0.0" z="0.0" unit="radian" />
+      <position name="BeamRightVolume_component0_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="BeamRightVolume_component0_rotation" x="0.0" y="0.0" z="0.0" unit="radian" />
+      <position name="BeamRightVolume_component0Sensor0Position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="BeamRightVolume_component0Sensor0Rotation" x="0.0" y="0.0" z="0.0" unit="radian" />
+      <position name="ECalScoring_BeamLeft_layer1_module0_position" x="214.099" y="122.8" z="1443.001" unit="mm" />
+      <rotation name="ECalScoring_BeamLeft_layer1_module0_rotation" x="0.0" y="0.0" z="-1.570796326795" unit="radian" />
+      <position name="ECalScoring_ElectronGap_layer1_module0_position" x="-23.38199999999999" y="130.465" z="1443.001" unit="mm" />
+      <rotation name="ECalScoring_ElectronGap_layer1_module0_rotation" x="0.0" y="0.0" z="-1.570796326795" unit="radian" />
+      <position name="ECalScoring_BeamRight_layer1_module0_position" x="-216.31099999999998" y="121.3" z="1443.001" unit="mm" />
+      <rotation name="ECalScoring_BeamRight_layer1_module0_rotation" x="0.0" y="0.0" z="-1.570796326795" unit="radian" />
+      <position name="ECalScoring_BeamLeft_layer2_module0_position" x="214.099" y="-122.8" z="1443.001" unit="mm" />
+      <rotation name="ECalScoring_BeamLeft_layer2_module0_rotation" x="0.0" y="0.0" z="-4.7123889803850005" unit="radian" />
+      <position name="ECalScoring_ElectronGap_layer2_module0_position" x="-23.38199999999999" y="-130.465" z="1443.001" unit="mm" />
+      <rotation name="ECalScoring_ElectronGap_layer2_module0_rotation" x="0.0" y="0.0" z="-4.7123889803850005" unit="radian" />
+      <position name="ECalScoring_BeamRight_layer2_module0_position" x="-216.31099999999998" y="-121.3" z="1443.001" unit="mm" />
+      <rotation name="ECalScoring_BeamRight_layer2_module0_rotation" x="0.0" y="0.0" z="-4.7123889803850005" unit="radian" />
+      <position name="crystal1-1_pos_pos_bot" x="50.20495188328156" y="-29.07473927539554" z="1528.1626281236922" unit="mm" />
+      <rotation name="crystal1-1_rot_pos_bot" x="-0.0084372997827221" y="-0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal1-1_pos_neg_bot" x="35.15547333249048" y="-29.07473927539554" z="1528.1626281236922" unit="mm" />
+      <rotation name="crystal1-1_rot_neg_bot" x="-0.0084372997827221" y="0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal1-1_pos_pos_top" x="50.20495188328156" y="29.974739275395542" z="1528.1626281236922" unit="mm" />
+      <rotation name="crystal1-1_rot_pos_top" x="0.0084372997827221" y="-0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal1-1_pos_neg_top" x="35.15547333249048" y="29.974739275395542" z="1528.1626281236922" unit="mm" />
+      <rotation name="crystal1-1_rot_neg_top" x="0.0084372997827221" y="0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal2-1_pos_pos_bot" x="65.05802548582456" y="-29.07473927539554" z="1528.2520480856124" unit="mm" />
+      <rotation name="crystal2-1_rot_pos_bot" x="-0.0084372997827221" y="-0.0253118993481663" z="0.0" unit="radian" />
+      <position name="crystal2-1_pos_pos_top" x="65.05802548582456" y="29.974739275395542" z="1528.2520480856124" unit="mm" />
+      <rotation name="crystal2-1_rot_pos_top" x="0.0084372997827221" y="-0.0253118993481663" z="0.0" unit="radian" />
+      <position name="crystal3-1_pos_pos_bot" x="79.9180994782841" y="-29.07473927539554" z="1528.3186477918262" unit="mm" />
+      <rotation name="crystal3-1_rot_pos_bot" x="-0.0084372997827221" y="-0.042186498913610496" z="0.0" unit="radian" />
+      <position name="crystal3-1_pos_pos_top" x="79.9180994782841" y="29.974739275395542" z="1528.3186477918262" unit="mm" />
+      <rotation name="crystal3-1_rot_pos_top" x="0.0084372997827221" y="-0.042186498913610496" z="0.0" unit="radian" />
+      <position name="crystal4-1_pos_pos_bot" x="94.78858692586502" y="-29.07473927539554" z="1528.3624082783765" unit="mm" />
+      <rotation name="crystal4-1_rot_pos_bot" x="-0.0084372997827221" y="-0.0590610984790547" z="0.0" unit="radian" />
+      <position name="crystal4-1_pos_pos_top" x="94.78858692586502" y="29.974739275395542" z="1528.3624082783765" unit="mm" />
+      <rotation name="crystal4-1_rot_pos_top" x="0.0084372997827221" y="-0.0590610984790547" z="0.0" unit="radian" />
+      <position name="crystal5-1_pos_pos_bot" x="109.67291416309662" y="-29.07473927539554" z="1528.3833170846683" unit="mm" />
+      <rotation name="crystal5-1_rot_pos_bot" x="-0.0084372997827221" y="-0.0759356980444989" z="0.0" unit="radian" />
+      <position name="crystal5-1_pos_pos_top" x="109.67291416309662" y="29.974739275395542" z="1528.3833170846683" unit="mm" />
+      <rotation name="crystal5-1_rot_pos_top" x="0.0084372997827221" y="-0.0759356980444989" z="0.0" unit="radian" />
+      <position name="crystal6-1_pos_pos_bot" x="124.57452638340096" y="-29.07473927539554" z="1528.381368257016" unit="mm" />
+      <rotation name="crystal6-1_rot_pos_bot" x="-0.0084372997827221" y="-0.0928102976099431" z="0.0" unit="radian" />
+      <position name="crystal6-1_pos_pos_top" x="124.57452638340096" y="29.974739275395542" z="1528.381368257016" unit="mm" />
+      <rotation name="crystal6-1_rot_pos_top" x="0.0084372997827221" y="-0.0928102976099431" z="0.0" unit="radian" />
+      <position name="crystal7-1_pos_pos_bot" x="139.4968932952259" y="-29.07473927539554" z="1528.3565623503396" unit="mm" />
+      <rotation name="crystal7-1_rot_pos_bot" x="-0.0084372997827221" y="-0.10968489717538729" z="0.0" unit="radian" />
+      <position name="crystal7-1_pos_pos_top" x="139.4968932952259" y="29.974739275395542" z="1528.3565623503396" unit="mm" />
+      <rotation name="crystal7-1_rot_pos_top" x="0.0084372997827221" y="-0.10968489717538729" z="0.0" unit="radian" />
+      <position name="crystal8-1_pos_pos_bot" x="154.44351486445828" y="-29.07473927539554" z="1528.3089064280052" unit="mm" />
+      <rotation name="crystal8-1_rot_pos_bot" x="-0.0084372997827221" y="-0.1265594967408315" z="0.0" unit="radian" />
+      <position name="crystal8-1_pos_pos_top" x="154.44351486445828" y="29.974739275395542" z="1528.3089064280052" unit="mm" />
+      <rotation name="crystal8-1_rot_pos_top" x="0.0084372997827221" y="-0.1265594967408315" z="0.0" unit="radian" />
+      <position name="crystal9-1_pos_pos_bot" x="169.41792716339802" y="-29.07473927539554" z="1528.2384140598156" unit="mm" />
+      <rotation name="crystal9-1_rot_pos_bot" x="-0.0084372997827221" y="-0.14343409630627568" z="0.0" unit="radian" />
+      <position name="crystal9-1_pos_pos_top" x="169.41792716339802" y="29.974739275395542" z="1528.2384140598156" unit="mm" />
+      <rotation name="crystal9-1_rot_pos_top" x="0.0084372997827221" y="-0.14343409630627568" z="0.0" unit="radian" />
+      <position name="crystal10-1_pos_pos_bot" x="184.42370834727978" y="-29.07473927539554" z="1528.1451053181452" unit="mm" />
+      <rotation name="crystal10-1_rot_pos_bot" x="-0.0084372997827221" y="-0.1603086958717199" z="0.0" unit="radian" />
+      <position name="crystal10-1_pos_pos_top" x="184.42370834727978" y="29.974739275395542" z="1528.1451053181452" unit="mm" />
+      <rotation name="crystal10-1_rot_pos_top" x="0.0084372997827221" y="-0.1603086958717199" z="0.0" unit="radian" />
+      <position name="crystal11-1_pos_pos_bot" x="199.46448478017476" y="-29.07473927539554" z="1528.0290067722244" unit="mm" />
+      <rotation name="crystal11-1_rot_pos_bot" x="-0.0084372997827221" y="-0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal11-1_pos_neg_bot" x="-114.1040595644027" y="-29.07473927539554" z="1528.0290067722244" unit="mm" />
+      <rotation name="crystal11-1_rot_neg_bot" x="-0.0084372997827221" y="0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal11-1_pos_pos_top" x="199.46448478017476" y="29.974739275395542" z="1528.0290067722244" unit="mm" />
+      <rotation name="crystal11-1_rot_pos_top" x="0.0084372997827221" y="-0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal11-1_pos_neg_top" x="-114.1040595644027" y="29.974739275395542" z="1528.0290067722244" unit="mm" />
+      <rotation name="crystal11-1_rot_neg_top" x="0.0084372997827221" y="0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal12-1_pos_pos_bot" x="214.5439373331128" y="-29.07473927539554" z="1527.8901514805746" unit="mm" />
+      <rotation name="crystal12-1_rot_pos_bot" x="-0.0084372997827221" y="-0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal12-1_pos_neg_bot" x="-129.1835121173408" y="-29.07473927539554" z="1527.8901514805746" unit="mm" />
+      <rotation name="crystal12-1_rot_neg_bot" x="-0.0084372997827221" y="0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal12-1_pos_pos_top" x="214.5439373331128" y="29.974739275395542" z="1527.8901514805746" unit="mm" />
+      <rotation name="crystal12-1_rot_pos_top" x="0.0084372997827221" y="-0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal12-1_pos_neg_top" x="-129.1835121173408" y="29.974739275395542" z="1527.8901514805746" unit="mm" />
+      <rotation name="crystal12-1_rot_neg_top" x="0.0084372997827221" y="0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal13-1_pos_pos_bot" x="229.66580787843168" y="-29.07473927539554" z="1527.7285789815953" unit="mm" />
+      <rotation name="crystal13-1_rot_pos_bot" x="-0.0084372997827221" y="-0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal13-1_pos_neg_bot" x="-144.30538266265967" y="-29.07473927539554" z="1527.7285789815953" unit="mm" />
+      <rotation name="crystal13-1_rot_neg_bot" x="-0.0084372997827221" y="0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal13-1_pos_pos_top" x="229.66580787843168" y="29.974739275395542" z="1527.7285789815953" unit="mm" />
+      <rotation name="crystal13-1_rot_pos_top" x="0.0084372997827221" y="-0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal13-1_pos_neg_top" x="-144.30538266265967" y="29.974739275395542" z="1527.7285789815953" unit="mm" />
+      <rotation name="crystal13-1_rot_neg_top" x="0.0084372997827221" y="0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal14-1_pos_pos_bot" x="244.83390600570817" y="-29.07473927539554" z="1527.5443352823047" unit="mm" />
+      <rotation name="crystal14-1_rot_pos_bot" x="-0.0084372997827221" y="-0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal14-1_pos_neg_bot" x="-159.47348078993616" y="-29.07473927539554" z="1527.5443352823047" unit="mm" />
+      <rotation name="crystal14-1_rot_neg_bot" x="-0.0084372997827221" y="0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal14-1_pos_pos_top" x="244.83390600570817" y="29.974739275395542" z="1527.5443352823047" unit="mm" />
+      <rotation name="crystal14-1_rot_pos_top" x="0.0084372997827221" y="-0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal14-1_pos_neg_top" x="-159.47348078993616" y="29.974739275395542" z="1527.5443352823047" unit="mm" />
+      <rotation name="crystal14-1_rot_neg_top" x="0.0084372997827221" y="0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal15-1_pos_pos_bot" x="260.0521159861688" y="-29.07473927539554" z="1527.3374728452397" unit="mm" />
+      <rotation name="crystal15-1_rot_pos_bot" x="-0.0084372997827221" y="-0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal15-1_pos_neg_bot" x="-174.6916907703968" y="-29.07473927539554" z="1527.3374728452397" unit="mm" />
+      <rotation name="crystal15-1_rot_neg_bot" x="-0.0084372997827221" y="0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal15-1_pos_pos_top" x="260.0521159861688" y="29.974739275395542" z="1527.3374728452397" unit="mm" />
+      <rotation name="crystal15-1_rot_pos_top" x="0.0084372997827221" y="-0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal15-1_pos_neg_top" x="-174.6916907703968" y="29.974739275395542" z="1527.3374728452397" unit="mm" />
+      <rotation name="crystal15-1_rot_neg_top" x="0.0084372997827221" y="0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal16-1_pos_pos_bot" x="275.32440401422616" y="-29.07473927539554" z="1527.108050573519" unit="mm" />
+      <rotation name="crystal16-1_rot_pos_bot" x="-0.0084372997827221" y="-0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal16-1_pos_neg_bot" x="-189.96397879845415" y="-29.07473927539554" z="1527.108050573519" unit="mm" />
+      <rotation name="crystal16-1_rot_neg_bot" x="-0.0084372997827221" y="0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal16-1_pos_pos_top" x="275.32440401422616" y="29.974739275395542" z="1527.108050573519" unit="mm" />
+      <rotation name="crystal16-1_rot_pos_top" x="0.0084372997827221" y="-0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal16-1_pos_neg_top" x="-189.96397879845415" y="29.974739275395542" z="1527.108050573519" unit="mm" />
+      <rotation name="crystal16-1_rot_neg_top" x="0.0084372997827221" y="0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal17-1_pos_pos_bot" x="290.6548257567732" y="-29.07473927539554" z="1526.8561337940675" unit="mm" />
+      <rotation name="crystal17-1_rot_pos_bot" x="-0.0084372997827221" y="-0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal17-1_pos_neg_bot" x="-205.2944005410012" y="-29.07473927539554" z="1526.8561337940675" unit="mm" />
+      <rotation name="crystal17-1_rot_neg_bot" x="-0.0084372997827221" y="0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal17-1_pos_pos_top" x="290.6548257567732" y="29.974739275395542" z="1526.8561337940675" unit="mm" />
+      <rotation name="crystal17-1_rot_pos_top" x="0.0084372997827221" y="-0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal17-1_pos_neg_top" x="-205.2944005410012" y="29.974739275395542" z="1526.8561337940675" unit="mm" />
+      <rotation name="crystal17-1_rot_neg_top" x="0.0084372997827221" y="0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal18-1_pos_pos_bot" x="306.0475342431027" y="-29.07473927539554" z="1526.581794239018" unit="mm" />
+      <rotation name="crystal18-1_rot_pos_bot" x="-0.0084372997827221" y="-0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal18-1_pos_neg_bot" x="-220.68710902733068" y="-29.07473927539554" z="1526.581794239018" unit="mm" />
+      <rotation name="crystal18-1_rot_neg_bot" x="-0.0084372997827221" y="0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal18-1_pos_pos_top" x="306.0475342431027" y="29.974739275395542" z="1526.581794239018" unit="mm" />
+      <rotation name="crystal18-1_rot_pos_top" x="0.0084372997827221" y="-0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal18-1_pos_neg_top" x="-220.68710902733068" y="29.974739275395542" z="1526.581794239018" unit="mm" />
+      <rotation name="crystal18-1_rot_neg_top" x="0.0084372997827221" y="0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal19-1_pos_pos_bot" x="321.5067881308382" y="-29.07473927539554" z="1526.2851100252847" unit="mm" />
+      <rotation name="crystal19-1_rot_pos_bot" x="-0.0084372997827221" y="-0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal19-1_pos_neg_bot" x="-236.14636291506616" y="-29.07473927539554" z="1526.2851100252847" unit="mm" />
+      <rotation name="crystal19-1_rot_neg_bot" x="-0.0084372997827221" y="0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal19-1_pos_pos_top" x="321.5067881308382" y="29.974739275395542" z="1526.2851100252847" unit="mm" />
+      <rotation name="crystal19-1_rot_pos_top" x="0.0084372997827221" y="-0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal19-1_pos_neg_top" x="-236.14636291506616" y="29.974739275395542" z="1526.2851100252847" unit="mm" />
+      <rotation name="crystal19-1_rot_neg_top" x="0.0084372997827221" y="0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal20-1_pos_pos_bot" x="337.03696038609246" y="-29.07473927539554" z="1525.9661656323178" unit="mm" />
+      <rotation name="crystal20-1_rot_pos_bot" x="-0.0084372997827221" y="-0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal20-1_pos_neg_bot" x="-251.67653517032045" y="-29.07473927539554" z="1525.9661656323178" unit="mm" />
+      <rotation name="crystal20-1_rot_neg_bot" x="-0.0084372997827221" y="0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal20-1_pos_pos_top" x="337.03696038609246" y="29.974739275395542" z="1525.9661656323178" unit="mm" />
+      <rotation name="crystal20-1_rot_pos_top" x="0.0084372997827221" y="-0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal20-1_pos_neg_top" x="-251.67653517032045" y="29.974739275395542" z="1525.9661656323178" unit="mm" />
+      <rotation name="crystal20-1_rot_neg_top" x="0.0084372997827221" y="0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal21-1_pos_pos_bot" x="352.64254741924634" y="-29.07473927539554" z="1525.625051878052" unit="mm" />
+      <rotation name="crystal21-1_rot_pos_bot" x="-0.0084372997827221" y="-0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal21-1_pos_neg_bot" x="-267.28212220347433" y="-29.07473927539554" z="1525.625051878052" unit="mm" />
+      <rotation name="crystal21-1_rot_neg_bot" x="-0.0084372997827221" y="0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal21-1_pos_pos_top" x="352.64254741924634" y="29.974739275395542" z="1525.625051878052" unit="mm" />
+      <rotation name="crystal21-1_rot_pos_top" x="0.0084372997827221" y="-0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal21-1_pos_neg_top" x="-267.28212220347433" y="29.974739275395542" z="1525.625051878052" unit="mm" />
+      <rotation name="crystal21-1_rot_neg_top" x="0.0084372997827221" y="0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal22-1_pos_pos_bot" x="368.32817872130425" y="-29.07473927539554" z="1525.2618658930442" unit="mm" />
+      <rotation name="crystal22-1_rot_pos_bot" x="-0.0084372997827221" y="-0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal22-1_pos_neg_bot" x="-282.96775350553224" y="-29.07473927539554" z="1525.2618658930442" unit="mm" />
+      <rotation name="crystal22-1_rot_neg_bot" x="-0.0084372997827221" y="0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal22-1_pos_pos_top" x="368.32817872130425" y="29.974739275395542" z="1525.2618658930442" unit="mm" />
+      <rotation name="crystal22-1_rot_pos_top" x="0.0084372997827221" y="-0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal22-1_pos_neg_top" x="-282.96775350553224" y="29.974739275395542" z="1525.2618658930442" unit="mm" />
+      <rotation name="crystal22-1_rot_neg_top" x="0.0084372997827221" y="0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal23-1_pos_pos_bot" x="384.09862704978" y="-29.07473927539554" z="1524.8767110928152" unit="mm" />
+      <rotation name="crystal23-1_rot_pos_bot" x="-0.0084372997827221" y="-0.3796784902224945" z="0.0" unit="radian" />
+      <position name="crystal23-1_pos_neg_bot" x="-298.738201834008" y="-29.07473927539554" z="1524.8767110928152" unit="mm" />
+      <rotation name="crystal23-1_rot_neg_bot" x="-0.0084372997827221" y="0.3796784902224945" z="0.0" unit="radian" />
+      <position name="crystal23-1_pos_pos_top" x="384.09862704978" y="29.974739275395542" z="1524.8767110928152" unit="mm" />
+      <rotation name="crystal23-1_rot_pos_top" x="0.0084372997827221" y="-0.3796784902224945" z="0.0" unit="radian" />
+      <position name="crystal23-1_pos_neg_top" x="-298.738201834008" y="29.974739275395542" z="1524.8767110928152" unit="mm" />
+      <rotation name="crystal23-1_rot_neg_top" x="0.0084372997827221" y="0.3796784902224945" z="0.0" unit="radian" />
+      <position name="crystal1-2_pos_pos_bot" x="50.20495188328156" y="-44.077812877938534" z="1528.2520480856124" unit="mm" />
+      <rotation name="crystal1-2_rot_pos_bot" x="-0.0253118993481663" y="-0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal1-2_pos_neg_bot" x="35.15547333249048" y="-44.077812877938534" z="1528.2520480856124" unit="mm" />
+      <rotation name="crystal1-2_rot_neg_bot" x="-0.0253118993481663" y="0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal1-2_pos_pos_top" x="50.20495188328156" y="44.97781287793853" z="1528.2520480856124" unit="mm" />
+      <rotation name="crystal1-2_rot_pos_top" x="0.0253118993481663" y="-0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal1-2_pos_neg_top" x="35.15547333249048" y="44.97781287793853" z="1528.2520480856124" unit="mm" />
+      <rotation name="crystal1-2_rot_neg_top" x="0.0253118993481663" y="0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal2-2_pos_pos_bot" x="65.05802548582456" y="-44.077812877938534" z="1528.3414680475323" unit="mm" />
+      <rotation name="crystal2-2_rot_pos_bot" x="-0.0253118993481663" y="-0.0253118993481663" z="0.0" unit="radian" />
+      <position name="crystal2-2_pos_neg_bot" x="20.302399729947485" y="-44.077812877938534" z="1528.3414680475323" unit="mm" />
+      <rotation name="crystal2-2_rot_neg_bot" x="-0.0253118993481663" y="0.0253118993481663" z="0.0" unit="radian" />
+      <position name="crystal2-2_pos_pos_top" x="65.05802548582456" y="44.97781287793853" z="1528.3414680475323" unit="mm" />
+      <rotation name="crystal2-2_rot_pos_top" x="0.0253118993481663" y="-0.0253118993481663" z="0.0" unit="radian" />
+      <position name="crystal2-2_pos_neg_top" x="20.302399729947485" y="44.97781287793853" z="1528.3414680475323" unit="mm" />
+      <rotation name="crystal2-2_rot_neg_top" x="0.0253118993481663" y="0.0253118993481663" z="0.0" unit="radian" />
+      <position name="crystal3-2_pos_pos_bot" x="79.9180994782841" y="-44.077812877938534" z="1528.4080677537463" unit="mm" />
+      <rotation name="crystal3-2_rot_pos_bot" x="-0.0253118993481663" y="-0.042186498913610496" z="0.0" unit="radian" />
+      <position name="crystal3-2_pos_neg_bot" x="5.442325737487934" y="-44.077812877938534" z="1528.4080677537463" unit="mm" />
+      <rotation name="crystal3-2_rot_neg_bot" x="-0.0253118993481663" y="0.042186498913610496" z="0.0" unit="radian" />
+      <position name="crystal3-2_pos_pos_top" x="79.9180994782841" y="44.97781287793853" z="1528.4080677537463" unit="mm" />
+      <rotation name="crystal3-2_rot_pos_top" x="0.0253118993481663" y="-0.042186498913610496" z="0.0" unit="radian" />
+      <position name="crystal3-2_pos_neg_top" x="5.442325737487934" y="44.97781287793853" z="1528.4080677537463" unit="mm" />
+      <rotation name="crystal3-2_rot_neg_top" x="0.0253118993481663" y="0.042186498913610496" z="0.0" unit="radian" />
+      <position name="crystal4-2_pos_pos_bot" x="94.78858692586502" y="-44.077812877938534" z="1528.4518282402964" unit="mm" />
+      <rotation name="crystal4-2_rot_pos_bot" x="-0.0253118993481663" y="-0.0590610984790547" z="0.0" unit="radian" />
+      <position name="crystal4-2_pos_neg_bot" x="-9.42816171009298" y="-44.077812877938534" z="1528.4518282402964" unit="mm" />
+      <rotation name="crystal4-2_rot_neg_bot" x="-0.0253118993481663" y="0.0590610984790547" z="0.0" unit="radian" />
+      <position name="crystal4-2_pos_pos_top" x="94.78858692586502" y="44.97781287793853" z="1528.4518282402964" unit="mm" />
+      <rotation name="crystal4-2_rot_pos_top" x="0.0253118993481663" y="-0.0590610984790547" z="0.0" unit="radian" />
+      <position name="crystal4-2_pos_neg_top" x="-9.42816171009298" y="44.97781287793853" z="1528.4518282402964" unit="mm" />
+      <rotation name="crystal4-2_rot_neg_top" x="0.0253118993481663" y="0.0590610984790547" z="0.0" unit="radian" />
+      <position name="crystal5-2_pos_pos_bot" x="109.67291416309662" y="-44.077812877938534" z="1528.4727370465882" unit="mm" />
+      <rotation name="crystal5-2_rot_pos_bot" x="-0.0253118993481663" y="-0.0759356980444989" z="0.0" unit="radian" />
+      <position name="crystal5-2_pos_neg_bot" x="-24.31248894732458" y="-44.077812877938534" z="1528.4727370465882" unit="mm" />
+      <rotation name="crystal5-2_rot_neg_bot" x="-0.0253118993481663" y="0.0759356980444989" z="0.0" unit="radian" />
+      <position name="crystal5-2_pos_pos_top" x="109.67291416309662" y="44.97781287793853" z="1528.4727370465882" unit="mm" />
+      <rotation name="crystal5-2_rot_pos_top" x="0.0253118993481663" y="-0.0759356980444989" z="0.0" unit="radian" />
+      <position name="crystal5-2_pos_neg_top" x="-24.31248894732458" y="44.97781287793853" z="1528.4727370465882" unit="mm" />
+      <rotation name="crystal5-2_rot_neg_top" x="0.0253118993481663" y="0.0759356980444989" z="0.0" unit="radian" />
+      <position name="crystal6-2_pos_pos_bot" x="124.57452638340096" y="-44.077812877938534" z="1528.4707882189361" unit="mm" />
+      <rotation name="crystal6-2_rot_pos_bot" x="-0.0253118993481663" y="-0.0928102976099431" z="0.0" unit="radian" />
+      <position name="crystal6-2_pos_neg_bot" x="-39.214101167628925" y="-44.077812877938534" z="1528.4707882189361" unit="mm" />
+      <rotation name="crystal6-2_rot_neg_bot" x="-0.0253118993481663" y="0.0928102976099431" z="0.0" unit="radian" />
+      <position name="crystal6-2_pos_pos_top" x="124.57452638340096" y="44.97781287793853" z="1528.4707882189361" unit="mm" />
+      <rotation name="crystal6-2_rot_pos_top" x="0.0253118993481663" y="-0.0928102976099431" z="0.0" unit="radian" />
+      <position name="crystal6-2_pos_neg_top" x="-39.214101167628925" y="44.97781287793853" z="1528.4707882189361" unit="mm" />
+      <rotation name="crystal6-2_rot_neg_top" x="0.0253118993481663" y="0.0928102976099431" z="0.0" unit="radian" />
+      <position name="crystal7-2_pos_pos_bot" x="139.4968932952259" y="-44.077812877938534" z="1528.4459823122595" unit="mm" />
+      <rotation name="crystal7-2_rot_pos_bot" x="-0.0253118993481663" y="-0.10968489717538729" z="0.0" unit="radian" />
+      <position name="crystal7-2_pos_neg_bot" x="-54.13646807945388" y="-44.077812877938534" z="1528.4459823122595" unit="mm" />
+      <rotation name="crystal7-2_rot_neg_bot" x="-0.0253118993481663" y="0.10968489717538729" z="0.0" unit="radian" />
+      <position name="crystal7-2_pos_pos_top" x="139.4968932952259" y="44.97781287793853" z="1528.4459823122595" unit="mm" />
+      <rotation name="crystal7-2_rot_pos_top" x="0.0253118993481663" y="-0.10968489717538729" z="0.0" unit="radian" />
+      <position name="crystal7-2_pos_neg_top" x="-54.13646807945388" y="44.97781287793853" z="1528.4459823122595" unit="mm" />
+      <rotation name="crystal7-2_rot_neg_top" x="0.0253118993481663" y="0.10968489717538729" z="0.0" unit="radian" />
+      <position name="crystal8-2_pos_pos_bot" x="154.44351486445828" y="-44.077812877938534" z="1528.3983263899254" unit="mm" />
+      <rotation name="crystal8-2_rot_pos_bot" x="-0.0253118993481663" y="-0.1265594967408315" z="0.0" unit="radian" />
+      <position name="crystal8-2_pos_neg_bot" x="-69.08308964868624" y="-44.077812877938534" z="1528.3983263899254" unit="mm" />
+      <rotation name="crystal8-2_rot_neg_bot" x="-0.0253118993481663" y="0.1265594967408315" z="0.0" unit="radian" />
+      <position name="crystal8-2_pos_pos_top" x="154.44351486445828" y="44.97781287793853" z="1528.3983263899254" unit="mm" />
+      <rotation name="crystal8-2_rot_pos_top" x="0.0253118993481663" y="-0.1265594967408315" z="0.0" unit="radian" />
+      <position name="crystal8-2_pos_neg_top" x="-69.08308964868624" y="44.97781287793853" z="1528.3983263899254" unit="mm" />
+      <rotation name="crystal8-2_rot_neg_top" x="0.0253118993481663" y="0.1265594967408315" z="0.0" unit="radian" />
+      <position name="crystal9-2_pos_pos_bot" x="169.41792716339802" y="-44.077812877938534" z="1528.3278340217357" unit="mm" />
+      <rotation name="crystal9-2_rot_pos_bot" x="-0.0253118993481663" y="-0.14343409630627568" z="0.0" unit="radian" />
+      <position name="crystal9-2_pos_neg_bot" x="-84.057501947626" y="-44.077812877938534" z="1528.3278340217357" unit="mm" />
+      <rotation name="crystal9-2_rot_neg_bot" x="-0.0253118993481663" y="0.14343409630627568" z="0.0" unit="radian" />
+      <position name="crystal9-2_pos_pos_top" x="169.41792716339802" y="44.97781287793853" z="1528.3278340217357" unit="mm" />
+      <rotation name="crystal9-2_rot_pos_top" x="0.0253118993481663" y="-0.14343409630627568" z="0.0" unit="radian" />
+      <position name="crystal9-2_pos_neg_top" x="-84.057501947626" y="44.97781287793853" z="1528.3278340217357" unit="mm" />
+      <rotation name="crystal9-2_rot_neg_top" x="0.0253118993481663" y="0.14343409630627568" z="0.0" unit="radian" />
+      <position name="crystal10-2_pos_pos_bot" x="184.42370834727978" y="-44.077812877938534" z="1528.2345252800653" unit="mm" />
+      <rotation name="crystal10-2_rot_pos_bot" x="-0.0253118993481663" y="-0.1603086958717199" z="0.0" unit="radian" />
+      <position name="crystal10-2_pos_neg_bot" x="-99.06328313150773" y="-44.077812877938534" z="1528.2345252800653" unit="mm" />
+      <rotation name="crystal10-2_rot_neg_bot" x="-0.0253118993481663" y="0.1603086958717199" z="0.0" unit="radian" />
+      <position name="crystal10-2_pos_pos_top" x="184.42370834727978" y="44.97781287793853" z="1528.2345252800653" unit="mm" />
+      <rotation name="crystal10-2_rot_pos_top" x="0.0253118993481663" y="-0.1603086958717199" z="0.0" unit="radian" />
+      <position name="crystal10-2_pos_neg_top" x="-99.06328313150773" y="44.97781287793853" z="1528.2345252800653" unit="mm" />
+      <rotation name="crystal10-2_rot_neg_top" x="0.0253118993481663" y="0.1603086958717199" z="0.0" unit="radian" />
+      <position name="crystal11-2_pos_pos_bot" x="199.46448478017476" y="-44.077812877938534" z="1528.1184267341444" unit="mm" />
+      <rotation name="crystal11-2_rot_pos_bot" x="-0.0253118993481663" y="-0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal11-2_pos_neg_bot" x="-114.1040595644027" y="-44.077812877938534" z="1528.1184267341444" unit="mm" />
+      <rotation name="crystal11-2_rot_neg_bot" x="-0.0253118993481663" y="0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal11-2_pos_pos_top" x="199.46448478017476" y="44.97781287793853" z="1528.1184267341444" unit="mm" />
+      <rotation name="crystal11-2_rot_pos_top" x="0.0253118993481663" y="-0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal11-2_pos_neg_top" x="-114.1040595644027" y="44.97781287793853" z="1528.1184267341444" unit="mm" />
+      <rotation name="crystal11-2_rot_neg_top" x="0.0253118993481663" y="0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal12-2_pos_pos_bot" x="214.5439373331128" y="-44.077812877938534" z="1527.9795714424947" unit="mm" />
+      <rotation name="crystal12-2_rot_pos_bot" x="-0.0253118993481663" y="-0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal12-2_pos_neg_bot" x="-129.1835121173408" y="-44.077812877938534" z="1527.9795714424947" unit="mm" />
+      <rotation name="crystal12-2_rot_neg_bot" x="-0.0253118993481663" y="0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal12-2_pos_pos_top" x="214.5439373331128" y="44.97781287793853" z="1527.9795714424947" unit="mm" />
+      <rotation name="crystal12-2_rot_pos_top" x="0.0253118993481663" y="-0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal12-2_pos_neg_top" x="-129.1835121173408" y="44.97781287793853" z="1527.9795714424947" unit="mm" />
+      <rotation name="crystal12-2_rot_neg_top" x="0.0253118993481663" y="0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal13-2_pos_pos_bot" x="229.66580787843168" y="-44.077812877938534" z="1527.8179989435152" unit="mm" />
+      <rotation name="crystal13-2_rot_pos_bot" x="-0.0253118993481663" y="-0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal13-2_pos_neg_bot" x="-144.30538266265967" y="-44.077812877938534" z="1527.8179989435152" unit="mm" />
+      <rotation name="crystal13-2_rot_neg_bot" x="-0.0253118993481663" y="0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal13-2_pos_pos_top" x="229.66580787843168" y="44.97781287793853" z="1527.8179989435152" unit="mm" />
+      <rotation name="crystal13-2_rot_pos_top" x="0.0253118993481663" y="-0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal13-2_pos_neg_top" x="-144.30538266265967" y="44.97781287793853" z="1527.8179989435152" unit="mm" />
+      <rotation name="crystal13-2_rot_neg_top" x="0.0253118993481663" y="0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal14-2_pos_pos_bot" x="244.83390600570817" y="-44.077812877938534" z="1527.6337552442246" unit="mm" />
+      <rotation name="crystal14-2_rot_pos_bot" x="-0.0253118993481663" y="-0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal14-2_pos_neg_bot" x="-159.47348078993616" y="-44.077812877938534" z="1527.6337552442246" unit="mm" />
+      <rotation name="crystal14-2_rot_neg_bot" x="-0.0253118993481663" y="0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal14-2_pos_pos_top" x="244.83390600570817" y="44.97781287793853" z="1527.6337552442246" unit="mm" />
+      <rotation name="crystal14-2_rot_pos_top" x="0.0253118993481663" y="-0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal14-2_pos_neg_top" x="-159.47348078993616" y="44.97781287793853" z="1527.6337552442246" unit="mm" />
+      <rotation name="crystal14-2_rot_neg_top" x="0.0253118993481663" y="0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal15-2_pos_pos_bot" x="260.0521159861688" y="-44.077812877938534" z="1527.42689280716" unit="mm" />
+      <rotation name="crystal15-2_rot_pos_bot" x="-0.0253118993481663" y="-0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal15-2_pos_neg_bot" x="-174.6916907703968" y="-44.077812877938534" z="1527.42689280716" unit="mm" />
+      <rotation name="crystal15-2_rot_neg_bot" x="-0.0253118993481663" y="0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal15-2_pos_pos_top" x="260.0521159861688" y="44.97781287793853" z="1527.42689280716" unit="mm" />
+      <rotation name="crystal15-2_rot_pos_top" x="0.0253118993481663" y="-0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal15-2_pos_neg_top" x="-174.6916907703968" y="44.97781287793853" z="1527.42689280716" unit="mm" />
+      <rotation name="crystal15-2_rot_neg_top" x="0.0253118993481663" y="0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal16-2_pos_pos_bot" x="275.32440401422616" y="-44.077812877938534" z="1527.1974705354392" unit="mm" />
+      <rotation name="crystal16-2_rot_pos_bot" x="-0.0253118993481663" y="-0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal16-2_pos_neg_bot" x="-189.96397879845415" y="-44.077812877938534" z="1527.1974705354392" unit="mm" />
+      <rotation name="crystal16-2_rot_neg_bot" x="-0.0253118993481663" y="0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal16-2_pos_pos_top" x="275.32440401422616" y="44.97781287793853" z="1527.1974705354392" unit="mm" />
+      <rotation name="crystal16-2_rot_pos_top" x="0.0253118993481663" y="-0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal16-2_pos_neg_top" x="-189.96397879845415" y="44.97781287793853" z="1527.1974705354392" unit="mm" />
+      <rotation name="crystal16-2_rot_neg_top" x="0.0253118993481663" y="0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal17-2_pos_pos_bot" x="290.6548257567732" y="-44.077812877938534" z="1526.9455537559877" unit="mm" />
+      <rotation name="crystal17-2_rot_pos_bot" x="-0.0253118993481663" y="-0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal17-2_pos_neg_bot" x="-205.2944005410012" y="-44.077812877938534" z="1526.9455537559877" unit="mm" />
+      <rotation name="crystal17-2_rot_neg_bot" x="-0.0253118993481663" y="0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal17-2_pos_pos_top" x="290.6548257567732" y="44.97781287793853" z="1526.9455537559877" unit="mm" />
+      <rotation name="crystal17-2_rot_pos_top" x="0.0253118993481663" y="-0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal17-2_pos_neg_top" x="-205.2944005410012" y="44.97781287793853" z="1526.9455537559877" unit="mm" />
+      <rotation name="crystal17-2_rot_neg_top" x="0.0253118993481663" y="0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal18-2_pos_pos_bot" x="306.0475342431027" y="-44.077812877938534" z="1526.6712142009383" unit="mm" />
+      <rotation name="crystal18-2_rot_pos_bot" x="-0.0253118993481663" y="-0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal18-2_pos_neg_bot" x="-220.68710902733068" y="-44.077812877938534" z="1526.6712142009383" unit="mm" />
+      <rotation name="crystal18-2_rot_neg_bot" x="-0.0253118993481663" y="0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal18-2_pos_pos_top" x="306.0475342431027" y="44.97781287793853" z="1526.6712142009383" unit="mm" />
+      <rotation name="crystal18-2_rot_pos_top" x="0.0253118993481663" y="-0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal18-2_pos_neg_top" x="-220.68710902733068" y="44.97781287793853" z="1526.6712142009383" unit="mm" />
+      <rotation name="crystal18-2_rot_neg_top" x="0.0253118993481663" y="0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal19-2_pos_pos_bot" x="321.5067881308382" y="-44.077812877938534" z="1526.3745299872046" unit="mm" />
+      <rotation name="crystal19-2_rot_pos_bot" x="-0.0253118993481663" y="-0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal19-2_pos_neg_bot" x="-236.14636291506616" y="-44.077812877938534" z="1526.3745299872046" unit="mm" />
+      <rotation name="crystal19-2_rot_neg_bot" x="-0.0253118993481663" y="0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal19-2_pos_pos_top" x="321.5067881308382" y="44.97781287793853" z="1526.3745299872046" unit="mm" />
+      <rotation name="crystal19-2_rot_pos_top" x="0.0253118993481663" y="-0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal19-2_pos_neg_top" x="-236.14636291506616" y="44.97781287793853" z="1526.3745299872046" unit="mm" />
+      <rotation name="crystal19-2_rot_neg_top" x="0.0253118993481663" y="0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal20-2_pos_pos_bot" x="337.03696038609246" y="-44.077812877938534" z="1526.055585594238" unit="mm" />
+      <rotation name="crystal20-2_rot_pos_bot" x="-0.0253118993481663" y="-0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal20-2_pos_neg_bot" x="-251.67653517032045" y="-44.077812877938534" z="1526.055585594238" unit="mm" />
+      <rotation name="crystal20-2_rot_neg_bot" x="-0.0253118993481663" y="0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal20-2_pos_pos_top" x="337.03696038609246" y="44.97781287793853" z="1526.055585594238" unit="mm" />
+      <rotation name="crystal20-2_rot_pos_top" x="0.0253118993481663" y="-0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal20-2_pos_neg_top" x="-251.67653517032045" y="44.97781287793853" z="1526.055585594238" unit="mm" />
+      <rotation name="crystal20-2_rot_neg_top" x="0.0253118993481663" y="0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal21-2_pos_pos_bot" x="352.64254741924634" y="-44.077812877938534" z="1525.7144718399722" unit="mm" />
+      <rotation name="crystal21-2_rot_pos_bot" x="-0.0253118993481663" y="-0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal21-2_pos_neg_bot" x="-267.28212220347433" y="-44.077812877938534" z="1525.7144718399722" unit="mm" />
+      <rotation name="crystal21-2_rot_neg_bot" x="-0.0253118993481663" y="0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal21-2_pos_pos_top" x="352.64254741924634" y="44.97781287793853" z="1525.7144718399722" unit="mm" />
+      <rotation name="crystal21-2_rot_pos_top" x="0.0253118993481663" y="-0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal21-2_pos_neg_top" x="-267.28212220347433" y="44.97781287793853" z="1525.7144718399722" unit="mm" />
+      <rotation name="crystal21-2_rot_neg_top" x="0.0253118993481663" y="0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal22-2_pos_pos_bot" x="368.32817872130425" y="-44.077812877938534" z="1525.351285854964" unit="mm" />
+      <rotation name="crystal22-2_rot_pos_bot" x="-0.0253118993481663" y="-0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal22-2_pos_neg_bot" x="-282.96775350553224" y="-44.077812877938534" z="1525.351285854964" unit="mm" />
+      <rotation name="crystal22-2_rot_neg_bot" x="-0.0253118993481663" y="0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal22-2_pos_pos_top" x="368.32817872130425" y="44.97781287793853" z="1525.351285854964" unit="mm" />
+      <rotation name="crystal22-2_rot_pos_top" x="0.0253118993481663" y="-0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal22-2_pos_neg_top" x="-282.96775350553224" y="44.97781287793853" z="1525.351285854964" unit="mm" />
+      <rotation name="crystal22-2_rot_neg_top" x="0.0253118993481663" y="0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal23-2_pos_pos_bot" x="384.09862704978" y="-44.077812877938534" z="1524.9661310547353" unit="mm" />
+      <rotation name="crystal23-2_rot_pos_bot" x="-0.0253118993481663" y="-0.3796784902224945" z="0.0" unit="radian" />
+      <position name="crystal23-2_pos_neg_bot" x="-298.738201834008" y="-44.077812877938534" z="1524.9661310547353" unit="mm" />
+      <rotation name="crystal23-2_rot_neg_bot" x="-0.0253118993481663" y="0.3796784902224945" z="0.0" unit="radian" />
+      <position name="crystal23-2_pos_pos_top" x="384.09862704978" y="44.97781287793853" z="1524.9661310547353" unit="mm" />
+      <rotation name="crystal23-2_rot_pos_top" x="0.0253118993481663" y="-0.3796784902224945" z="0.0" unit="radian" />
+      <position name="crystal23-2_pos_neg_top" x="-298.738201834008" y="44.97781287793853" z="1524.9661310547353" unit="mm" />
+      <rotation name="crystal23-2_rot_neg_top" x="0.0253118993481663" y="0.3796784902224945" z="0.0" unit="radian" />
+      <position name="crystal1-3_pos_pos_bot" x="50.20495188328156" y="-59.08788687039808" z="1528.3186477918262" unit="mm" />
+      <rotation name="crystal1-3_rot_pos_bot" x="-0.042186498913610496" y="-0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal1-3_pos_neg_bot" x="35.15547333249048" y="-59.08788687039808" z="1528.3186477918262" unit="mm" />
+      <rotation name="crystal1-3_rot_neg_bot" x="-0.042186498913610496" y="0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal1-3_pos_pos_top" x="50.20495188328156" y="59.987886870398086" z="1528.3186477918262" unit="mm" />
+      <rotation name="crystal1-3_rot_pos_top" x="0.042186498913610496" y="-0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal1-3_pos_neg_top" x="35.15547333249048" y="59.987886870398086" z="1528.3186477918262" unit="mm" />
+      <rotation name="crystal1-3_rot_neg_top" x="0.042186498913610496" y="0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal2-3_pos_pos_bot" x="65.05802548582456" y="-59.08788687039808" z="1528.4080677537463" unit="mm" />
+      <rotation name="crystal2-3_rot_pos_bot" x="-0.042186498913610496" y="-0.0253118993481663" z="0.0" unit="radian" />
+      <position name="crystal2-3_pos_neg_bot" x="20.302399729947485" y="-59.08788687039808" z="1528.4080677537463" unit="mm" />
+      <rotation name="crystal2-3_rot_neg_bot" x="-0.042186498913610496" y="0.0253118993481663" z="0.0" unit="radian" />
+      <position name="crystal2-3_pos_pos_top" x="65.05802548582456" y="59.987886870398086" z="1528.4080677537463" unit="mm" />
+      <rotation name="crystal2-3_rot_pos_top" x="0.042186498913610496" y="-0.0253118993481663" z="0.0" unit="radian" />
+      <position name="crystal2-3_pos_neg_top" x="20.302399729947485" y="59.987886870398086" z="1528.4080677537463" unit="mm" />
+      <rotation name="crystal2-3_rot_neg_top" x="0.042186498913610496" y="0.0253118993481663" z="0.0" unit="radian" />
+      <position name="crystal3-3_pos_pos_bot" x="79.9180994782841" y="-59.08788687039808" z="1528.47466745996" unit="mm" />
+      <rotation name="crystal3-3_rot_pos_bot" x="-0.042186498913610496" y="-0.042186498913610496" z="0.0" unit="radian" />
+      <position name="crystal3-3_pos_neg_bot" x="5.442325737487934" y="-59.08788687039808" z="1528.47466745996" unit="mm" />
+      <rotation name="crystal3-3_rot_neg_bot" x="-0.042186498913610496" y="0.042186498913610496" z="0.0" unit="radian" />
+      <position name="crystal3-3_pos_pos_top" x="79.9180994782841" y="59.987886870398086" z="1528.47466745996" unit="mm" />
+      <rotation name="crystal3-3_rot_pos_top" x="0.042186498913610496" y="-0.042186498913610496" z="0.0" unit="radian" />
+      <position name="crystal3-3_pos_neg_top" x="5.442325737487934" y="59.987886870398086" z="1528.47466745996" unit="mm" />
+      <rotation name="crystal3-3_rot_neg_top" x="0.042186498913610496" y="0.042186498913610496" z="0.0" unit="radian" />
+      <position name="crystal4-3_pos_pos_bot" x="94.78858692586502" y="-59.08788687039808" z="1528.5184279465104" unit="mm" />
+      <rotation name="crystal4-3_rot_pos_bot" x="-0.042186498913610496" y="-0.0590610984790547" z="0.0" unit="radian" />
+      <position name="crystal4-3_pos_neg_bot" x="-9.42816171009298" y="-59.08788687039808" z="1528.5184279465104" unit="mm" />
+      <rotation name="crystal4-3_rot_neg_bot" x="-0.042186498913610496" y="0.0590610984790547" z="0.0" unit="radian" />
+      <position name="crystal4-3_pos_pos_top" x="94.78858692586502" y="59.987886870398086" z="1528.5184279465104" unit="mm" />
+      <rotation name="crystal4-3_rot_pos_top" x="0.042186498913610496" y="-0.0590610984790547" z="0.0" unit="radian" />
+      <position name="crystal4-3_pos_neg_top" x="-9.42816171009298" y="59.987886870398086" z="1528.5184279465104" unit="mm" />
+      <rotation name="crystal4-3_rot_neg_top" x="0.042186498913610496" y="0.0590610984790547" z="0.0" unit="radian" />
+      <position name="crystal5-3_pos_pos_bot" x="109.67291416309662" y="-59.08788687039808" z="1528.5393367528022" unit="mm" />
+      <rotation name="crystal5-3_rot_pos_bot" x="-0.042186498913610496" y="-0.0759356980444989" z="0.0" unit="radian" />
+      <position name="crystal5-3_pos_neg_bot" x="-24.31248894732458" y="-59.08788687039808" z="1528.5393367528022" unit="mm" />
+      <rotation name="crystal5-3_rot_neg_bot" x="-0.042186498913610496" y="0.0759356980444989" z="0.0" unit="radian" />
+      <position name="crystal5-3_pos_pos_top" x="109.67291416309662" y="59.987886870398086" z="1528.5393367528022" unit="mm" />
+      <rotation name="crystal5-3_rot_pos_top" x="0.042186498913610496" y="-0.0759356980444989" z="0.0" unit="radian" />
+      <position name="crystal5-3_pos_neg_top" x="-24.31248894732458" y="59.987886870398086" z="1528.5393367528022" unit="mm" />
+      <rotation name="crystal5-3_rot_neg_top" x="0.042186498913610496" y="0.0759356980444989" z="0.0" unit="radian" />
+      <position name="crystal6-3_pos_pos_bot" x="124.57452638340096" y="-59.08788687039808" z="1528.53738792515" unit="mm" />
+      <rotation name="crystal6-3_rot_pos_bot" x="-0.042186498913610496" y="-0.0928102976099431" z="0.0" unit="radian" />
+      <position name="crystal6-3_pos_neg_bot" x="-39.214101167628925" y="-59.08788687039808" z="1528.53738792515" unit="mm" />
+      <rotation name="crystal6-3_rot_neg_bot" x="-0.042186498913610496" y="0.0928102976099431" z="0.0" unit="radian" />
+      <position name="crystal6-3_pos_pos_top" x="124.57452638340096" y="59.987886870398086" z="1528.53738792515" unit="mm" />
+      <rotation name="crystal6-3_rot_pos_top" x="0.042186498913610496" y="-0.0928102976099431" z="0.0" unit="radian" />
+      <position name="crystal6-3_pos_neg_top" x="-39.214101167628925" y="59.987886870398086" z="1528.53738792515" unit="mm" />
+      <rotation name="crystal6-3_rot_neg_top" x="0.042186498913610496" y="0.0928102976099431" z="0.0" unit="radian" />
+      <position name="crystal7-3_pos_pos_bot" x="139.4968932952259" y="-59.08788687039808" z="1528.5125820184735" unit="mm" />
+      <rotation name="crystal7-3_rot_pos_bot" x="-0.042186498913610496" y="-0.10968489717538729" z="0.0" unit="radian" />
+      <position name="crystal7-3_pos_neg_bot" x="-54.13646807945388" y="-59.08788687039808" z="1528.5125820184735" unit="mm" />
+      <rotation name="crystal7-3_rot_neg_bot" x="-0.042186498913610496" y="0.10968489717538729" z="0.0" unit="radian" />
+      <position name="crystal7-3_pos_pos_top" x="139.4968932952259" y="59.987886870398086" z="1528.5125820184735" unit="mm" />
+      <rotation name="crystal7-3_rot_pos_top" x="0.042186498913610496" y="-0.10968489717538729" z="0.0" unit="radian" />
+      <position name="crystal7-3_pos_neg_top" x="-54.13646807945388" y="59.987886870398086" z="1528.5125820184735" unit="mm" />
+      <rotation name="crystal7-3_rot_neg_top" x="0.042186498913610496" y="0.10968489717538729" z="0.0" unit="radian" />
+      <position name="crystal8-3_pos_pos_bot" x="154.44351486445828" y="-59.08788687039808" z="1528.4649260961392" unit="mm" />
+      <rotation name="crystal8-3_rot_pos_bot" x="-0.042186498913610496" y="-0.1265594967408315" z="0.0" unit="radian" />
+      <position name="crystal8-3_pos_neg_bot" x="-69.08308964868624" y="-59.08788687039808" z="1528.4649260961392" unit="mm" />
+      <rotation name="crystal8-3_rot_neg_bot" x="-0.042186498913610496" y="0.1265594967408315" z="0.0" unit="radian" />
+      <position name="crystal8-3_pos_pos_top" x="154.44351486445828" y="59.987886870398086" z="1528.4649260961392" unit="mm" />
+      <rotation name="crystal8-3_rot_pos_top" x="0.042186498913610496" y="-0.1265594967408315" z="0.0" unit="radian" />
+      <position name="crystal8-3_pos_neg_top" x="-69.08308964868624" y="59.987886870398086" z="1528.4649260961392" unit="mm" />
+      <rotation name="crystal8-3_rot_neg_top" x="0.042186498913610496" y="0.1265594967408315" z="0.0" unit="radian" />
+      <position name="crystal9-3_pos_pos_bot" x="169.41792716339802" y="-59.08788687039808" z="1528.3944337279495" unit="mm" />
+      <rotation name="crystal9-3_rot_pos_bot" x="-0.042186498913610496" y="-0.14343409630627568" z="0.0" unit="radian" />
+      <position name="crystal9-3_pos_neg_bot" x="-84.057501947626" y="-59.08788687039808" z="1528.3944337279495" unit="mm" />
+      <rotation name="crystal9-3_rot_neg_bot" x="-0.042186498913610496" y="0.14343409630627568" z="0.0" unit="radian" />
+      <position name="crystal9-3_pos_pos_top" x="169.41792716339802" y="59.987886870398086" z="1528.3944337279495" unit="mm" />
+      <rotation name="crystal9-3_rot_pos_top" x="0.042186498913610496" y="-0.14343409630627568" z="0.0" unit="radian" />
+      <position name="crystal9-3_pos_neg_top" x="-84.057501947626" y="59.987886870398086" z="1528.3944337279495" unit="mm" />
+      <rotation name="crystal9-3_rot_neg_top" x="0.042186498913610496" y="0.14343409630627568" z="0.0" unit="radian" />
+      <position name="crystal10-3_pos_pos_bot" x="184.42370834727978" y="-59.08788687039808" z="1528.301124986279" unit="mm" />
+      <rotation name="crystal10-3_rot_pos_bot" x="-0.042186498913610496" y="-0.1603086958717199" z="0.0" unit="radian" />
+      <position name="crystal10-3_pos_neg_bot" x="-99.06328313150773" y="-59.08788687039808" z="1528.301124986279" unit="mm" />
+      <rotation name="crystal10-3_rot_neg_bot" x="-0.042186498913610496" y="0.1603086958717199" z="0.0" unit="radian" />
+      <position name="crystal10-3_pos_pos_top" x="184.42370834727978" y="59.987886870398086" z="1528.301124986279" unit="mm" />
+      <rotation name="crystal10-3_rot_pos_top" x="0.042186498913610496" y="-0.1603086958717199" z="0.0" unit="radian" />
+      <position name="crystal10-3_pos_neg_top" x="-99.06328313150773" y="59.987886870398086" z="1528.301124986279" unit="mm" />
+      <rotation name="crystal10-3_rot_neg_top" x="0.042186498913610496" y="0.1603086958717199" z="0.0" unit="radian" />
+      <position name="crystal11-3_pos_pos_bot" x="199.46448478017476" y="-59.08788687039808" z="1528.1850264403583" unit="mm" />
+      <rotation name="crystal11-3_rot_pos_bot" x="-0.042186498913610496" y="-0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal11-3_pos_neg_bot" x="-114.1040595644027" y="-59.08788687039808" z="1528.1850264403583" unit="mm" />
+      <rotation name="crystal11-3_rot_neg_bot" x="-0.042186498913610496" y="0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal11-3_pos_pos_top" x="199.46448478017476" y="59.987886870398086" z="1528.1850264403583" unit="mm" />
+      <rotation name="crystal11-3_rot_pos_top" x="0.042186498913610496" y="-0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal11-3_pos_neg_top" x="-114.1040595644027" y="59.987886870398086" z="1528.1850264403583" unit="mm" />
+      <rotation name="crystal11-3_rot_neg_top" x="0.042186498913610496" y="0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal12-3_pos_pos_bot" x="214.5439373331128" y="-59.08788687039808" z="1528.0461711487085" unit="mm" />
+      <rotation name="crystal12-3_rot_pos_bot" x="-0.042186498913610496" y="-0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal12-3_pos_neg_bot" x="-129.1835121173408" y="-59.08788687039808" z="1528.0461711487085" unit="mm" />
+      <rotation name="crystal12-3_rot_neg_bot" x="-0.042186498913610496" y="0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal12-3_pos_pos_top" x="214.5439373331128" y="59.987886870398086" z="1528.0461711487085" unit="mm" />
+      <rotation name="crystal12-3_rot_pos_top" x="0.042186498913610496" y="-0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal12-3_pos_neg_top" x="-129.1835121173408" y="59.987886870398086" z="1528.0461711487085" unit="mm" />
+      <rotation name="crystal12-3_rot_neg_top" x="0.042186498913610496" y="0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal13-3_pos_pos_bot" x="229.66580787843168" y="-59.08788687039808" z="1527.8845986497292" unit="mm" />
+      <rotation name="crystal13-3_rot_pos_bot" x="-0.042186498913610496" y="-0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal13-3_pos_neg_bot" x="-144.30538266265967" y="-59.08788687039808" z="1527.8845986497292" unit="mm" />
+      <rotation name="crystal13-3_rot_neg_bot" x="-0.042186498913610496" y="0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal13-3_pos_pos_top" x="229.66580787843168" y="59.987886870398086" z="1527.8845986497292" unit="mm" />
+      <rotation name="crystal13-3_rot_pos_top" x="0.042186498913610496" y="-0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal13-3_pos_neg_top" x="-144.30538266265967" y="59.987886870398086" z="1527.8845986497292" unit="mm" />
+      <rotation name="crystal13-3_rot_neg_top" x="0.042186498913610496" y="0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal14-3_pos_pos_bot" x="244.83390600570817" y="-59.08788687039808" z="1527.7003549504386" unit="mm" />
+      <rotation name="crystal14-3_rot_pos_bot" x="-0.042186498913610496" y="-0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal14-3_pos_neg_bot" x="-159.47348078993616" y="-59.08788687039808" z="1527.7003549504386" unit="mm" />
+      <rotation name="crystal14-3_rot_neg_bot" x="-0.042186498913610496" y="0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal14-3_pos_pos_top" x="244.83390600570817" y="59.987886870398086" z="1527.7003549504386" unit="mm" />
+      <rotation name="crystal14-3_rot_pos_top" x="0.042186498913610496" y="-0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal14-3_pos_neg_top" x="-159.47348078993616" y="59.987886870398086" z="1527.7003549504386" unit="mm" />
+      <rotation name="crystal14-3_rot_neg_top" x="0.042186498913610496" y="0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal15-3_pos_pos_bot" x="260.0521159861688" y="-59.08788687039808" z="1527.4934925133737" unit="mm" />
+      <rotation name="crystal15-3_rot_pos_bot" x="-0.042186498913610496" y="-0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal15-3_pos_neg_bot" x="-174.6916907703968" y="-59.08788687039808" z="1527.4934925133737" unit="mm" />
+      <rotation name="crystal15-3_rot_neg_bot" x="-0.042186498913610496" y="0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal15-3_pos_pos_top" x="260.0521159861688" y="59.987886870398086" z="1527.4934925133737" unit="mm" />
+      <rotation name="crystal15-3_rot_pos_top" x="0.042186498913610496" y="-0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal15-3_pos_neg_top" x="-174.6916907703968" y="59.987886870398086" z="1527.4934925133737" unit="mm" />
+      <rotation name="crystal15-3_rot_neg_top" x="0.042186498913610496" y="0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal16-3_pos_pos_bot" x="275.32440401422616" y="-59.08788687039808" z="1527.264070241653" unit="mm" />
+      <rotation name="crystal16-3_rot_pos_bot" x="-0.042186498913610496" y="-0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal16-3_pos_neg_bot" x="-189.96397879845415" y="-59.08788687039808" z="1527.264070241653" unit="mm" />
+      <rotation name="crystal16-3_rot_neg_bot" x="-0.042186498913610496" y="0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal16-3_pos_pos_top" x="275.32440401422616" y="59.987886870398086" z="1527.264070241653" unit="mm" />
+      <rotation name="crystal16-3_rot_pos_top" x="0.042186498913610496" y="-0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal16-3_pos_neg_top" x="-189.96397879845415" y="59.987886870398086" z="1527.264070241653" unit="mm" />
+      <rotation name="crystal16-3_rot_neg_top" x="0.042186498913610496" y="0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal17-3_pos_pos_bot" x="290.6548257567732" y="-59.08788687039808" z="1527.0121534622015" unit="mm" />
+      <rotation name="crystal17-3_rot_pos_bot" x="-0.042186498913610496" y="-0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal17-3_pos_neg_bot" x="-205.2944005410012" y="-59.08788687039808" z="1527.0121534622015" unit="mm" />
+      <rotation name="crystal17-3_rot_neg_bot" x="-0.042186498913610496" y="0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal17-3_pos_pos_top" x="290.6548257567732" y="59.987886870398086" z="1527.0121534622015" unit="mm" />
+      <rotation name="crystal17-3_rot_pos_top" x="0.042186498913610496" y="-0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal17-3_pos_neg_top" x="-205.2944005410012" y="59.987886870398086" z="1527.0121534622015" unit="mm" />
+      <rotation name="crystal17-3_rot_neg_top" x="0.042186498913610496" y="0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal18-3_pos_pos_bot" x="306.0475342431027" y="-59.08788687039808" z="1526.737813907152" unit="mm" />
+      <rotation name="crystal18-3_rot_pos_bot" x="-0.042186498913610496" y="-0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal18-3_pos_neg_bot" x="-220.68710902733068" y="-59.08788687039808" z="1526.737813907152" unit="mm" />
+      <rotation name="crystal18-3_rot_neg_bot" x="-0.042186498913610496" y="0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal18-3_pos_pos_top" x="306.0475342431027" y="59.987886870398086" z="1526.737813907152" unit="mm" />
+      <rotation name="crystal18-3_rot_pos_top" x="0.042186498913610496" y="-0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal18-3_pos_neg_top" x="-220.68710902733068" y="59.987886870398086" z="1526.737813907152" unit="mm" />
+      <rotation name="crystal18-3_rot_neg_top" x="0.042186498913610496" y="0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal19-3_pos_pos_bot" x="321.5067881308382" y="-59.08788687039808" z="1526.4411296934186" unit="mm" />
+      <rotation name="crystal19-3_rot_pos_bot" x="-0.042186498913610496" y="-0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal19-3_pos_neg_bot" x="-236.14636291506616" y="-59.08788687039808" z="1526.4411296934186" unit="mm" />
+      <rotation name="crystal19-3_rot_neg_bot" x="-0.042186498913610496" y="0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal19-3_pos_pos_top" x="321.5067881308382" y="59.987886870398086" z="1526.4411296934186" unit="mm" />
+      <rotation name="crystal19-3_rot_pos_top" x="0.042186498913610496" y="-0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal19-3_pos_neg_top" x="-236.14636291506616" y="59.987886870398086" z="1526.4411296934186" unit="mm" />
+      <rotation name="crystal19-3_rot_neg_top" x="0.042186498913610496" y="0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal20-3_pos_pos_bot" x="337.03696038609246" y="-59.08788687039808" z="1526.1221853004517" unit="mm" />
+      <rotation name="crystal20-3_rot_pos_bot" x="-0.042186498913610496" y="-0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal20-3_pos_neg_bot" x="-251.67653517032045" y="-59.08788687039808" z="1526.1221853004517" unit="mm" />
+      <rotation name="crystal20-3_rot_neg_bot" x="-0.042186498913610496" y="0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal20-3_pos_pos_top" x="337.03696038609246" y="59.987886870398086" z="1526.1221853004517" unit="mm" />
+      <rotation name="crystal20-3_rot_pos_top" x="0.042186498913610496" y="-0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal20-3_pos_neg_top" x="-251.67653517032045" y="59.987886870398086" z="1526.1221853004517" unit="mm" />
+      <rotation name="crystal20-3_rot_neg_top" x="0.042186498913610496" y="0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal21-3_pos_pos_bot" x="352.64254741924634" y="-59.08788687039808" z="1525.781071546186" unit="mm" />
+      <rotation name="crystal21-3_rot_pos_bot" x="-0.042186498913610496" y="-0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal21-3_pos_neg_bot" x="-267.28212220347433" y="-59.08788687039808" z="1525.781071546186" unit="mm" />
+      <rotation name="crystal21-3_rot_neg_bot" x="-0.042186498913610496" y="0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal21-3_pos_pos_top" x="352.64254741924634" y="59.987886870398086" z="1525.781071546186" unit="mm" />
+      <rotation name="crystal21-3_rot_pos_top" x="0.042186498913610496" y="-0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal21-3_pos_neg_top" x="-267.28212220347433" y="59.987886870398086" z="1525.781071546186" unit="mm" />
+      <rotation name="crystal21-3_rot_neg_top" x="0.042186498913610496" y="0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal22-3_pos_pos_bot" x="368.32817872130425" y="-59.08788687039808" z="1525.417885561178" unit="mm" />
+      <rotation name="crystal22-3_rot_pos_bot" x="-0.042186498913610496" y="-0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal22-3_pos_neg_bot" x="-282.96775350553224" y="-59.08788687039808" z="1525.417885561178" unit="mm" />
+      <rotation name="crystal22-3_rot_neg_bot" x="-0.042186498913610496" y="0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal22-3_pos_pos_top" x="368.32817872130425" y="59.987886870398086" z="1525.417885561178" unit="mm" />
+      <rotation name="crystal22-3_rot_pos_top" x="0.042186498913610496" y="-0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal22-3_pos_neg_top" x="-282.96775350553224" y="59.987886870398086" z="1525.417885561178" unit="mm" />
+      <rotation name="crystal22-3_rot_neg_top" x="0.042186498913610496" y="0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal23-3_pos_pos_bot" x="384.09862704978" y="-59.08788687039808" z="1525.032730760949" unit="mm" />
+      <rotation name="crystal23-3_rot_pos_bot" x="-0.042186498913610496" y="-0.3796784902224945" z="0.0" unit="radian" />
+      <position name="crystal23-3_pos_neg_bot" x="-298.738201834008" y="-59.08788687039808" z="1525.032730760949" unit="mm" />
+      <rotation name="crystal23-3_rot_neg_bot" x="-0.042186498913610496" y="0.3796784902224945" z="0.0" unit="radian" />
+      <position name="crystal23-3_pos_pos_top" x="384.09862704978" y="59.987886870398086" z="1525.032730760949" unit="mm" />
+      <rotation name="crystal23-3_rot_pos_top" x="0.042186498913610496" y="-0.3796784902224945" z="0.0" unit="radian" />
+      <position name="crystal23-3_pos_neg_top" x="-298.738201834008" y="59.987886870398086" z="1525.032730760949" unit="mm" />
+      <rotation name="crystal23-3_rot_neg_top" x="0.042186498913610496" y="0.3796784902224945" z="0.0" unit="radian" />
+      <position name="crystal1-4_pos_pos_bot" x="50.20495188328156" y="-74.108374317979" z="1528.3624082783765" unit="mm" />
+      <rotation name="crystal1-4_rot_pos_bot" x="-0.0590610984790547" y="-0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal1-4_pos_neg_bot" x="35.15547333249048" y="-74.108374317979" z="1528.3624082783765" unit="mm" />
+      <rotation name="crystal1-4_rot_neg_bot" x="-0.0590610984790547" y="0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal1-4_pos_pos_top" x="50.20495188328156" y="75.008374317979" z="1528.3624082783765" unit="mm" />
+      <rotation name="crystal1-4_rot_pos_top" x="0.0590610984790547" y="-0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal1-4_pos_neg_top" x="35.15547333249048" y="75.008374317979" z="1528.3624082783765" unit="mm" />
+      <rotation name="crystal1-4_rot_neg_top" x="0.0590610984790547" y="0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal2-4_pos_pos_bot" x="65.05802548582456" y="-74.108374317979" z="1528.4518282402964" unit="mm" />
+      <rotation name="crystal2-4_rot_pos_bot" x="-0.0590610984790547" y="-0.0253118993481663" z="0.0" unit="radian" />
+      <position name="crystal2-4_pos_neg_bot" x="20.302399729947485" y="-74.108374317979" z="1528.4518282402964" unit="mm" />
+      <rotation name="crystal2-4_rot_neg_bot" x="-0.0590610984790547" y="0.0253118993481663" z="0.0" unit="radian" />
+      <position name="crystal2-4_pos_pos_top" x="65.05802548582456" y="75.008374317979" z="1528.4518282402964" unit="mm" />
+      <rotation name="crystal2-4_rot_pos_top" x="0.0590610984790547" y="-0.0253118993481663" z="0.0" unit="radian" />
+      <position name="crystal2-4_pos_neg_top" x="20.302399729947485" y="75.008374317979" z="1528.4518282402964" unit="mm" />
+      <rotation name="crystal2-4_rot_neg_top" x="0.0590610984790547" y="0.0253118993481663" z="0.0" unit="radian" />
+      <position name="crystal3-4_pos_pos_bot" x="79.9180994782841" y="-74.108374317979" z="1528.5184279465104" unit="mm" />
+      <rotation name="crystal3-4_rot_pos_bot" x="-0.0590610984790547" y="-0.042186498913610496" z="0.0" unit="radian" />
+      <position name="crystal3-4_pos_neg_bot" x="5.442325737487934" y="-74.108374317979" z="1528.5184279465104" unit="mm" />
+      <rotation name="crystal3-4_rot_neg_bot" x="-0.0590610984790547" y="0.042186498913610496" z="0.0" unit="radian" />
+      <position name="crystal3-4_pos_pos_top" x="79.9180994782841" y="75.008374317979" z="1528.5184279465104" unit="mm" />
+      <rotation name="crystal3-4_rot_pos_top" x="0.0590610984790547" y="-0.042186498913610496" z="0.0" unit="radian" />
+      <position name="crystal3-4_pos_neg_top" x="5.442325737487934" y="75.008374317979" z="1528.5184279465104" unit="mm" />
+      <rotation name="crystal3-4_rot_neg_top" x="0.0590610984790547" y="0.042186498913610496" z="0.0" unit="radian" />
+      <position name="crystal4-4_pos_pos_bot" x="94.78858692586502" y="-74.108374317979" z="1528.5621884330608" unit="mm" />
+      <rotation name="crystal4-4_rot_pos_bot" x="-0.0590610984790547" y="-0.0590610984790547" z="0.0" unit="radian" />
+      <position name="crystal4-4_pos_neg_bot" x="-9.42816171009298" y="-74.108374317979" z="1528.5621884330608" unit="mm" />
+      <rotation name="crystal4-4_rot_neg_bot" x="-0.0590610984790547" y="0.0590610984790547" z="0.0" unit="radian" />
+      <position name="crystal4-4_pos_pos_top" x="94.78858692586502" y="75.008374317979" z="1528.5621884330608" unit="mm" />
+      <rotation name="crystal4-4_rot_pos_top" x="0.0590610984790547" y="-0.0590610984790547" z="0.0" unit="radian" />
+      <position name="crystal4-4_pos_neg_top" x="-9.42816171009298" y="75.008374317979" z="1528.5621884330608" unit="mm" />
+      <rotation name="crystal4-4_rot_neg_top" x="0.0590610984790547" y="0.0590610984790547" z="0.0" unit="radian" />
+      <position name="crystal5-4_pos_pos_bot" x="109.67291416309662" y="-74.108374317979" z="1528.5830972393524" unit="mm" />
+      <rotation name="crystal5-4_rot_pos_bot" x="-0.0590610984790547" y="-0.0759356980444989" z="0.0" unit="radian" />
+      <position name="crystal5-4_pos_neg_bot" x="-24.31248894732458" y="-74.108374317979" z="1528.5830972393524" unit="mm" />
+      <rotation name="crystal5-4_rot_neg_bot" x="-0.0590610984790547" y="0.0759356980444989" z="0.0" unit="radian" />
+      <position name="crystal5-4_pos_pos_top" x="109.67291416309662" y="75.008374317979" z="1528.5830972393524" unit="mm" />
+      <rotation name="crystal5-4_rot_pos_top" x="0.0590610984790547" y="-0.0759356980444989" z="0.0" unit="radian" />
+      <position name="crystal5-4_pos_neg_top" x="-24.31248894732458" y="75.008374317979" z="1528.5830972393524" unit="mm" />
+      <rotation name="crystal5-4_rot_neg_top" x="0.0590610984790547" y="0.0759356980444989" z="0.0" unit="radian" />
+      <position name="crystal6-4_pos_pos_bot" x="124.57452638340096" y="-74.108374317979" z="1528.5811484117003" unit="mm" />
+      <rotation name="crystal6-4_rot_pos_bot" x="-0.0590610984790547" y="-0.0928102976099431" z="0.0" unit="radian" />
+      <position name="crystal6-4_pos_neg_bot" x="-39.214101167628925" y="-74.108374317979" z="1528.5811484117003" unit="mm" />
+      <rotation name="crystal6-4_rot_neg_bot" x="-0.0590610984790547" y="0.0928102976099431" z="0.0" unit="radian" />
+      <position name="crystal6-4_pos_pos_top" x="124.57452638340096" y="75.008374317979" z="1528.5811484117003" unit="mm" />
+      <rotation name="crystal6-4_rot_pos_top" x="0.0590610984790547" y="-0.0928102976099431" z="0.0" unit="radian" />
+      <position name="crystal6-4_pos_neg_top" x="-39.214101167628925" y="75.008374317979" z="1528.5811484117003" unit="mm" />
+      <rotation name="crystal6-4_rot_neg_top" x="0.0590610984790547" y="0.0928102976099431" z="0.0" unit="radian" />
+      <position name="crystal7-4_pos_pos_bot" x="139.4968932952259" y="-74.108374317979" z="1528.5563425050236" unit="mm" />
+      <rotation name="crystal7-4_rot_pos_bot" x="-0.0590610984790547" y="-0.10968489717538729" z="0.0" unit="radian" />
+      <position name="crystal7-4_pos_neg_bot" x="-54.13646807945388" y="-74.108374317979" z="1528.5563425050236" unit="mm" />
+      <rotation name="crystal7-4_rot_neg_bot" x="-0.0590610984790547" y="0.10968489717538729" z="0.0" unit="radian" />
+      <position name="crystal7-4_pos_pos_top" x="139.4968932952259" y="75.008374317979" z="1528.5563425050236" unit="mm" />
+      <rotation name="crystal7-4_rot_pos_top" x="0.0590610984790547" y="-0.10968489717538729" z="0.0" unit="radian" />
+      <position name="crystal7-4_pos_neg_top" x="-54.13646807945388" y="75.008374317979" z="1528.5563425050236" unit="mm" />
+      <rotation name="crystal7-4_rot_neg_top" x="0.0590610984790547" y="0.10968489717538729" z="0.0" unit="radian" />
+      <position name="crystal8-4_pos_pos_bot" x="154.44351486445828" y="-74.108374317979" z="1528.5086865826895" unit="mm" />
+      <rotation name="crystal8-4_rot_pos_bot" x="-0.0590610984790547" y="-0.1265594967408315" z="0.0" unit="radian" />
+      <position name="crystal8-4_pos_neg_bot" x="-69.08308964868624" y="-74.108374317979" z="1528.5086865826895" unit="mm" />
+      <rotation name="crystal8-4_rot_neg_bot" x="-0.0590610984790547" y="0.1265594967408315" z="0.0" unit="radian" />
+      <position name="crystal8-4_pos_pos_top" x="154.44351486445828" y="75.008374317979" z="1528.5086865826895" unit="mm" />
+      <rotation name="crystal8-4_rot_pos_top" x="0.0590610984790547" y="-0.1265594967408315" z="0.0" unit="radian" />
+      <position name="crystal8-4_pos_neg_top" x="-69.08308964868624" y="75.008374317979" z="1528.5086865826895" unit="mm" />
+      <rotation name="crystal8-4_rot_neg_top" x="0.0590610984790547" y="0.1265594967408315" z="0.0" unit="radian" />
+      <position name="crystal9-4_pos_pos_bot" x="169.41792716339802" y="-74.108374317979" z="1528.4381942144998" unit="mm" />
+      <rotation name="crystal9-4_rot_pos_bot" x="-0.0590610984790547" y="-0.14343409630627568" z="0.0" unit="radian" />
+      <position name="crystal9-4_pos_neg_bot" x="-84.057501947626" y="-74.108374317979" z="1528.4381942144998" unit="mm" />
+      <rotation name="crystal9-4_rot_neg_bot" x="-0.0590610984790547" y="0.14343409630627568" z="0.0" unit="radian" />
+      <position name="crystal9-4_pos_pos_top" x="169.41792716339802" y="75.008374317979" z="1528.4381942144998" unit="mm" />
+      <rotation name="crystal9-4_rot_pos_top" x="0.0590610984790547" y="-0.14343409630627568" z="0.0" unit="radian" />
+      <position name="crystal9-4_pos_neg_top" x="-84.057501947626" y="75.008374317979" z="1528.4381942144998" unit="mm" />
+      <rotation name="crystal9-4_rot_neg_top" x="0.0590610984790547" y="0.14343409630627568" z="0.0" unit="radian" />
+      <position name="crystal10-4_pos_pos_bot" x="184.42370834727978" y="-74.108374317979" z="1528.3448854728294" unit="mm" />
+      <rotation name="crystal10-4_rot_pos_bot" x="-0.0590610984790547" y="-0.1603086958717199" z="0.0" unit="radian" />
+      <position name="crystal10-4_pos_neg_bot" x="-99.06328313150773" y="-74.108374317979" z="1528.3448854728294" unit="mm" />
+      <rotation name="crystal10-4_rot_neg_bot" x="-0.0590610984790547" y="0.1603086958717199" z="0.0" unit="radian" />
+      <position name="crystal10-4_pos_pos_top" x="184.42370834727978" y="75.008374317979" z="1528.3448854728294" unit="mm" />
+      <rotation name="crystal10-4_rot_pos_top" x="0.0590610984790547" y="-0.1603086958717199" z="0.0" unit="radian" />
+      <position name="crystal10-4_pos_neg_top" x="-99.06328313150773" y="75.008374317979" z="1528.3448854728294" unit="mm" />
+      <rotation name="crystal10-4_rot_neg_top" x="0.0590610984790547" y="0.1603086958717199" z="0.0" unit="radian" />
+      <position name="crystal11-4_pos_pos_bot" x="199.46448478017476" y="-74.108374317979" z="1528.2287869269085" unit="mm" />
+      <rotation name="crystal11-4_rot_pos_bot" x="-0.0590610984790547" y="-0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal11-4_pos_neg_bot" x="-114.1040595644027" y="-74.108374317979" z="1528.2287869269085" unit="mm" />
+      <rotation name="crystal11-4_rot_neg_bot" x="-0.0590610984790547" y="0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal11-4_pos_pos_top" x="199.46448478017476" y="75.008374317979" z="1528.2287869269085" unit="mm" />
+      <rotation name="crystal11-4_rot_pos_top" x="0.0590610984790547" y="-0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal11-4_pos_neg_top" x="-114.1040595644027" y="75.008374317979" z="1528.2287869269085" unit="mm" />
+      <rotation name="crystal11-4_rot_neg_top" x="0.0590610984790547" y="0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal12-4_pos_pos_bot" x="214.5439373331128" y="-74.108374317979" z="1528.0899316352588" unit="mm" />
+      <rotation name="crystal12-4_rot_pos_bot" x="-0.0590610984790547" y="-0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal12-4_pos_neg_bot" x="-129.1835121173408" y="-74.108374317979" z="1528.0899316352588" unit="mm" />
+      <rotation name="crystal12-4_rot_neg_bot" x="-0.0590610984790547" y="0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal12-4_pos_pos_top" x="214.5439373331128" y="75.008374317979" z="1528.0899316352588" unit="mm" />
+      <rotation name="crystal12-4_rot_pos_top" x="0.0590610984790547" y="-0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal12-4_pos_neg_top" x="-129.1835121173408" y="75.008374317979" z="1528.0899316352588" unit="mm" />
+      <rotation name="crystal12-4_rot_neg_top" x="0.0590610984790547" y="0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal13-4_pos_pos_bot" x="229.66580787843168" y="-74.108374317979" z="1527.9283591362796" unit="mm" />
+      <rotation name="crystal13-4_rot_pos_bot" x="-0.0590610984790547" y="-0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal13-4_pos_neg_bot" x="-144.30538266265967" y="-74.108374317979" z="1527.9283591362796" unit="mm" />
+      <rotation name="crystal13-4_rot_neg_bot" x="-0.0590610984790547" y="0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal13-4_pos_pos_top" x="229.66580787843168" y="75.008374317979" z="1527.9283591362796" unit="mm" />
+      <rotation name="crystal13-4_rot_pos_top" x="0.0590610984790547" y="-0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal13-4_pos_neg_top" x="-144.30538266265967" y="75.008374317979" z="1527.9283591362796" unit="mm" />
+      <rotation name="crystal13-4_rot_neg_top" x="0.0590610984790547" y="0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal14-4_pos_pos_bot" x="244.83390600570817" y="-74.108374317979" z="1527.744115436989" unit="mm" />
+      <rotation name="crystal14-4_rot_pos_bot" x="-0.0590610984790547" y="-0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal14-4_pos_neg_bot" x="-159.47348078993616" y="-74.108374317979" z="1527.744115436989" unit="mm" />
+      <rotation name="crystal14-4_rot_neg_bot" x="-0.0590610984790547" y="0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal14-4_pos_pos_top" x="244.83390600570817" y="75.008374317979" z="1527.744115436989" unit="mm" />
+      <rotation name="crystal14-4_rot_pos_top" x="0.0590610984790547" y="-0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal14-4_pos_neg_top" x="-159.47348078993616" y="75.008374317979" z="1527.744115436989" unit="mm" />
+      <rotation name="crystal14-4_rot_neg_top" x="0.0590610984790547" y="0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal15-4_pos_pos_bot" x="260.0521159861688" y="-74.108374317979" z="1527.537252999924" unit="mm" />
+      <rotation name="crystal15-4_rot_pos_bot" x="-0.0590610984790547" y="-0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal15-4_pos_neg_bot" x="-174.6916907703968" y="-74.108374317979" z="1527.537252999924" unit="mm" />
+      <rotation name="crystal15-4_rot_neg_bot" x="-0.0590610984790547" y="0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal15-4_pos_pos_top" x="260.0521159861688" y="75.008374317979" z="1527.537252999924" unit="mm" />
+      <rotation name="crystal15-4_rot_pos_top" x="0.0590610984790547" y="-0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal15-4_pos_neg_top" x="-174.6916907703968" y="75.008374317979" z="1527.537252999924" unit="mm" />
+      <rotation name="crystal15-4_rot_neg_top" x="0.0590610984790547" y="0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal16-4_pos_pos_bot" x="275.32440401422616" y="-74.108374317979" z="1527.3078307282033" unit="mm" />
+      <rotation name="crystal16-4_rot_pos_bot" x="-0.0590610984790547" y="-0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal16-4_pos_neg_bot" x="-189.96397879845415" y="-74.108374317979" z="1527.3078307282033" unit="mm" />
+      <rotation name="crystal16-4_rot_neg_bot" x="-0.0590610984790547" y="0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal16-4_pos_pos_top" x="275.32440401422616" y="75.008374317979" z="1527.3078307282033" unit="mm" />
+      <rotation name="crystal16-4_rot_pos_top" x="0.0590610984790547" y="-0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal16-4_pos_neg_top" x="-189.96397879845415" y="75.008374317979" z="1527.3078307282033" unit="mm" />
+      <rotation name="crystal16-4_rot_neg_top" x="0.0590610984790547" y="0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal17-4_pos_pos_bot" x="290.6548257567732" y="-74.108374317979" z="1527.0559139487518" unit="mm" />
+      <rotation name="crystal17-4_rot_pos_bot" x="-0.0590610984790547" y="-0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal17-4_pos_neg_bot" x="-205.2944005410012" y="-74.108374317979" z="1527.0559139487518" unit="mm" />
+      <rotation name="crystal17-4_rot_neg_bot" x="-0.0590610984790547" y="0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal17-4_pos_pos_top" x="290.6548257567732" y="75.008374317979" z="1527.0559139487518" unit="mm" />
+      <rotation name="crystal17-4_rot_pos_top" x="0.0590610984790547" y="-0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal17-4_pos_neg_top" x="-205.2944005410012" y="75.008374317979" z="1527.0559139487518" unit="mm" />
+      <rotation name="crystal17-4_rot_neg_top" x="0.0590610984790547" y="0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal18-4_pos_pos_bot" x="306.0475342431027" y="-74.108374317979" z="1526.7815743937024" unit="mm" />
+      <rotation name="crystal18-4_rot_pos_bot" x="-0.0590610984790547" y="-0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal18-4_pos_neg_bot" x="-220.68710902733068" y="-74.108374317979" z="1526.7815743937024" unit="mm" />
+      <rotation name="crystal18-4_rot_neg_bot" x="-0.0590610984790547" y="0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal18-4_pos_pos_top" x="306.0475342431027" y="75.008374317979" z="1526.7815743937024" unit="mm" />
+      <rotation name="crystal18-4_rot_pos_top" x="0.0590610984790547" y="-0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal18-4_pos_neg_top" x="-220.68710902733068" y="75.008374317979" z="1526.7815743937024" unit="mm" />
+      <rotation name="crystal18-4_rot_neg_top" x="0.0590610984790547" y="0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal19-4_pos_pos_bot" x="321.5067881308382" y="-74.108374317979" z="1526.4848901799687" unit="mm" />
+      <rotation name="crystal19-4_rot_pos_bot" x="-0.0590610984790547" y="-0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal19-4_pos_neg_bot" x="-236.14636291506616" y="-74.108374317979" z="1526.4848901799687" unit="mm" />
+      <rotation name="crystal19-4_rot_neg_bot" x="-0.0590610984790547" y="0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal19-4_pos_pos_top" x="321.5067881308382" y="75.008374317979" z="1526.4848901799687" unit="mm" />
+      <rotation name="crystal19-4_rot_pos_top" x="0.0590610984790547" y="-0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal19-4_pos_neg_top" x="-236.14636291506616" y="75.008374317979" z="1526.4848901799687" unit="mm" />
+      <rotation name="crystal19-4_rot_neg_top" x="0.0590610984790547" y="0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal20-4_pos_pos_bot" x="337.03696038609246" y="-74.108374317979" z="1526.165945787002" unit="mm" />
+      <rotation name="crystal20-4_rot_pos_bot" x="-0.0590610984790547" y="-0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal20-4_pos_neg_bot" x="-251.67653517032045" y="-74.108374317979" z="1526.165945787002" unit="mm" />
+      <rotation name="crystal20-4_rot_neg_bot" x="-0.0590610984790547" y="0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal20-4_pos_pos_top" x="337.03696038609246" y="75.008374317979" z="1526.165945787002" unit="mm" />
+      <rotation name="crystal20-4_rot_pos_top" x="0.0590610984790547" y="-0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal20-4_pos_neg_top" x="-251.67653517032045" y="75.008374317979" z="1526.165945787002" unit="mm" />
+      <rotation name="crystal20-4_rot_neg_top" x="0.0590610984790547" y="0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal21-4_pos_pos_bot" x="352.64254741924634" y="-74.108374317979" z="1525.8248320327364" unit="mm" />
+      <rotation name="crystal21-4_rot_pos_bot" x="-0.0590610984790547" y="-0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal21-4_pos_neg_bot" x="-267.28212220347433" y="-74.108374317979" z="1525.8248320327364" unit="mm" />
+      <rotation name="crystal21-4_rot_neg_bot" x="-0.0590610984790547" y="0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal21-4_pos_pos_top" x="352.64254741924634" y="75.008374317979" z="1525.8248320327364" unit="mm" />
+      <rotation name="crystal21-4_rot_pos_top" x="0.0590610984790547" y="-0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal21-4_pos_neg_top" x="-267.28212220347433" y="75.008374317979" z="1525.8248320327364" unit="mm" />
+      <rotation name="crystal21-4_rot_neg_top" x="0.0590610984790547" y="0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal22-4_pos_pos_bot" x="368.32817872130425" y="-74.108374317979" z="1525.4616460477282" unit="mm" />
+      <rotation name="crystal22-4_rot_pos_bot" x="-0.0590610984790547" y="-0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal22-4_pos_neg_bot" x="-282.96775350553224" y="-74.108374317979" z="1525.4616460477282" unit="mm" />
+      <rotation name="crystal22-4_rot_neg_bot" x="-0.0590610984790547" y="0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal22-4_pos_pos_top" x="368.32817872130425" y="75.008374317979" z="1525.4616460477282" unit="mm" />
+      <rotation name="crystal22-4_rot_pos_top" x="0.0590610984790547" y="-0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal22-4_pos_neg_top" x="-282.96775350553224" y="75.008374317979" z="1525.4616460477282" unit="mm" />
+      <rotation name="crystal22-4_rot_neg_top" x="0.0590610984790547" y="0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal23-4_pos_pos_bot" x="384.09862704978" y="-74.108374317979" z="1525.0764912474995" unit="mm" />
+      <rotation name="crystal23-4_rot_pos_bot" x="-0.0590610984790547" y="-0.3796784902224945" z="0.0" unit="radian" />
+      <position name="crystal23-4_pos_neg_bot" x="-298.738201834008" y="-74.108374317979" z="1525.0764912474995" unit="mm" />
+      <rotation name="crystal23-4_rot_neg_bot" x="-0.0590610984790547" y="0.3796784902224945" z="0.0" unit="radian" />
+      <position name="crystal23-4_pos_pos_top" x="384.09862704978" y="75.008374317979" z="1525.0764912474995" unit="mm" />
+      <rotation name="crystal23-4_rot_pos_top" x="0.0590610984790547" y="-0.3796784902224945" z="0.0" unit="radian" />
+      <position name="crystal23-4_pos_neg_top" x="-298.738201834008" y="75.008374317979" z="1525.0764912474995" unit="mm" />
+      <rotation name="crystal23-4_rot_neg_top" x="0.0590610984790547" y="0.3796784902224945" z="0.0" unit="radian" />
+      <position name="crystal1-5_pos_pos_bot" x="50.20495188328156" y="-89.1427015552106" z="1528.3833170846683" unit="mm" />
+      <rotation name="crystal1-5_rot_pos_bot" x="-0.0759356980444989" y="-0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal1-5_pos_neg_bot" x="35.15547333249048" y="-89.1427015552106" z="1528.3833170846683" unit="mm" />
+      <rotation name="crystal1-5_rot_neg_bot" x="-0.0759356980444989" y="0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal1-5_pos_pos_top" x="50.20495188328156" y="90.0427015552106" z="1528.3833170846683" unit="mm" />
+      <rotation name="crystal1-5_rot_pos_top" x="0.0759356980444989" y="-0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal1-5_pos_neg_top" x="35.15547333249048" y="90.0427015552106" z="1528.3833170846683" unit="mm" />
+      <rotation name="crystal1-5_rot_neg_top" x="0.0759356980444989" y="0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal2-5_pos_pos_bot" x="65.05802548582456" y="-89.1427015552106" z="1528.4727370465882" unit="mm" />
+      <rotation name="crystal2-5_rot_pos_bot" x="-0.0759356980444989" y="-0.0253118993481663" z="0.0" unit="radian" />
+      <position name="crystal2-5_pos_neg_bot" x="20.302399729947485" y="-89.1427015552106" z="1528.4727370465882" unit="mm" />
+      <rotation name="crystal2-5_rot_neg_bot" x="-0.0759356980444989" y="0.0253118993481663" z="0.0" unit="radian" />
+      <position name="crystal2-5_pos_pos_top" x="65.05802548582456" y="90.0427015552106" z="1528.4727370465882" unit="mm" />
+      <rotation name="crystal2-5_rot_pos_top" x="0.0759356980444989" y="-0.0253118993481663" z="0.0" unit="radian" />
+      <position name="crystal2-5_pos_neg_top" x="20.302399729947485" y="90.0427015552106" z="1528.4727370465882" unit="mm" />
+      <rotation name="crystal2-5_rot_neg_top" x="0.0759356980444989" y="0.0253118993481663" z="0.0" unit="radian" />
+      <position name="crystal3-5_pos_pos_bot" x="79.9180994782841" y="-89.1427015552106" z="1528.5393367528022" unit="mm" />
+      <rotation name="crystal3-5_rot_pos_bot" x="-0.0759356980444989" y="-0.042186498913610496" z="0.0" unit="radian" />
+      <position name="crystal3-5_pos_neg_bot" x="5.442325737487934" y="-89.1427015552106" z="1528.5393367528022" unit="mm" />
+      <rotation name="crystal3-5_rot_neg_bot" x="-0.0759356980444989" y="0.042186498913610496" z="0.0" unit="radian" />
+      <position name="crystal3-5_pos_pos_top" x="79.9180994782841" y="90.0427015552106" z="1528.5393367528022" unit="mm" />
+      <rotation name="crystal3-5_rot_pos_top" x="0.0759356980444989" y="-0.042186498913610496" z="0.0" unit="radian" />
+      <position name="crystal3-5_pos_neg_top" x="5.442325737487934" y="90.0427015552106" z="1528.5393367528022" unit="mm" />
+      <rotation name="crystal3-5_rot_neg_top" x="0.0759356980444989" y="0.042186498913610496" z="0.0" unit="radian" />
+      <position name="crystal4-5_pos_pos_bot" x="94.78858692586502" y="-89.1427015552106" z="1528.5830972393524" unit="mm" />
+      <rotation name="crystal4-5_rot_pos_bot" x="-0.0759356980444989" y="-0.0590610984790547" z="0.0" unit="radian" />
+      <position name="crystal4-5_pos_neg_bot" x="-9.42816171009298" y="-89.1427015552106" z="1528.5830972393524" unit="mm" />
+      <rotation name="crystal4-5_rot_neg_bot" x="-0.0759356980444989" y="0.0590610984790547" z="0.0" unit="radian" />
+      <position name="crystal4-5_pos_pos_top" x="94.78858692586502" y="90.0427015552106" z="1528.5830972393524" unit="mm" />
+      <rotation name="crystal4-5_rot_pos_top" x="0.0759356980444989" y="-0.0590610984790547" z="0.0" unit="radian" />
+      <position name="crystal4-5_pos_neg_top" x="-9.42816171009298" y="90.0427015552106" z="1528.5830972393524" unit="mm" />
+      <rotation name="crystal4-5_rot_neg_top" x="0.0759356980444989" y="0.0590610984790547" z="0.0" unit="radian" />
+      <position name="crystal5-5_pos_pos_bot" x="109.67291416309662" y="-89.1427015552106" z="1528.6040060456442" unit="mm" />
+      <rotation name="crystal5-5_rot_pos_bot" x="-0.0759356980444989" y="-0.0759356980444989" z="0.0" unit="radian" />
+      <position name="crystal5-5_pos_neg_bot" x="-24.31248894732458" y="-89.1427015552106" z="1528.6040060456442" unit="mm" />
+      <rotation name="crystal5-5_rot_neg_bot" x="-0.0759356980444989" y="0.0759356980444989" z="0.0" unit="radian" />
+      <position name="crystal5-5_pos_pos_top" x="109.67291416309662" y="90.0427015552106" z="1528.6040060456442" unit="mm" />
+      <rotation name="crystal5-5_rot_pos_top" x="0.0759356980444989" y="-0.0759356980444989" z="0.0" unit="radian" />
+      <position name="crystal5-5_pos_neg_top" x="-24.31248894732458" y="90.0427015552106" z="1528.6040060456442" unit="mm" />
+      <rotation name="crystal5-5_rot_neg_top" x="0.0759356980444989" y="0.0759356980444989" z="0.0" unit="radian" />
+      <position name="crystal6-5_pos_pos_bot" x="124.57452638340096" y="-89.1427015552106" z="1528.602057217992" unit="mm" />
+      <rotation name="crystal6-5_rot_pos_bot" x="-0.0759356980444989" y="-0.0928102976099431" z="0.0" unit="radian" />
+      <position name="crystal6-5_pos_neg_bot" x="-39.214101167628925" y="-89.1427015552106" z="1528.602057217992" unit="mm" />
+      <rotation name="crystal6-5_rot_neg_bot" x="-0.0759356980444989" y="0.0928102976099431" z="0.0" unit="radian" />
+      <position name="crystal6-5_pos_pos_top" x="124.57452638340096" y="90.0427015552106" z="1528.602057217992" unit="mm" />
+      <rotation name="crystal6-5_rot_pos_top" x="0.0759356980444989" y="-0.0928102976099431" z="0.0" unit="radian" />
+      <position name="crystal6-5_pos_neg_top" x="-39.214101167628925" y="90.0427015552106" z="1528.602057217992" unit="mm" />
+      <rotation name="crystal6-5_rot_neg_top" x="0.0759356980444989" y="0.0928102976099431" z="0.0" unit="radian" />
+      <position name="crystal7-5_pos_pos_bot" x="139.4968932952259" y="-89.1427015552106" z="1528.5772513113154" unit="mm" />
+      <rotation name="crystal7-5_rot_pos_bot" x="-0.0759356980444989" y="-0.10968489717538729" z="0.0" unit="radian" />
+      <position name="crystal7-5_pos_neg_bot" x="-54.13646807945388" y="-89.1427015552106" z="1528.5772513113154" unit="mm" />
+      <rotation name="crystal7-5_rot_neg_bot" x="-0.0759356980444989" y="0.10968489717538729" z="0.0" unit="radian" />
+      <position name="crystal7-5_pos_pos_top" x="139.4968932952259" y="90.0427015552106" z="1528.5772513113154" unit="mm" />
+      <rotation name="crystal7-5_rot_pos_top" x="0.0759356980444989" y="-0.10968489717538729" z="0.0" unit="radian" />
+      <position name="crystal7-5_pos_neg_top" x="-54.13646807945388" y="90.0427015552106" z="1528.5772513113154" unit="mm" />
+      <rotation name="crystal7-5_rot_neg_top" x="0.0759356980444989" y="0.10968489717538729" z="0.0" unit="radian" />
+      <position name="crystal8-5_pos_pos_bot" x="154.44351486445828" y="-89.1427015552106" z="1528.5295953889813" unit="mm" />
+      <rotation name="crystal8-5_rot_pos_bot" x="-0.0759356980444989" y="-0.1265594967408315" z="0.0" unit="radian" />
+      <position name="crystal8-5_pos_neg_bot" x="-69.08308964868624" y="-89.1427015552106" z="1528.5295953889813" unit="mm" />
+      <rotation name="crystal8-5_rot_neg_bot" x="-0.0759356980444989" y="0.1265594967408315" z="0.0" unit="radian" />
+      <position name="crystal8-5_pos_pos_top" x="154.44351486445828" y="90.0427015552106" z="1528.5295953889813" unit="mm" />
+      <rotation name="crystal8-5_rot_pos_top" x="0.0759356980444989" y="-0.1265594967408315" z="0.0" unit="radian" />
+      <position name="crystal8-5_pos_neg_top" x="-69.08308964868624" y="90.0427015552106" z="1528.5295953889813" unit="mm" />
+      <rotation name="crystal8-5_rot_neg_top" x="0.0759356980444989" y="0.1265594967408315" z="0.0" unit="radian" />
+      <position name="crystal9-5_pos_pos_bot" x="169.41792716339802" y="-89.1427015552106" z="1528.4591030207916" unit="mm" />
+      <rotation name="crystal9-5_rot_pos_bot" x="-0.0759356980444989" y="-0.14343409630627568" z="0.0" unit="radian" />
+      <position name="crystal9-5_pos_neg_bot" x="-84.057501947626" y="-89.1427015552106" z="1528.4591030207916" unit="mm" />
+      <rotation name="crystal9-5_rot_neg_bot" x="-0.0759356980444989" y="0.14343409630627568" z="0.0" unit="radian" />
+      <position name="crystal9-5_pos_pos_top" x="169.41792716339802" y="90.0427015552106" z="1528.4591030207916" unit="mm" />
+      <rotation name="crystal9-5_rot_pos_top" x="0.0759356980444989" y="-0.14343409630627568" z="0.0" unit="radian" />
+      <position name="crystal9-5_pos_neg_top" x="-84.057501947626" y="90.0427015552106" z="1528.4591030207916" unit="mm" />
+      <rotation name="crystal9-5_rot_neg_top" x="0.0759356980444989" y="0.14343409630627568" z="0.0" unit="radian" />
+      <position name="crystal10-5_pos_pos_bot" x="184.42370834727978" y="-89.1427015552106" z="1528.3657942791212" unit="mm" />
+      <rotation name="crystal10-5_rot_pos_bot" x="-0.0759356980444989" y="-0.1603086958717199" z="0.0" unit="radian" />
+      <position name="crystal10-5_pos_neg_bot" x="-99.06328313150773" y="-89.1427015552106" z="1528.3657942791212" unit="mm" />
+      <rotation name="crystal10-5_rot_neg_bot" x="-0.0759356980444989" y="0.1603086958717199" z="0.0" unit="radian" />
+      <position name="crystal10-5_pos_pos_top" x="184.42370834727978" y="90.0427015552106" z="1528.3657942791212" unit="mm" />
+      <rotation name="crystal10-5_rot_pos_top" x="0.0759356980444989" y="-0.1603086958717199" z="0.0" unit="radian" />
+      <position name="crystal10-5_pos_neg_top" x="-99.06328313150773" y="90.0427015552106" z="1528.3657942791212" unit="mm" />
+      <rotation name="crystal10-5_rot_neg_top" x="0.0759356980444989" y="0.1603086958717199" z="0.0" unit="radian" />
+      <position name="crystal11-5_pos_pos_bot" x="199.46448478017476" y="-89.1427015552106" z="1528.2496957332003" unit="mm" />
+      <rotation name="crystal11-5_rot_pos_bot" x="-0.0759356980444989" y="-0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal11-5_pos_neg_bot" x="-114.1040595644027" y="-89.1427015552106" z="1528.2496957332003" unit="mm" />
+      <rotation name="crystal11-5_rot_neg_bot" x="-0.0759356980444989" y="0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal11-5_pos_pos_top" x="199.46448478017476" y="90.0427015552106" z="1528.2496957332003" unit="mm" />
+      <rotation name="crystal11-5_rot_pos_top" x="0.0759356980444989" y="-0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal11-5_pos_neg_top" x="-114.1040595644027" y="90.0427015552106" z="1528.2496957332003" unit="mm" />
+      <rotation name="crystal11-5_rot_neg_top" x="0.0759356980444989" y="0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal12-5_pos_pos_bot" x="214.5439373331128" y="-89.1427015552106" z="1528.1108404415506" unit="mm" />
+      <rotation name="crystal12-5_rot_pos_bot" x="-0.0759356980444989" y="-0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal12-5_pos_neg_bot" x="-129.1835121173408" y="-89.1427015552106" z="1528.1108404415506" unit="mm" />
+      <rotation name="crystal12-5_rot_neg_bot" x="-0.0759356980444989" y="0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal12-5_pos_pos_top" x="214.5439373331128" y="90.0427015552106" z="1528.1108404415506" unit="mm" />
+      <rotation name="crystal12-5_rot_pos_top" x="0.0759356980444989" y="-0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal12-5_pos_neg_top" x="-129.1835121173408" y="90.0427015552106" z="1528.1108404415506" unit="mm" />
+      <rotation name="crystal12-5_rot_neg_top" x="0.0759356980444989" y="0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal13-5_pos_pos_bot" x="229.66580787843168" y="-89.1427015552106" z="1527.9492679425712" unit="mm" />
+      <rotation name="crystal13-5_rot_pos_bot" x="-0.0759356980444989" y="-0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal13-5_pos_neg_bot" x="-144.30538266265967" y="-89.1427015552106" z="1527.9492679425712" unit="mm" />
+      <rotation name="crystal13-5_rot_neg_bot" x="-0.0759356980444989" y="0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal13-5_pos_pos_top" x="229.66580787843168" y="90.0427015552106" z="1527.9492679425712" unit="mm" />
+      <rotation name="crystal13-5_rot_pos_top" x="0.0759356980444989" y="-0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal13-5_pos_neg_top" x="-144.30538266265967" y="90.0427015552106" z="1527.9492679425712" unit="mm" />
+      <rotation name="crystal13-5_rot_neg_top" x="0.0759356980444989" y="0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal14-5_pos_pos_bot" x="244.83390600570817" y="-89.1427015552106" z="1527.7650242432805" unit="mm" />
+      <rotation name="crystal14-5_rot_pos_bot" x="-0.0759356980444989" y="-0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal14-5_pos_neg_bot" x="-159.47348078993616" y="-89.1427015552106" z="1527.7650242432805" unit="mm" />
+      <rotation name="crystal14-5_rot_neg_bot" x="-0.0759356980444989" y="0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal14-5_pos_pos_top" x="244.83390600570817" y="90.0427015552106" z="1527.7650242432805" unit="mm" />
+      <rotation name="crystal14-5_rot_pos_top" x="0.0759356980444989" y="-0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal14-5_pos_neg_top" x="-159.47348078993616" y="90.0427015552106" z="1527.7650242432805" unit="mm" />
+      <rotation name="crystal14-5_rot_neg_top" x="0.0759356980444989" y="0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal15-5_pos_pos_bot" x="260.0521159861688" y="-89.1427015552106" z="1527.5581618062158" unit="mm" />
+      <rotation name="crystal15-5_rot_pos_bot" x="-0.0759356980444989" y="-0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal15-5_pos_neg_bot" x="-174.6916907703968" y="-89.1427015552106" z="1527.5581618062158" unit="mm" />
+      <rotation name="crystal15-5_rot_neg_bot" x="-0.0759356980444989" y="0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal15-5_pos_pos_top" x="260.0521159861688" y="90.0427015552106" z="1527.5581618062158" unit="mm" />
+      <rotation name="crystal15-5_rot_pos_top" x="0.0759356980444989" y="-0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal15-5_pos_neg_top" x="-174.6916907703968" y="90.0427015552106" z="1527.5581618062158" unit="mm" />
+      <rotation name="crystal15-5_rot_neg_top" x="0.0759356980444989" y="0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal16-5_pos_pos_bot" x="275.32440401422616" y="-89.1427015552106" z="1527.328739534495" unit="mm" />
+      <rotation name="crystal16-5_rot_pos_bot" x="-0.0759356980444989" y="-0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal16-5_pos_neg_bot" x="-189.96397879845415" y="-89.1427015552106" z="1527.328739534495" unit="mm" />
+      <rotation name="crystal16-5_rot_neg_bot" x="-0.0759356980444989" y="0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal16-5_pos_pos_top" x="275.32440401422616" y="90.0427015552106" z="1527.328739534495" unit="mm" />
+      <rotation name="crystal16-5_rot_pos_top" x="0.0759356980444989" y="-0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal16-5_pos_neg_top" x="-189.96397879845415" y="90.0427015552106" z="1527.328739534495" unit="mm" />
+      <rotation name="crystal16-5_rot_neg_top" x="0.0759356980444989" y="0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal17-5_pos_pos_bot" x="290.6548257567732" y="-89.1427015552106" z="1527.0768227550436" unit="mm" />
+      <rotation name="crystal17-5_rot_pos_bot" x="-0.0759356980444989" y="-0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal17-5_pos_neg_bot" x="-205.2944005410012" y="-89.1427015552106" z="1527.0768227550436" unit="mm" />
+      <rotation name="crystal17-5_rot_neg_bot" x="-0.0759356980444989" y="0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal17-5_pos_pos_top" x="290.6548257567732" y="90.0427015552106" z="1527.0768227550436" unit="mm" />
+      <rotation name="crystal17-5_rot_pos_top" x="0.0759356980444989" y="-0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal17-5_pos_neg_top" x="-205.2944005410012" y="90.0427015552106" z="1527.0768227550436" unit="mm" />
+      <rotation name="crystal17-5_rot_neg_top" x="0.0759356980444989" y="0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal18-5_pos_pos_bot" x="306.0475342431027" y="-89.1427015552106" z="1526.8024831999942" unit="mm" />
+      <rotation name="crystal18-5_rot_pos_bot" x="-0.0759356980444989" y="-0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal18-5_pos_neg_bot" x="-220.68710902733068" y="-89.1427015552106" z="1526.8024831999942" unit="mm" />
+      <rotation name="crystal18-5_rot_neg_bot" x="-0.0759356980444989" y="0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal18-5_pos_pos_top" x="306.0475342431027" y="90.0427015552106" z="1526.8024831999942" unit="mm" />
+      <rotation name="crystal18-5_rot_pos_top" x="0.0759356980444989" y="-0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal18-5_pos_neg_top" x="-220.68710902733068" y="90.0427015552106" z="1526.8024831999942" unit="mm" />
+      <rotation name="crystal18-5_rot_neg_top" x="0.0759356980444989" y="0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal19-5_pos_pos_bot" x="321.5067881308382" y="-89.1427015552106" z="1526.5057989862605" unit="mm" />
+      <rotation name="crystal19-5_rot_pos_bot" x="-0.0759356980444989" y="-0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal19-5_pos_neg_bot" x="-236.14636291506616" y="-89.1427015552106" z="1526.5057989862605" unit="mm" />
+      <rotation name="crystal19-5_rot_neg_bot" x="-0.0759356980444989" y="0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal19-5_pos_pos_top" x="321.5067881308382" y="90.0427015552106" z="1526.5057989862605" unit="mm" />
+      <rotation name="crystal19-5_rot_pos_top" x="0.0759356980444989" y="-0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal19-5_pos_neg_top" x="-236.14636291506616" y="90.0427015552106" z="1526.5057989862605" unit="mm" />
+      <rotation name="crystal19-5_rot_neg_top" x="0.0759356980444989" y="0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal20-5_pos_pos_bot" x="337.03696038609246" y="-89.1427015552106" z="1526.186854593294" unit="mm" />
+      <rotation name="crystal20-5_rot_pos_bot" x="-0.0759356980444989" y="-0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal20-5_pos_neg_bot" x="-251.67653517032045" y="-89.1427015552106" z="1526.186854593294" unit="mm" />
+      <rotation name="crystal20-5_rot_neg_bot" x="-0.0759356980444989" y="0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal20-5_pos_pos_top" x="337.03696038609246" y="90.0427015552106" z="1526.186854593294" unit="mm" />
+      <rotation name="crystal20-5_rot_pos_top" x="0.0759356980444989" y="-0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal20-5_pos_neg_top" x="-251.67653517032045" y="90.0427015552106" z="1526.186854593294" unit="mm" />
+      <rotation name="crystal20-5_rot_neg_top" x="0.0759356980444989" y="0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal21-5_pos_pos_bot" x="352.64254741924634" y="-89.1427015552106" z="1525.8457408390282" unit="mm" />
+      <rotation name="crystal21-5_rot_pos_bot" x="-0.0759356980444989" y="-0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal21-5_pos_neg_bot" x="-267.28212220347433" y="-89.1427015552106" z="1525.8457408390282" unit="mm" />
+      <rotation name="crystal21-5_rot_neg_bot" x="-0.0759356980444989" y="0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal21-5_pos_pos_top" x="352.64254741924634" y="90.0427015552106" z="1525.8457408390282" unit="mm" />
+      <rotation name="crystal21-5_rot_pos_top" x="0.0759356980444989" y="-0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal21-5_pos_neg_top" x="-267.28212220347433" y="90.0427015552106" z="1525.8457408390282" unit="mm" />
+      <rotation name="crystal21-5_rot_neg_top" x="0.0759356980444989" y="0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal22-5_pos_pos_bot" x="368.32817872130425" y="-89.1427015552106" z="1525.48255485402" unit="mm" />
+      <rotation name="crystal22-5_rot_pos_bot" x="-0.0759356980444989" y="-0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal22-5_pos_neg_bot" x="-282.96775350553224" y="-89.1427015552106" z="1525.48255485402" unit="mm" />
+      <rotation name="crystal22-5_rot_neg_bot" x="-0.0759356980444989" y="0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal22-5_pos_pos_top" x="368.32817872130425" y="90.0427015552106" z="1525.48255485402" unit="mm" />
+      <rotation name="crystal22-5_rot_pos_top" x="0.0759356980444989" y="-0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal22-5_pos_neg_top" x="-282.96775350553224" y="90.0427015552106" z="1525.48255485402" unit="mm" />
+      <rotation name="crystal22-5_rot_neg_top" x="0.0759356980444989" y="0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal23-5_pos_pos_bot" x="384.09862704978" y="-89.1427015552106" z="1525.0974000537913" unit="mm" />
+      <rotation name="crystal23-5_rot_pos_bot" x="-0.0759356980444989" y="-0.3796784902224945" z="0.0" unit="radian" />
+      <position name="crystal23-5_pos_neg_bot" x="-298.738201834008" y="-89.1427015552106" z="1525.0974000537913" unit="mm" />
+      <rotation name="crystal23-5_rot_neg_bot" x="-0.0759356980444989" y="0.3796784902224945" z="0.0" unit="radian" />
+      <position name="crystal23-5_pos_pos_top" x="384.09862704978" y="90.0427015552106" z="1525.0974000537913" unit="mm" />
+      <rotation name="crystal23-5_rot_pos_top" x="0.0759356980444989" y="-0.3796784902224945" z="0.0" unit="radian" />
+      <position name="crystal23-5_pos_neg_top" x="-298.738201834008" y="90.0427015552106" z="1525.0974000537913" unit="mm" />
+      <rotation name="crystal23-5_rot_neg_top" x="0.0759356980444989" y="0.3796784902224945" z="0.0" unit="radian" />
+      <rotation name="hodo_rot" x="0.0" y="0.0" z="0.0" unit="radian" />
+      <position name="hodo_pos_L1TP0" x="73.63" y="44.2" z="1103.5" unit="mm" />
+      <position name="hodo_forecover_pos_L1TP0" x="73.63" y="44.2" z="1098.625" unit="mm" />
+      <position name="hodo_postcover_pos_L1TP0" x="73.63" y="44.2" z="1108.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L1TP0" x="65.75500000000001" y="44.2" z="1103.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L1TP0" x="81.50500000000001" y="44.2" z="1103.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L1TP0" x="73.63" y="74.17500000000001" z="1103.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L1TP0" x="73.63" y="14.225000000000003" z="1103.5" unit="mm" />
+      <position name="hodo_pos_L1BP0" x="73.63" y="-44.2" z="1103.5" unit="mm" />
+      <position name="hodo_forecover_pos_L1BP0" x="73.63" y="-44.2" z="1098.625" unit="mm" />
+      <position name="hodo_postcover_pos_L1BP0" x="73.63" y="-44.2" z="1108.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L1BP0" x="65.75500000000001" y="-44.2" z="1103.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L1BP0" x="81.50500000000001" y="-44.2" z="1103.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L1BP0" x="73.63" y="-14.225000000000003" z="1103.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L1BP0" x="73.63" y="-74.17500000000001" z="1103.5" unit="mm" />
+      <position name="hodo_pos_L1TP1" x="98.63" y="44.2" z="1103.5" unit="mm" />
+      <position name="hodo_forecover_pos_L1TP1" x="98.63" y="44.2" z="1098.625" unit="mm" />
+      <position name="hodo_postcover_pos_L1TP1" x="98.63" y="44.2" z="1108.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L1TP1" x="81.555" y="44.2" z="1103.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L1TP1" x="115.70500000000001" y="44.2" z="1103.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L1TP1" x="98.63" y="74.17500000000001" z="1103.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L1TP1" x="98.63" y="14.225000000000003" z="1103.5" unit="mm" />
+      <position name="hodo_pos_L1BP1" x="98.63" y="-44.2" z="1103.5" unit="mm" />
+      <position name="hodo_forecover_pos_L1BP1" x="98.63" y="-44.2" z="1098.625" unit="mm" />
+      <position name="hodo_postcover_pos_L1BP1" x="98.63" y="-44.2" z="1108.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L1BP1" x="81.555" y="-44.2" z="1103.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L1BP1" x="115.70500000000001" y="-44.2" z="1103.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L1BP1" x="98.63" y="-14.225000000000003" z="1103.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L1BP1" x="98.63" y="-74.17500000000001" z="1103.5" unit="mm" />
+      <position name="hodo_pos_L1TP2" x="137.78" y="44.2" z="1103.5" unit="mm" />
+      <position name="hodo_forecover_pos_L1TP2" x="137.78" y="44.2" z="1098.625" unit="mm" />
+      <position name="hodo_postcover_pos_L1TP2" x="137.78" y="44.2" z="1108.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L1TP2" x="115.75500000000001" y="44.2" z="1103.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L1TP2" x="159.805" y="44.2" z="1103.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L1TP2" x="137.78" y="74.17500000000001" z="1103.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L1TP2" x="137.78" y="14.225000000000003" z="1103.5" unit="mm" />
+      <position name="hodo_pos_L1BP2" x="137.78" y="-44.2" z="1103.5" unit="mm" />
+      <position name="hodo_forecover_pos_L1BP2" x="137.78" y="-44.2" z="1098.625" unit="mm" />
+      <position name="hodo_postcover_pos_L1BP2" x="137.78" y="-44.2" z="1108.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L1BP2" x="115.75500000000001" y="-44.2" z="1103.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L1BP2" x="159.805" y="-44.2" z="1103.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L1BP2" x="137.78" y="-14.225000000000003" z="1103.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L1BP2" x="137.78" y="-74.17500000000001" z="1103.5" unit="mm" />
+      <position name="hodo_pos_L1TP3" x="181.88" y="44.2" z="1103.5" unit="mm" />
+      <position name="hodo_forecover_pos_L1TP3" x="181.88" y="44.2" z="1098.625" unit="mm" />
+      <position name="hodo_postcover_pos_L1TP3" x="181.88" y="44.2" z="1108.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L1TP3" x="159.855" y="44.2" z="1103.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L1TP3" x="203.905" y="44.2" z="1103.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L1TP3" x="181.88" y="74.17500000000001" z="1103.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L1TP3" x="181.88" y="14.225000000000003" z="1103.5" unit="mm" />
+      <position name="hodo_pos_L1BP3" x="181.88" y="-44.2" z="1103.5" unit="mm" />
+      <position name="hodo_forecover_pos_L1BP3" x="181.88" y="-44.2" z="1098.625" unit="mm" />
+      <position name="hodo_postcover_pos_L1BP3" x="181.88" y="-44.2" z="1108.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L1BP3" x="159.855" y="-44.2" z="1103.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L1BP3" x="203.905" y="-44.2" z="1103.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L1BP3" x="181.88" y="-14.225000000000003" z="1103.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L1BP3" x="181.88" y="-74.17500000000001" z="1103.5" unit="mm" />
+      <position name="hodo_pos_L1TP4" x="225.98000000000002" y="44.2" z="1103.5" unit="mm" />
+      <position name="hodo_forecover_pos_L1TP4" x="225.98000000000002" y="44.2" z="1098.625" unit="mm" />
+      <position name="hodo_postcover_pos_L1TP4" x="225.98000000000002" y="44.2" z="1108.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L1TP4" x="203.955" y="44.2" z="1103.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L1TP4" x="248.00500000000002" y="44.2" z="1103.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L1TP4" x="225.98000000000002" y="74.17500000000001" z="1103.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L1TP4" x="225.98000000000002" y="14.225000000000003" z="1103.5" unit="mm" />
+      <position name="hodo_pos_L1BP4" x="225.98000000000002" y="-44.2" z="1103.5" unit="mm" />
+      <position name="hodo_forecover_pos_L1BP4" x="225.98000000000002" y="-44.2" z="1098.625" unit="mm" />
+      <position name="hodo_postcover_pos_L1BP4" x="225.98000000000002" y="-44.2" z="1108.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L1BP4" x="203.955" y="-44.2" z="1103.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L1BP4" x="248.00500000000002" y="-44.2" z="1103.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L1BP4" x="225.98000000000002" y="-14.225000000000003" z="1103.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L1BP4" x="225.98000000000002" y="-74.17500000000001" z="1103.5" unit="mm" />
+      <position name="hodo_pos_L2TP0" x="78.61999999999999" y="44.2" z="1115.5" unit="mm" />
+      <position name="hodo_forecover_pos_L2TP0" x="78.61999999999999" y="44.2" z="1110.625" unit="mm" />
+      <position name="hodo_postcover_pos_L2TP0" x="78.61999999999999" y="44.2" z="1120.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L2TP0" x="69.095" y="44.2" z="1115.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L2TP0" x="88.145" y="44.2" z="1115.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L2TP0" x="78.61999999999999" y="74.17500000000001" z="1115.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L2TP0" x="78.61999999999999" y="14.225000000000003" z="1115.5" unit="mm" />
+      <position name="hodo_pos_L2BP0" x="78.61999999999999" y="-44.2" z="1115.5" unit="mm" />
+      <position name="hodo_forecover_pos_L2BP0" x="78.61999999999999" y="-44.2" z="1110.625" unit="mm" />
+      <position name="hodo_postcover_pos_L2BP0" x="78.61999999999999" y="-44.2" z="1120.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L2BP0" x="69.095" y="-44.2" z="1115.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L2BP0" x="88.145" y="-44.2" z="1115.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L2BP0" x="78.61999999999999" y="-14.225000000000003" z="1115.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L2BP0" x="78.61999999999999" y="-74.17500000000001" z="1115.5" unit="mm" />
+      <position name="hodo_pos_L2TP1" x="110.22" y="44.2" z="1115.5" unit="mm" />
+      <position name="hodo_forecover_pos_L2TP1" x="110.22" y="44.2" z="1110.625" unit="mm" />
+      <position name="hodo_postcover_pos_L2TP1" x="110.22" y="44.2" z="1120.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L2TP1" x="88.19500000000001" y="44.2" z="1115.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L2TP1" x="132.245" y="44.2" z="1115.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L2TP1" x="110.22" y="74.17500000000001" z="1115.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L2TP1" x="110.22" y="14.225000000000003" z="1115.5" unit="mm" />
+      <position name="hodo_pos_L2BP1" x="110.22" y="-44.2" z="1115.5" unit="mm" />
+      <position name="hodo_forecover_pos_L2BP1" x="110.22" y="-44.2" z="1110.625" unit="mm" />
+      <position name="hodo_postcover_pos_L2BP1" x="110.22" y="-44.2" z="1120.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L2BP1" x="88.19500000000001" y="-44.2" z="1115.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L2BP1" x="132.245" y="-44.2" z="1115.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L2BP1" x="110.22" y="-14.225000000000003" z="1115.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L2BP1" x="110.22" y="-74.17500000000001" z="1115.5" unit="mm" />
+      <position name="hodo_pos_L2TP2" x="154.32000000000002" y="44.2" z="1115.5" unit="mm" />
+      <position name="hodo_forecover_pos_L2TP2" x="154.32000000000002" y="44.2" z="1110.625" unit="mm" />
+      <position name="hodo_postcover_pos_L2TP2" x="154.32000000000002" y="44.2" z="1120.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L2TP2" x="132.29500000000002" y="44.2" z="1115.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L2TP2" x="176.34500000000003" y="44.2" z="1115.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L2TP2" x="154.32000000000002" y="74.17500000000001" z="1115.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L2TP2" x="154.32000000000002" y="14.225000000000003" z="1115.5" unit="mm" />
+      <position name="hodo_pos_L2BP2" x="154.32000000000002" y="-44.2" z="1115.5" unit="mm" />
+      <position name="hodo_forecover_pos_L2BP2" x="154.32000000000002" y="-44.2" z="1110.625" unit="mm" />
+      <position name="hodo_postcover_pos_L2BP2" x="154.32000000000002" y="-44.2" z="1120.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L2BP2" x="132.29500000000002" y="-44.2" z="1115.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L2BP2" x="176.34500000000003" y="-44.2" z="1115.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L2BP2" x="154.32000000000002" y="-14.225000000000003" z="1115.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L2BP2" x="154.32000000000002" y="-74.17500000000001" z="1115.5" unit="mm" />
+      <position name="hodo_pos_L2TP3" x="198.42000000000004" y="44.2" z="1115.5" unit="mm" />
+      <position name="hodo_forecover_pos_L2TP3" x="198.42000000000004" y="44.2" z="1110.625" unit="mm" />
+      <position name="hodo_postcover_pos_L2TP3" x="198.42000000000004" y="44.2" z="1120.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L2TP3" x="176.39500000000004" y="44.2" z="1115.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L2TP3" x="220.44500000000005" y="44.2" z="1115.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L2TP3" x="198.42000000000004" y="74.17500000000001" z="1115.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L2TP3" x="198.42000000000004" y="14.225000000000003" z="1115.5" unit="mm" />
+      <position name="hodo_pos_L2BP3" x="198.42000000000004" y="-44.2" z="1115.5" unit="mm" />
+      <position name="hodo_forecover_pos_L2BP3" x="198.42000000000004" y="-44.2" z="1110.625" unit="mm" />
+      <position name="hodo_postcover_pos_L2BP3" x="198.42000000000004" y="-44.2" z="1120.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L2BP3" x="176.39500000000004" y="-44.2" z="1115.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L2BP3" x="220.44500000000005" y="-44.2" z="1115.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L2BP3" x="198.42000000000004" y="-14.225000000000003" z="1115.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L2BP3" x="198.42000000000004" y="-74.17500000000001" z="1115.5" unit="mm" />
+      <position name="hodo_pos_L2TP4" x="235.92000000000002" y="44.2" z="1115.5" unit="mm" />
+      <position name="hodo_forecover_pos_L2TP4" x="235.92000000000002" y="44.2" z="1110.625" unit="mm" />
+      <position name="hodo_postcover_pos_L2TP4" x="235.92000000000002" y="44.2" z="1120.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L2TP4" x="220.495" y="44.2" z="1115.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L2TP4" x="251.34500000000003" y="44.2" z="1115.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L2TP4" x="235.92000000000002" y="74.17500000000001" z="1115.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L2TP4" x="235.92000000000002" y="14.225000000000003" z="1115.5" unit="mm" />
+      <position name="hodo_pos_L2BP4" x="235.92000000000002" y="-44.2" z="1115.5" unit="mm" />
+      <position name="hodo_forecover_pos_L2BP4" x="235.92000000000002" y="-44.2" z="1110.625" unit="mm" />
+      <position name="hodo_postcover_pos_L2BP4" x="235.92000000000002" y="-44.2" z="1120.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L2BP4" x="220.495" y="-44.2" z="1115.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L2BP4" x="251.34500000000003" y="-44.2" z="1115.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L2BP4" x="235.92000000000002" y="-14.225000000000003" z="1115.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L2BP4" x="235.92000000000002" y="-74.17500000000001" z="1115.5" unit="mm" />
+      <position name="hodo_bufferT_pos" x="153.99" y="54.2" z="1109.5" unit="mm" />
+      <position name="hodo_bufferB_pos" x="153.99" y="-54.2" z="1109.5" unit="mm" />
+      <position name="front_flange_1inworld_volumepos" x="2.1420000000000003" y="0" z="137.80000000000001" unit="cm" />
+      <position name="back_flange_1inworld_volumepos" x="-12.608499999999999" y="0" z="180.80000000000001" unit="cm" />
+      <position name="ECAL_chamber_1inworld_volumepos" x="-11.940800000000001" y="0" z="159.30000000000001" unit="cm" />
+      <position name="al_honeycomb_1inworld_volumepos" x="-18.858000000000001" y="0" z="155.80000000000001" unit="cm" />
+      <position name="layer_1_top_1inworld_volumepos" x="4.1920000000000002" y="8.0999999999999996" z="152.80000000000001" unit="cm" />
+      <position name="layer_2_top_1inworld_volumepos" x="4.1920000000000002" y="6.6899999999999995" z="152.80000000000001" unit="cm" />
+      <position name="layer_3_top_1inworld_volumepos" x="4.1920000000000002" y="5.2799999999999994" z="152.80000000000001" unit="cm" />
+      <position name="layer_4_top_1inworld_volumepos" x="4.1920000000000002" y="3.8699999999999992" z="152.80000000000001" unit="cm" />
+      <position name="layer_1_bottom_1inworld_volumepos" x="4.1920000000000002" y="-4.0999999999999996" z="152.80000000000001" unit="cm" />
+      <position name="layer_2_bottom_1inworld_volumepos" x="4.1920000000000002" y="-5.5099999999999998" z="152.80000000000001" unit="cm" />
+      <position name="layer_3_bottom_1inworld_volumepos" x="4.1920000000000002" y="-6.9199999999999999" z="152.80000000000001" unit="cm" />
+      <position name="layer_4_bottom_1inworld_volumepos" x="4.1920000000000002" y="-8.3300000000000001" z="152.80000000000001" unit="cm" />
+      <position name="layer_5T_left_1inworld_volumepos" x="4.1920000000000002" y="2.46" z="152.80000000000001" unit="cm" />
+      <position name="layer_5B_left_1inworld_volumepos" x="4.1920000000000002" y="-2.6899999999999995" z="152.80000000000001" unit="cm" />
+      <position name="steel_bar_1inworld_volumepos" x="-35.357999999999997" y="0.90000000000000002" z="152.80000000000001" unit="cm" />
+      <position name="cu_Tpipe_inner_left_1inworld_volumepos" x="1.6420000000000003" y="2.7000000000000002" z="152.80000000000001" unit="cm" />
+      <rotation name="cu_Tpipe_inner_left_1inworld_volumerot" x="0" y="-0.95599999999999996" z="0" unit="deg" />
+      <position name="cu_Tpipe_inner_right_1inworld_volumepos" x="-9.1580000000000013" y="2.7000000000000002" z="152.80000000000001" unit="cm" />
+      <rotation name="cu_Tpipe_inner_right_1inworld_volumerot" x="0" y="9.6799999999999997" z="0" unit="deg" />
+      <position name="cu_Bpipe_inner_left_1inworld_volumepos" x="1.6420000000000003" y="-2.7000000000000002" z="152.80000000000001" unit="cm" />
+      <rotation name="cu_Bpipe_inner_left_1inworld_volumerot" x="0" y="-0.95599999999999996" z="0" unit="deg" />
+      <position name="cu_Bpipe_inner_right_1inworld_volumepos" x="-9.1580000000000013" y="-2.7000000000000002" z="152.80000000000001" unit="cm" />
+      <rotation name="cu_Bpipe_inner_right_1inworld_volumerot" x="0" y="9.6799999999999997" z="0" unit="deg" />
+      <position name="cu_Tpipe_outer_right1_1inworld_volumepos" x="-10.858000000000001" y="1.3999999999999999" z="154.30000000000001" unit="cm" />
+      <rotation name="cu_Tpipe_outer_right1_1inworld_volumerot" x="0" y="10" z="0" unit="deg" />
+      <position name="cu_Tpipe_outer_right2_1inworld_volumepos" x="-27.858000000000001" y="1.3999999999999999" z="154.30000000000001" unit="cm" />
+      <position name="cu_Tpipe_outer_right3_1inworld_volumepos" x="-34.857999999999997" y="1.5" z="142.10000000000002" unit="cm" />
+      <rotation name="cu_Tpipe_outer_right3_1inworld_volumerot" x="-0" y="90" z="0" unit="deg" />
+      <position name="cu_Bpipe_outer_right_1inworld_volumepos" x="-34.857999999999997" y="-1.5" z="142.10000000000002" unit="cm" />
+      <rotation name="cu_Bpipe_outer_right_1inworld_volumerot" x="-0" y="90" z="0" unit="deg" />
+      <position name="cu_Bpipe_outer_right1_1inworld_volumepos" x="-10.858000000000001" y="-1.3999999999999999" z="154.30000000000001" unit="cm" />
+      <rotation name="cu_Bpipe_outer_right1_1inworld_volumerot" x="0" y="10" z="0" unit="deg" />
+      <position name="cu_Bpipe_outer_right2_1inworld_volumepos" x="-27.858000000000001" y="-1.3999999999999999" z="154.30000000000001" unit="cm" />
+      <position name="al_pipe_across_top1_1inworld_volumepos" x="2.1420000000000003" y="9" z="142.10000000000002" unit="cm" />
+      <rotation name="al_pipe_across_top1_1inworld_volumerot" x="-90" y="86.999999999999957" z="180" unit="deg" />
+      <position name="al_pipe_across_top2_1inworld_volumepos" x="2.1420000000000003" y="4" z="142.10000000000002" unit="cm" />
+      <rotation name="al_pipe_across_top2_1inworld_volumerot" x="-90" y="89.000000000000099" z="180" unit="deg" />
+      <position name="al_pipe_across_bottom1_1inworld_volumepos" x="2.1420000000000003" y="-9" z="142.10000000000002" unit="cm" />
+      <rotation name="al_pipe_across_bottom1_1inworld_volumerot" x="90" y="86.999999999999957" z="0" unit="deg" />
+      <position name="al_pipe_across_bottom2_1inworld_volumepos" x="2.1420000000000003" y="-4" z="142.10000000000002" unit="cm" />
+      <rotation name="al_pipe_across_bottom2_1inworld_volumerot" x="90" y="89.000000000000099" z="0" unit="deg" />
+      <position name="cu_plate_top_left_1inworld_volumepos" x="22.141999999999999" y="1.6000000000000001" z="152.80000000000001" unit="cm" />
+      <position name="cu_plate_bottom_left_1inworld_volumepos" x="22.141999999999999" y="-1.6000000000000001" z="152.80000000000001" unit="cm" />
+      <position name="cu_plate_top_right_1inworld_volumepos" x="-20.858000000000001" y="1.6000000000000001" z="152.80000000000001" unit="cm" />
+      <position name="cu_plate_bottom_right_1inworld_volumepos" x="-20.858000000000001" y="-1.6000000000000001" z="152.80000000000001" unit="cm" />
+      <position name="cu_plate_top_middle_1inworld_volumepos" x="-3.3579999999999997" y="3.1000000000000001" z="152.80000000000001" unit="cm" />
+      <position name="cu_plate_bottom_middle_1inworld_volumepos" x="-3.3579999999999997" y="-3.1000000000000001" z="152.80000000000001" unit="cm" />
+      <position name="hodo_flange_1intracking_volumepos" x="2.1170000000000004" y="0" z="134.30000000000001" unit="cm" />
+      <position name="arms1_block1_1intracking_volumepos" x="21.517000000000003" y="14.938225000000001" z="132.70000000000002" unit="cm" />
+      <position name="arms1_block2_1intracking_volumepos" x="9.5170000000000012" y="14.938225000000001" z="132.70000000000002" unit="cm" />
+      <position name="arms1_block3_1intracking_volumepos" x="21.517000000000003" y="-14.938225000000001" z="132.70000000000002" unit="cm" />
+      <position name="arms1_block4_1intracking_volumepos" x="9.5170000000000012" y="-14.938225000000001" z="132.70000000000002" unit="cm" />
+      <position name="cross_bar_top_1intracking_volumepos" x="15.517000000000003" y="16.34" z="132.70000000000002" unit="cm" />
+      <position name="cross_bar_bottom_1intracking_volumepos" x="15.517000000000003" y="-16.34" z="132.70000000000002" unit="cm" />
+      <position name="support_arm_bottom_left_plus_block_1intracking_volumepos" x="21.517000000000003" y="-12.771562277258594" z="121.10000000000001" unit="cm" />
+      <position name="support_arm_bottom_right_1intracking_volumepos" x="9.5170000000000012" y="-12.771562277258594" z="121.10000000000001" unit="cm" />
+      <position name="support_arm_top_left_1intracking_volumepos" x="21.517000000000003" y="12.771562277258594" z="121.10000000000001" unit="cm" />
+      <rotation name="support_arm_top_left_1intracking_volumerot" x="0" y="-0" z="180" unit="deg" />
+      <position name="support_arm_top_right_1intracking_volumepos" x="9.5170000000000012" y="12.771562277258594" z="121.10000000000001" unit="cm" />
+      <rotation name="support_arm_top_right_1intracking_volumerot" x="0" y="-0" z="180" unit="deg" />
+      <position name="u_support_bar_bottom_1intracking_volumepos" x="15.517000000000003" y="-9.8400000000000034" z="110.899" unit="cm" />
+      <position name="u_support_bar_upper1_1intracking_volumepos" x="15.517000000000003" y="-8.5400000000000027" z="110.65000000000001" unit="cm" />
+      <position name="u_support_bar_upper2_1intracking_volumepos" x="15.517000000000003" y="-8.5400000000000027" z="111.2" unit="cm" />
+      <position name="u_support_bar_top_1intracking_volumepos" x="15.517000000000003" y="9.8400000000000034" z="110.899" unit="cm" />
+      <position name="u_support_bar_upper3_1intracking_volumepos" x="15.517000000000003" y="8.5400000000000027" z="110.65000000000001" unit="cm" />
+      <position name="u_support_bar_upper4_1intracking_volumepos" x="15.517000000000003" y="8.5400000000000027" z="111.2" unit="cm" />
+      <constant name="svt_chamber_box_z" value="609.6" />
+      <constant name="svt_chamber_flare1_z" value="1285.621" />
+      <constant name="svt_chamber_flare2_z" value="1478.407" />
+      <constant name="svt_chamber_flange_z" value="1614.297" />
+      <constant name="svt_chamber_x" value="21.17" />
+      <constant name="svt_chamber_z" value="1318-1623.822" />
+    </define>
+    <materials>
+      <element Z="1" formula="H" name="H">
+        <atom type="A" unit="g/mol" value="1.00794" />
+      </element>
+      <element Z="82" formula="Pb" name="Pb">
+        <atom type="A" unit="g/mol" value="207.217" />
+      </element>
+      <element Z="74" formula="W" name="W">
+        <atom type="A" unit="g/mol" value="183.842" />
+      </element>
+      <element Z="8" formula="O" name="O">
+        <atom type="A" unit="g/mol" value="15.9994" />
+      </element>
+      <element Z="6" formula="C" name="C">
+        <atom type="A" unit="g/mol" value="12.0107" />
+      </element>
+      <element Z="22" formula="Ti" name="Ti">
+        <atom type="A" unit="g/mol" value="47.8667" />
+      </element>
+      <material name="Vacuum">
+        <D type="density" unit="g/cm3" value="0.00000001" />
+        <fraction n="1" ref="H" />
+      </material>
+      <material name="WorldMaterial">
+        <D type="density" unit="g/cm3" value="0.0000000000000001" />
+        <fraction n="1.0" ref="Vacuum" />
+      </material>
+      <material name="TrackingMaterial">
+        <D type="density" unit="g/cm3" value="0.0000000000000001" />
+        <fraction n="1.0" ref="Vacuum" />
+      </material>
+      <material name="LeadTungstate">
+        <D value="8.28" unit="g/cm3" type="density" />
+        <composite n="1" ref="Pb" />
+        <composite n="1" ref="W" />
+        <composite n="4" ref="O" />
+      </material>
+      <material name="EJ204_PlasticScintillator">
+        <D value="1.032" unit="g/cm3" type="density" />
+        <fraction n="0.523618" ref="H" />
+        <fraction n="0.476382" ref="C" />
+      </material>
+      <material name="TitaniumDioxide">
+        <D value="4.23" unit="g/cm3" type="density" />
+        <composite n="1" ref="Ti" />
+        <composite n="2" ref="O" />
+      </material>
+      <material name="Mylar">
+        <D value="1.4" unit="g/cm3" type="density" />
+        <fraction n="0.041958" ref="H" />
+        <fraction n="0.625017" ref="C" />
+        <fraction n="0.333025" ref="O" />
+      </material>
+      <material name="GenericFoam">
+        <D value="0.052" unit="g/cm3" type="density" />
+        <fraction n="0.5" ref="H" />
+        <fraction n="0.5" ref="C" />
+      </material>
+      <element name="Al" formula="Al" Z="13">
+        <atom type="A" unit="g/mol" value="26.9815" />
+      </element>
+      <material name="Aluminum">
+        <RL type="X0" unit="cm" value="8.89632" />
+        <NIL type="lambda" unit="cm" value="38.8766" />
+        <D type="density" unit="g/cm3" value="2.699" />
+        <composite n="1" ref="Al" />
+      </material>
+      <element name="Si" formula="Si" Z="14">
+        <atom type="A" unit="g/mol" value="28.0854" />
+      </element>
+      <material name="Silicon">
+        <RL type="X0" unit="cm" value="9.36607" />
+        <NIL type="lambda" unit="cm" value="45.7531" />
+        <D type="density" unit="g/cm3" value="2.33" />
+        <composite n="1" ref="Si" />
+      </material>
+      <element name="N" formula="N" Z="7">
+        <atom type="A" unit="g/mol" value="14.0068" />
+      </element>
+      <material name="Kapton">
+        <D value="1.43" unit="g/cm3" />
+        <composite n="22" ref="C" />
+        <composite n="10" ref="H" />
+        <composite n="2" ref="N" />
+        <composite n="5" ref="O" />
+      </material>
+      <material name="Epoxy">
+        <D type="density" value="1.3" unit="g/cm3" />
+        <composite n="44" ref="H" />
+        <composite n="15" ref="C" />
+        <composite n="7" ref="O" />
+      </material>
+      <material name="CarbonFiber">
+        <D type="density" value="1.5" unit="g/cm3" />
+        <fraction n="0.65" ref="C" />
+        <fraction n="0.35" ref="Epoxy" />
+      </material>
+      <element name="Cl" formula="Cl" Z="17">
+        <atom type="A" unit="g/mol" value="35.4526" />
+      </element>
+      <material name="Quartz">
+        <D type="density" value="2.2" unit="g/cm3" />
+        <composite n="1" ref="Si" />
+        <composite n="2" ref="O" />
+      </material>
+      <material name="G10">
+        <D type="density" value="1.7" unit="g/cm3" />
+        <fraction n="0.08" ref="Cl" />
+        <fraction n="0.773" ref="Quartz" />
+        <fraction n="0.147" ref="Epoxy" />
+      </material>
+      <material name="Polystyrene">
+        <D value="1.032" unit="g/cm3" />
+        <composite n="19" ref="C" />
+        <composite n="21" ref="H" />
+      </material>
+      <material name="Carbon">
+        <RL type="X0" unit="cm" value="21.3485" />
+        <NIL type="lambda" unit="cm" value="40.1008" />
+        <D type="density" unit="g/cm3" value="2" />
+        <composite n="1" ref="C" />
+      </material>
+      <material name="G4_Al" Z="13">
+        <D unit="g/cm3" value="2.6989999999999998" />
+        <atom unit="g/mole" value="26.981538" />
+      </material>
+      <material name="AlHoneycomb" Z="13">
+        <D unit="g/cm3" value="0.13" />
+        <atom unit="g/mole" value="26.981538" />
+      </material>
+      <element name="MANGANESE_elm" formula="MN" Z="25">
+        <atom unit="g/mole" value="54.938048999999999" />
+      </element>
+      <element name="SILICON_elm" formula="SI" Z="14">
+        <atom unit="g/mole" value="28.0855" />
+      </element>
+      <element name="CHROMIUM_elm" formula="CR" Z="24">
+        <atom unit="g/mole" value="51.996099999999998" />
+      </element>
+      <element name="NICKEL_elm" formula="NI" Z="28">
+        <atom unit="g/mole" value="58.693399999999997" />
+      </element>
+      <element name="IRON_elm" formula="FE" Z="26">
+        <atom unit="g/mole" value="55.844999999999999" />
+      </element>
+      <material name="StainlessSteel">
+        <D unit="g/cm3" value="8.0199999999999996" />
+        <fraction n="0.18999999761581421" ref="CHROMIUM_elm" />
+        <fraction n="0.68000000715255737" ref="IRON_elm" />
+        <fraction n="0.019999999552965164" ref="MANGANESE_elm" />
+        <fraction n="0.10000000149011612" ref="NICKEL_elm" />
+        <fraction n="0.0099999997764825821" ref="SILICON_elm" />
+      </material>
+      <material name="G4_Cu" Z="29">
+        <D unit="g/cm3" value="8.9600000000000009" />
+        <atom unit="g/mole" value="63.545645059999998" />
+      </material>
+      <element name="OXYGEN_elm" formula="O" Z="8">
+        <atom unit="g/mole" value="15.9994" />
+      </element>
+      <element name="CARBON_elm" formula="C" Z="6">
+        <atom unit="g/mole" value="12.0107" />
+      </element>
+      <element name="HYDROGEN_elm" formula="H" Z="1">
+        <atom unit="g/mole" value="1.0079400000000001" />
+      </element>
+      <material name="G10_FR4">
+        <D unit="g/cm3" value="1.8500000000000001" />
+        <fraction n="0.40416482090950012" ref="CARBON_elm" />
+        <fraction n="0.067835167050361633" ref="HYDROGEN_elm" />
+        <fraction n="0.28119435906410217" ref="OXYGEN_elm" />
+        <fraction n="0.24680563807487488" ref="SILICON_elm" />
+      </material>
+      <material name="SiO2">
+        <D unit="g/cm3" value="2.2000000000000002" />
+        <fraction n="0.53256505727767944" ref="OXYGEN_elm" />
+        <fraction n="0.46743491291999817" ref="SILICON_elm" />
+      </material>
+      <element Z="26" formula="Fe" name="Iron">
+        <atom value="55.845" />
+      </element>
+      <element Z="24" formula="Cr" name="Chromium">
+        <atom value="51.9961" />
+      </element>
+      <element Z="28" formula="Ni" name="Nickel">
+        <atom value="58.6934" />
+      </element>
+      <material formula=" " name="Stainless_304">
+        <D value="8.00" />
+        <fraction n="0.733078" ref="Iron" />
+        <fraction n="0.191516" ref="Chromium" />
+        <fraction n="0.075406" ref="Nickel" />
+      </material>
+      <material Z="1" name="G4_Galactic" state="gas">
+        <T unit="K" value="2.73" />
+        <P unit="pascal" value="3e-18" />
+        <!-- <MEE unit="eV" value="21.8"/> -->
+        <D unit="g/cm3" value="2e-25" />
+        <atom unit="g/mole" value="1.01" />
+      </material>
+    </materials>
+    <solids>
+      <box name="world_box" x="world_x" y="world_y" z="world_z" />
+      <tube name="tracking_cylinder" deltaphi="6.283185307179586" rmin="0.0" rmax="tracking_region_radius" z="2*tracking_region_zmax" />
+      <box name="baseBox" x="406.4" y="1282.6999999999998" z="171.196" />
+      <box name="base_plateBox" x="406.4" y="1282.6999999999998" z="6.35" />
+      <box name="support_plate_bottom_L14Box" x="234.95" y="456.4" z="9.524999999999999" />
+      <box name="support_plate_top_L14Box" x="234.95" y="456.4" z="9.524999999999999" />
+      <box name="support_plate_bottom_L46Box" x="342.9" y="533.4" z="12.7" />
+      <box name="support_plate_top_L46Box" x="342.9" y="533.4" z="12.7" />
+      <box name="module_L1b_halfmodule_axialBox" x="14.525" y="30.0" z="0.2" />
+      <box name="module_L1b_halfmodule_axial_sensorBox" x="14.525" y="30.0" z="0.2" />
+      <box name="module_L1b_halfmodule_axial_sensor_activeBox" x="14.025" y="30.0" z="0.2" />
+      <box name="module_L1b_halfmodule_stereoBox" x="14.525" y="30.0" z="0.2" />
+      <box name="module_L1b_halfmodule_stereo_sensorBox" x="14.525" y="30.0" z="0.2" />
+      <box name="module_L1b_halfmodule_stereo_sensor_activeBox" x="14.025" y="30.0" z="0.2" />
+      <box name="module_L1t_halfmodule_axialBox" x="14.525" y="30.0" z="0.2" />
+      <box name="module_L1t_halfmodule_axial_sensorBox" x="14.525" y="30.0" z="0.2" />
+      <box name="module_L1t_halfmodule_axial_sensor_activeBox" x="14.025" y="30.0" z="0.2" />
+      <box name="module_L1t_halfmodule_stereoBox" x="14.525" y="30.0" z="0.2" />
+      <box name="module_L1t_halfmodule_stereo_sensorBox" x="14.525" y="30.0" z="0.2" />
+      <box name="module_L1t_halfmodule_stereo_sensor_activeBox" x="14.025" y="30.0" z="0.2" />
+      <box name="module_L2b_halfmodule_axialBox" x="14.525" y="30.0" z="0.2" />
+      <box name="module_L2b_halfmodule_axial_sensorBox" x="14.525" y="30.0" z="0.2" />
+      <box name="module_L2b_halfmodule_axial_sensor_activeBox" x="14.025" y="30.0" z="0.2" />
+      <box name="module_L2b_halfmodule_stereoBox" x="14.525" y="30.0" z="0.2" />
+      <box name="module_L2b_halfmodule_stereo_sensorBox" x="14.525" y="30.0" z="0.2" />
+      <box name="module_L2b_halfmodule_stereo_sensor_activeBox" x="14.025" y="30.0" z="0.2" />
+      <box name="module_L2t_halfmodule_axialBox" x="14.525" y="30.0" z="0.2" />
+      <box name="module_L2t_halfmodule_axial_sensorBox" x="14.525" y="30.0" z="0.2" />
+      <box name="module_L2t_halfmodule_axial_sensor_activeBox" x="14.025" y="30.0" z="0.2" />
+      <box name="module_L2t_halfmodule_stereoBox" x="14.525" y="30.0" z="0.2" />
+      <box name="module_L2t_halfmodule_stereo_sensorBox" x="14.525" y="30.0" z="0.2" />
+      <box name="module_L2t_halfmodule_stereo_sensor_activeBox" x="14.025" y="30.0" z="0.2" />
+      <box name="module_L3b_halfmodule_axialBox" x="47.17" y="200.0" z="1.8405" />
+      <box name="module_L3b_halfmodule_axial_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L3b_halfmodule_axial_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L3b_halfmodule_axial_laminationBox" x="38.0" y="100.0" z="0.05" />
+      <box name="module_L3b_halfmodule_axial_cfBox" x="36.02" y="100.0" z="0.203" />
+      <box name="module_L3b_halfmodule_axial_hybridBox" x="40.34" y="70.0" z="1.5875" />
+      <box name="module_L3b_halfmodule_stereoBox" x="47.17" y="200.0" z="1.8405" />
+      <box name="module_L3b_halfmodule_stereo_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L3b_halfmodule_stereo_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L3b_halfmodule_stereo_laminationBox" x="38.0" y="100.0" z="0.05" />
+      <box name="module_L3b_halfmodule_stereo_cfBox" x="36.02" y="100.0" z="0.203" />
+      <box name="module_L3b_halfmodule_stereo_hybridBox" x="40.34" y="70.0" z="1.5875" />
+      <box name="module_L3t_halfmodule_axialBox" x="47.17" y="200.0" z="1.8405" />
+      <box name="module_L3t_halfmodule_axial_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L3t_halfmodule_axial_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L3t_halfmodule_axial_laminationBox" x="38.0" y="100.0" z="0.05" />
+      <box name="module_L3t_halfmodule_axial_cfBox" x="36.02" y="100.0" z="0.203" />
+      <box name="module_L3t_halfmodule_axial_hybridBox" x="40.34" y="70.0" z="1.5875" />
+      <box name="module_L3t_halfmodule_stereoBox" x="47.17" y="200.0" z="1.8405" />
+      <box name="module_L3t_halfmodule_stereo_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L3t_halfmodule_stereo_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L3t_halfmodule_stereo_laminationBox" x="38.0" y="100.0" z="0.05" />
+      <box name="module_L3t_halfmodule_stereo_cfBox" x="36.02" y="100.0" z="0.203" />
+      <box name="module_L3t_halfmodule_stereo_hybridBox" x="40.34" y="70.0" z="1.5875" />
+      <box name="module_L4b_halfmodule_axialBox" x="47.17" y="200.0" z="1.8405" />
+      <box name="module_L4b_halfmodule_axial_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L4b_halfmodule_axial_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L4b_halfmodule_axial_laminationBox" x="38.0" y="100.0" z="0.05" />
+      <box name="module_L4b_halfmodule_axial_cfBox" x="36.02" y="100.0" z="0.203" />
+      <box name="module_L4b_halfmodule_axial_hybridBox" x="40.34" y="70.0" z="1.5875" />
+      <box name="module_L4b_halfmodule_stereoBox" x="47.17" y="200.0" z="1.8405" />
+      <box name="module_L4b_halfmodule_stereo_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L4b_halfmodule_stereo_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L4b_halfmodule_stereo_laminationBox" x="38.0" y="100.0" z="0.05" />
+      <box name="module_L4b_halfmodule_stereo_cfBox" x="36.02" y="100.0" z="0.203" />
+      <box name="module_L4b_halfmodule_stereo_hybridBox" x="40.34" y="70.0" z="1.5875" />
+      <box name="module_L4t_halfmodule_axialBox" x="47.17" y="200.0" z="1.8405" />
+      <box name="module_L4t_halfmodule_axial_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L4t_halfmodule_axial_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L4t_halfmodule_axial_laminationBox" x="38.0" y="100.0" z="0.05" />
+      <box name="module_L4t_halfmodule_axial_cfBox" x="36.02" y="100.0" z="0.203" />
+      <box name="module_L4t_halfmodule_axial_hybridBox" x="40.34" y="70.0" z="1.5875" />
+      <box name="module_L4t_halfmodule_stereoBox" x="47.17" y="200.0" z="1.8405" />
+      <box name="module_L4t_halfmodule_stereo_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L4t_halfmodule_stereo_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L4t_halfmodule_stereo_laminationBox" x="38.0" y="100.0" z="0.05" />
+      <box name="module_L4t_halfmodule_stereo_cfBox" x="36.02" y="100.0" z="0.203" />
+      <box name="module_L4t_halfmodule_stereo_hybridBox" x="40.34" y="70.0" z="1.5875" />
+      <box name="module_L5b_halfmodule_axial_holeBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L5b_halfmodule_axial_hole_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L5b_halfmodule_axial_hole_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L5b_halfmodule_axial_hole_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L5b_halfmodule_axial_slotBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L5b_halfmodule_axial_slot_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L5b_halfmodule_axial_slot_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L5b_halfmodule_axial_slot_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L5b_halfmodule_stereo_holeBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L5b_halfmodule_stereo_hole_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L5b_halfmodule_stereo_hole_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L5b_halfmodule_stereo_hole_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L5b_halfmodule_stereo_slotBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L5b_halfmodule_stereo_slot_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L5b_halfmodule_stereo_slot_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L5b_halfmodule_stereo_slot_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L5t_halfmodule_axial_holeBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L5t_halfmodule_axial_hole_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L5t_halfmodule_axial_hole_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L5t_halfmodule_axial_hole_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L5t_halfmodule_axial_slotBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L5t_halfmodule_axial_slot_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L5t_halfmodule_axial_slot_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L5t_halfmodule_axial_slot_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L5t_halfmodule_stereo_holeBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L5t_halfmodule_stereo_hole_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L5t_halfmodule_stereo_hole_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L5t_halfmodule_stereo_hole_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L5t_halfmodule_stereo_slotBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L5t_halfmodule_stereo_slot_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L5t_halfmodule_stereo_slot_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L5t_halfmodule_stereo_slot_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L6b_halfmodule_axial_holeBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L6b_halfmodule_axial_hole_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L6b_halfmodule_axial_hole_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L6b_halfmodule_axial_hole_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L6b_halfmodule_axial_slotBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L6b_halfmodule_axial_slot_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L6b_halfmodule_axial_slot_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L6b_halfmodule_axial_slot_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L6b_halfmodule_stereo_holeBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L6b_halfmodule_stereo_hole_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L6b_halfmodule_stereo_hole_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L6b_halfmodule_stereo_hole_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L6b_halfmodule_stereo_slotBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L6b_halfmodule_stereo_slot_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L6b_halfmodule_stereo_slot_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L6b_halfmodule_stereo_slot_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L6t_halfmodule_axial_holeBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L6t_halfmodule_axial_hole_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L6t_halfmodule_axial_hole_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L6t_halfmodule_axial_hole_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L6t_halfmodule_axial_slotBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L6t_halfmodule_axial_slot_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L6t_halfmodule_axial_slot_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L6t_halfmodule_axial_slot_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L6t_halfmodule_stereo_holeBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L6t_halfmodule_stereo_hole_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L6t_halfmodule_stereo_hole_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L6t_halfmodule_stereo_hole_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L6t_halfmodule_stereo_slotBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L6t_halfmodule_stereo_slot_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L6t_halfmodule_stereo_slot_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L6t_halfmodule_stereo_slot_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L7b_halfmodule_axial_holeBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L7b_halfmodule_axial_hole_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L7b_halfmodule_axial_hole_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L7b_halfmodule_axial_hole_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L7b_halfmodule_axial_slotBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L7b_halfmodule_axial_slot_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L7b_halfmodule_axial_slot_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L7b_halfmodule_axial_slot_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L7b_halfmodule_stereo_holeBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L7b_halfmodule_stereo_hole_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L7b_halfmodule_stereo_hole_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L7b_halfmodule_stereo_hole_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L7b_halfmodule_stereo_slotBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L7b_halfmodule_stereo_slot_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L7b_halfmodule_stereo_slot_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L7b_halfmodule_stereo_slot_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L7t_halfmodule_axial_holeBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L7t_halfmodule_axial_hole_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L7t_halfmodule_axial_hole_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L7t_halfmodule_axial_hole_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L7t_halfmodule_axial_slotBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L7t_halfmodule_axial_slot_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L7t_halfmodule_axial_slot_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L7t_halfmodule_axial_slot_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L7t_halfmodule_stereo_holeBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L7t_halfmodule_stereo_hole_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L7t_halfmodule_stereo_hole_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L7t_halfmodule_stereo_hole_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L7t_halfmodule_stereo_slotBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L7t_halfmodule_stereo_slot_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L7t_halfmodule_stereo_slot_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L7t_halfmodule_stereo_slot_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="BeamLeftBox" x="211.6" y="382.492" z="0.001" />
+      <box name="BeamLeftVolume_component0Box" x="211.6" y="382.492" z="0.001" />
+      <box name="BeamLeftVolume_component0Sensor0Box" x="211.6" y="382.492" z="0.001" />
+      <box name="ElectronGapBox" x="196.26999999999998" y="92.46999999999997" z="0.001" />
+      <box name="ElectronGapVolume_component0Box" x="196.26999999999998" y="92.46999999999997" z="0.001" />
+      <box name="ElectronGapVolume_component0Sensor0Box" x="196.26999999999998" y="92.46999999999997" z="0.001" />
+      <box name="BeamRightBox" x="214.6" y="293.38800000000003" z="0.001" />
+      <box name="BeamRightVolume_component0Box" x="214.6" y="293.38800000000003" z="0.001" />
+      <box name="BeamRightVolume_component0Sensor0Box" x="214.6" y="293.38800000000003" z="0.001" />
+      <trd name="crystal_trap" x1="13.3" x2="16.0" y1="13.3" y2="16.0" z="160.0" />
+      <box name="hodo_pixel_L1TP0" x="15.7" y="59.9" z="9.5" />
+      <box name="hodo_cover_L1TP0" x="15.7" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L1TP0" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L1TP0" x="15.799999999999999" y="0.05" z="10.0" />
+      <box name="hodo_pixel_L1BP0" x="15.7" y="59.9" z="9.5" />
+      <box name="hodo_cover_L1BP0" x="15.7" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L1BP0" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L1BP0" x="15.799999999999999" y="0.05" z="10.0" />
+      <box name="hodo_pixel_L1TP1" x="34.1" y="59.9" z="9.5" />
+      <box name="hodo_cover_L1TP1" x="34.1" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L1TP1" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L1TP1" x="34.2" y="0.05" z="10.0" />
+      <box name="hodo_pixel_L1BP1" x="34.1" y="59.9" z="9.5" />
+      <box name="hodo_cover_L1BP1" x="34.1" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L1BP1" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L1BP1" x="34.2" y="0.05" z="10.0" />
+      <box name="hodo_pixel_L1TP2" x="44.0" y="59.9" z="9.5" />
+      <box name="hodo_cover_L1TP2" x="44.0" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L1TP2" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L1TP2" x="44.1" y="0.05" z="10.0" />
+      <box name="hodo_pixel_L1BP2" x="44.0" y="59.9" z="9.5" />
+      <box name="hodo_cover_L1BP2" x="44.0" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L1BP2" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L1BP2" x="44.1" y="0.05" z="10.0" />
+      <box name="hodo_pixel_L1TP3" x="44.0" y="59.9" z="9.5" />
+      <box name="hodo_cover_L1TP3" x="44.0" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L1TP3" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L1TP3" x="44.1" y="0.05" z="10.0" />
+      <box name="hodo_pixel_L1BP3" x="44.0" y="59.9" z="9.5" />
+      <box name="hodo_cover_L1BP3" x="44.0" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L1BP3" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L1BP3" x="44.1" y="0.05" z="10.0" />
+      <box name="hodo_pixel_L1TP4" x="44.0" y="59.9" z="9.5" />
+      <box name="hodo_cover_L1TP4" x="44.0" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L1TP4" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L1TP4" x="44.1" y="0.05" z="10.0" />
+      <box name="hodo_pixel_L1BP4" x="44.0" y="59.9" z="9.5" />
+      <box name="hodo_cover_L1BP4" x="44.0" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L1BP4" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L1BP4" x="44.1" y="0.05" z="10.0" />
+      <box name="hodo_pixel_L2TP0" x="19.0" y="59.9" z="9.5" />
+      <box name="hodo_cover_L2TP0" x="19.0" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L2TP0" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L2TP0" x="19.1" y="0.05" z="10.0" />
+      <box name="hodo_pixel_L2BP0" x="19.0" y="59.9" z="9.5" />
+      <box name="hodo_cover_L2BP0" x="19.0" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L2BP0" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L2BP0" x="19.1" y="0.05" z="10.0" />
+      <box name="hodo_pixel_L2TP1" x="44.0" y="59.9" z="9.5" />
+      <box name="hodo_cover_L2TP1" x="44.0" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L2TP1" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L2TP1" x="44.1" y="0.05" z="10.0" />
+      <box name="hodo_pixel_L2BP1" x="44.0" y="59.9" z="9.5" />
+      <box name="hodo_cover_L2BP1" x="44.0" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L2BP1" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L2BP1" x="44.1" y="0.05" z="10.0" />
+      <box name="hodo_pixel_L2TP2" x="44.0" y="59.9" z="9.5" />
+      <box name="hodo_cover_L2TP2" x="44.0" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L2TP2" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L2TP2" x="44.1" y="0.05" z="10.0" />
+      <box name="hodo_pixel_L2BP2" x="44.0" y="59.9" z="9.5" />
+      <box name="hodo_cover_L2BP2" x="44.0" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L2BP2" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L2BP2" x="44.1" y="0.05" z="10.0" />
+      <box name="hodo_pixel_L2TP3" x="44.0" y="59.9" z="9.5" />
+      <box name="hodo_cover_L2TP3" x="44.0" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L2TP3" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L2TP3" x="44.1" y="0.05" z="10.0" />
+      <box name="hodo_pixel_L2BP3" x="44.0" y="59.9" z="9.5" />
+      <box name="hodo_cover_L2BP3" x="44.0" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L2BP3" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L2BP3" x="44.1" y="0.05" z="10.0" />
+      <box name="hodo_pixel_L2TP4" x="30.8" y="59.9" z="9.5" />
+      <box name="hodo_cover_L2TP4" x="30.8" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L2TP4" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L2TP4" x="30.900000000000002" y="0.05" z="10.0" />
+      <box name="hodo_pixel_L2BP4" x="30.8" y="59.9" z="9.5" />
+      <box name="hodo_cover_L2BP4" x="30.8" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L2BP4" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L2BP4" x="30.900000000000002" y="0.05" z="10.0" />
+      <box name="hodo_buffer" x="187.64" y="80.0" z="2.0" />
+      <box name="world_volume_solid" x="2000" y="2000" z="2000" lunit="cm" />
+      <box name="front_flange_box_shape" x="76.835000000000008" y="45.719999999999999" z="2" lunit="cm" />
+      <trap name="front_chamber_trap_shape" z="3" theta="-0.98799999999999999" phi="0" x1="33.119799999999998" x2="33.119799999999998" x3="33.406400000000005" x4="33.406400000000005" y1="1.6000000000000001" y2="1.6000000000000001" alpha1="0" alpha2="0" aunit="deg" lunit="cm" />
+      <subtraction name="front_minus_chamber_shape">
+        <first ref="front_flange_box_shape" />
+        <second ref="front_chamber_trap_shape" />
+        <position name="front_minus_chamber_shapefront_chamber_trap_shapepos" x="-14.6309" y="0" z="0" unit="cm" />
+      </subtraction>
+      <eltube name="flange_photontube_inside_shape" dx="1.1000000000000001" dy="1.1000000000000001" dz="3" lunit="cm" />
+      <subtraction name="front_minus_photontube_shape">
+        <first ref="front_minus_chamber_shape" />
+        <second ref="flange_photontube_inside_shape" />
+        <position name="front_minus_photontube_shapeflange_photontube_inside_shapepos" x="2.0007000000000001" y="0" z="0" unit="cm" />
+        <rotation name="front_minus_photontube_shapeflange_photontube_inside_shaperot" x="0" y="1.7480000000000002" z="0" unit="deg" />
+      </subtraction>
+      <trap name="front_egap_trap_shape" z="3" theta="-4.7960000000000003" phi="0" x1="2.5683000000000002" x2="2.5683000000000002" x3="2.9716000000000005" x4="2.9716000000000005" y1="5.266" y2="5.266" alpha1="0" alpha2="0" aunit="deg" lunit="cm" />
+      <subtraction name="front_minus_egap_shape">
+        <first ref="front_minus_photontube_shape" />
+        <second ref="front_egap_trap_shape" />
+        <position name="front_minus_egap_shapefront_egap_trap_shapepos" x="-4.4683000000000002" y="0" z="0" unit="cm" />
+      </subtraction>
+      <eltube name="flange_egap_inside_tube_shape" dx="2.633" dy="2.633" dz="3" lunit="cm" />
+      <subtraction name="front_minus_egapleft_shape">
+        <first ref="front_minus_egap_shape" />
+        <second ref="flange_egap_inside_tube_shape" />
+        <position name="front_minus_egapleft_shapeflange_egap_inside_tube_shapepos" x="-3.0832999999999999" y="0" z="0" unit="cm" />
+        <rotation name="front_minus_egapleft_shapeflange_egap_inside_tube_shaperot" x="0" y="-0.95599999999999996" z="0" unit="deg" />
+      </subtraction>
+      <eltube name="flange_egap_inside_tube2_shape" dx="2.633" dy="2.633" dz="3" lunit="cm" />
+      <subtraction name="front_flange_shape">
+        <first ref="front_minus_egapleft_shape" />
+        <second ref="flange_egap_inside_tube2_shape" />
+        <position name="front_flange_shapeflange_egap_inside_tube2_shapepos" x="-5.8532000000000002" y="0" z="0" unit="cm" />
+        <rotation name="front_flange_shapeflange_egap_inside_tube2_shaperot" x="0" y="-8.5939999999999994" z="0" unit="deg" />
+      </subtraction>
+      <box name="back_flange_box_shape" x="50.5" y="16" z="2" lunit="cm" />
+      <trap name="back_chamber_trap_shape" z="3" theta="-0.98799999999999999" phi="0" x1="37.227899999999998" x2="37.227899999999998" x3="37.514499999999998" x4="37.514499999999998" y1="1.6000000000000001" y2="1.6000000000000001" alpha1="0" alpha2="0" aunit="deg" lunit="cm" />
+      <subtraction name="back_minus_chamber_shape">
+        <first ref="back_flange_box_shape" />
+        <second ref="back_chamber_trap_shape" />
+        <position name="back_minus_chamber_shapeback_chamber_trap_shapepos" x="-0.62210000000000043" y="0" z="0" unit="cm" />
+      </subtraction>
+      <eltube name="flange_photontube_inside2_shape" dx="1.1000000000000001" dy="1.1000000000000001" dz="3" lunit="cm" />
+      <subtraction name="back_minus_photontube_shape">
+        <first ref="back_minus_chamber_shape" />
+        <second ref="flange_photontube_inside2_shape" />
+        <position name="back_minus_photontube_shapeflange_photontube_inside2_shapepos" x="18.063500000000001" y="0" z="0" unit="cm" />
+        <rotation name="back_minus_photontube_shapeflange_photontube_inside2_shaperot" x="0" y="1.7480000000000002" z="0" unit="deg" />
+      </subtraction>
+      <trap name="back_egap_trap_shape" z="3" theta="-4.7960000000000003" phi="0" x1="8.3492999999999995" x2="8.3492999999999995" x3="8.7525999999999993" x4="8.7525999999999993" y1="5.266" y2="5.266" alpha1="0" alpha2="0" aunit="deg" lunit="cm" />
+      <subtraction name="back_minus_egap_shape">
+        <first ref="back_minus_photontube_shape" />
+        <second ref="back_egap_trap_shape" />
+        <position name="back_minus_egap_shapeback_egap_trap_shapepos" x="6.674199999999999" y="0" z="0" unit="cm" />
+      </subtraction>
+      <eltube name="flange_egap_inside_tube3_shape" dx="2.633" dy="2.633" dz="3" lunit="cm" />
+      <subtraction name="back_minus_egapleft_shape">
+        <first ref="back_minus_egap_shape" />
+        <second ref="flange_egap_inside_tube3_shape" />
+        <position name="back_minus_egapleft_shapeflange_egap_inside_tube3_shapepos" x="10.9497" y="0" z="0" unit="cm" />
+        <rotation name="back_minus_egapleft_shapeflange_egap_inside_tube3_shaperot" x="0" y="-0.95599999999999996" z="0" unit="deg" />
+      </subtraction>
+      <eltube name="flange_egap_inside_tube4_shape" dx="2.633" dy="2.633" dz="3" lunit="cm" />
+      <subtraction name="back_flange_shape">
+        <first ref="back_minus_egapleft_shape" />
+        <second ref="flange_egap_inside_tube4_shape" />
+        <position name="back_flange_shapeflange_egap_inside_tube4_shapepos" x="2.3986999999999994" y="0" z="0" unit="cm" />
+        <rotation name="back_flange_shapeflange_egap_inside_tube4_shaperot" x="0" y="-8.5939999999999994" z="0" unit="deg" />
+      </subtraction>
+      <trap name="chamber_trap_shape" z="45" theta="-1.8640000000000001" phi="0" x1="37.700000000000003" x2="37.700000000000003" x3="40.629000000000005" x4="40.629000000000005" y1="2.8000000000000003" y2="2.8000000000000003" alpha1="0" alpha2="0" aunit="deg" lunit="cm" />
+      <box name="chamber_cutaway_box_shape" x="50" y="1" z="30" lunit="cm" />
+      <subtraction name="chamber_trim1_shape">
+        <first ref="chamber_trap_shape" />
+        <second ref="chamber_cutaway_box_shape" />
+        <position name="chamber_trim1_shapechamber_cutaway_box_shapepos" x="0" y="1.6000000000000001" z="-9" unit="cm" />
+      </subtraction>
+      <box name="chamber_cutaway_box2_shape" x="50" y="1" z="30" lunit="cm" />
+      <subtraction name="chamber_trim2_shape">
+        <first ref="chamber_trim1_shape" />
+        <second ref="chamber_cutaway_box2_shape" />
+        <position name="chamber_trim2_shapechamber_cutaway_box2_shapepos" x="0" y="-1.6000000000000001" z="-9" unit="cm" />
+      </subtraction>
+      <eltube name="photontube_outside_shape" dx="1.3" dy="1.3" dz="23.5" lunit="cm" />
+      <union name="chamber_with_photontube_shape">
+        <first ref="chamber_trim2_shape" />
+        <second ref="photontube_outside_shape" />
+        <position name="chamber_with_photontube_shapephotontube_outside_shapepos" x="16.739699999999999" y="0" z="0" unit="cm" />
+        <rotation name="chamber_with_photontube_shapephotontube_outside_shaperot" x="0" y="1.7480000000000002" z="0" unit="deg" />
+      </union>
+      <trap name="egap_outside_trap_upper_shape" z="45" theta="-4.7960000000000003" phi="0" x1="10.691200000000002" x2="5.2344000000000008" x3="16.741099999999999" x4="11.284300000000002" y1="3.2330000000000001" y2="3.2330000000000001" alpha1="0.26900000000000002" alpha2="0.26900000000000002" aunit="deg" lunit="cm" />
+      <union name="chamber_with_egap_upper_shape">
+        <first ref="chamber_with_photontube_shape" />
+        <second ref="egap_outside_trap_upper_shape" />
+        <position name="chamber_with_egap_upper_shapeegap_outside_trap_upper_shapepos" x="7.7018000000000004" y="1.6165" z="0" unit="cm" />
+      </union>
+      <trap name="egap_outside_trap_lower_shape" z="45" theta="-4.7960000000000003" phi="0" x1="5.2344000000000008" x2="10.691200000000002" x3="11.284300000000002" x4="16.741099999999999" y1="3.2330000000000001" y2="3.2330000000000001" alpha1="-0.26900000000000002" alpha2="-0.26900000000000002" aunit="deg" lunit="cm" />
+      <union name="chamber_with_egap_lower_shape">
+        <first ref="chamber_with_egap_upper_shape" />
+        <second ref="egap_outside_trap_lower_shape" />
+        <position name="chamber_with_egap_lower_shapeegap_outside_trap_lower_shapepos" x="7.7018000000000004" y="-1.6165" z="0" unit="cm" />
+      </union>
+      <box name="chamber_cutaway_box3_shape" x="50" y="1" z="30" lunit="cm" />
+      <subtraction name="chamber_with_egap_trimtop_shape">
+        <first ref="chamber_with_egap_lower_shape" />
+        <second ref="chamber_cutaway_box3_shape" />
+        <position name="chamber_with_egap_trimtop_shapechamber_cutaway_box3_shapepos" x="0" y="3.4329999999999998" z="-9" unit="cm" />
+      </subtraction>
+      <box name="chamber_cutaway_box4_shape" x="50" y="1" z="30" lunit="cm" />
+      <subtraction name="chamber_with_egap_trimbot_shape">
+        <first ref="chamber_with_egap_trimtop_shape" />
+        <second ref="chamber_cutaway_box4_shape" />
+        <position name="chamber_with_egap_trimbot_shapechamber_cutaway_box4_shapepos" x="0" y="-3.4329999999999998" z="-9" unit="cm" />
+      </subtraction>
+      <box name="back_end_box_shape" x="76.835000000000008" y="45.719999999999999" z="5" lunit="cm" />
+      <subtraction name="chamber_outside_trim1_shape">
+        <first ref="chamber_with_egap_trimbot_shape" />
+        <second ref="back_end_box_shape" />
+        <position name="chamber_outside_trim1_shapeback_end_box_shapepos" x="0" y="0" z="-23" unit="cm" />
+      </subtraction>
+      <box name="back_end_box2_shape" x="76.835000000000008" y="45.719999999999999" z="5" lunit="cm" />
+      <subtraction name="chamber_outside_trim2_shape">
+        <first ref="chamber_outside_trim1_shape" />
+        <second ref="back_end_box2_shape" />
+        <position name="chamber_outside_trim2_shapeback_end_box2_shapepos" x="0" y="0" z="23" unit="cm" />
+      </subtraction>
+      <eltube name="photontube_inside_shape" dx="1.1000000000000001" dy="1.1000000000000001" dz="23.5" lunit="cm" />
+      <subtraction name="chamber_minus_photontube_shape">
+        <first ref="chamber_outside_trim2_shape" />
+        <second ref="photontube_inside_shape" />
+        <position name="chamber_minus_photontube_shapephotontube_inside_shapepos" x="16.739699999999999" y="0" z="0" unit="cm" />
+        <rotation name="chamber_minus_photontube_shapephotontube_inside_shaperot" x="0" y="1.7480000000000002" z="0" unit="deg" />
+      </subtraction>
+      <trap name="chamber_inside_trap_shape" z="45.000100000000003" theta="-0.98799999999999999" phi="0" x1="33.1676" x2="33.1676" x3="37.466699999999996" x4="37.466699999999996" y1="1.6000000000000001" y2="1.6000000000000001" alpha1="0" alpha2="0" aunit="deg" lunit="cm" />
+      <subtraction name="chamber_minus_inside_shape">
+        <first ref="chamber_minus_photontube_shape" />
+        <second ref="chamber_inside_trap_shape" />
+        <position name="chamber_minus_inside_shapechamber_inside_trap_shapepos" x="-0.91889999999999938" y="0" z="0" unit="cm" />
+      </subtraction>
+      <trap name="egap_inside_trap_shape" z="45.000100000000003" theta="-4.7960000000000003" phi="0" x1="2.6355000000000004" x2="2.6355000000000004" x3="8.6853999999999996" x4="8.6853999999999996" y1="5.266" y2="5.266" alpha1="0" alpha2="0" aunit="deg" lunit="cm" />
+      <subtraction name="chamber_minus_egapinside_shape">
+        <first ref="chamber_minus_inside_shape" />
+        <second ref="egap_inside_trap_shape" />
+        <position name="chamber_minus_egapinside_shapeegap_inside_trap_shapepos" x="7.8105000000000011" y="0" z="0" unit="cm" />
+      </subtraction>
+      <eltube name="egap_inside_tube_shape" dx="2.633" dy="2.633" dz="24" lunit="cm" />
+      <subtraction name="chamber_minus_egap_left_shape">
+        <first ref="chamber_minus_egapinside_shape" />
+        <second ref="egap_inside_tube_shape" />
+        <position name="chamber_minus_egap_left_shapeegap_inside_tube_shapepos" x="10.640750000000001" y="0" z="0" unit="cm" />
+        <rotation name="chamber_minus_egap_left_shapeegap_inside_tube_shaperot" x="0" y="-0.95599999999999996" z="0" unit="deg" />
+      </subtraction>
+      <tube name="egap_inside_tube2_shape" rmin="0" rmax="2.633" z="48" startphi="0" deltaphi="360" aunit="deg" lunit="cm" />
+      <subtraction name="ECAL_chamber_shape">
+        <first ref="chamber_minus_egap_left_shape" />
+        <second ref="egap_inside_tube2_shape" />
+        <position name="ECAL_chamber_shapeegap_inside_tube2_shapepos" x="4.9802999999999997" y="0" z="0" unit="cm" />
+        <rotation name="ECAL_chamber_shapeegap_inside_tube2_shaperot" x="0" y="-8.5939999999999994" z="0" unit="deg" />
+      </subtraction>
+      <box name="al_honeycomb_shape" x="6" y="1.6000000000000001" z="6" lunit="cm" />
+      <box name="ecal_box_outer1_shape" x="80" y="1.3999999999999999" z="20.100000000000001" lunit="cm" />
+      <box name="ecal_box_inner1_shape" x="78" y="2" z="21" lunit="cm" />
+      <subtraction name="ecal_box_minus_inner1_shape">
+        <first ref="ecal_box_outer1_shape" />
+        <second ref="ecal_box_inner1_shape" />
+        <position name="ecal_box_minus_inner1_shapeecal_box_inner1_shapepos" x="0" y="0.16" z="1.8500000000000001" unit="cm" />
+      </subtraction>
+      <box name="ecal_box_inner2_shape" x="68" y="1.2" z="7.4199999999999999" lunit="cm" />
+      <subtraction name="ecal_box_minus_inner2_shape">
+        <first ref="ecal_box_minus_inner1_shape" />
+        <second ref="ecal_box_inner2_shape" />
+        <position name="ecal_box_minus_inner2_shapeecal_box_inner2_shapepos" x="0" y="0.16" z="-10.050000000000001" unit="cm" />
+      </subtraction>
+      <para name="ppd_0_shape" x="0.59999999999999998" y="1.3999999999999999" z="1.5" alpha="0" theta="0" phi="0" aunit="deg" lunit="cm" />
+      <union name="box_with_ppd_shape">
+        <first ref="ecal_box_minus_inner2_shape" />
+        <second ref="ppd_0_shape" />
+        <position name="box_with_ppd_shapeppd_0_shapepos" x="0" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <para name="ppd_1_shape" x="0.59999999999999998" y="1.3999999999999999" z="1.5" alpha="0" theta="-3.8700000000000001" phi="0" aunit="deg" lunit="cm" />
+      <union name="box_with_ppd1_shape">
+        <first ref="box_with_ppd_shape" />
+        <second ref="ppd_1_shape" />
+        <position name="box_with_ppd1_shapeppd_1_shapepos" x="-5.2400000000000002" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <para name="ppd_2_shape" x="0.59999999999999998" y="1.3999999999999999" z="1.5" alpha="0" theta="-7.7400000000000002" phi="0" aunit="deg" lunit="cm" />
+      <union name="box_with_ppd2_shape">
+        <first ref="box_with_ppd1_shape" />
+        <second ref="ppd_2_shape" />
+        <position name="box_with_ppd2_shapeppd_2_shapepos" x="-10.5" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <para name="ppd_3_shape" x="0.59999999999999998" y="1.3999999999999999" z="1.5" alpha="0" theta="-11.619999999999999" phi="0" aunit="deg" lunit="cm" />
+      <union name="box_with_ppd3_shape">
+        <first ref="box_with_ppd2_shape" />
+        <second ref="ppd_3_shape" />
+        <position name="box_with_ppd3_shapeppd_3_shapepos" x="-15.800000000000001" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <para name="ppd_4_shape" x="0.59999999999999998" y="1.3999999999999999" z="1.5" alpha="0" theta="-15.49" phi="0" aunit="deg" lunit="cm" />
+      <union name="box_with_ppd4_shape">
+        <first ref="box_with_ppd3_shape" />
+        <second ref="ppd_4_shape" />
+        <position name="box_with_ppd4_shapeppd_4_shapepos" x="-21.170000000000002" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <para name="ppd_5_shape" x="0.59999999999999998" y="1.3999999999999999" z="1.5" alpha="0" theta="-19.359999999999999" phi="0" aunit="deg" lunit="cm" />
+      <union name="box_with_ppd5_shape">
+        <first ref="box_with_ppd4_shape" />
+        <second ref="ppd_5_shape" />
+        <position name="box_with_ppd5_shapeppd_5_shapepos" x="-26.640000000000001" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <para name="ppd_6_shape" x="0.59999999999999998" y="1.3999999999999999" z="1.5" alpha="0" theta="3.8700000000000001" phi="0" aunit="deg" lunit="cm" />
+      <union name="box_with_ppd6_shape">
+        <first ref="box_with_ppd5_shape" />
+        <second ref="ppd_6_shape" />
+        <position name="box_with_ppd6_shapeppd_6_shapepos" x="5.2400000000000002" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <para name="ppd_7_shape" x="0.59999999999999998" y="1.3999999999999999" z="1.5" alpha="0" theta="7.7400000000000002" phi="0" aunit="deg" lunit="cm" />
+      <union name="box_with_ppd7_shape">
+        <first ref="box_with_ppd6_shape" />
+        <second ref="ppd_7_shape" />
+        <position name="box_with_ppd7_shapeppd_7_shapepos" x="10.5" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <para name="ppd_8_shape" x="0.59999999999999998" y="1.3999999999999999" z="1.5" alpha="0" theta="11.619999999999999" phi="0" aunit="deg" lunit="cm" />
+      <union name="box_with_ppd8_shape">
+        <first ref="box_with_ppd7_shape" />
+        <second ref="ppd_8_shape" />
+        <position name="box_with_ppd8_shapeppd_8_shapepos" x="15.800000000000001" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <para name="ppd_9_shape" x="0.59999999999999998" y="1.3999999999999999" z="1.5" alpha="0" theta="15.49" phi="0" aunit="deg" lunit="cm" />
+      <union name="box_with_ppd9_shape">
+        <first ref="box_with_ppd8_shape" />
+        <second ref="ppd_9_shape" />
+        <position name="box_with_ppd9_shapeppd_9_shapepos" x="21.170000000000002" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <para name="ppd_10_shape" x="0.59999999999999998" y="1.3999999999999999" z="1.5" alpha="0" theta="19.359999999999999" phi="0" aunit="deg" lunit="cm" />
+      <union name="layer_1_top_shape">
+        <first ref="box_with_ppd9_shape" />
+        <second ref="ppd_10_shape" />
+        <position name="layer_1_top_shapeppd_10_shapepos" x="26.640000000000001" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <union name="layer_2_top_shape">
+        <first ref="box_with_ppd9_shape" />
+        <second ref="ppd_10_shape" />
+        <position name="layer_2_top_shapeppd_10_shapepos" x="26.640000000000001" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <union name="layer_3_top_shape">
+        <first ref="box_with_ppd9_shape" />
+        <second ref="ppd_10_shape" />
+        <position name="layer_3_top_shapeppd_10_shapepos" x="26.640000000000001" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <union name="layer_4_top_shape">
+        <first ref="box_with_ppd9_shape" />
+        <second ref="ppd_10_shape" />
+        <position name="layer_4_top_shapeppd_10_shapepos" x="26.640000000000001" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <union name="layer_1_bottom_shape">
+        <first ref="box_with_ppd9_shape" />
+        <second ref="ppd_10_shape" />
+        <position name="layer_1_bottom_shapeppd_10_shapepos" x="26.640000000000001" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <union name="layer_2_bottom_shape">
+        <first ref="box_with_ppd9_shape" />
+        <second ref="ppd_10_shape" />
+        <position name="layer_2_bottom_shapeppd_10_shapepos" x="26.640000000000001" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <union name="layer_3_bottom_shape">
+        <first ref="box_with_ppd9_shape" />
+        <second ref="ppd_10_shape" />
+        <position name="layer_3_bottom_shapeppd_10_shapepos" x="26.640000000000001" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <union name="layer_4_bottom_shape">
+        <first ref="box_with_ppd9_shape" />
+        <second ref="ppd_10_shape" />
+        <position name="layer_4_bottom_shapeppd_10_shapepos" x="26.640000000000001" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <para name="ppd_left2_shape" x="0.40000000000000002" y="1.3999999999999999" z="20.100000000000001" alpha="0" theta="0.96999999999999997" phi="0" aunit="deg" lunit="cm" />
+      <union name="layer_5a1_1_shape">
+        <first ref="ecal_box_minus_inner2_shape" />
+        <second ref="ppd_left2_shape" />
+        <position name="layer_5a1_1_shapeppd_left2_shapepos" x="-1.903" y="0" z="0" unit="cm" />
+      </union>
+      <para name="ppd_left1_shape" x="0.502" y="1.3999999999999999" z="1.5" alpha="0" theta="0.96999999999999997" phi="0" aunit="deg" lunit="cm" />
+      <union name="layer_5a1_shape">
+        <first ref="layer_5a1_1_shape" />
+        <second ref="ppd_left1_shape" />
+        <position name="layer_5a1_shapeppd_left1_shapepos" x="-1.6499999999999999" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <trd name="electron_hole_left_shape" x1="38.177" x2="38.856999999999999" y1="4" y2="4" z="20.199999999999999" lunit="cm" />
+      <subtraction name="layer_5a2_shape">
+        <first ref="layer_5a1_shape" />
+        <second ref="electron_hole_left_shape" />
+        <position name="layer_5a2_shapeelectron_hole_left_shapepos" x="-21.361499999999999" y="0" z="0" unit="cm" />
+      </subtraction>
+      <union name="layer_5a3_shape">
+        <first ref="layer_5a2_shape" />
+        <second ref="ppd_6_shape" />
+        <position name="layer_5a3_shapeppd_6_shapepos" x="5.2400000000000002" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <union name="layer_5a4_shape">
+        <first ref="layer_5a3_shape" />
+        <second ref="ppd_7_shape" />
+        <position name="layer_5a4_shapeppd_7_shapepos" x="10.5" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <union name="layer_5a5_shape">
+        <first ref="layer_5a4_shape" />
+        <second ref="ppd_8_shape" />
+        <position name="layer_5a5_shapeppd_8_shapepos" x="15.800000000000001" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <union name="layer_5a6_shape">
+        <first ref="layer_5a5_shape" />
+        <second ref="ppd_9_shape" />
+        <position name="layer_5a6_shapeppd_9_shapepos" x="21.170000000000002" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <union name="layer_5a7_shape">
+        <first ref="layer_5a6_shape" />
+        <second ref="ppd_10_shape" />
+        <position name="layer_5a7_shapeppd_10_shapepos" x="26.640000000000001" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <union name="layer_5T_left_shape">
+        <first ref="layer_5a7_shape" />
+        <second ref="ppd_0_shape" />
+        <position name="layer_5T_left_shapeppd_0_shapepos" x="0" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <union name="layer_5B_left_shape">
+        <first ref="layer_5a7_shape" />
+        <second ref="ppd_0_shape" />
+        <position name="layer_5B_left_shapeppd_0_shapepos" x="0" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <box name="steel_bar_shape" x="3" y="1.5" z="20" lunit="cm" />
+      <tube name="cu_Tpipe_inner_left_shape" rmin="0.29999999999999999" rmax="0.40000000000000002" z="20.100000000000001" startphi="0" deltaphi="360" aunit="deg" lunit="cm" />
+      <tube name="cu_Tpipe_inner_right_shape" rmin="0.29999999999999999" rmax="0.40000000000000002" z="20.100000000000001" startphi="0" deltaphi="360" aunit="deg" lunit="cm" />
+      <tube name="cu_Bpipe_inner_left_shape" rmin="0.29999999999999999" rmax="0.40000000000000002" z="20.100000000000001" startphi="0" deltaphi="360" aunit="deg" lunit="cm" />
+      <tube name="cu_Bpipe_inner_right_shape" rmin="0.29999999999999999" rmax="0.40000000000000002" z="20.100000000000001" startphi="0" deltaphi="360" aunit="deg" lunit="cm" />
+      <eltube name="cu_Tpipe_outer_right1_shape" dx="0.5" dy="0.10000000000000001" dz="10" lunit="cm" />
+      <eltube name="cu_Tpipe_outer_right2_shape" dx="0.5" dy="0.10000000000000001" dz="10" lunit="cm" />
+      <tube name="cu_Tpipe_outer_right3_shape" rmin="0.29999999999999999" rmax="0.40000000000000002" z="8" startphi="0" deltaphi="360" aunit="deg" lunit="cm" />
+      <tube name="cu_Bpipe_outer_right_shape" rmin="0.29999999999999999" rmax="0.40000000000000002" z="8" startphi="0" deltaphi="360" aunit="deg" lunit="cm" />
+      <eltube name="cu_Bpipe_outer_right1_shape" dx="0.5" dy="0.10000000000000001" dz="10" lunit="cm" />
+      <eltube name="cu_Bpipe_outer_right2_shape" dx="0.5" dy="0.10000000000000001" dz="10" lunit="cm" />
+      <tube name="al_pipe_across_top1_shape" rmin="0.29999999999999999" rmax="0.40000000000000002" z="66" startphi="0" deltaphi="360" aunit="deg" lunit="cm" />
+      <tube name="al_pipe_across_top2_shape" rmin="0.29999999999999999" rmax="0.40000000000000002" z="74" startphi="0" deltaphi="360" aunit="deg" lunit="cm" />
+      <tube name="al_pipe_across_bottom1_shape" rmin="0.29999999999999999" rmax="0.40000000000000002" z="70" startphi="0" deltaphi="360" aunit="deg" lunit="cm" />
+      <tube name="al_pipe_across_bottom2_shape" rmin="0.29999999999999999" rmax="0.40000000000000002" z="78" startphi="0" deltaphi="360" aunit="deg" lunit="cm" />
+      <para name="cu_plate_top_left_shape" x="40" y="0.10000000000000001" z="20" alpha="0" theta="0.96999999999999997" phi="0" aunit="deg" lunit="cm" />
+      <para name="cu_plate_bottom_left_shape" x="40" y="0.10000000000000001" z="20" alpha="0" theta="0.96999999999999997" phi="0" aunit="deg" lunit="cm" />
+      <para name="cu_plate_top_right_shape" x="22" y="0.10000000000000001" z="20" alpha="0" theta="9.6799999999999997" phi="180" aunit="deg" lunit="cm" />
+      <para name="cu_plate_bottom_right_shape" x="22" y="0.10000000000000001" z="20" alpha="0" theta="-9.6799999999999997" phi="0" aunit="deg" lunit="cm" />
+      <trd name="cu_plate_top_middle_shape" x1="7" x2="9.8000000000000007" y1="0.10000000000000001" y2="0.10000000000000001" z="20" lunit="cm" />
+      <trd name="cu_plate_bottom_middle_shape" x1="7" x2="9.8000000000000007" y1="0.10000000000000001" y2="0.10000000000000001" z="20" lunit="cm" />
+      <box name="tracking_volume_solid" x="2000" y="2000" z="2000" lunit="cm" />
+      <box name="hodo_flange_outer_shape" x="76.835000000000008" y="45.719999999999999" z="5" lunit="cm" />
+      <box name="hodo_flange_inner_shape" x="65.035000000000011" y="33.480000000000004" z="5.0010000000000003" lunit="cm" />
+      <subtraction name="hodo_flange_only_shape">
+        <first ref="hodo_flange_outer_shape" />
+        <second ref="hodo_flange_inner_shape" />
+      </subtraction>
+      <box name="Flange_extrusion_1_shape" x="2.5" y="3.5" z="1.5" lunit="cm" />
+      <union name="hodo_flange_ex1_shape">
+        <first ref="hodo_flange_only_shape" />
+        <second ref="Flange_extrusion_1_shape" />
+        <position name="hodo_flange_ex1_shapeFlange_extrusion_1_shapepos" x="19.400000000000002" y="14.990000000000002" z="-0.10000000000000001" unit="cm" />
+      </union>
+      <box name="Flange_extrusion_2_shape" x="2.5" y="3.5" z="1.5" lunit="cm" />
+      <union name="hodo_flange_ex2_shape">
+        <first ref="hodo_flange_ex1_shape" />
+        <second ref="Flange_extrusion_2_shape" />
+        <position name="hodo_flange_ex2_shapeFlange_extrusion_2_shapepos" x="19.400000000000002" y="-14.990000000000002" z="-0.10000000000000001" unit="cm" />
+      </union>
+      <box name="Flange_extrusion_3_shape" x="2.5" y="3.5" z="1.5" lunit="cm" />
+      <union name="hodo_flange_ex3_shape">
+        <first ref="hodo_flange_ex2_shape" />
+        <second ref="Flange_extrusion_3_shape" />
+        <position name="hodo_flange_ex3_shapeFlange_extrusion_3_shapepos" x="7.4000000000000004" y="14.990000000000002" z="-0.10000000000000001" unit="cm" />
+      </union>
+      <box name="Flange_extrusion_4_shape" x="2.5" y="3.5" z="1.5" lunit="cm" />
+      <union name="hodo_flange_shape">
+        <first ref="hodo_flange_ex3_shape" />
+        <second ref="Flange_extrusion_4_shape" />
+        <position name="hodo_flange_shapeFlange_extrusion_4_shapepos" x="7.4000000000000004" y="-14.990000000000002" z="-0.10000000000000001" unit="cm" />
+      </union>
+      <trap name="arms1_block1_shape" z="1.5" theta="3.9490533936242498" phi="90" x1="2.5" x2="2.5" x3="2.5" x4="2.5" y1="3.7071000000000001" y2="3.5" alpha1="0" alpha2="0" aunit="deg" lunit="cm" />
+      <trap name="arms1_block2_shape" z="1.5" theta="3.9490533936242498" phi="90" x1="2.5" x2="2.5" x3="2.5" x4="2.5" y1="3.7071000000000001" y2="3.5" alpha1="0" alpha2="0" aunit="deg" lunit="cm" />
+      <trap name="arms1_block3_shape" z="1.5" theta="-3.9490533936242498" phi="90" x1="2.5" x2="2.5" x3="2.5" x4="2.5" y1="3.7071000000000001" y2="3.5" alpha1="0" alpha2="0" aunit="deg" lunit="cm" />
+      <trap name="arms1_block4_shape" z="1.5" theta="-3.9490533936242498" phi="90" x1="2.5" x2="2.5" x3="2.5" x4="2.5" y1="3.7071000000000001" y2="3.5" alpha1="0" alpha2="0" aunit="deg" lunit="cm" />
+      <box name="cross_bar_top_shape" x="9.5" y="0.80000000000000004" z="1.5" lunit="cm" />
+      <box name="cross_bar_bottom_shape" x="9.5" y="0.80000000000000004" z="1.5" lunit="cm" />
+      <trap name="support_arm_bottom_left_arm_shape" z="21.700000000000003" theta="-9.8039344658558196" phi="90" x1="0.60000000000000009" x2="0.60000000000000009" x3="0.60000000000000009" x4="0.60000000000000009" y1="2.2938300486668619" y2="3.2271000000000001" alpha1="0" alpha2="0" aunit="deg" lunit="cm" />
+      <box name="support_arm_bottom_left_notch_shape" x="2" y="1.7800000000000002" z="1.401" lunit="cm" />
+      <box name="end_block_bottom_left_block_shape" x="2" y="0.78000000000000003" z="1.4000000000000001" lunit="cm" />
+      <box name="end_block_bottom_left_subs_shape" x="2.0010000000000003" y="1" z="1.401" lunit="cm" />
+      <subtraction name="support_arm_bottom_left_with_notch_shape">
+        <first ref="support_arm_bottom_left_arm_shape" />
+        <second ref="support_arm_bottom_left_notch_shape" />
+        <position name="support_arm_bottom_left_with_notch_shapesupport_arm_bottom_left_notch_shapepos" x="0" y="2.9215622772585932" z="-10.151000000000002" unit="cm" />
+      </subtraction>
+      <subtraction name="end_block_bottom_left_shape">
+        <first ref="end_block_bottom_left_block_shape" />
+        <second ref="end_block_bottom_left_subs_shape" />
+        <position name="end_block_bottom_left_shapeend_block_bottom_left_subs_shapepos" x="0" y="0.60999999999999999" z="-0.30099999999999999" unit="cm" />
+      </subtraction>
+      <union name="support_arm_bottom_left_plus_block_shape">
+        <first ref="support_arm_bottom_left_with_notch_shape" />
+        <second ref="end_block_bottom_left_shape" />
+        <position name="support_arm_bottom_left_plus_block_shapeend_block_bottom_left_shapepos" x="0" y="2.4215622772585932" z="-10.15" unit="cm" />
+      </union>
+      <union name="support_arm_bottom_right_shape">
+        <first ref="support_arm_bottom_left_with_notch_shape" />
+        <second ref="end_block_bottom_left_shape" />
+        <position name="support_arm_bottom_right_shapeend_block_bottom_left_shapepos" x="0" y="2.4215622772585932" z="-10.15" unit="cm" />
+      </union>
+      <union name="support_arm_top_left_shape">
+        <first ref="support_arm_bottom_left_with_notch_shape" />
+        <second ref="end_block_bottom_left_shape" />
+        <position name="support_arm_top_left_shapeend_block_bottom_left_shapepos" x="0" y="2.4215622772585932" z="-10.15" unit="cm" />
+      </union>
+      <union name="support_arm_top_right_shape">
+        <first ref="support_arm_bottom_left_with_notch_shape" />
+        <second ref="end_block_bottom_left_shape" />
+        <position name="support_arm_top_right_shapeend_block_bottom_left_shapepos" x="0" y="2.4215622772585932" z="-10.15" unit="cm" />
+      </union>
+      <box name="u_support_bar_bottom_shape" x="16" y="0.80000000000000004" z="0.90000000000000002" lunit="cm" />
+      <box name="u_support_bar_upper1_shape" x="16" y="1.8" z="0.40000000000000002" lunit="cm" />
+      <box name="u_support_bar_upper2_shape" x="16" y="1.8" z="0.30000000000000004" lunit="cm" />
+      <box name="u_support_bar_top_shape" x="16" y="0.80000000000000004" z="0.90000000000000002" lunit="cm" />
+      <box name="u_support_bar_upper3_shape" x="16" y="1.8" z="0.40000000000000002" lunit="cm" />
+      <box name="u_support_bar_upper4_shape" x="16" y="1.8" z="0.30000000000000004" lunit="cm" />
+      <box lunit="mm" name="svt_chamber_outer_box" x="454.152" y="203.2" z="1219.2" />
+      <box lunit="mm" name="svt_chamber_inner_box" x="416.052" y="177.8" z="1221.2" />
+      <subtraction name="svt_chamber_box">
+        <first ref="svt_chamber_outer_box" />
+        <second ref="svt_chamber_inner_box" />
+      </subtraction>
+      <trd lunit="mm" name="svt_chamber_outer_flare1" x1="454.152" x2="454.152" y1="203.2" y2="254.832" z="132.842" />
+      <trd lunit="mm" name="svt_chamber_inner_flare1" x1="416.052" x2="416.052" y1="172.864" y2="234.368" z="158.242" />
+      <subtraction name="svt_chamber_flare1">
+        <first ref="svt_chamber_outer_flare1" />
+        <second ref="svt_chamber_inner_flare1" />
+      </subtraction>
+      <trd lunit="mm" name="svt_chamber_outer_flare2" x1="454.152" x2="679.704" y1="254.832" y2="353.06" z="252.73" />
+      <trd lunit="mm" name="svt_chamber_inner_flare2" x1="404.718" x2="652.938" y1="224.496" y2="332.596" z="278.13" />
+      <subtraction name="svt_chamber_flare2">
+        <first ref="svt_chamber_outer_flare2" />
+        <second ref="svt_chamber_inner_flare2" />
+      </subtraction>
+      <box lunit="mm" name="svt_chamber_outer_flange" x="768.35" y="457.2" z="19.05" />
+      <box lunit="mm" name="svt_chamber_inner_flange" x="654.05" y="342.9" z="25.4" />
+      <subtraction name="svt_chamber_flange">
+        <first ref="svt_chamber_outer_flange" />
+        <second ref="svt_chamber_inner_flange" />
+      </subtraction>
+      <box lunit="mm" name="WorldBox" x="80000" y="80000" z="80000" />
+    </solids>
+    <structure>
+      <volume name="base_plate_volume">
+        <materialref ref="Aluminum" />
+        <solidref ref="base_plateBox" />
+        <visref ref="BasePlateVis" />
+      </volume>
+      <volume name="support_plate_bottom_L14_volume">
+        <materialref ref="Aluminum" />
+        <solidref ref="support_plate_bottom_L14Box" />
+        <visref ref="SupportPlateVis" />
+      </volume>
+      <volume name="support_plate_top_L14_volume">
+        <materialref ref="Aluminum" />
+        <solidref ref="support_plate_top_L14Box" />
+        <visref ref="SupportPlateVis" />
+      </volume>
+      <volume name="support_plate_bottom_L46_volume">
+        <materialref ref="Aluminum" />
+        <solidref ref="support_plate_bottom_L46Box" />
+        <visref ref="SupportPlateVis" />
+      </volume>
+      <volume name="support_plate_top_L46_volume">
+        <materialref ref="Aluminum" />
+        <solidref ref="support_plate_top_L46Box" />
+        <visref ref="SupportPlateVis" />
+      </volume>
+      <volume name="module_L1b_halfmodule_axial_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L1b_halfmodule_axial_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L1b_halfmodule_axial_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L1b_halfmodule_axial_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L1b_halfmodule_axial_sensor_active_volume" />
+          <positionref ref="module_L1b_halfmodule_axial_sensor_active_position" />
+          <rotationref ref="module_L1b_halfmodule_axial_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L1b_halfmodule_axial_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L1b_halfmodule_axialBox" />
+        <physvol>
+          <volumeref ref="module_L1b_halfmodule_axial_sensor_volume" />
+          <positionref ref="module_L1b_halfmodule_axial_sensor_position" />
+          <rotationref ref="module_L1b_halfmodule_axial_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <visref ref="HalfModuleVis" />
+      </volume>
+      <volume name="module_L1b_halfmodule_stereo_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L1b_halfmodule_stereo_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L1b_halfmodule_stereo_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L1b_halfmodule_stereo_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L1b_halfmodule_stereo_sensor_active_volume" />
+          <positionref ref="module_L1b_halfmodule_stereo_sensor_active_position" />
+          <rotationref ref="module_L1b_halfmodule_stereo_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L1b_halfmodule_stereo_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L1b_halfmodule_stereoBox" />
+        <physvol>
+          <volumeref ref="module_L1b_halfmodule_stereo_sensor_volume" />
+          <positionref ref="module_L1b_halfmodule_stereo_sensor_position" />
+          <rotationref ref="module_L1b_halfmodule_stereo_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <visref ref="HalfModuleVis" />
+      </volume>
+      <volume name="module_L1t_halfmodule_axial_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L1t_halfmodule_axial_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L1t_halfmodule_axial_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L1t_halfmodule_axial_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L1t_halfmodule_axial_sensor_active_volume" />
+          <positionref ref="module_L1t_halfmodule_axial_sensor_active_position" />
+          <rotationref ref="module_L1t_halfmodule_axial_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L1t_halfmodule_axial_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L1t_halfmodule_axialBox" />
+        <physvol>
+          <volumeref ref="module_L1t_halfmodule_axial_sensor_volume" />
+          <positionref ref="module_L1t_halfmodule_axial_sensor_position" />
+          <rotationref ref="module_L1t_halfmodule_axial_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <visref ref="HalfModuleVis" />
+      </volume>
+      <volume name="module_L1t_halfmodule_stereo_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L1t_halfmodule_stereo_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L1t_halfmodule_stereo_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L1t_halfmodule_stereo_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L1t_halfmodule_stereo_sensor_active_volume" />
+          <positionref ref="module_L1t_halfmodule_stereo_sensor_active_position" />
+          <rotationref ref="module_L1t_halfmodule_stereo_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L1t_halfmodule_stereo_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L1t_halfmodule_stereoBox" />
+        <physvol>
+          <volumeref ref="module_L1t_halfmodule_stereo_sensor_volume" />
+          <positionref ref="module_L1t_halfmodule_stereo_sensor_position" />
+          <rotationref ref="module_L1t_halfmodule_stereo_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <visref ref="HalfModuleVis" />
+      </volume>
+      <volume name="module_L2b_halfmodule_axial_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L2b_halfmodule_axial_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L2b_halfmodule_axial_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L2b_halfmodule_axial_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L2b_halfmodule_axial_sensor_active_volume" />
+          <positionref ref="module_L2b_halfmodule_axial_sensor_active_position" />
+          <rotationref ref="module_L2b_halfmodule_axial_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L2b_halfmodule_axial_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L2b_halfmodule_axialBox" />
+        <physvol>
+          <volumeref ref="module_L2b_halfmodule_axial_sensor_volume" />
+          <positionref ref="module_L2b_halfmodule_axial_sensor_position" />
+          <rotationref ref="module_L2b_halfmodule_axial_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <visref ref="HalfModuleVis" />
+      </volume>
+      <volume name="module_L2b_halfmodule_stereo_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L2b_halfmodule_stereo_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L2b_halfmodule_stereo_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L2b_halfmodule_stereo_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L2b_halfmodule_stereo_sensor_active_volume" />
+          <positionref ref="module_L2b_halfmodule_stereo_sensor_active_position" />
+          <rotationref ref="module_L2b_halfmodule_stereo_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L2b_halfmodule_stereo_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L2b_halfmodule_stereoBox" />
+        <physvol>
+          <volumeref ref="module_L2b_halfmodule_stereo_sensor_volume" />
+          <positionref ref="module_L2b_halfmodule_stereo_sensor_position" />
+          <rotationref ref="module_L2b_halfmodule_stereo_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <visref ref="HalfModuleVis" />
+      </volume>
+      <volume name="module_L2t_halfmodule_axial_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L2t_halfmodule_axial_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L2t_halfmodule_axial_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L2t_halfmodule_axial_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L2t_halfmodule_axial_sensor_active_volume" />
+          <positionref ref="module_L2t_halfmodule_axial_sensor_active_position" />
+          <rotationref ref="module_L2t_halfmodule_axial_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L2t_halfmodule_axial_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L2t_halfmodule_axialBox" />
+        <physvol>
+          <volumeref ref="module_L2t_halfmodule_axial_sensor_volume" />
+          <positionref ref="module_L2t_halfmodule_axial_sensor_position" />
+          <rotationref ref="module_L2t_halfmodule_axial_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <visref ref="HalfModuleVis" />
+      </volume>
+      <volume name="module_L2t_halfmodule_stereo_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L2t_halfmodule_stereo_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L2t_halfmodule_stereo_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L2t_halfmodule_stereo_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L2t_halfmodule_stereo_sensor_active_volume" />
+          <positionref ref="module_L2t_halfmodule_stereo_sensor_active_position" />
+          <rotationref ref="module_L2t_halfmodule_stereo_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L2t_halfmodule_stereo_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L2t_halfmodule_stereoBox" />
+        <physvol>
+          <volumeref ref="module_L2t_halfmodule_stereo_sensor_volume" />
+          <positionref ref="module_L2t_halfmodule_stereo_sensor_position" />
+          <rotationref ref="module_L2t_halfmodule_stereo_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <visref ref="HalfModuleVis" />
+      </volume>
+      <volume name="module_L3b_halfmodule_axial_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L3b_halfmodule_axial_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L3b_halfmodule_axial_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L3b_halfmodule_axial_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L3b_halfmodule_axial_sensor_active_volume" />
+          <positionref ref="module_L3b_halfmodule_axial_sensor_active_position" />
+          <rotationref ref="module_L3b_halfmodule_axial_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L3b_halfmodule_axial_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L3b_halfmodule_axial_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L3b_halfmodule_axial_cf_volume">
+        <materialref ref="CarbonFiber" />
+        <solidref ref="module_L3b_halfmodule_axial_cfBox" />
+        <visref ref="CarbonFiberVis" />
+      </volume>
+      <volume name="module_L3b_halfmodule_axial_hybrid_volume">
+        <materialref ref="G10" />
+        <solidref ref="module_L3b_halfmodule_axial_hybridBox" />
+        <visref ref="HybridVis" />
+      </volume>
+      <volume name="module_L3b_halfmodule_axial_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L3b_halfmodule_axialBox" />
+        <physvol>
+          <volumeref ref="module_L3b_halfmodule_axial_sensor_volume" />
+          <positionref ref="module_L3b_halfmodule_axial_sensor_position" />
+          <rotationref ref="module_L3b_halfmodule_axial_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L3b_halfmodule_axial_lamination_volume" />
+          <positionref ref="module_L3b_halfmodule_axial_lamination_position" />
+          <rotationref ref="module_L3b_halfmodule_axial_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L3b_halfmodule_axial_cf_volume" />
+          <positionref ref="module_L3b_halfmodule_axial_cf_position" />
+          <rotationref ref="module_L3b_halfmodule_axial_cf_rotation" />
+          <physvolid field_name="component" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L3b_halfmodule_axial_hybrid_volume" />
+          <positionref ref="module_L3b_halfmodule_axial_hybrid_position" />
+          <rotationref ref="module_L3b_halfmodule_axial_hybrid_rotation" />
+          <physvolid field_name="component" value="3" />
+        </physvol>
+        <visref ref="HalfModuleVis" />
+      </volume>
+      <volume name="module_L3b_halfmodule_stereo_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L3b_halfmodule_stereo_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L3b_halfmodule_stereo_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L3b_halfmodule_stereo_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L3b_halfmodule_stereo_sensor_active_volume" />
+          <positionref ref="module_L3b_halfmodule_stereo_sensor_active_position" />
+          <rotationref ref="module_L3b_halfmodule_stereo_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L3b_halfmodule_stereo_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L3b_halfmodule_stereo_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L3b_halfmodule_stereo_cf_volume">
+        <materialref ref="CarbonFiber" />
+        <solidref ref="module_L3b_halfmodule_stereo_cfBox" />
+        <visref ref="CarbonFiberVis" />
+      </volume>
+      <volume name="module_L3b_halfmodule_stereo_hybrid_volume">
+        <materialref ref="G10" />
+        <solidref ref="module_L3b_halfmodule_stereo_hybridBox" />
+        <visref ref="HybridVis" />
+      </volume>
+      <volume name="module_L3b_halfmodule_stereo_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L3b_halfmodule_stereoBox" />
+        <physvol>
+          <volumeref ref="module_L3b_halfmodule_stereo_sensor_volume" />
+          <positionref ref="module_L3b_halfmodule_stereo_sensor_position" />
+          <rotationref ref="module_L3b_halfmodule_stereo_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L3b_halfmodule_stereo_lamination_volume" />
+          <positionref ref="module_L3b_halfmodule_stereo_lamination_position" />
+          <rotationref ref="module_L3b_halfmodule_stereo_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L3b_halfmodule_stereo_cf_volume" />
+          <positionref ref="module_L3b_halfmodule_stereo_cf_position" />
+          <rotationref ref="module_L3b_halfmodule_stereo_cf_rotation" />
+          <physvolid field_name="component" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L3b_halfmodule_stereo_hybrid_volume" />
+          <positionref ref="module_L3b_halfmodule_stereo_hybrid_position" />
+          <rotationref ref="module_L3b_halfmodule_stereo_hybrid_rotation" />
+          <physvolid field_name="component" value="3" />
+        </physvol>
+        <visref ref="HalfModuleVis" />
+      </volume>
+      <volume name="module_L3t_halfmodule_axial_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L3t_halfmodule_axial_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L3t_halfmodule_axial_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L3t_halfmodule_axial_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L3t_halfmodule_axial_sensor_active_volume" />
+          <positionref ref="module_L3t_halfmodule_axial_sensor_active_position" />
+          <rotationref ref="module_L3t_halfmodule_axial_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L3t_halfmodule_axial_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L3t_halfmodule_axial_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L3t_halfmodule_axial_cf_volume">
+        <materialref ref="CarbonFiber" />
+        <solidref ref="module_L3t_halfmodule_axial_cfBox" />
+        <visref ref="CarbonFiberVis" />
+      </volume>
+      <volume name="module_L3t_halfmodule_axial_hybrid_volume">
+        <materialref ref="G10" />
+        <solidref ref="module_L3t_halfmodule_axial_hybridBox" />
+        <visref ref="HybridVis" />
+      </volume>
+      <volume name="module_L3t_halfmodule_axial_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L3t_halfmodule_axialBox" />
+        <physvol>
+          <volumeref ref="module_L3t_halfmodule_axial_sensor_volume" />
+          <positionref ref="module_L3t_halfmodule_axial_sensor_position" />
+          <rotationref ref="module_L3t_halfmodule_axial_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L3t_halfmodule_axial_lamination_volume" />
+          <positionref ref="module_L3t_halfmodule_axial_lamination_position" />
+          <rotationref ref="module_L3t_halfmodule_axial_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L3t_halfmodule_axial_cf_volume" />
+          <positionref ref="module_L3t_halfmodule_axial_cf_position" />
+          <rotationref ref="module_L3t_halfmodule_axial_cf_rotation" />
+          <physvolid field_name="component" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L3t_halfmodule_axial_hybrid_volume" />
+          <positionref ref="module_L3t_halfmodule_axial_hybrid_position" />
+          <rotationref ref="module_L3t_halfmodule_axial_hybrid_rotation" />
+          <physvolid field_name="component" value="3" />
+        </physvol>
+        <visref ref="HalfModuleVis" />
+      </volume>
+      <volume name="module_L3t_halfmodule_stereo_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L3t_halfmodule_stereo_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L3t_halfmodule_stereo_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L3t_halfmodule_stereo_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L3t_halfmodule_stereo_sensor_active_volume" />
+          <positionref ref="module_L3t_halfmodule_stereo_sensor_active_position" />
+          <rotationref ref="module_L3t_halfmodule_stereo_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L3t_halfmodule_stereo_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L3t_halfmodule_stereo_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L3t_halfmodule_stereo_cf_volume">
+        <materialref ref="CarbonFiber" />
+        <solidref ref="module_L3t_halfmodule_stereo_cfBox" />
+        <visref ref="CarbonFiberVis" />
+      </volume>
+      <volume name="module_L3t_halfmodule_stereo_hybrid_volume">
+        <materialref ref="G10" />
+        <solidref ref="module_L3t_halfmodule_stereo_hybridBox" />
+        <visref ref="HybridVis" />
+      </volume>
+      <volume name="module_L3t_halfmodule_stereo_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L3t_halfmodule_stereoBox" />
+        <physvol>
+          <volumeref ref="module_L3t_halfmodule_stereo_sensor_volume" />
+          <positionref ref="module_L3t_halfmodule_stereo_sensor_position" />
+          <rotationref ref="module_L3t_halfmodule_stereo_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L3t_halfmodule_stereo_lamination_volume" />
+          <positionref ref="module_L3t_halfmodule_stereo_lamination_position" />
+          <rotationref ref="module_L3t_halfmodule_stereo_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L3t_halfmodule_stereo_cf_volume" />
+          <positionref ref="module_L3t_halfmodule_stereo_cf_position" />
+          <rotationref ref="module_L3t_halfmodule_stereo_cf_rotation" />
+          <physvolid field_name="component" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L3t_halfmodule_stereo_hybrid_volume" />
+          <positionref ref="module_L3t_halfmodule_stereo_hybrid_position" />
+          <rotationref ref="module_L3t_halfmodule_stereo_hybrid_rotation" />
+          <physvolid field_name="component" value="3" />
+        </physvol>
+        <visref ref="HalfModuleVis" />
+      </volume>
+      <volume name="module_L4b_halfmodule_axial_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L4b_halfmodule_axial_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L4b_halfmodule_axial_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L4b_halfmodule_axial_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L4b_halfmodule_axial_sensor_active_volume" />
+          <positionref ref="module_L4b_halfmodule_axial_sensor_active_position" />
+          <rotationref ref="module_L4b_halfmodule_axial_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L4b_halfmodule_axial_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L4b_halfmodule_axial_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L4b_halfmodule_axial_cf_volume">
+        <materialref ref="CarbonFiber" />
+        <solidref ref="module_L4b_halfmodule_axial_cfBox" />
+        <visref ref="CarbonFiberVis" />
+      </volume>
+      <volume name="module_L4b_halfmodule_axial_hybrid_volume">
+        <materialref ref="G10" />
+        <solidref ref="module_L4b_halfmodule_axial_hybridBox" />
+        <visref ref="HybridVis" />
+      </volume>
+      <volume name="module_L4b_halfmodule_axial_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L4b_halfmodule_axialBox" />
+        <physvol>
+          <volumeref ref="module_L4b_halfmodule_axial_sensor_volume" />
+          <positionref ref="module_L4b_halfmodule_axial_sensor_position" />
+          <rotationref ref="module_L4b_halfmodule_axial_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L4b_halfmodule_axial_lamination_volume" />
+          <positionref ref="module_L4b_halfmodule_axial_lamination_position" />
+          <rotationref ref="module_L4b_halfmodule_axial_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L4b_halfmodule_axial_cf_volume" />
+          <positionref ref="module_L4b_halfmodule_axial_cf_position" />
+          <rotationref ref="module_L4b_halfmodule_axial_cf_rotation" />
+          <physvolid field_name="component" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L4b_halfmodule_axial_hybrid_volume" />
+          <positionref ref="module_L4b_halfmodule_axial_hybrid_position" />
+          <rotationref ref="module_L4b_halfmodule_axial_hybrid_rotation" />
+          <physvolid field_name="component" value="3" />
+        </physvol>
+        <visref ref="HalfModuleVis" />
+      </volume>
+      <volume name="module_L4b_halfmodule_stereo_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L4b_halfmodule_stereo_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L4b_halfmodule_stereo_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L4b_halfmodule_stereo_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L4b_halfmodule_stereo_sensor_active_volume" />
+          <positionref ref="module_L4b_halfmodule_stereo_sensor_active_position" />
+          <rotationref ref="module_L4b_halfmodule_stereo_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L4b_halfmodule_stereo_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L4b_halfmodule_stereo_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L4b_halfmodule_stereo_cf_volume">
+        <materialref ref="CarbonFiber" />
+        <solidref ref="module_L4b_halfmodule_stereo_cfBox" />
+        <visref ref="CarbonFiberVis" />
+      </volume>
+      <volume name="module_L4b_halfmodule_stereo_hybrid_volume">
+        <materialref ref="G10" />
+        <solidref ref="module_L4b_halfmodule_stereo_hybridBox" />
+        <visref ref="HybridVis" />
+      </volume>
+      <volume name="module_L4b_halfmodule_stereo_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L4b_halfmodule_stereoBox" />
+        <physvol>
+          <volumeref ref="module_L4b_halfmodule_stereo_sensor_volume" />
+          <positionref ref="module_L4b_halfmodule_stereo_sensor_position" />
+          <rotationref ref="module_L4b_halfmodule_stereo_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L4b_halfmodule_stereo_lamination_volume" />
+          <positionref ref="module_L4b_halfmodule_stereo_lamination_position" />
+          <rotationref ref="module_L4b_halfmodule_stereo_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L4b_halfmodule_stereo_cf_volume" />
+          <positionref ref="module_L4b_halfmodule_stereo_cf_position" />
+          <rotationref ref="module_L4b_halfmodule_stereo_cf_rotation" />
+          <physvolid field_name="component" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L4b_halfmodule_stereo_hybrid_volume" />
+          <positionref ref="module_L4b_halfmodule_stereo_hybrid_position" />
+          <rotationref ref="module_L4b_halfmodule_stereo_hybrid_rotation" />
+          <physvolid field_name="component" value="3" />
+        </physvol>
+        <visref ref="HalfModuleVis" />
+      </volume>
+      <volume name="module_L4t_halfmodule_axial_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L4t_halfmodule_axial_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L4t_halfmodule_axial_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L4t_halfmodule_axial_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L4t_halfmodule_axial_sensor_active_volume" />
+          <positionref ref="module_L4t_halfmodule_axial_sensor_active_position" />
+          <rotationref ref="module_L4t_halfmodule_axial_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L4t_halfmodule_axial_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L4t_halfmodule_axial_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L4t_halfmodule_axial_cf_volume">
+        <materialref ref="CarbonFiber" />
+        <solidref ref="module_L4t_halfmodule_axial_cfBox" />
+        <visref ref="CarbonFiberVis" />
+      </volume>
+      <volume name="module_L4t_halfmodule_axial_hybrid_volume">
+        <materialref ref="G10" />
+        <solidref ref="module_L4t_halfmodule_axial_hybridBox" />
+        <visref ref="HybridVis" />
+      </volume>
+      <volume name="module_L4t_halfmodule_axial_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L4t_halfmodule_axialBox" />
+        <physvol>
+          <volumeref ref="module_L4t_halfmodule_axial_sensor_volume" />
+          <positionref ref="module_L4t_halfmodule_axial_sensor_position" />
+          <rotationref ref="module_L4t_halfmodule_axial_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L4t_halfmodule_axial_lamination_volume" />
+          <positionref ref="module_L4t_halfmodule_axial_lamination_position" />
+          <rotationref ref="module_L4t_halfmodule_axial_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L4t_halfmodule_axial_cf_volume" />
+          <positionref ref="module_L4t_halfmodule_axial_cf_position" />
+          <rotationref ref="module_L4t_halfmodule_axial_cf_rotation" />
+          <physvolid field_name="component" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L4t_halfmodule_axial_hybrid_volume" />
+          <positionref ref="module_L4t_halfmodule_axial_hybrid_position" />
+          <rotationref ref="module_L4t_halfmodule_axial_hybrid_rotation" />
+          <physvolid field_name="component" value="3" />
+        </physvol>
+        <visref ref="HalfModuleVis" />
+      </volume>
+      <volume name="module_L4t_halfmodule_stereo_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L4t_halfmodule_stereo_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L4t_halfmodule_stereo_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L4t_halfmodule_stereo_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L4t_halfmodule_stereo_sensor_active_volume" />
+          <positionref ref="module_L4t_halfmodule_stereo_sensor_active_position" />
+          <rotationref ref="module_L4t_halfmodule_stereo_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L4t_halfmodule_stereo_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L4t_halfmodule_stereo_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L4t_halfmodule_stereo_cf_volume">
+        <materialref ref="CarbonFiber" />
+        <solidref ref="module_L4t_halfmodule_stereo_cfBox" />
+        <visref ref="CarbonFiberVis" />
+      </volume>
+      <volume name="module_L4t_halfmodule_stereo_hybrid_volume">
+        <materialref ref="G10" />
+        <solidref ref="module_L4t_halfmodule_stereo_hybridBox" />
+        <visref ref="HybridVis" />
+      </volume>
+      <volume name="module_L4t_halfmodule_stereo_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L4t_halfmodule_stereoBox" />
+        <physvol>
+          <volumeref ref="module_L4t_halfmodule_stereo_sensor_volume" />
+          <positionref ref="module_L4t_halfmodule_stereo_sensor_position" />
+          <rotationref ref="module_L4t_halfmodule_stereo_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L4t_halfmodule_stereo_lamination_volume" />
+          <positionref ref="module_L4t_halfmodule_stereo_lamination_position" />
+          <rotationref ref="module_L4t_halfmodule_stereo_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L4t_halfmodule_stereo_cf_volume" />
+          <positionref ref="module_L4t_halfmodule_stereo_cf_position" />
+          <rotationref ref="module_L4t_halfmodule_stereo_cf_rotation" />
+          <physvolid field_name="component" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L4t_halfmodule_stereo_hybrid_volume" />
+          <positionref ref="module_L4t_halfmodule_stereo_hybrid_position" />
+          <rotationref ref="module_L4t_halfmodule_stereo_hybrid_rotation" />
+          <physvolid field_name="component" value="3" />
+        </physvol>
+        <visref ref="HalfModuleVis" />
+      </volume>
+      <volume name="module_L5b_halfmodule_axial_hole_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L5b_halfmodule_axial_hole_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L5b_halfmodule_axial_hole_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L5b_halfmodule_axial_hole_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L5b_halfmodule_axial_hole_sensor_active_volume" />
+          <positionref ref="module_L5b_halfmodule_axial_hole_sensor_active_position" />
+          <rotationref ref="module_L5b_halfmodule_axial_hole_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L5b_halfmodule_axial_hole_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L5b_halfmodule_axial_hole_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L5b_halfmodule_axial_hole_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L5b_halfmodule_axial_holeBox" />
+        <physvol>
+          <volumeref ref="module_L5b_halfmodule_axial_hole_sensor_volume" />
+          <positionref ref="module_L5b_halfmodule_axial_hole_sensor_position" />
+          <rotationref ref="module_L5b_halfmodule_axial_hole_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L5b_halfmodule_axial_hole_lamination_volume" />
+          <positionref ref="module_L5b_halfmodule_axial_hole_lamination_position" />
+          <rotationref ref="module_L5b_halfmodule_axial_hole_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L5b_halfmodule_axial_slot_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L5b_halfmodule_axial_slot_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L5b_halfmodule_axial_slot_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L5b_halfmodule_axial_slot_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L5b_halfmodule_axial_slot_sensor_active_volume" />
+          <positionref ref="module_L5b_halfmodule_axial_slot_sensor_active_position" />
+          <rotationref ref="module_L5b_halfmodule_axial_slot_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L5b_halfmodule_axial_slot_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L5b_halfmodule_axial_slot_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L5b_halfmodule_axial_slot_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L5b_halfmodule_axial_slotBox" />
+        <physvol>
+          <volumeref ref="module_L5b_halfmodule_axial_slot_sensor_volume" />
+          <positionref ref="module_L5b_halfmodule_axial_slot_sensor_position" />
+          <rotationref ref="module_L5b_halfmodule_axial_slot_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L5b_halfmodule_axial_slot_lamination_volume" />
+          <positionref ref="module_L5b_halfmodule_axial_slot_lamination_position" />
+          <rotationref ref="module_L5b_halfmodule_axial_slot_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L5b_halfmodule_stereo_hole_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L5b_halfmodule_stereo_hole_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L5b_halfmodule_stereo_hole_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L5b_halfmodule_stereo_hole_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L5b_halfmodule_stereo_hole_sensor_active_volume" />
+          <positionref ref="module_L5b_halfmodule_stereo_hole_sensor_active_position" />
+          <rotationref ref="module_L5b_halfmodule_stereo_hole_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L5b_halfmodule_stereo_hole_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L5b_halfmodule_stereo_hole_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L5b_halfmodule_stereo_hole_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L5b_halfmodule_stereo_holeBox" />
+        <physvol>
+          <volumeref ref="module_L5b_halfmodule_stereo_hole_sensor_volume" />
+          <positionref ref="module_L5b_halfmodule_stereo_hole_sensor_position" />
+          <rotationref ref="module_L5b_halfmodule_stereo_hole_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L5b_halfmodule_stereo_hole_lamination_volume" />
+          <positionref ref="module_L5b_halfmodule_stereo_hole_lamination_position" />
+          <rotationref ref="module_L5b_halfmodule_stereo_hole_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L5b_halfmodule_stereo_slot_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L5b_halfmodule_stereo_slot_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L5b_halfmodule_stereo_slot_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L5b_halfmodule_stereo_slot_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L5b_halfmodule_stereo_slot_sensor_active_volume" />
+          <positionref ref="module_L5b_halfmodule_stereo_slot_sensor_active_position" />
+          <rotationref ref="module_L5b_halfmodule_stereo_slot_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L5b_halfmodule_stereo_slot_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L5b_halfmodule_stereo_slot_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L5b_halfmodule_stereo_slot_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L5b_halfmodule_stereo_slotBox" />
+        <physvol>
+          <volumeref ref="module_L5b_halfmodule_stereo_slot_sensor_volume" />
+          <positionref ref="module_L5b_halfmodule_stereo_slot_sensor_position" />
+          <rotationref ref="module_L5b_halfmodule_stereo_slot_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L5b_halfmodule_stereo_slot_lamination_volume" />
+          <positionref ref="module_L5b_halfmodule_stereo_slot_lamination_position" />
+          <rotationref ref="module_L5b_halfmodule_stereo_slot_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L5t_halfmodule_axial_hole_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L5t_halfmodule_axial_hole_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L5t_halfmodule_axial_hole_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L5t_halfmodule_axial_hole_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L5t_halfmodule_axial_hole_sensor_active_volume" />
+          <positionref ref="module_L5t_halfmodule_axial_hole_sensor_active_position" />
+          <rotationref ref="module_L5t_halfmodule_axial_hole_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L5t_halfmodule_axial_hole_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L5t_halfmodule_axial_hole_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L5t_halfmodule_axial_hole_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L5t_halfmodule_axial_holeBox" />
+        <physvol>
+          <volumeref ref="module_L5t_halfmodule_axial_hole_sensor_volume" />
+          <positionref ref="module_L5t_halfmodule_axial_hole_sensor_position" />
+          <rotationref ref="module_L5t_halfmodule_axial_hole_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L5t_halfmodule_axial_hole_lamination_volume" />
+          <positionref ref="module_L5t_halfmodule_axial_hole_lamination_position" />
+          <rotationref ref="module_L5t_halfmodule_axial_hole_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L5t_halfmodule_axial_slot_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L5t_halfmodule_axial_slot_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L5t_halfmodule_axial_slot_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L5t_halfmodule_axial_slot_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L5t_halfmodule_axial_slot_sensor_active_volume" />
+          <positionref ref="module_L5t_halfmodule_axial_slot_sensor_active_position" />
+          <rotationref ref="module_L5t_halfmodule_axial_slot_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L5t_halfmodule_axial_slot_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L5t_halfmodule_axial_slot_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L5t_halfmodule_axial_slot_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L5t_halfmodule_axial_slotBox" />
+        <physvol>
+          <volumeref ref="module_L5t_halfmodule_axial_slot_sensor_volume" />
+          <positionref ref="module_L5t_halfmodule_axial_slot_sensor_position" />
+          <rotationref ref="module_L5t_halfmodule_axial_slot_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L5t_halfmodule_axial_slot_lamination_volume" />
+          <positionref ref="module_L5t_halfmodule_axial_slot_lamination_position" />
+          <rotationref ref="module_L5t_halfmodule_axial_slot_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L5t_halfmodule_stereo_hole_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L5t_halfmodule_stereo_hole_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L5t_halfmodule_stereo_hole_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L5t_halfmodule_stereo_hole_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L5t_halfmodule_stereo_hole_sensor_active_volume" />
+          <positionref ref="module_L5t_halfmodule_stereo_hole_sensor_active_position" />
+          <rotationref ref="module_L5t_halfmodule_stereo_hole_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L5t_halfmodule_stereo_hole_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L5t_halfmodule_stereo_hole_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L5t_halfmodule_stereo_hole_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L5t_halfmodule_stereo_holeBox" />
+        <physvol>
+          <volumeref ref="module_L5t_halfmodule_stereo_hole_sensor_volume" />
+          <positionref ref="module_L5t_halfmodule_stereo_hole_sensor_position" />
+          <rotationref ref="module_L5t_halfmodule_stereo_hole_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L5t_halfmodule_stereo_hole_lamination_volume" />
+          <positionref ref="module_L5t_halfmodule_stereo_hole_lamination_position" />
+          <rotationref ref="module_L5t_halfmodule_stereo_hole_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L5t_halfmodule_stereo_slot_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L5t_halfmodule_stereo_slot_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L5t_halfmodule_stereo_slot_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L5t_halfmodule_stereo_slot_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L5t_halfmodule_stereo_slot_sensor_active_volume" />
+          <positionref ref="module_L5t_halfmodule_stereo_slot_sensor_active_position" />
+          <rotationref ref="module_L5t_halfmodule_stereo_slot_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L5t_halfmodule_stereo_slot_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L5t_halfmodule_stereo_slot_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L5t_halfmodule_stereo_slot_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L5t_halfmodule_stereo_slotBox" />
+        <physvol>
+          <volumeref ref="module_L5t_halfmodule_stereo_slot_sensor_volume" />
+          <positionref ref="module_L5t_halfmodule_stereo_slot_sensor_position" />
+          <rotationref ref="module_L5t_halfmodule_stereo_slot_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L5t_halfmodule_stereo_slot_lamination_volume" />
+          <positionref ref="module_L5t_halfmodule_stereo_slot_lamination_position" />
+          <rotationref ref="module_L5t_halfmodule_stereo_slot_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L6b_halfmodule_axial_hole_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L6b_halfmodule_axial_hole_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L6b_halfmodule_axial_hole_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L6b_halfmodule_axial_hole_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L6b_halfmodule_axial_hole_sensor_active_volume" />
+          <positionref ref="module_L6b_halfmodule_axial_hole_sensor_active_position" />
+          <rotationref ref="module_L6b_halfmodule_axial_hole_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L6b_halfmodule_axial_hole_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L6b_halfmodule_axial_hole_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L6b_halfmodule_axial_hole_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L6b_halfmodule_axial_holeBox" />
+        <physvol>
+          <volumeref ref="module_L6b_halfmodule_axial_hole_sensor_volume" />
+          <positionref ref="module_L6b_halfmodule_axial_hole_sensor_position" />
+          <rotationref ref="module_L6b_halfmodule_axial_hole_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L6b_halfmodule_axial_hole_lamination_volume" />
+          <positionref ref="module_L6b_halfmodule_axial_hole_lamination_position" />
+          <rotationref ref="module_L6b_halfmodule_axial_hole_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L6b_halfmodule_axial_slot_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L6b_halfmodule_axial_slot_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L6b_halfmodule_axial_slot_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L6b_halfmodule_axial_slot_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L6b_halfmodule_axial_slot_sensor_active_volume" />
+          <positionref ref="module_L6b_halfmodule_axial_slot_sensor_active_position" />
+          <rotationref ref="module_L6b_halfmodule_axial_slot_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L6b_halfmodule_axial_slot_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L6b_halfmodule_axial_slot_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L6b_halfmodule_axial_slot_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L6b_halfmodule_axial_slotBox" />
+        <physvol>
+          <volumeref ref="module_L6b_halfmodule_axial_slot_sensor_volume" />
+          <positionref ref="module_L6b_halfmodule_axial_slot_sensor_position" />
+          <rotationref ref="module_L6b_halfmodule_axial_slot_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L6b_halfmodule_axial_slot_lamination_volume" />
+          <positionref ref="module_L6b_halfmodule_axial_slot_lamination_position" />
+          <rotationref ref="module_L6b_halfmodule_axial_slot_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L6b_halfmodule_stereo_hole_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L6b_halfmodule_stereo_hole_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L6b_halfmodule_stereo_hole_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L6b_halfmodule_stereo_hole_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L6b_halfmodule_stereo_hole_sensor_active_volume" />
+          <positionref ref="module_L6b_halfmodule_stereo_hole_sensor_active_position" />
+          <rotationref ref="module_L6b_halfmodule_stereo_hole_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L6b_halfmodule_stereo_hole_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L6b_halfmodule_stereo_hole_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L6b_halfmodule_stereo_hole_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L6b_halfmodule_stereo_holeBox" />
+        <physvol>
+          <volumeref ref="module_L6b_halfmodule_stereo_hole_sensor_volume" />
+          <positionref ref="module_L6b_halfmodule_stereo_hole_sensor_position" />
+          <rotationref ref="module_L6b_halfmodule_stereo_hole_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L6b_halfmodule_stereo_hole_lamination_volume" />
+          <positionref ref="module_L6b_halfmodule_stereo_hole_lamination_position" />
+          <rotationref ref="module_L6b_halfmodule_stereo_hole_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L6b_halfmodule_stereo_slot_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L6b_halfmodule_stereo_slot_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L6b_halfmodule_stereo_slot_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L6b_halfmodule_stereo_slot_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L6b_halfmodule_stereo_slot_sensor_active_volume" />
+          <positionref ref="module_L6b_halfmodule_stereo_slot_sensor_active_position" />
+          <rotationref ref="module_L6b_halfmodule_stereo_slot_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L6b_halfmodule_stereo_slot_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L6b_halfmodule_stereo_slot_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L6b_halfmodule_stereo_slot_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L6b_halfmodule_stereo_slotBox" />
+        <physvol>
+          <volumeref ref="module_L6b_halfmodule_stereo_slot_sensor_volume" />
+          <positionref ref="module_L6b_halfmodule_stereo_slot_sensor_position" />
+          <rotationref ref="module_L6b_halfmodule_stereo_slot_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L6b_halfmodule_stereo_slot_lamination_volume" />
+          <positionref ref="module_L6b_halfmodule_stereo_slot_lamination_position" />
+          <rotationref ref="module_L6b_halfmodule_stereo_slot_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L6t_halfmodule_axial_hole_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L6t_halfmodule_axial_hole_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L6t_halfmodule_axial_hole_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L6t_halfmodule_axial_hole_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L6t_halfmodule_axial_hole_sensor_active_volume" />
+          <positionref ref="module_L6t_halfmodule_axial_hole_sensor_active_position" />
+          <rotationref ref="module_L6t_halfmodule_axial_hole_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L6t_halfmodule_axial_hole_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L6t_halfmodule_axial_hole_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L6t_halfmodule_axial_hole_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L6t_halfmodule_axial_holeBox" />
+        <physvol>
+          <volumeref ref="module_L6t_halfmodule_axial_hole_sensor_volume" />
+          <positionref ref="module_L6t_halfmodule_axial_hole_sensor_position" />
+          <rotationref ref="module_L6t_halfmodule_axial_hole_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L6t_halfmodule_axial_hole_lamination_volume" />
+          <positionref ref="module_L6t_halfmodule_axial_hole_lamination_position" />
+          <rotationref ref="module_L6t_halfmodule_axial_hole_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L6t_halfmodule_axial_slot_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L6t_halfmodule_axial_slot_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L6t_halfmodule_axial_slot_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L6t_halfmodule_axial_slot_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L6t_halfmodule_axial_slot_sensor_active_volume" />
+          <positionref ref="module_L6t_halfmodule_axial_slot_sensor_active_position" />
+          <rotationref ref="module_L6t_halfmodule_axial_slot_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L6t_halfmodule_axial_slot_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L6t_halfmodule_axial_slot_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L6t_halfmodule_axial_slot_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L6t_halfmodule_axial_slotBox" />
+        <physvol>
+          <volumeref ref="module_L6t_halfmodule_axial_slot_sensor_volume" />
+          <positionref ref="module_L6t_halfmodule_axial_slot_sensor_position" />
+          <rotationref ref="module_L6t_halfmodule_axial_slot_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L6t_halfmodule_axial_slot_lamination_volume" />
+          <positionref ref="module_L6t_halfmodule_axial_slot_lamination_position" />
+          <rotationref ref="module_L6t_halfmodule_axial_slot_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L6t_halfmodule_stereo_hole_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L6t_halfmodule_stereo_hole_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L6t_halfmodule_stereo_hole_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L6t_halfmodule_stereo_hole_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L6t_halfmodule_stereo_hole_sensor_active_volume" />
+          <positionref ref="module_L6t_halfmodule_stereo_hole_sensor_active_position" />
+          <rotationref ref="module_L6t_halfmodule_stereo_hole_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L6t_halfmodule_stereo_hole_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L6t_halfmodule_stereo_hole_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L6t_halfmodule_stereo_hole_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L6t_halfmodule_stereo_holeBox" />
+        <physvol>
+          <volumeref ref="module_L6t_halfmodule_stereo_hole_sensor_volume" />
+          <positionref ref="module_L6t_halfmodule_stereo_hole_sensor_position" />
+          <rotationref ref="module_L6t_halfmodule_stereo_hole_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L6t_halfmodule_stereo_hole_lamination_volume" />
+          <positionref ref="module_L6t_halfmodule_stereo_hole_lamination_position" />
+          <rotationref ref="module_L6t_halfmodule_stereo_hole_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L6t_halfmodule_stereo_slot_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L6t_halfmodule_stereo_slot_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L6t_halfmodule_stereo_slot_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L6t_halfmodule_stereo_slot_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L6t_halfmodule_stereo_slot_sensor_active_volume" />
+          <positionref ref="module_L6t_halfmodule_stereo_slot_sensor_active_position" />
+          <rotationref ref="module_L6t_halfmodule_stereo_slot_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L6t_halfmodule_stereo_slot_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L6t_halfmodule_stereo_slot_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L6t_halfmodule_stereo_slot_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L6t_halfmodule_stereo_slotBox" />
+        <physvol>
+          <volumeref ref="module_L6t_halfmodule_stereo_slot_sensor_volume" />
+          <positionref ref="module_L6t_halfmodule_stereo_slot_sensor_position" />
+          <rotationref ref="module_L6t_halfmodule_stereo_slot_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L6t_halfmodule_stereo_slot_lamination_volume" />
+          <positionref ref="module_L6t_halfmodule_stereo_slot_lamination_position" />
+          <rotationref ref="module_L6t_halfmodule_stereo_slot_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L7b_halfmodule_axial_hole_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L7b_halfmodule_axial_hole_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L7b_halfmodule_axial_hole_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L7b_halfmodule_axial_hole_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L7b_halfmodule_axial_hole_sensor_active_volume" />
+          <positionref ref="module_L7b_halfmodule_axial_hole_sensor_active_position" />
+          <rotationref ref="module_L7b_halfmodule_axial_hole_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L7b_halfmodule_axial_hole_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L7b_halfmodule_axial_hole_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L7b_halfmodule_axial_hole_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L7b_halfmodule_axial_holeBox" />
+        <physvol>
+          <volumeref ref="module_L7b_halfmodule_axial_hole_sensor_volume" />
+          <positionref ref="module_L7b_halfmodule_axial_hole_sensor_position" />
+          <rotationref ref="module_L7b_halfmodule_axial_hole_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L7b_halfmodule_axial_hole_lamination_volume" />
+          <positionref ref="module_L7b_halfmodule_axial_hole_lamination_position" />
+          <rotationref ref="module_L7b_halfmodule_axial_hole_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L7b_halfmodule_axial_slot_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L7b_halfmodule_axial_slot_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L7b_halfmodule_axial_slot_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L7b_halfmodule_axial_slot_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L7b_halfmodule_axial_slot_sensor_active_volume" />
+          <positionref ref="module_L7b_halfmodule_axial_slot_sensor_active_position" />
+          <rotationref ref="module_L7b_halfmodule_axial_slot_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L7b_halfmodule_axial_slot_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L7b_halfmodule_axial_slot_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L7b_halfmodule_axial_slot_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L7b_halfmodule_axial_slotBox" />
+        <physvol>
+          <volumeref ref="module_L7b_halfmodule_axial_slot_sensor_volume" />
+          <positionref ref="module_L7b_halfmodule_axial_slot_sensor_position" />
+          <rotationref ref="module_L7b_halfmodule_axial_slot_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L7b_halfmodule_axial_slot_lamination_volume" />
+          <positionref ref="module_L7b_halfmodule_axial_slot_lamination_position" />
+          <rotationref ref="module_L7b_halfmodule_axial_slot_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L7b_halfmodule_stereo_hole_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L7b_halfmodule_stereo_hole_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L7b_halfmodule_stereo_hole_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L7b_halfmodule_stereo_hole_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L7b_halfmodule_stereo_hole_sensor_active_volume" />
+          <positionref ref="module_L7b_halfmodule_stereo_hole_sensor_active_position" />
+          <rotationref ref="module_L7b_halfmodule_stereo_hole_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L7b_halfmodule_stereo_hole_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L7b_halfmodule_stereo_hole_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L7b_halfmodule_stereo_hole_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L7b_halfmodule_stereo_holeBox" />
+        <physvol>
+          <volumeref ref="module_L7b_halfmodule_stereo_hole_sensor_volume" />
+          <positionref ref="module_L7b_halfmodule_stereo_hole_sensor_position" />
+          <rotationref ref="module_L7b_halfmodule_stereo_hole_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L7b_halfmodule_stereo_hole_lamination_volume" />
+          <positionref ref="module_L7b_halfmodule_stereo_hole_lamination_position" />
+          <rotationref ref="module_L7b_halfmodule_stereo_hole_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L7b_halfmodule_stereo_slot_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L7b_halfmodule_stereo_slot_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L7b_halfmodule_stereo_slot_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L7b_halfmodule_stereo_slot_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L7b_halfmodule_stereo_slot_sensor_active_volume" />
+          <positionref ref="module_L7b_halfmodule_stereo_slot_sensor_active_position" />
+          <rotationref ref="module_L7b_halfmodule_stereo_slot_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L7b_halfmodule_stereo_slot_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L7b_halfmodule_stereo_slot_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L7b_halfmodule_stereo_slot_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L7b_halfmodule_stereo_slotBox" />
+        <physvol>
+          <volumeref ref="module_L7b_halfmodule_stereo_slot_sensor_volume" />
+          <positionref ref="module_L7b_halfmodule_stereo_slot_sensor_position" />
+          <rotationref ref="module_L7b_halfmodule_stereo_slot_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L7b_halfmodule_stereo_slot_lamination_volume" />
+          <positionref ref="module_L7b_halfmodule_stereo_slot_lamination_position" />
+          <rotationref ref="module_L7b_halfmodule_stereo_slot_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L7t_halfmodule_axial_hole_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L7t_halfmodule_axial_hole_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L7t_halfmodule_axial_hole_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L7t_halfmodule_axial_hole_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L7t_halfmodule_axial_hole_sensor_active_volume" />
+          <positionref ref="module_L7t_halfmodule_axial_hole_sensor_active_position" />
+          <rotationref ref="module_L7t_halfmodule_axial_hole_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L7t_halfmodule_axial_hole_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L7t_halfmodule_axial_hole_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L7t_halfmodule_axial_hole_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L7t_halfmodule_axial_holeBox" />
+        <physvol>
+          <volumeref ref="module_L7t_halfmodule_axial_hole_sensor_volume" />
+          <positionref ref="module_L7t_halfmodule_axial_hole_sensor_position" />
+          <rotationref ref="module_L7t_halfmodule_axial_hole_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L7t_halfmodule_axial_hole_lamination_volume" />
+          <positionref ref="module_L7t_halfmodule_axial_hole_lamination_position" />
+          <rotationref ref="module_L7t_halfmodule_axial_hole_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L7t_halfmodule_axial_slot_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L7t_halfmodule_axial_slot_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L7t_halfmodule_axial_slot_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L7t_halfmodule_axial_slot_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L7t_halfmodule_axial_slot_sensor_active_volume" />
+          <positionref ref="module_L7t_halfmodule_axial_slot_sensor_active_position" />
+          <rotationref ref="module_L7t_halfmodule_axial_slot_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L7t_halfmodule_axial_slot_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L7t_halfmodule_axial_slot_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L7t_halfmodule_axial_slot_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L7t_halfmodule_axial_slotBox" />
+        <physvol>
+          <volumeref ref="module_L7t_halfmodule_axial_slot_sensor_volume" />
+          <positionref ref="module_L7t_halfmodule_axial_slot_sensor_position" />
+          <rotationref ref="module_L7t_halfmodule_axial_slot_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L7t_halfmodule_axial_slot_lamination_volume" />
+          <positionref ref="module_L7t_halfmodule_axial_slot_lamination_position" />
+          <rotationref ref="module_L7t_halfmodule_axial_slot_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L7t_halfmodule_stereo_hole_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L7t_halfmodule_stereo_hole_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L7t_halfmodule_stereo_hole_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L7t_halfmodule_stereo_hole_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L7t_halfmodule_stereo_hole_sensor_active_volume" />
+          <positionref ref="module_L7t_halfmodule_stereo_hole_sensor_active_position" />
+          <rotationref ref="module_L7t_halfmodule_stereo_hole_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L7t_halfmodule_stereo_hole_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L7t_halfmodule_stereo_hole_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L7t_halfmodule_stereo_hole_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L7t_halfmodule_stereo_holeBox" />
+        <physvol>
+          <volumeref ref="module_L7t_halfmodule_stereo_hole_sensor_volume" />
+          <positionref ref="module_L7t_halfmodule_stereo_hole_sensor_position" />
+          <rotationref ref="module_L7t_halfmodule_stereo_hole_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L7t_halfmodule_stereo_hole_lamination_volume" />
+          <positionref ref="module_L7t_halfmodule_stereo_hole_lamination_position" />
+          <rotationref ref="module_L7t_halfmodule_stereo_hole_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L7t_halfmodule_stereo_slot_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L7t_halfmodule_stereo_slot_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L7t_halfmodule_stereo_slot_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L7t_halfmodule_stereo_slot_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L7t_halfmodule_stereo_slot_sensor_active_volume" />
+          <positionref ref="module_L7t_halfmodule_stereo_slot_sensor_active_position" />
+          <rotationref ref="module_L7t_halfmodule_stereo_slot_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L7t_halfmodule_stereo_slot_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L7t_halfmodule_stereo_slot_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L7t_halfmodule_stereo_slot_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L7t_halfmodule_stereo_slotBox" />
+        <physvol>
+          <volumeref ref="module_L7t_halfmodule_stereo_slot_sensor_volume" />
+          <positionref ref="module_L7t_halfmodule_stereo_slot_sensor_position" />
+          <rotationref ref="module_L7t_halfmodule_stereo_slot_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L7t_halfmodule_stereo_slot_lamination_volume" />
+          <positionref ref="module_L7t_halfmodule_stereo_slot_lamination_position" />
+          <rotationref ref="module_L7t_halfmodule_stereo_slot_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="base_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="baseBox" />
+        <physvol>
+          <volumeref ref="base_plate_volume" />
+          <positionref ref="base_plate_position" />
+          <rotationref ref="base_plate_rotation" />
+        </physvol>
+        <physvol>
+          <volumeref ref="support_plate_bottom_L14_volume" />
+          <positionref ref="support_plate_bottom_L14_position" />
+          <rotationref ref="support_plate_bottom_L14_rotation" />
+        </physvol>
+        <physvol>
+          <volumeref ref="support_plate_top_L14_volume" />
+          <positionref ref="support_plate_top_L14_position" />
+          <rotationref ref="support_plate_top_L14_rotation" />
+        </physvol>
+        <physvol>
+          <volumeref ref="support_plate_bottom_L46_volume" />
+          <positionref ref="support_plate_bottom_L46_position" />
+          <rotationref ref="support_plate_bottom_L46_rotation" />
+        </physvol>
+        <physvol>
+          <volumeref ref="support_plate_top_L46_volume" />
+          <positionref ref="support_plate_top_L46_position" />
+          <rotationref ref="support_plate_top_L46_rotation" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L1b_halfmodule_axial_volume" />
+          <positionref ref="module_L1b_halfmodule_axial_position" />
+          <rotationref ref="module_L1b_halfmodule_axial_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="2" />
+          <physvolid field_name="module" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L1b_halfmodule_stereo_volume" />
+          <positionref ref="module_L1b_halfmodule_stereo_position" />
+          <rotationref ref="module_L1b_halfmodule_stereo_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="1" />
+          <physvolid field_name="module" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L1t_halfmodule_axial_volume" />
+          <positionref ref="module_L1t_halfmodule_axial_position" />
+          <rotationref ref="module_L1t_halfmodule_axial_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="1" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L1t_halfmodule_stereo_volume" />
+          <positionref ref="module_L1t_halfmodule_stereo_position" />
+          <rotationref ref="module_L1t_halfmodule_stereo_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="2" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L2b_halfmodule_axial_volume" />
+          <positionref ref="module_L2b_halfmodule_axial_position" />
+          <rotationref ref="module_L2b_halfmodule_axial_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="4" />
+          <physvolid field_name="module" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L2b_halfmodule_stereo_volume" />
+          <positionref ref="module_L2b_halfmodule_stereo_position" />
+          <rotationref ref="module_L2b_halfmodule_stereo_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="3" />
+          <physvolid field_name="module" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L2t_halfmodule_axial_volume" />
+          <positionref ref="module_L2t_halfmodule_axial_position" />
+          <rotationref ref="module_L2t_halfmodule_axial_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="3" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L2t_halfmodule_stereo_volume" />
+          <positionref ref="module_L2t_halfmodule_stereo_position" />
+          <rotationref ref="module_L2t_halfmodule_stereo_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="4" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L3b_halfmodule_axial_volume" />
+          <positionref ref="module_L3b_halfmodule_axial_position" />
+          <rotationref ref="module_L3b_halfmodule_axial_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="6" />
+          <physvolid field_name="module" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L3b_halfmodule_stereo_volume" />
+          <positionref ref="module_L3b_halfmodule_stereo_position" />
+          <rotationref ref="module_L3b_halfmodule_stereo_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="5" />
+          <physvolid field_name="module" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L3t_halfmodule_axial_volume" />
+          <positionref ref="module_L3t_halfmodule_axial_position" />
+          <rotationref ref="module_L3t_halfmodule_axial_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="5" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L3t_halfmodule_stereo_volume" />
+          <positionref ref="module_L3t_halfmodule_stereo_position" />
+          <rotationref ref="module_L3t_halfmodule_stereo_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="6" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L4b_halfmodule_axial_volume" />
+          <positionref ref="module_L4b_halfmodule_axial_position" />
+          <rotationref ref="module_L4b_halfmodule_axial_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="8" />
+          <physvolid field_name="module" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L4b_halfmodule_stereo_volume" />
+          <positionref ref="module_L4b_halfmodule_stereo_position" />
+          <rotationref ref="module_L4b_halfmodule_stereo_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="7" />
+          <physvolid field_name="module" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L4t_halfmodule_axial_volume" />
+          <positionref ref="module_L4t_halfmodule_axial_position" />
+          <rotationref ref="module_L4t_halfmodule_axial_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="7" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L4t_halfmodule_stereo_volume" />
+          <positionref ref="module_L4t_halfmodule_stereo_position" />
+          <rotationref ref="module_L4t_halfmodule_stereo_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="8" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L5b_halfmodule_axial_hole_volume" />
+          <positionref ref="module_L5b_halfmodule_axial_hole_position" />
+          <rotationref ref="module_L5b_halfmodule_axial_hole_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="10" />
+          <physvolid field_name="module" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L5b_halfmodule_axial_slot_volume" />
+          <positionref ref="module_L5b_halfmodule_axial_slot_position" />
+          <rotationref ref="module_L5b_halfmodule_axial_slot_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="10" />
+          <physvolid field_name="module" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L5b_halfmodule_stereo_hole_volume" />
+          <positionref ref="module_L5b_halfmodule_stereo_hole_position" />
+          <rotationref ref="module_L5b_halfmodule_stereo_hole_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="9" />
+          <physvolid field_name="module" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L5b_halfmodule_stereo_slot_volume" />
+          <positionref ref="module_L5b_halfmodule_stereo_slot_position" />
+          <rotationref ref="module_L5b_halfmodule_stereo_slot_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="9" />
+          <physvolid field_name="module" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L5t_halfmodule_axial_hole_volume" />
+          <positionref ref="module_L5t_halfmodule_axial_hole_position" />
+          <rotationref ref="module_L5t_halfmodule_axial_hole_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="9" />
+          <physvolid field_name="module" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L5t_halfmodule_axial_slot_volume" />
+          <positionref ref="module_L5t_halfmodule_axial_slot_position" />
+          <rotationref ref="module_L5t_halfmodule_axial_slot_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="9" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L5t_halfmodule_stereo_hole_volume" />
+          <positionref ref="module_L5t_halfmodule_stereo_hole_position" />
+          <rotationref ref="module_L5t_halfmodule_stereo_hole_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="10" />
+          <physvolid field_name="module" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L5t_halfmodule_stereo_slot_volume" />
+          <positionref ref="module_L5t_halfmodule_stereo_slot_position" />
+          <rotationref ref="module_L5t_halfmodule_stereo_slot_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="10" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L6b_halfmodule_axial_hole_volume" />
+          <positionref ref="module_L6b_halfmodule_axial_hole_position" />
+          <rotationref ref="module_L6b_halfmodule_axial_hole_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="12" />
+          <physvolid field_name="module" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L6b_halfmodule_axial_slot_volume" />
+          <positionref ref="module_L6b_halfmodule_axial_slot_position" />
+          <rotationref ref="module_L6b_halfmodule_axial_slot_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="12" />
+          <physvolid field_name="module" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L6b_halfmodule_stereo_hole_volume" />
+          <positionref ref="module_L6b_halfmodule_stereo_hole_position" />
+          <rotationref ref="module_L6b_halfmodule_stereo_hole_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="11" />
+          <physvolid field_name="module" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L6b_halfmodule_stereo_slot_volume" />
+          <positionref ref="module_L6b_halfmodule_stereo_slot_position" />
+          <rotationref ref="module_L6b_halfmodule_stereo_slot_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="11" />
+          <physvolid field_name="module" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L6t_halfmodule_axial_hole_volume" />
+          <positionref ref="module_L6t_halfmodule_axial_hole_position" />
+          <rotationref ref="module_L6t_halfmodule_axial_hole_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="11" />
+          <physvolid field_name="module" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L6t_halfmodule_axial_slot_volume" />
+          <positionref ref="module_L6t_halfmodule_axial_slot_position" />
+          <rotationref ref="module_L6t_halfmodule_axial_slot_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="11" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L6t_halfmodule_stereo_hole_volume" />
+          <positionref ref="module_L6t_halfmodule_stereo_hole_position" />
+          <rotationref ref="module_L6t_halfmodule_stereo_hole_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="12" />
+          <physvolid field_name="module" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L6t_halfmodule_stereo_slot_volume" />
+          <positionref ref="module_L6t_halfmodule_stereo_slot_position" />
+          <rotationref ref="module_L6t_halfmodule_stereo_slot_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="12" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L7b_halfmodule_axial_hole_volume" />
+          <positionref ref="module_L7b_halfmodule_axial_hole_position" />
+          <rotationref ref="module_L7b_halfmodule_axial_hole_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="14" />
+          <physvolid field_name="module" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L7b_halfmodule_axial_slot_volume" />
+          <positionref ref="module_L7b_halfmodule_axial_slot_position" />
+          <rotationref ref="module_L7b_halfmodule_axial_slot_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="14" />
+          <physvolid field_name="module" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L7b_halfmodule_stereo_hole_volume" />
+          <positionref ref="module_L7b_halfmodule_stereo_hole_position" />
+          <rotationref ref="module_L7b_halfmodule_stereo_hole_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="13" />
+          <physvolid field_name="module" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L7b_halfmodule_stereo_slot_volume" />
+          <positionref ref="module_L7b_halfmodule_stereo_slot_position" />
+          <rotationref ref="module_L7b_halfmodule_stereo_slot_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="13" />
+          <physvolid field_name="module" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L7t_halfmodule_axial_hole_volume" />
+          <positionref ref="module_L7t_halfmodule_axial_hole_position" />
+          <rotationref ref="module_L7t_halfmodule_axial_hole_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="13" />
+          <physvolid field_name="module" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L7t_halfmodule_axial_slot_volume" />
+          <positionref ref="module_L7t_halfmodule_axial_slot_position" />
+          <rotationref ref="module_L7t_halfmodule_axial_slot_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="13" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L7t_halfmodule_stereo_hole_volume" />
+          <positionref ref="module_L7t_halfmodule_stereo_hole_position" />
+          <rotationref ref="module_L7t_halfmodule_stereo_hole_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="14" />
+          <physvolid field_name="module" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L7t_halfmodule_stereo_slot_volume" />
+          <positionref ref="module_L7t_halfmodule_stereo_slot_position" />
+          <rotationref ref="module_L7t_halfmodule_stereo_slot_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="14" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <visref ref="SvtBoxVis" />
+      </volume>
+      <volume name="BeamLeftVolume_component0Sensor0">
+        <materialref ref="Vacuum" />
+        <solidref ref="BeamLeftVolume_component0Sensor0Box" />
+        <sdref ref="ECalScoring" />
+      </volume>
+      <volume name="BeamLeftVolume_component0">
+        <materialref ref="Vacuum" />
+        <solidref ref="BeamLeftVolume_component0Box" />
+        <physvol>
+          <volumeref ref="BeamLeftVolume_component0Sensor0" />
+          <positionref ref="BeamLeftVolume_component0Sensor0Position" />
+          <rotationref ref="BeamLeftVolume_component0Sensor0Rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+      </volume>
+      <volume name="BeamLeftVolume">
+        <materialref ref="Vacuum" />
+        <solidref ref="BeamLeftBox" />
+        <physvol>
+          <volumeref ref="BeamLeftVolume_component0" />
+          <positionref ref="BeamLeftVolume_component0_position" />
+          <rotationref ref="BeamLeftVolume_component0_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+      </volume>
+      <volume name="ElectronGapVolume_component0Sensor0">
+        <materialref ref="Vacuum" />
+        <solidref ref="ElectronGapVolume_component0Sensor0Box" />
+        <sdref ref="ECalScoring" />
+      </volume>
+      <volume name="ElectronGapVolume_component0">
+        <materialref ref="Vacuum" />
+        <solidref ref="ElectronGapVolume_component0Box" />
+        <physvol>
+          <volumeref ref="ElectronGapVolume_component0Sensor0" />
+          <positionref ref="ElectronGapVolume_component0Sensor0Position" />
+          <rotationref ref="ElectronGapVolume_component0Sensor0Rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+      </volume>
+      <volume name="ElectronGapVolume">
+        <materialref ref="Vacuum" />
+        <solidref ref="ElectronGapBox" />
+        <physvol>
+          <volumeref ref="ElectronGapVolume_component0" />
+          <positionref ref="ElectronGapVolume_component0_position" />
+          <rotationref ref="ElectronGapVolume_component0_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+      </volume>
+      <volume name="BeamRightVolume_component0Sensor0">
+        <materialref ref="Vacuum" />
+        <solidref ref="BeamRightVolume_component0Sensor0Box" />
+        <sdref ref="ECalScoring" />
+      </volume>
+      <volume name="BeamRightVolume_component0">
+        <materialref ref="Vacuum" />
+        <solidref ref="BeamRightVolume_component0Box" />
+        <physvol>
+          <volumeref ref="BeamRightVolume_component0Sensor0" />
+          <positionref ref="BeamRightVolume_component0Sensor0Position" />
+          <rotationref ref="BeamRightVolume_component0Sensor0Rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+      </volume>
+      <volume name="BeamRightVolume">
+        <materialref ref="Vacuum" />
+        <solidref ref="BeamRightBox" />
+        <physvol>
+          <volumeref ref="BeamRightVolume_component0" />
+          <positionref ref="BeamRightVolume_component0_position" />
+          <rotationref ref="BeamRightVolume_component0_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+      </volume>
+      <volume name="crystal_volume">
+        <materialref ref="LeadTungstate" />
+        <solidref ref="crystal_trap" />
+        <sdref ref="Ecal" />
+        <visref ref="ECALVis" />
+      </volume>
+      <volume name="hodo_vol_L1TP0">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L1TP0" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L1TP0">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L1TP0" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L1TP0">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L1TP0" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L1TP0">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L1TP0" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_vol_L1BP0">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L1BP0" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L1BP0">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L1BP0" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L1BP0">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L1BP0" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L1BP0">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L1BP0" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_vol_L1TP1">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L1TP1" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L1TP1">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L1TP1" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L1TP1">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L1TP1" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L1TP1">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L1TP1" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_vol_L1BP1">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L1BP1" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L1BP1">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L1BP1" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L1BP1">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L1BP1" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L1BP1">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L1BP1" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_vol_L1TP2">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L1TP2" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L1TP2">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L1TP2" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L1TP2">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L1TP2" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L1TP2">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L1TP2" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_vol_L1BP2">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L1BP2" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L1BP2">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L1BP2" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L1BP2">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L1BP2" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L1BP2">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L1BP2" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_vol_L1TP3">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L1TP3" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L1TP3">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L1TP3" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L1TP3">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L1TP3" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L1TP3">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L1TP3" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_vol_L1BP3">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L1BP3" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L1BP3">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L1BP3" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L1BP3">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L1BP3" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L1BP3">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L1BP3" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_vol_L1TP4">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L1TP4" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L1TP4">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L1TP4" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L1TP4">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L1TP4" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L1TP4">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L1TP4" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_vol_L1BP4">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L1BP4" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L1BP4">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L1BP4" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L1BP4">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L1BP4" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L1BP4">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L1BP4" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_vol_L2TP0">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L2TP0" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L2TP0">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L2TP0" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L2TP0">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L2TP0" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L2TP0">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L2TP0" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_vol_L2BP0">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L2BP0" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L2BP0">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L2BP0" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L2BP0">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L2BP0" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L2BP0">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L2BP0" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_vol_L2TP1">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L2TP1" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L2TP1">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L2TP1" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L2TP1">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L2TP1" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L2TP1">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L2TP1" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_vol_L2BP1">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L2BP1" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L2BP1">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L2BP1" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L2BP1">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L2BP1" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L2BP1">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L2BP1" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_vol_L2TP2">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L2TP2" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L2TP2">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L2TP2" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L2TP2">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L2TP2" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L2TP2">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L2TP2" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_vol_L2BP2">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L2BP2" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L2BP2">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L2BP2" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L2BP2">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L2BP2" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L2BP2">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L2BP2" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_vol_L2TP3">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L2TP3" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L2TP3">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L2TP3" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L2TP3">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L2TP3" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L2TP3">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L2TP3" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_vol_L2BP3">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L2BP3" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L2BP3">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L2BP3" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L2BP3">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L2BP3" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L2BP3">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L2BP3" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_vol_L2TP4">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L2TP4" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L2TP4">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L2TP4" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L2TP4">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L2TP4" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L2TP4">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L2TP4" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_vol_L2BP4">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L2BP4" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L2BP4">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L2BP4" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L2BP4">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L2BP4" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L2BP4">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L2BP4" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_buffer_vol">
+        <materialref ref="Carbon" />
+        <solidref ref="hodo_buffer" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="front_flange">
+        <materialref ref="G4_Al" />
+        <solidref ref="front_flange_shape" />
+      </volume>
+      <volume name="back_flange">
+        <materialref ref="G4_Al" />
+        <solidref ref="back_flange_shape" />
+      </volume>
+      <volume name="ECAL_chamber">
+        <materialref ref="G4_Al" />
+        <solidref ref="ECAL_chamber_shape" />
+      </volume>
+      <volume name="al_honeycomb">
+        <materialref ref="AlHoneycomb" />
+        <solidref ref="al_honeycomb_shape" />
+      </volume>
+      <volume name="layer_1_top">
+        <materialref ref="G4_Al" />
+        <solidref ref="layer_1_top_shape" />
+      </volume>
+      <volume name="layer_2_top">
+        <materialref ref="G4_Al" />
+        <solidref ref="layer_2_top_shape" />
+      </volume>
+      <volume name="layer_3_top">
+        <materialref ref="G4_Al" />
+        <solidref ref="layer_3_top_shape" />
+      </volume>
+      <volume name="layer_4_top">
+        <materialref ref="G4_Al" />
+        <solidref ref="layer_4_top_shape" />
+      </volume>
+      <volume name="layer_1_bottom">
+        <materialref ref="G4_Al" />
+        <solidref ref="layer_1_bottom_shape" />
+      </volume>
+      <volume name="layer_2_bottom">
+        <materialref ref="G4_Al" />
+        <solidref ref="layer_2_bottom_shape" />
+      </volume>
+      <volume name="layer_3_bottom">
+        <materialref ref="G4_Al" />
+        <solidref ref="layer_3_bottom_shape" />
+      </volume>
+      <volume name="layer_4_bottom">
+        <materialref ref="G4_Al" />
+        <solidref ref="layer_4_bottom_shape" />
+      </volume>
+      <volume name="layer_5T_left">
+        <materialref ref="G4_Al" />
+        <solidref ref="layer_5T_left_shape" />
+      </volume>
+      <volume name="layer_5B_left">
+        <materialref ref="G4_Al" />
+        <solidref ref="layer_5B_left_shape" />
+      </volume>
+      <volume name="steel_bar">
+        <materialref ref="StainlessSteel" />
+        <solidref ref="steel_bar_shape" />
+      </volume>
+      <volume name="cu_Tpipe_inner_left">
+        <materialref ref="G4_Cu" />
+        <solidref ref="cu_Tpipe_inner_left_shape" />
+      </volume>
+      <volume name="cu_Tpipe_inner_right">
+        <materialref ref="G4_Cu" />
+        <solidref ref="cu_Tpipe_inner_right_shape" />
+      </volume>
+      <volume name="cu_Bpipe_inner_left">
+        <materialref ref="G4_Cu" />
+        <solidref ref="cu_Bpipe_inner_left_shape" />
+      </volume>
+      <volume name="cu_Bpipe_inner_right">
+        <materialref ref="G4_Cu" />
+        <solidref ref="cu_Bpipe_inner_right_shape" />
+      </volume>
+      <volume name="cu_Tpipe_outer_right1">
+        <materialref ref="G4_Cu" />
+        <solidref ref="cu_Tpipe_outer_right1_shape" />
+      </volume>
+      <volume name="cu_Tpipe_outer_right2">
+        <materialref ref="G4_Cu" />
+        <solidref ref="cu_Tpipe_outer_right2_shape" />
+      </volume>
+      <volume name="cu_Tpipe_outer_right3">
+        <materialref ref="G4_Cu" />
+        <solidref ref="cu_Tpipe_outer_right3_shape" />
+      </volume>
+      <volume name="cu_Bpipe_outer_right">
+        <materialref ref="G4_Cu" />
+        <solidref ref="cu_Bpipe_outer_right_shape" />
+      </volume>
+      <volume name="cu_Bpipe_outer_right1">
+        <materialref ref="G4_Cu" />
+        <solidref ref="cu_Bpipe_outer_right1_shape" />
+      </volume>
+      <volume name="cu_Bpipe_outer_right2">
+        <materialref ref="G4_Cu" />
+        <solidref ref="cu_Bpipe_outer_right2_shape" />
+      </volume>
+      <volume name="al_pipe_across_top1">
+        <materialref ref="G4_Al" />
+        <solidref ref="al_pipe_across_top1_shape" />
+      </volume>
+      <volume name="al_pipe_across_top2">
+        <materialref ref="G4_Al" />
+        <solidref ref="al_pipe_across_top2_shape" />
+      </volume>
+      <volume name="al_pipe_across_bottom1">
+        <materialref ref="G4_Al" />
+        <solidref ref="al_pipe_across_bottom1_shape" />
+      </volume>
+      <volume name="al_pipe_across_bottom2">
+        <materialref ref="G4_Al" />
+        <solidref ref="al_pipe_across_bottom2_shape" />
+      </volume>
+      <volume name="cu_plate_top_left">
+        <materialref ref="G4_Cu" />
+        <solidref ref="cu_plate_top_left_shape" />
+      </volume>
+      <volume name="cu_plate_bottom_left">
+        <materialref ref="G4_Cu" />
+        <solidref ref="cu_plate_bottom_left_shape" />
+      </volume>
+      <volume name="cu_plate_top_right">
+        <materialref ref="G4_Cu" />
+        <solidref ref="cu_plate_top_right_shape" />
+      </volume>
+      <volume name="cu_plate_bottom_right">
+        <materialref ref="G4_Cu" />
+        <solidref ref="cu_plate_bottom_right_shape" />
+      </volume>
+      <volume name="cu_plate_top_middle">
+        <materialref ref="G4_Cu" />
+        <solidref ref="cu_plate_top_middle_shape" />
+      </volume>
+      <volume name="cu_plate_bottom_middle">
+        <materialref ref="G4_Cu" />
+        <solidref ref="cu_plate_bottom_middle_shape" />
+      </volume>
+      <volume name="hodo_flange">
+        <materialref ref="Aluminum" />
+        <solidref ref="hodo_flange_shape" />
+      </volume>
+      <volume name="arms1_block1">
+        <materialref ref="G10_FR4" />
+        <solidref ref="arms1_block1_shape" />
+      </volume>
+      <volume name="arms1_block2">
+        <materialref ref="G10_FR4" />
+        <solidref ref="arms1_block2_shape" />
+      </volume>
+      <volume name="arms1_block3">
+        <materialref ref="G10_FR4" />
+        <solidref ref="arms1_block3_shape" />
+      </volume>
+      <volume name="arms1_block4">
+        <materialref ref="G10_FR4" />
+        <solidref ref="arms1_block4_shape" />
+      </volume>
+      <volume name="cross_bar_top">
+        <materialref ref="G10_FR4" />
+        <solidref ref="cross_bar_top_shape" />
+      </volume>
+      <volume name="cross_bar_bottom">
+        <materialref ref="G10_FR4" />
+        <solidref ref="cross_bar_bottom_shape" />
+      </volume>
+      <volume name="support_arm_bottom_left_plus_block">
+        <materialref ref="G10_FR4" />
+        <solidref ref="support_arm_bottom_left_plus_block_shape" />
+      </volume>
+      <volume name="support_arm_bottom_right">
+        <materialref ref="G10_FR4" />
+        <solidref ref="support_arm_bottom_right_shape" />
+      </volume>
+      <volume name="support_arm_top_left">
+        <materialref ref="G10_FR4" />
+        <solidref ref="support_arm_top_left_shape" />
+      </volume>
+      <volume name="support_arm_top_right">
+        <materialref ref="G10_FR4" />
+        <solidref ref="support_arm_top_right_shape" />
+      </volume>
+      <volume name="u_support_bar_bottom">
+        <materialref ref="G10_FR4" />
+        <solidref ref="u_support_bar_bottom_shape" />
+      </volume>
+      <volume name="u_support_bar_upper1">
+        <materialref ref="G10_FR4" />
+        <solidref ref="u_support_bar_upper1_shape" />
+      </volume>
+      <volume name="u_support_bar_upper2">
+        <materialref ref="G10_FR4" />
+        <solidref ref="u_support_bar_upper2_shape" />
+      </volume>
+      <volume name="u_support_bar_top">
+        <materialref ref="G10_FR4" />
+        <solidref ref="u_support_bar_top_shape" />
+      </volume>
+      <volume name="u_support_bar_upper3">
+        <materialref ref="G10_FR4" />
+        <solidref ref="u_support_bar_upper3_shape" />
+      </volume>
+      <volume name="u_support_bar_upper4">
+        <materialref ref="G10_FR4" />
+        <solidref ref="u_support_bar_upper4_shape" />
+      </volume>
+      <volume name="svt_chamber_box_vol">
+        <materialref ref="Stainless_304" />
+        <solidref ref="svt_chamber_box" />
+      </volume>
+      <volume name="svt_chamber_flare1_vol">
+        <materialref ref="Stainless_304" />
+        <solidref ref="svt_chamber_flare1" />
+      </volume>
+      <volume name="svt_chamber_flare2_vol">
+        <materialref ref="Stainless_304" />
+        <solidref ref="svt_chamber_flare2" />
+      </volume>
+      <volume name="svt_chamber_flange_vol">
+        <materialref ref="Stainless_304" />
+        <solidref ref="svt_chamber_flange" />
+      </volume>
+      <volume name="tracking_volume">
+        <materialref ref="TrackingMaterial" />
+        <solidref ref="tracking_cylinder" />
+        <physvol>
+          <volumeref ref="base_volume" />
+          <positionref ref="base_position" />
+          <rotationref ref="base_rotation" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L1TP0" />
+          <positionref ref="hodo_pos_L1TP0" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="0" />
+          <physvolid field_name="ix" value="0" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1TP0" />
+          <positionref ref="hodo_forecover_pos_L1TP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1TP0" />
+          <positionref ref="hodo_postcover_pos_L1TP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1TP0" />
+          <positionref ref="hodo_sidereflR_pos_L1TP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1TP0" />
+          <positionref ref="hodo_siderefl2L_pos_L1TP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1TP0" />
+          <positionref ref="hodo_topreflT_pos_L1TP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1TP0" />
+          <positionref ref="hodo_toprefl2B_pos_L1TP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L1BP0" />
+          <positionref ref="hodo_pos_L1BP0" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="0" />
+          <physvolid field_name="ix" value="0" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1BP0" />
+          <positionref ref="hodo_forecover_pos_L1BP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1BP0" />
+          <positionref ref="hodo_postcover_pos_L1BP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1BP0" />
+          <positionref ref="hodo_sidereflR_pos_L1BP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1BP0" />
+          <positionref ref="hodo_siderefl2L_pos_L1BP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1BP0" />
+          <positionref ref="hodo_topreflT_pos_L1BP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1BP0" />
+          <positionref ref="hodo_toprefl2B_pos_L1BP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L1TP1" />
+          <positionref ref="hodo_pos_L1TP1" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="0" />
+          <physvolid field_name="ix" value="1" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1TP1" />
+          <positionref ref="hodo_forecover_pos_L1TP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1TP1" />
+          <positionref ref="hodo_postcover_pos_L1TP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1TP1" />
+          <positionref ref="hodo_sidereflR_pos_L1TP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1TP1" />
+          <positionref ref="hodo_siderefl2L_pos_L1TP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1TP1" />
+          <positionref ref="hodo_topreflT_pos_L1TP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1TP1" />
+          <positionref ref="hodo_toprefl2B_pos_L1TP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L1BP1" />
+          <positionref ref="hodo_pos_L1BP1" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="0" />
+          <physvolid field_name="ix" value="1" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1BP1" />
+          <positionref ref="hodo_forecover_pos_L1BP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1BP1" />
+          <positionref ref="hodo_postcover_pos_L1BP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1BP1" />
+          <positionref ref="hodo_sidereflR_pos_L1BP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1BP1" />
+          <positionref ref="hodo_siderefl2L_pos_L1BP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1BP1" />
+          <positionref ref="hodo_topreflT_pos_L1BP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1BP1" />
+          <positionref ref="hodo_toprefl2B_pos_L1BP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L1TP2" />
+          <positionref ref="hodo_pos_L1TP2" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="0" />
+          <physvolid field_name="ix" value="2" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1TP2" />
+          <positionref ref="hodo_forecover_pos_L1TP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1TP2" />
+          <positionref ref="hodo_postcover_pos_L1TP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1TP2" />
+          <positionref ref="hodo_sidereflR_pos_L1TP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1TP2" />
+          <positionref ref="hodo_siderefl2L_pos_L1TP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1TP2" />
+          <positionref ref="hodo_topreflT_pos_L1TP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1TP2" />
+          <positionref ref="hodo_toprefl2B_pos_L1TP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L1BP2" />
+          <positionref ref="hodo_pos_L1BP2" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="0" />
+          <physvolid field_name="ix" value="2" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1BP2" />
+          <positionref ref="hodo_forecover_pos_L1BP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1BP2" />
+          <positionref ref="hodo_postcover_pos_L1BP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1BP2" />
+          <positionref ref="hodo_sidereflR_pos_L1BP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1BP2" />
+          <positionref ref="hodo_siderefl2L_pos_L1BP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1BP2" />
+          <positionref ref="hodo_topreflT_pos_L1BP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1BP2" />
+          <positionref ref="hodo_toprefl2B_pos_L1BP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L1TP3" />
+          <positionref ref="hodo_pos_L1TP3" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="0" />
+          <physvolid field_name="ix" value="3" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1TP3" />
+          <positionref ref="hodo_forecover_pos_L1TP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1TP3" />
+          <positionref ref="hodo_postcover_pos_L1TP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1TP3" />
+          <positionref ref="hodo_sidereflR_pos_L1TP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1TP3" />
+          <positionref ref="hodo_siderefl2L_pos_L1TP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1TP3" />
+          <positionref ref="hodo_topreflT_pos_L1TP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1TP3" />
+          <positionref ref="hodo_toprefl2B_pos_L1TP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L1BP3" />
+          <positionref ref="hodo_pos_L1BP3" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="0" />
+          <physvolid field_name="ix" value="3" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1BP3" />
+          <positionref ref="hodo_forecover_pos_L1BP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1BP3" />
+          <positionref ref="hodo_postcover_pos_L1BP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1BP3" />
+          <positionref ref="hodo_sidereflR_pos_L1BP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1BP3" />
+          <positionref ref="hodo_siderefl2L_pos_L1BP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1BP3" />
+          <positionref ref="hodo_topreflT_pos_L1BP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1BP3" />
+          <positionref ref="hodo_toprefl2B_pos_L1BP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L1TP4" />
+          <positionref ref="hodo_pos_L1TP4" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="0" />
+          <physvolid field_name="ix" value="4" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1TP4" />
+          <positionref ref="hodo_forecover_pos_L1TP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1TP4" />
+          <positionref ref="hodo_postcover_pos_L1TP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1TP4" />
+          <positionref ref="hodo_sidereflR_pos_L1TP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1TP4" />
+          <positionref ref="hodo_siderefl2L_pos_L1TP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1TP4" />
+          <positionref ref="hodo_topreflT_pos_L1TP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1TP4" />
+          <positionref ref="hodo_toprefl2B_pos_L1TP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L1BP4" />
+          <positionref ref="hodo_pos_L1BP4" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="0" />
+          <physvolid field_name="ix" value="4" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1BP4" />
+          <positionref ref="hodo_forecover_pos_L1BP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1BP4" />
+          <positionref ref="hodo_postcover_pos_L1BP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1BP4" />
+          <positionref ref="hodo_sidereflR_pos_L1BP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1BP4" />
+          <positionref ref="hodo_siderefl2L_pos_L1BP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1BP4" />
+          <positionref ref="hodo_topreflT_pos_L1BP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1BP4" />
+          <positionref ref="hodo_toprefl2B_pos_L1BP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L2TP0" />
+          <positionref ref="hodo_pos_L2TP0" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="1" />
+          <physvolid field_name="ix" value="0" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2TP0" />
+          <positionref ref="hodo_forecover_pos_L2TP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2TP0" />
+          <positionref ref="hodo_postcover_pos_L2TP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2TP0" />
+          <positionref ref="hodo_sidereflR_pos_L2TP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2TP0" />
+          <positionref ref="hodo_siderefl2L_pos_L2TP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2TP0" />
+          <positionref ref="hodo_topreflT_pos_L2TP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2TP0" />
+          <positionref ref="hodo_toprefl2B_pos_L2TP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L2BP0" />
+          <positionref ref="hodo_pos_L2BP0" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="1" />
+          <physvolid field_name="ix" value="0" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2BP0" />
+          <positionref ref="hodo_forecover_pos_L2BP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2BP0" />
+          <positionref ref="hodo_postcover_pos_L2BP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2BP0" />
+          <positionref ref="hodo_sidereflR_pos_L2BP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2BP0" />
+          <positionref ref="hodo_siderefl2L_pos_L2BP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2BP0" />
+          <positionref ref="hodo_topreflT_pos_L2BP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2BP0" />
+          <positionref ref="hodo_toprefl2B_pos_L2BP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L2TP1" />
+          <positionref ref="hodo_pos_L2TP1" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="1" />
+          <physvolid field_name="ix" value="1" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2TP1" />
+          <positionref ref="hodo_forecover_pos_L2TP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2TP1" />
+          <positionref ref="hodo_postcover_pos_L2TP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2TP1" />
+          <positionref ref="hodo_sidereflR_pos_L2TP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2TP1" />
+          <positionref ref="hodo_siderefl2L_pos_L2TP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2TP1" />
+          <positionref ref="hodo_topreflT_pos_L2TP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2TP1" />
+          <positionref ref="hodo_toprefl2B_pos_L2TP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L2BP1" />
+          <positionref ref="hodo_pos_L2BP1" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="1" />
+          <physvolid field_name="ix" value="1" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2BP1" />
+          <positionref ref="hodo_forecover_pos_L2BP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2BP1" />
+          <positionref ref="hodo_postcover_pos_L2BP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2BP1" />
+          <positionref ref="hodo_sidereflR_pos_L2BP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2BP1" />
+          <positionref ref="hodo_siderefl2L_pos_L2BP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2BP1" />
+          <positionref ref="hodo_topreflT_pos_L2BP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2BP1" />
+          <positionref ref="hodo_toprefl2B_pos_L2BP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L2TP2" />
+          <positionref ref="hodo_pos_L2TP2" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="1" />
+          <physvolid field_name="ix" value="2" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2TP2" />
+          <positionref ref="hodo_forecover_pos_L2TP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2TP2" />
+          <positionref ref="hodo_postcover_pos_L2TP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2TP2" />
+          <positionref ref="hodo_sidereflR_pos_L2TP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2TP2" />
+          <positionref ref="hodo_siderefl2L_pos_L2TP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2TP2" />
+          <positionref ref="hodo_topreflT_pos_L2TP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2TP2" />
+          <positionref ref="hodo_toprefl2B_pos_L2TP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L2BP2" />
+          <positionref ref="hodo_pos_L2BP2" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="1" />
+          <physvolid field_name="ix" value="2" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2BP2" />
+          <positionref ref="hodo_forecover_pos_L2BP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2BP2" />
+          <positionref ref="hodo_postcover_pos_L2BP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2BP2" />
+          <positionref ref="hodo_sidereflR_pos_L2BP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2BP2" />
+          <positionref ref="hodo_siderefl2L_pos_L2BP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2BP2" />
+          <positionref ref="hodo_topreflT_pos_L2BP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2BP2" />
+          <positionref ref="hodo_toprefl2B_pos_L2BP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L2TP3" />
+          <positionref ref="hodo_pos_L2TP3" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="1" />
+          <physvolid field_name="ix" value="3" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2TP3" />
+          <positionref ref="hodo_forecover_pos_L2TP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2TP3" />
+          <positionref ref="hodo_postcover_pos_L2TP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2TP3" />
+          <positionref ref="hodo_sidereflR_pos_L2TP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2TP3" />
+          <positionref ref="hodo_siderefl2L_pos_L2TP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2TP3" />
+          <positionref ref="hodo_topreflT_pos_L2TP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2TP3" />
+          <positionref ref="hodo_toprefl2B_pos_L2TP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L2BP3" />
+          <positionref ref="hodo_pos_L2BP3" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="1" />
+          <physvolid field_name="ix" value="3" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2BP3" />
+          <positionref ref="hodo_forecover_pos_L2BP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2BP3" />
+          <positionref ref="hodo_postcover_pos_L2BP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2BP3" />
+          <positionref ref="hodo_sidereflR_pos_L2BP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2BP3" />
+          <positionref ref="hodo_siderefl2L_pos_L2BP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2BP3" />
+          <positionref ref="hodo_topreflT_pos_L2BP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2BP3" />
+          <positionref ref="hodo_toprefl2B_pos_L2BP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L2TP4" />
+          <positionref ref="hodo_pos_L2TP4" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="1" />
+          <physvolid field_name="ix" value="4" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2TP4" />
+          <positionref ref="hodo_forecover_pos_L2TP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2TP4" />
+          <positionref ref="hodo_postcover_pos_L2TP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2TP4" />
+          <positionref ref="hodo_sidereflR_pos_L2TP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2TP4" />
+          <positionref ref="hodo_siderefl2L_pos_L2TP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2TP4" />
+          <positionref ref="hodo_topreflT_pos_L2TP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2TP4" />
+          <positionref ref="hodo_toprefl2B_pos_L2TP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L2BP4" />
+          <positionref ref="hodo_pos_L2BP4" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="1" />
+          <physvolid field_name="ix" value="4" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2BP4" />
+          <positionref ref="hodo_forecover_pos_L2BP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2BP4" />
+          <positionref ref="hodo_postcover_pos_L2BP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2BP4" />
+          <positionref ref="hodo_sidereflR_pos_L2BP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2BP4" />
+          <positionref ref="hodo_siderefl2L_pos_L2BP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2BP4" />
+          <positionref ref="hodo_topreflT_pos_L2BP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2BP4" />
+          <positionref ref="hodo_toprefl2B_pos_L2BP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_buffer_vol" />
+          <positionref ref="hodo_bufferT_pos" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_buffer_vol" />
+          <positionref ref="hodo_bufferB_pos" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol name="hodo_flange_1">
+          <volumeref ref="hodo_flange" />
+          <positionref ref="hodo_flange_1intracking_volumepos" />
+        </physvol>
+        <physvol name="arms1_block1_1">
+          <volumeref ref="arms1_block1" />
+          <positionref ref="arms1_block1_1intracking_volumepos" />
+        </physvol>
+        <physvol name="arms1_block2_1">
+          <volumeref ref="arms1_block2" />
+          <positionref ref="arms1_block2_1intracking_volumepos" />
+        </physvol>
+        <physvol name="arms1_block3_1">
+          <volumeref ref="arms1_block3" />
+          <positionref ref="arms1_block3_1intracking_volumepos" />
+        </physvol>
+        <physvol name="arms1_block4_1">
+          <volumeref ref="arms1_block4" />
+          <positionref ref="arms1_block4_1intracking_volumepos" />
+        </physvol>
+        <physvol name="cross_bar_top_1">
+          <volumeref ref="cross_bar_top" />
+          <positionref ref="cross_bar_top_1intracking_volumepos" />
+        </physvol>
+        <physvol name="cross_bar_bottom_1">
+          <volumeref ref="cross_bar_bottom" />
+          <positionref ref="cross_bar_bottom_1intracking_volumepos" />
+        </physvol>
+        <physvol name="support_arm_bottom_left_plus_block_1">
+          <volumeref ref="support_arm_bottom_left_plus_block" />
+          <positionref ref="support_arm_bottom_left_plus_block_1intracking_volumepos" />
+        </physvol>
+        <physvol name="support_arm_bottom_right_1">
+          <volumeref ref="support_arm_bottom_right" />
+          <positionref ref="support_arm_bottom_right_1intracking_volumepos" />
+        </physvol>
+        <physvol name="support_arm_top_left_1">
+          <volumeref ref="support_arm_top_left" />
+          <positionref ref="support_arm_top_left_1intracking_volumepos" />
+          <rotationref ref="support_arm_top_left_1intracking_volumerot" />
+        </physvol>
+        <physvol name="support_arm_top_right_1">
+          <volumeref ref="support_arm_top_right" />
+          <positionref ref="support_arm_top_right_1intracking_volumepos" />
+          <rotationref ref="support_arm_top_right_1intracking_volumerot" />
+        </physvol>
+        <physvol name="u_support_bar_bottom_1">
+          <volumeref ref="u_support_bar_bottom" />
+          <positionref ref="u_support_bar_bottom_1intracking_volumepos" />
+        </physvol>
+        <physvol name="u_support_bar_upper1_1">
+          <volumeref ref="u_support_bar_upper1" />
+          <positionref ref="u_support_bar_upper1_1intracking_volumepos" />
+        </physvol>
+        <physvol name="u_support_bar_upper2_1">
+          <volumeref ref="u_support_bar_upper2" />
+          <positionref ref="u_support_bar_upper2_1intracking_volumepos" />
+        </physvol>
+        <physvol name="u_support_bar_top_1">
+          <volumeref ref="u_support_bar_top" />
+          <positionref ref="u_support_bar_top_1intracking_volumepos" />
+        </physvol>
+        <physvol name="u_support_bar_upper3_1">
+          <volumeref ref="u_support_bar_upper3" />
+          <positionref ref="u_support_bar_upper3_1intracking_volumepos" />
+        </physvol>
+        <physvol name="u_support_bar_upper4_1">
+          <volumeref ref="u_support_bar_upper4" />
+          <positionref ref="u_support_bar_upper4_1intracking_volumepos" />
+        </physvol>
+        <physvol>
+          <volumeref ref="svt_chamber_box_vol" />
+          <position name="svt_chamber_box_position" x="svt_chamber_x" y="0" z="svt_chamber_z+svt_chamber_box_z" />
+        </physvol>
+        <physvol>
+          <volumeref ref="svt_chamber_flare1_vol" />
+          <position name="svt_chamber_flare1_position" x="svt_chamber_x" y="0" z="svt_chamber_z+svt_chamber_flare1_z" />
+        </physvol>
+        <physvol>
+          <volumeref ref="svt_chamber_flare2_vol" />
+          <position name="svt_chamber_flare2_position" x="svt_chamber_x" y="0" z="svt_chamber_z+svt_chamber_flare2_z" />
+        </physvol>
+        <physvol>
+          <volumeref ref="svt_chamber_flange_vol" />
+          <position name="svt_chamber_flange_position" x="svt_chamber_x" y="0" z="svt_chamber_z+svt_chamber_flange_z" />
+        </physvol>
+        <regionref ref="TrackingRegion" />
+        <visref ref="TrackingVis" />
+      </volume>
+      <volume name="world_volume">
+        <materialref ref="WorldMaterial" />
+        <solidref ref="world_box" />
+        <physvol>
+          <volumeref ref="tracking_volume" />
+          <positionref ref="tracking_region_pos" />
+          <rotationref ref="identity_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="BeamLeftVolume" />
+          <positionref ref="ECalScoring_BeamLeft_layer1_module0_position" />
+          <rotationref ref="ECalScoring_BeamLeft_layer1_module0_rotation" />
+          <physvolid field_name="system" value="29" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="1" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="ElectronGapVolume" />
+          <positionref ref="ECalScoring_ElectronGap_layer1_module0_position" />
+          <rotationref ref="ECalScoring_ElectronGap_layer1_module0_rotation" />
+          <physvolid field_name="system" value="29" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="1" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="BeamRightVolume" />
+          <positionref ref="ECalScoring_BeamRight_layer1_module0_position" />
+          <rotationref ref="ECalScoring_BeamRight_layer1_module0_rotation" />
+          <physvolid field_name="system" value="29" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="1" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="BeamLeftVolume" />
+          <positionref ref="ECalScoring_BeamLeft_layer2_module0_position" />
+          <rotationref ref="ECalScoring_BeamLeft_layer2_module0_rotation" />
+          <physvolid field_name="system" value="29" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="2" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="ElectronGapVolume" />
+          <positionref ref="ECalScoring_ElectronGap_layer2_module0_position" />
+          <rotationref ref="ECalScoring_ElectronGap_layer2_module0_rotation" />
+          <physvolid field_name="system" value="29" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="2" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="BeamRightVolume" />
+          <positionref ref="ECalScoring_BeamRight_layer2_module0_position" />
+          <rotationref ref="ECalScoring_BeamRight_layer2_module0_rotation" />
+          <physvolid field_name="system" value="29" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="2" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-1_pos_pos_bot" />
+          <rotationref ref="crystal1-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="1" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-1_pos_neg_bot" />
+          <rotationref ref="crystal1-1_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-1" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-1_pos_pos_top" />
+          <rotationref ref="crystal1-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="1" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-1_pos_neg_top" />
+          <rotationref ref="crystal1-1_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-1" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal2-1_pos_pos_bot" />
+          <rotationref ref="crystal2-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="2" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal2-1_pos_pos_top" />
+          <rotationref ref="crystal2-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="2" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal3-1_pos_pos_bot" />
+          <rotationref ref="crystal3-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="3" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal3-1_pos_pos_top" />
+          <rotationref ref="crystal3-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="3" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal4-1_pos_pos_bot" />
+          <rotationref ref="crystal4-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="4" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal4-1_pos_pos_top" />
+          <rotationref ref="crystal4-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="4" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal5-1_pos_pos_bot" />
+          <rotationref ref="crystal5-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="5" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal5-1_pos_pos_top" />
+          <rotationref ref="crystal5-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="5" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal6-1_pos_pos_bot" />
+          <rotationref ref="crystal6-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="6" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal6-1_pos_pos_top" />
+          <rotationref ref="crystal6-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="6" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal7-1_pos_pos_bot" />
+          <rotationref ref="crystal7-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="7" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal7-1_pos_pos_top" />
+          <rotationref ref="crystal7-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="7" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal8-1_pos_pos_bot" />
+          <rotationref ref="crystal8-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="8" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal8-1_pos_pos_top" />
+          <rotationref ref="crystal8-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="8" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal9-1_pos_pos_bot" />
+          <rotationref ref="crystal9-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="9" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal9-1_pos_pos_top" />
+          <rotationref ref="crystal9-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="9" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal10-1_pos_pos_bot" />
+          <rotationref ref="crystal10-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="10" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal10-1_pos_pos_top" />
+          <rotationref ref="crystal10-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="10" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-1_pos_pos_bot" />
+          <rotationref ref="crystal11-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="11" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-1_pos_neg_bot" />
+          <rotationref ref="crystal11-1_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-11" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-1_pos_pos_top" />
+          <rotationref ref="crystal11-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="11" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-1_pos_neg_top" />
+          <rotationref ref="crystal11-1_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-11" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-1_pos_pos_bot" />
+          <rotationref ref="crystal12-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="12" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-1_pos_neg_bot" />
+          <rotationref ref="crystal12-1_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-12" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-1_pos_pos_top" />
+          <rotationref ref="crystal12-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="12" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-1_pos_neg_top" />
+          <rotationref ref="crystal12-1_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-12" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-1_pos_pos_bot" />
+          <rotationref ref="crystal13-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="13" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-1_pos_neg_bot" />
+          <rotationref ref="crystal13-1_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-13" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-1_pos_pos_top" />
+          <rotationref ref="crystal13-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="13" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-1_pos_neg_top" />
+          <rotationref ref="crystal13-1_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-13" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-1_pos_pos_bot" />
+          <rotationref ref="crystal14-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="14" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-1_pos_neg_bot" />
+          <rotationref ref="crystal14-1_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-14" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-1_pos_pos_top" />
+          <rotationref ref="crystal14-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="14" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-1_pos_neg_top" />
+          <rotationref ref="crystal14-1_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-14" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-1_pos_pos_bot" />
+          <rotationref ref="crystal15-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="15" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-1_pos_neg_bot" />
+          <rotationref ref="crystal15-1_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-15" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-1_pos_pos_top" />
+          <rotationref ref="crystal15-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="15" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-1_pos_neg_top" />
+          <rotationref ref="crystal15-1_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-15" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-1_pos_pos_bot" />
+          <rotationref ref="crystal16-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="16" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-1_pos_neg_bot" />
+          <rotationref ref="crystal16-1_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-16" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-1_pos_pos_top" />
+          <rotationref ref="crystal16-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="16" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-1_pos_neg_top" />
+          <rotationref ref="crystal16-1_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-16" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-1_pos_pos_bot" />
+          <rotationref ref="crystal17-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="17" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-1_pos_neg_bot" />
+          <rotationref ref="crystal17-1_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-17" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-1_pos_pos_top" />
+          <rotationref ref="crystal17-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="17" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-1_pos_neg_top" />
+          <rotationref ref="crystal17-1_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-17" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-1_pos_pos_bot" />
+          <rotationref ref="crystal18-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="18" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-1_pos_neg_bot" />
+          <rotationref ref="crystal18-1_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-18" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-1_pos_pos_top" />
+          <rotationref ref="crystal18-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="18" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-1_pos_neg_top" />
+          <rotationref ref="crystal18-1_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-18" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-1_pos_pos_bot" />
+          <rotationref ref="crystal19-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="19" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-1_pos_neg_bot" />
+          <rotationref ref="crystal19-1_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-19" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-1_pos_pos_top" />
+          <rotationref ref="crystal19-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="19" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-1_pos_neg_top" />
+          <rotationref ref="crystal19-1_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-19" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-1_pos_pos_bot" />
+          <rotationref ref="crystal20-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="20" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-1_pos_neg_bot" />
+          <rotationref ref="crystal20-1_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-20" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-1_pos_pos_top" />
+          <rotationref ref="crystal20-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="20" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-1_pos_neg_top" />
+          <rotationref ref="crystal20-1_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-20" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-1_pos_pos_bot" />
+          <rotationref ref="crystal21-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="21" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-1_pos_neg_bot" />
+          <rotationref ref="crystal21-1_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-21" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-1_pos_pos_top" />
+          <rotationref ref="crystal21-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="21" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-1_pos_neg_top" />
+          <rotationref ref="crystal21-1_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-21" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-1_pos_pos_bot" />
+          <rotationref ref="crystal22-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="22" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-1_pos_neg_bot" />
+          <rotationref ref="crystal22-1_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-22" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-1_pos_pos_top" />
+          <rotationref ref="crystal22-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="22" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-1_pos_neg_top" />
+          <rotationref ref="crystal22-1_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-22" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-1_pos_pos_bot" />
+          <rotationref ref="crystal23-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="23" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-1_pos_neg_bot" />
+          <rotationref ref="crystal23-1_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-23" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-1_pos_pos_top" />
+          <rotationref ref="crystal23-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="23" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-1_pos_neg_top" />
+          <rotationref ref="crystal23-1_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-23" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-2_pos_pos_bot" />
+          <rotationref ref="crystal1-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="1" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-2_pos_neg_bot" />
+          <rotationref ref="crystal1-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-1" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-2_pos_pos_top" />
+          <rotationref ref="crystal1-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="1" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-2_pos_neg_top" />
+          <rotationref ref="crystal1-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-1" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal2-2_pos_pos_bot" />
+          <rotationref ref="crystal2-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="2" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal2-2_pos_neg_bot" />
+          <rotationref ref="crystal2-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-2" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal2-2_pos_pos_top" />
+          <rotationref ref="crystal2-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="2" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal2-2_pos_neg_top" />
+          <rotationref ref="crystal2-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-2" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal3-2_pos_pos_bot" />
+          <rotationref ref="crystal3-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="3" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal3-2_pos_neg_bot" />
+          <rotationref ref="crystal3-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-3" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal3-2_pos_pos_top" />
+          <rotationref ref="crystal3-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="3" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal3-2_pos_neg_top" />
+          <rotationref ref="crystal3-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-3" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal4-2_pos_pos_bot" />
+          <rotationref ref="crystal4-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="4" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal4-2_pos_neg_bot" />
+          <rotationref ref="crystal4-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-4" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal4-2_pos_pos_top" />
+          <rotationref ref="crystal4-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="4" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal4-2_pos_neg_top" />
+          <rotationref ref="crystal4-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-4" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal5-2_pos_pos_bot" />
+          <rotationref ref="crystal5-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="5" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal5-2_pos_neg_bot" />
+          <rotationref ref="crystal5-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-5" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal5-2_pos_pos_top" />
+          <rotationref ref="crystal5-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="5" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal5-2_pos_neg_top" />
+          <rotationref ref="crystal5-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-5" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal6-2_pos_pos_bot" />
+          <rotationref ref="crystal6-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="6" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal6-2_pos_neg_bot" />
+          <rotationref ref="crystal6-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-6" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal6-2_pos_pos_top" />
+          <rotationref ref="crystal6-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="6" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal6-2_pos_neg_top" />
+          <rotationref ref="crystal6-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-6" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal7-2_pos_pos_bot" />
+          <rotationref ref="crystal7-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="7" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal7-2_pos_neg_bot" />
+          <rotationref ref="crystal7-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-7" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal7-2_pos_pos_top" />
+          <rotationref ref="crystal7-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="7" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal7-2_pos_neg_top" />
+          <rotationref ref="crystal7-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-7" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal8-2_pos_pos_bot" />
+          <rotationref ref="crystal8-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="8" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal8-2_pos_neg_bot" />
+          <rotationref ref="crystal8-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-8" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal8-2_pos_pos_top" />
+          <rotationref ref="crystal8-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="8" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal8-2_pos_neg_top" />
+          <rotationref ref="crystal8-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-8" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal9-2_pos_pos_bot" />
+          <rotationref ref="crystal9-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="9" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal9-2_pos_neg_bot" />
+          <rotationref ref="crystal9-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-9" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal9-2_pos_pos_top" />
+          <rotationref ref="crystal9-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="9" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal9-2_pos_neg_top" />
+          <rotationref ref="crystal9-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-9" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal10-2_pos_pos_bot" />
+          <rotationref ref="crystal10-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="10" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal10-2_pos_neg_bot" />
+          <rotationref ref="crystal10-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-10" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal10-2_pos_pos_top" />
+          <rotationref ref="crystal10-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="10" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal10-2_pos_neg_top" />
+          <rotationref ref="crystal10-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-10" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-2_pos_pos_bot" />
+          <rotationref ref="crystal11-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="11" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-2_pos_neg_bot" />
+          <rotationref ref="crystal11-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-11" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-2_pos_pos_top" />
+          <rotationref ref="crystal11-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="11" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-2_pos_neg_top" />
+          <rotationref ref="crystal11-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-11" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-2_pos_pos_bot" />
+          <rotationref ref="crystal12-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="12" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-2_pos_neg_bot" />
+          <rotationref ref="crystal12-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-12" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-2_pos_pos_top" />
+          <rotationref ref="crystal12-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="12" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-2_pos_neg_top" />
+          <rotationref ref="crystal12-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-12" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-2_pos_pos_bot" />
+          <rotationref ref="crystal13-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="13" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-2_pos_neg_bot" />
+          <rotationref ref="crystal13-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-13" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-2_pos_pos_top" />
+          <rotationref ref="crystal13-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="13" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-2_pos_neg_top" />
+          <rotationref ref="crystal13-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-13" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-2_pos_pos_bot" />
+          <rotationref ref="crystal14-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="14" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-2_pos_neg_bot" />
+          <rotationref ref="crystal14-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-14" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-2_pos_pos_top" />
+          <rotationref ref="crystal14-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="14" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-2_pos_neg_top" />
+          <rotationref ref="crystal14-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-14" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-2_pos_pos_bot" />
+          <rotationref ref="crystal15-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="15" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-2_pos_neg_bot" />
+          <rotationref ref="crystal15-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-15" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-2_pos_pos_top" />
+          <rotationref ref="crystal15-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="15" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-2_pos_neg_top" />
+          <rotationref ref="crystal15-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-15" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-2_pos_pos_bot" />
+          <rotationref ref="crystal16-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="16" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-2_pos_neg_bot" />
+          <rotationref ref="crystal16-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-16" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-2_pos_pos_top" />
+          <rotationref ref="crystal16-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="16" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-2_pos_neg_top" />
+          <rotationref ref="crystal16-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-16" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-2_pos_pos_bot" />
+          <rotationref ref="crystal17-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="17" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-2_pos_neg_bot" />
+          <rotationref ref="crystal17-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-17" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-2_pos_pos_top" />
+          <rotationref ref="crystal17-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="17" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-2_pos_neg_top" />
+          <rotationref ref="crystal17-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-17" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-2_pos_pos_bot" />
+          <rotationref ref="crystal18-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="18" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-2_pos_neg_bot" />
+          <rotationref ref="crystal18-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-18" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-2_pos_pos_top" />
+          <rotationref ref="crystal18-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="18" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-2_pos_neg_top" />
+          <rotationref ref="crystal18-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-18" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-2_pos_pos_bot" />
+          <rotationref ref="crystal19-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="19" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-2_pos_neg_bot" />
+          <rotationref ref="crystal19-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-19" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-2_pos_pos_top" />
+          <rotationref ref="crystal19-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="19" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-2_pos_neg_top" />
+          <rotationref ref="crystal19-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-19" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-2_pos_pos_bot" />
+          <rotationref ref="crystal20-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="20" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-2_pos_neg_bot" />
+          <rotationref ref="crystal20-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-20" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-2_pos_pos_top" />
+          <rotationref ref="crystal20-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="20" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-2_pos_neg_top" />
+          <rotationref ref="crystal20-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-20" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-2_pos_pos_bot" />
+          <rotationref ref="crystal21-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="21" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-2_pos_neg_bot" />
+          <rotationref ref="crystal21-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-21" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-2_pos_pos_top" />
+          <rotationref ref="crystal21-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="21" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-2_pos_neg_top" />
+          <rotationref ref="crystal21-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-21" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-2_pos_pos_bot" />
+          <rotationref ref="crystal22-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="22" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-2_pos_neg_bot" />
+          <rotationref ref="crystal22-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-22" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-2_pos_pos_top" />
+          <rotationref ref="crystal22-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="22" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-2_pos_neg_top" />
+          <rotationref ref="crystal22-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-22" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-2_pos_pos_bot" />
+          <rotationref ref="crystal23-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="23" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-2_pos_neg_bot" />
+          <rotationref ref="crystal23-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-23" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-2_pos_pos_top" />
+          <rotationref ref="crystal23-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="23" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-2_pos_neg_top" />
+          <rotationref ref="crystal23-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-23" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-3_pos_pos_bot" />
+          <rotationref ref="crystal1-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="1" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-3_pos_neg_bot" />
+          <rotationref ref="crystal1-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-1" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-3_pos_pos_top" />
+          <rotationref ref="crystal1-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="1" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-3_pos_neg_top" />
+          <rotationref ref="crystal1-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-1" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal2-3_pos_pos_bot" />
+          <rotationref ref="crystal2-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="2" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal2-3_pos_neg_bot" />
+          <rotationref ref="crystal2-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-2" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal2-3_pos_pos_top" />
+          <rotationref ref="crystal2-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="2" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal2-3_pos_neg_top" />
+          <rotationref ref="crystal2-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-2" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal3-3_pos_pos_bot" />
+          <rotationref ref="crystal3-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="3" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal3-3_pos_neg_bot" />
+          <rotationref ref="crystal3-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-3" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal3-3_pos_pos_top" />
+          <rotationref ref="crystal3-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="3" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal3-3_pos_neg_top" />
+          <rotationref ref="crystal3-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-3" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal4-3_pos_pos_bot" />
+          <rotationref ref="crystal4-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="4" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal4-3_pos_neg_bot" />
+          <rotationref ref="crystal4-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-4" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal4-3_pos_pos_top" />
+          <rotationref ref="crystal4-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="4" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal4-3_pos_neg_top" />
+          <rotationref ref="crystal4-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-4" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal5-3_pos_pos_bot" />
+          <rotationref ref="crystal5-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="5" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal5-3_pos_neg_bot" />
+          <rotationref ref="crystal5-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-5" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal5-3_pos_pos_top" />
+          <rotationref ref="crystal5-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="5" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal5-3_pos_neg_top" />
+          <rotationref ref="crystal5-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-5" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal6-3_pos_pos_bot" />
+          <rotationref ref="crystal6-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="6" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal6-3_pos_neg_bot" />
+          <rotationref ref="crystal6-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-6" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal6-3_pos_pos_top" />
+          <rotationref ref="crystal6-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="6" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal6-3_pos_neg_top" />
+          <rotationref ref="crystal6-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-6" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal7-3_pos_pos_bot" />
+          <rotationref ref="crystal7-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="7" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal7-3_pos_neg_bot" />
+          <rotationref ref="crystal7-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-7" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal7-3_pos_pos_top" />
+          <rotationref ref="crystal7-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="7" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal7-3_pos_neg_top" />
+          <rotationref ref="crystal7-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-7" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal8-3_pos_pos_bot" />
+          <rotationref ref="crystal8-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="8" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal8-3_pos_neg_bot" />
+          <rotationref ref="crystal8-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-8" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal8-3_pos_pos_top" />
+          <rotationref ref="crystal8-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="8" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal8-3_pos_neg_top" />
+          <rotationref ref="crystal8-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-8" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal9-3_pos_pos_bot" />
+          <rotationref ref="crystal9-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="9" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal9-3_pos_neg_bot" />
+          <rotationref ref="crystal9-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-9" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal9-3_pos_pos_top" />
+          <rotationref ref="crystal9-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="9" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal9-3_pos_neg_top" />
+          <rotationref ref="crystal9-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-9" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal10-3_pos_pos_bot" />
+          <rotationref ref="crystal10-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="10" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal10-3_pos_neg_bot" />
+          <rotationref ref="crystal10-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-10" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal10-3_pos_pos_top" />
+          <rotationref ref="crystal10-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="10" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal10-3_pos_neg_top" />
+          <rotationref ref="crystal10-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-10" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-3_pos_pos_bot" />
+          <rotationref ref="crystal11-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="11" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-3_pos_neg_bot" />
+          <rotationref ref="crystal11-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-11" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-3_pos_pos_top" />
+          <rotationref ref="crystal11-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="11" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-3_pos_neg_top" />
+          <rotationref ref="crystal11-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-11" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-3_pos_pos_bot" />
+          <rotationref ref="crystal12-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="12" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-3_pos_neg_bot" />
+          <rotationref ref="crystal12-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-12" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-3_pos_pos_top" />
+          <rotationref ref="crystal12-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="12" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-3_pos_neg_top" />
+          <rotationref ref="crystal12-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-12" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-3_pos_pos_bot" />
+          <rotationref ref="crystal13-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="13" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-3_pos_neg_bot" />
+          <rotationref ref="crystal13-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-13" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-3_pos_pos_top" />
+          <rotationref ref="crystal13-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="13" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-3_pos_neg_top" />
+          <rotationref ref="crystal13-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-13" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-3_pos_pos_bot" />
+          <rotationref ref="crystal14-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="14" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-3_pos_neg_bot" />
+          <rotationref ref="crystal14-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-14" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-3_pos_pos_top" />
+          <rotationref ref="crystal14-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="14" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-3_pos_neg_top" />
+          <rotationref ref="crystal14-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-14" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-3_pos_pos_bot" />
+          <rotationref ref="crystal15-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="15" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-3_pos_neg_bot" />
+          <rotationref ref="crystal15-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-15" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-3_pos_pos_top" />
+          <rotationref ref="crystal15-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="15" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-3_pos_neg_top" />
+          <rotationref ref="crystal15-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-15" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-3_pos_pos_bot" />
+          <rotationref ref="crystal16-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="16" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-3_pos_neg_bot" />
+          <rotationref ref="crystal16-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-16" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-3_pos_pos_top" />
+          <rotationref ref="crystal16-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="16" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-3_pos_neg_top" />
+          <rotationref ref="crystal16-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-16" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-3_pos_pos_bot" />
+          <rotationref ref="crystal17-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="17" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-3_pos_neg_bot" />
+          <rotationref ref="crystal17-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-17" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-3_pos_pos_top" />
+          <rotationref ref="crystal17-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="17" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-3_pos_neg_top" />
+          <rotationref ref="crystal17-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-17" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-3_pos_pos_bot" />
+          <rotationref ref="crystal18-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="18" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-3_pos_neg_bot" />
+          <rotationref ref="crystal18-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-18" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-3_pos_pos_top" />
+          <rotationref ref="crystal18-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="18" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-3_pos_neg_top" />
+          <rotationref ref="crystal18-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-18" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-3_pos_pos_bot" />
+          <rotationref ref="crystal19-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="19" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-3_pos_neg_bot" />
+          <rotationref ref="crystal19-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-19" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-3_pos_pos_top" />
+          <rotationref ref="crystal19-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="19" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-3_pos_neg_top" />
+          <rotationref ref="crystal19-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-19" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-3_pos_pos_bot" />
+          <rotationref ref="crystal20-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="20" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-3_pos_neg_bot" />
+          <rotationref ref="crystal20-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-20" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-3_pos_pos_top" />
+          <rotationref ref="crystal20-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="20" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-3_pos_neg_top" />
+          <rotationref ref="crystal20-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-20" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-3_pos_pos_bot" />
+          <rotationref ref="crystal21-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="21" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-3_pos_neg_bot" />
+          <rotationref ref="crystal21-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-21" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-3_pos_pos_top" />
+          <rotationref ref="crystal21-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="21" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-3_pos_neg_top" />
+          <rotationref ref="crystal21-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-21" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-3_pos_pos_bot" />
+          <rotationref ref="crystal22-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="22" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-3_pos_neg_bot" />
+          <rotationref ref="crystal22-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-22" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-3_pos_pos_top" />
+          <rotationref ref="crystal22-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="22" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-3_pos_neg_top" />
+          <rotationref ref="crystal22-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-22" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-3_pos_pos_bot" />
+          <rotationref ref="crystal23-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="23" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-3_pos_neg_bot" />
+          <rotationref ref="crystal23-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-23" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-3_pos_pos_top" />
+          <rotationref ref="crystal23-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="23" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-3_pos_neg_top" />
+          <rotationref ref="crystal23-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-23" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-4_pos_pos_bot" />
+          <rotationref ref="crystal1-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="1" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-4_pos_neg_bot" />
+          <rotationref ref="crystal1-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-1" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-4_pos_pos_top" />
+          <rotationref ref="crystal1-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="1" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-4_pos_neg_top" />
+          <rotationref ref="crystal1-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-1" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal2-4_pos_pos_bot" />
+          <rotationref ref="crystal2-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="2" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal2-4_pos_neg_bot" />
+          <rotationref ref="crystal2-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-2" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal2-4_pos_pos_top" />
+          <rotationref ref="crystal2-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="2" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal2-4_pos_neg_top" />
+          <rotationref ref="crystal2-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-2" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal3-4_pos_pos_bot" />
+          <rotationref ref="crystal3-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="3" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal3-4_pos_neg_bot" />
+          <rotationref ref="crystal3-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-3" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal3-4_pos_pos_top" />
+          <rotationref ref="crystal3-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="3" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal3-4_pos_neg_top" />
+          <rotationref ref="crystal3-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-3" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal4-4_pos_pos_bot" />
+          <rotationref ref="crystal4-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="4" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal4-4_pos_neg_bot" />
+          <rotationref ref="crystal4-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-4" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal4-4_pos_pos_top" />
+          <rotationref ref="crystal4-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="4" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal4-4_pos_neg_top" />
+          <rotationref ref="crystal4-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-4" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal5-4_pos_pos_bot" />
+          <rotationref ref="crystal5-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="5" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal5-4_pos_neg_bot" />
+          <rotationref ref="crystal5-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-5" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal5-4_pos_pos_top" />
+          <rotationref ref="crystal5-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="5" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal5-4_pos_neg_top" />
+          <rotationref ref="crystal5-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-5" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal6-4_pos_pos_bot" />
+          <rotationref ref="crystal6-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="6" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal6-4_pos_neg_bot" />
+          <rotationref ref="crystal6-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-6" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal6-4_pos_pos_top" />
+          <rotationref ref="crystal6-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="6" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal6-4_pos_neg_top" />
+          <rotationref ref="crystal6-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-6" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal7-4_pos_pos_bot" />
+          <rotationref ref="crystal7-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="7" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal7-4_pos_neg_bot" />
+          <rotationref ref="crystal7-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-7" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal7-4_pos_pos_top" />
+          <rotationref ref="crystal7-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="7" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal7-4_pos_neg_top" />
+          <rotationref ref="crystal7-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-7" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal8-4_pos_pos_bot" />
+          <rotationref ref="crystal8-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="8" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal8-4_pos_neg_bot" />
+          <rotationref ref="crystal8-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-8" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal8-4_pos_pos_top" />
+          <rotationref ref="crystal8-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="8" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal8-4_pos_neg_top" />
+          <rotationref ref="crystal8-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-8" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal9-4_pos_pos_bot" />
+          <rotationref ref="crystal9-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="9" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal9-4_pos_neg_bot" />
+          <rotationref ref="crystal9-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-9" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal9-4_pos_pos_top" />
+          <rotationref ref="crystal9-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="9" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal9-4_pos_neg_top" />
+          <rotationref ref="crystal9-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-9" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal10-4_pos_pos_bot" />
+          <rotationref ref="crystal10-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="10" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal10-4_pos_neg_bot" />
+          <rotationref ref="crystal10-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-10" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal10-4_pos_pos_top" />
+          <rotationref ref="crystal10-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="10" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal10-4_pos_neg_top" />
+          <rotationref ref="crystal10-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-10" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-4_pos_pos_bot" />
+          <rotationref ref="crystal11-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="11" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-4_pos_neg_bot" />
+          <rotationref ref="crystal11-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-11" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-4_pos_pos_top" />
+          <rotationref ref="crystal11-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="11" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-4_pos_neg_top" />
+          <rotationref ref="crystal11-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-11" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-4_pos_pos_bot" />
+          <rotationref ref="crystal12-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="12" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-4_pos_neg_bot" />
+          <rotationref ref="crystal12-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-12" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-4_pos_pos_top" />
+          <rotationref ref="crystal12-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="12" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-4_pos_neg_top" />
+          <rotationref ref="crystal12-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-12" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-4_pos_pos_bot" />
+          <rotationref ref="crystal13-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="13" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-4_pos_neg_bot" />
+          <rotationref ref="crystal13-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-13" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-4_pos_pos_top" />
+          <rotationref ref="crystal13-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="13" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-4_pos_neg_top" />
+          <rotationref ref="crystal13-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-13" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-4_pos_pos_bot" />
+          <rotationref ref="crystal14-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="14" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-4_pos_neg_bot" />
+          <rotationref ref="crystal14-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-14" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-4_pos_pos_top" />
+          <rotationref ref="crystal14-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="14" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-4_pos_neg_top" />
+          <rotationref ref="crystal14-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-14" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-4_pos_pos_bot" />
+          <rotationref ref="crystal15-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="15" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-4_pos_neg_bot" />
+          <rotationref ref="crystal15-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-15" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-4_pos_pos_top" />
+          <rotationref ref="crystal15-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="15" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-4_pos_neg_top" />
+          <rotationref ref="crystal15-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-15" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-4_pos_pos_bot" />
+          <rotationref ref="crystal16-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="16" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-4_pos_neg_bot" />
+          <rotationref ref="crystal16-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-16" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-4_pos_pos_top" />
+          <rotationref ref="crystal16-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="16" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-4_pos_neg_top" />
+          <rotationref ref="crystal16-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-16" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-4_pos_pos_bot" />
+          <rotationref ref="crystal17-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="17" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-4_pos_neg_bot" />
+          <rotationref ref="crystal17-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-17" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-4_pos_pos_top" />
+          <rotationref ref="crystal17-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="17" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-4_pos_neg_top" />
+          <rotationref ref="crystal17-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-17" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-4_pos_pos_bot" />
+          <rotationref ref="crystal18-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="18" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-4_pos_neg_bot" />
+          <rotationref ref="crystal18-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-18" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-4_pos_pos_top" />
+          <rotationref ref="crystal18-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="18" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-4_pos_neg_top" />
+          <rotationref ref="crystal18-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-18" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-4_pos_pos_bot" />
+          <rotationref ref="crystal19-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="19" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-4_pos_neg_bot" />
+          <rotationref ref="crystal19-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-19" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-4_pos_pos_top" />
+          <rotationref ref="crystal19-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="19" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-4_pos_neg_top" />
+          <rotationref ref="crystal19-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-19" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-4_pos_pos_bot" />
+          <rotationref ref="crystal20-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="20" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-4_pos_neg_bot" />
+          <rotationref ref="crystal20-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-20" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-4_pos_pos_top" />
+          <rotationref ref="crystal20-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="20" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-4_pos_neg_top" />
+          <rotationref ref="crystal20-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-20" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-4_pos_pos_bot" />
+          <rotationref ref="crystal21-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="21" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-4_pos_neg_bot" />
+          <rotationref ref="crystal21-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-21" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-4_pos_pos_top" />
+          <rotationref ref="crystal21-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="21" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-4_pos_neg_top" />
+          <rotationref ref="crystal21-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-21" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-4_pos_pos_bot" />
+          <rotationref ref="crystal22-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="22" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-4_pos_neg_bot" />
+          <rotationref ref="crystal22-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-22" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-4_pos_pos_top" />
+          <rotationref ref="crystal22-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="22" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-4_pos_neg_top" />
+          <rotationref ref="crystal22-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-22" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-4_pos_pos_bot" />
+          <rotationref ref="crystal23-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="23" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-4_pos_neg_bot" />
+          <rotationref ref="crystal23-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-23" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-4_pos_pos_top" />
+          <rotationref ref="crystal23-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="23" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-4_pos_neg_top" />
+          <rotationref ref="crystal23-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-23" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-5_pos_pos_bot" />
+          <rotationref ref="crystal1-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="1" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-5_pos_neg_bot" />
+          <rotationref ref="crystal1-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-1" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-5_pos_pos_top" />
+          <rotationref ref="crystal1-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="1" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-5_pos_neg_top" />
+          <rotationref ref="crystal1-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-1" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal2-5_pos_pos_bot" />
+          <rotationref ref="crystal2-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="2" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal2-5_pos_neg_bot" />
+          <rotationref ref="crystal2-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-2" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal2-5_pos_pos_top" />
+          <rotationref ref="crystal2-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="2" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal2-5_pos_neg_top" />
+          <rotationref ref="crystal2-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-2" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal3-5_pos_pos_bot" />
+          <rotationref ref="crystal3-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="3" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal3-5_pos_neg_bot" />
+          <rotationref ref="crystal3-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-3" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal3-5_pos_pos_top" />
+          <rotationref ref="crystal3-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="3" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal3-5_pos_neg_top" />
+          <rotationref ref="crystal3-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-3" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal4-5_pos_pos_bot" />
+          <rotationref ref="crystal4-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="4" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal4-5_pos_neg_bot" />
+          <rotationref ref="crystal4-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-4" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal4-5_pos_pos_top" />
+          <rotationref ref="crystal4-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="4" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal4-5_pos_neg_top" />
+          <rotationref ref="crystal4-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-4" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal5-5_pos_pos_bot" />
+          <rotationref ref="crystal5-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="5" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal5-5_pos_neg_bot" />
+          <rotationref ref="crystal5-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-5" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal5-5_pos_pos_top" />
+          <rotationref ref="crystal5-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="5" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal5-5_pos_neg_top" />
+          <rotationref ref="crystal5-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-5" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal6-5_pos_pos_bot" />
+          <rotationref ref="crystal6-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="6" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal6-5_pos_neg_bot" />
+          <rotationref ref="crystal6-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-6" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal6-5_pos_pos_top" />
+          <rotationref ref="crystal6-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="6" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal6-5_pos_neg_top" />
+          <rotationref ref="crystal6-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-6" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal7-5_pos_pos_bot" />
+          <rotationref ref="crystal7-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="7" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal7-5_pos_neg_bot" />
+          <rotationref ref="crystal7-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-7" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal7-5_pos_pos_top" />
+          <rotationref ref="crystal7-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="7" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal7-5_pos_neg_top" />
+          <rotationref ref="crystal7-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-7" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal8-5_pos_pos_bot" />
+          <rotationref ref="crystal8-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="8" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal8-5_pos_neg_bot" />
+          <rotationref ref="crystal8-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-8" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal8-5_pos_pos_top" />
+          <rotationref ref="crystal8-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="8" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal8-5_pos_neg_top" />
+          <rotationref ref="crystal8-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-8" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal9-5_pos_pos_bot" />
+          <rotationref ref="crystal9-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="9" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal9-5_pos_neg_bot" />
+          <rotationref ref="crystal9-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-9" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal9-5_pos_pos_top" />
+          <rotationref ref="crystal9-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="9" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal9-5_pos_neg_top" />
+          <rotationref ref="crystal9-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-9" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal10-5_pos_pos_bot" />
+          <rotationref ref="crystal10-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="10" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal10-5_pos_neg_bot" />
+          <rotationref ref="crystal10-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-10" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal10-5_pos_pos_top" />
+          <rotationref ref="crystal10-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="10" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal10-5_pos_neg_top" />
+          <rotationref ref="crystal10-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-10" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-5_pos_pos_bot" />
+          <rotationref ref="crystal11-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="11" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-5_pos_neg_bot" />
+          <rotationref ref="crystal11-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-11" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-5_pos_pos_top" />
+          <rotationref ref="crystal11-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="11" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-5_pos_neg_top" />
+          <rotationref ref="crystal11-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-11" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-5_pos_pos_bot" />
+          <rotationref ref="crystal12-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="12" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-5_pos_neg_bot" />
+          <rotationref ref="crystal12-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-12" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-5_pos_pos_top" />
+          <rotationref ref="crystal12-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="12" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-5_pos_neg_top" />
+          <rotationref ref="crystal12-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-12" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-5_pos_pos_bot" />
+          <rotationref ref="crystal13-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="13" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-5_pos_neg_bot" />
+          <rotationref ref="crystal13-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-13" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-5_pos_pos_top" />
+          <rotationref ref="crystal13-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="13" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-5_pos_neg_top" />
+          <rotationref ref="crystal13-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-13" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-5_pos_pos_bot" />
+          <rotationref ref="crystal14-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="14" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-5_pos_neg_bot" />
+          <rotationref ref="crystal14-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-14" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-5_pos_pos_top" />
+          <rotationref ref="crystal14-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="14" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-5_pos_neg_top" />
+          <rotationref ref="crystal14-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-14" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-5_pos_pos_bot" />
+          <rotationref ref="crystal15-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="15" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-5_pos_neg_bot" />
+          <rotationref ref="crystal15-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-15" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-5_pos_pos_top" />
+          <rotationref ref="crystal15-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="15" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-5_pos_neg_top" />
+          <rotationref ref="crystal15-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-15" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-5_pos_pos_bot" />
+          <rotationref ref="crystal16-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="16" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-5_pos_neg_bot" />
+          <rotationref ref="crystal16-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-16" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-5_pos_pos_top" />
+          <rotationref ref="crystal16-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="16" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-5_pos_neg_top" />
+          <rotationref ref="crystal16-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-16" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-5_pos_pos_bot" />
+          <rotationref ref="crystal17-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="17" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-5_pos_neg_bot" />
+          <rotationref ref="crystal17-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-17" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-5_pos_pos_top" />
+          <rotationref ref="crystal17-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="17" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-5_pos_neg_top" />
+          <rotationref ref="crystal17-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-17" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-5_pos_pos_bot" />
+          <rotationref ref="crystal18-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="18" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-5_pos_neg_bot" />
+          <rotationref ref="crystal18-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-18" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-5_pos_pos_top" />
+          <rotationref ref="crystal18-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="18" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-5_pos_neg_top" />
+          <rotationref ref="crystal18-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-18" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-5_pos_pos_bot" />
+          <rotationref ref="crystal19-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="19" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-5_pos_neg_bot" />
+          <rotationref ref="crystal19-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-19" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-5_pos_pos_top" />
+          <rotationref ref="crystal19-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="19" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-5_pos_neg_top" />
+          <rotationref ref="crystal19-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-19" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-5_pos_pos_bot" />
+          <rotationref ref="crystal20-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="20" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-5_pos_neg_bot" />
+          <rotationref ref="crystal20-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-20" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-5_pos_pos_top" />
+          <rotationref ref="crystal20-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="20" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-5_pos_neg_top" />
+          <rotationref ref="crystal20-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-20" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-5_pos_pos_bot" />
+          <rotationref ref="crystal21-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="21" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-5_pos_neg_bot" />
+          <rotationref ref="crystal21-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-21" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-5_pos_pos_top" />
+          <rotationref ref="crystal21-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="21" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-5_pos_neg_top" />
+          <rotationref ref="crystal21-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-21" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-5_pos_pos_bot" />
+          <rotationref ref="crystal22-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="22" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-5_pos_neg_bot" />
+          <rotationref ref="crystal22-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-22" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-5_pos_pos_top" />
+          <rotationref ref="crystal22-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="22" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-5_pos_neg_top" />
+          <rotationref ref="crystal22-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-22" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-5_pos_pos_bot" />
+          <rotationref ref="crystal23-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="23" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-5_pos_neg_bot" />
+          <rotationref ref="crystal23-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-23" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-5_pos_pos_top" />
+          <rotationref ref="crystal23-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="23" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-5_pos_neg_top" />
+          <rotationref ref="crystal23-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-23" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol name="front_flange_1">
+          <volumeref ref="front_flange" />
+          <positionref ref="front_flange_1inworld_volumepos" />
+        </physvol>
+        <physvol name="back_flange_1">
+          <volumeref ref="back_flange" />
+          <positionref ref="back_flange_1inworld_volumepos" />
+        </physvol>
+        <physvol name="ECAL_chamber_1">
+          <volumeref ref="ECAL_chamber" />
+          <positionref ref="ECAL_chamber_1inworld_volumepos" />
+        </physvol>
+        <physvol name="al_honeycomb_1">
+          <volumeref ref="al_honeycomb" />
+          <positionref ref="al_honeycomb_1inworld_volumepos" />
+        </physvol>
+        <physvol name="layer_1_top_1">
+          <volumeref ref="layer_1_top" />
+          <positionref ref="layer_1_top_1inworld_volumepos" />
+        </physvol>
+        <physvol name="layer_2_top_1">
+          <volumeref ref="layer_2_top" />
+          <positionref ref="layer_2_top_1inworld_volumepos" />
+        </physvol>
+        <physvol name="layer_3_top_1">
+          <volumeref ref="layer_3_top" />
+          <positionref ref="layer_3_top_1inworld_volumepos" />
+        </physvol>
+        <physvol name="layer_4_top_1">
+          <volumeref ref="layer_4_top" />
+          <positionref ref="layer_4_top_1inworld_volumepos" />
+        </physvol>
+        <physvol name="layer_1_bottom_1">
+          <volumeref ref="layer_1_bottom" />
+          <positionref ref="layer_1_bottom_1inworld_volumepos" />
+        </physvol>
+        <physvol name="layer_2_bottom_1">
+          <volumeref ref="layer_2_bottom" />
+          <positionref ref="layer_2_bottom_1inworld_volumepos" />
+        </physvol>
+        <physvol name="layer_3_bottom_1">
+          <volumeref ref="layer_3_bottom" />
+          <positionref ref="layer_3_bottom_1inworld_volumepos" />
+        </physvol>
+        <physvol name="layer_4_bottom_1">
+          <volumeref ref="layer_4_bottom" />
+          <positionref ref="layer_4_bottom_1inworld_volumepos" />
+        </physvol>
+        <physvol name="layer_5T_left_1">
+          <volumeref ref="layer_5T_left" />
+          <positionref ref="layer_5T_left_1inworld_volumepos" />
+        </physvol>
+        <physvol name="layer_5B_left_1">
+          <volumeref ref="layer_5B_left" />
+          <positionref ref="layer_5B_left_1inworld_volumepos" />
+        </physvol>
+        <physvol name="steel_bar_1">
+          <volumeref ref="steel_bar" />
+          <positionref ref="steel_bar_1inworld_volumepos" />
+        </physvol>
+        <physvol name="cu_Tpipe_inner_left_1">
+          <volumeref ref="cu_Tpipe_inner_left" />
+          <positionref ref="cu_Tpipe_inner_left_1inworld_volumepos" />
+          <rotationref ref="cu_Tpipe_inner_left_1inworld_volumerot" />
+        </physvol>
+        <physvol name="cu_Tpipe_inner_right_1">
+          <volumeref ref="cu_Tpipe_inner_right" />
+          <positionref ref="cu_Tpipe_inner_right_1inworld_volumepos" />
+          <rotationref ref="cu_Tpipe_inner_right_1inworld_volumerot" />
+        </physvol>
+        <physvol name="cu_Bpipe_inner_left_1">
+          <volumeref ref="cu_Bpipe_inner_left" />
+          <positionref ref="cu_Bpipe_inner_left_1inworld_volumepos" />
+          <rotationref ref="cu_Bpipe_inner_left_1inworld_volumerot" />
+        </physvol>
+        <physvol name="cu_Bpipe_inner_right_1">
+          <volumeref ref="cu_Bpipe_inner_right" />
+          <positionref ref="cu_Bpipe_inner_right_1inworld_volumepos" />
+          <rotationref ref="cu_Bpipe_inner_right_1inworld_volumerot" />
+        </physvol>
+        <physvol name="cu_Tpipe_outer_right1_1">
+          <volumeref ref="cu_Tpipe_outer_right1" />
+          <positionref ref="cu_Tpipe_outer_right1_1inworld_volumepos" />
+          <rotationref ref="cu_Tpipe_outer_right1_1inworld_volumerot" />
+        </physvol>
+        <physvol name="cu_Tpipe_outer_right2_1">
+          <volumeref ref="cu_Tpipe_outer_right2" />
+          <positionref ref="cu_Tpipe_outer_right2_1inworld_volumepos" />
+        </physvol>
+        <physvol name="cu_Tpipe_outer_right3_1">
+          <volumeref ref="cu_Tpipe_outer_right3" />
+          <positionref ref="cu_Tpipe_outer_right3_1inworld_volumepos" />
+          <rotationref ref="cu_Tpipe_outer_right3_1inworld_volumerot" />
+        </physvol>
+        <physvol name="cu_Bpipe_outer_right_1">
+          <volumeref ref="cu_Bpipe_outer_right" />
+          <positionref ref="cu_Bpipe_outer_right_1inworld_volumepos" />
+          <rotationref ref="cu_Bpipe_outer_right_1inworld_volumerot" />
+        </physvol>
+        <physvol name="cu_Bpipe_outer_right1_1">
+          <volumeref ref="cu_Bpipe_outer_right1" />
+          <positionref ref="cu_Bpipe_outer_right1_1inworld_volumepos" />
+          <rotationref ref="cu_Bpipe_outer_right1_1inworld_volumerot" />
+        </physvol>
+        <physvol name="cu_Bpipe_outer_right2_1">
+          <volumeref ref="cu_Bpipe_outer_right2" />
+          <positionref ref="cu_Bpipe_outer_right2_1inworld_volumepos" />
+        </physvol>
+        <physvol name="al_pipe_across_top1_1">
+          <volumeref ref="al_pipe_across_top1" />
+          <positionref ref="al_pipe_across_top1_1inworld_volumepos" />
+          <rotationref ref="al_pipe_across_top1_1inworld_volumerot" />
+        </physvol>
+        <physvol name="al_pipe_across_top2_1">
+          <volumeref ref="al_pipe_across_top2" />
+          <positionref ref="al_pipe_across_top2_1inworld_volumepos" />
+          <rotationref ref="al_pipe_across_top2_1inworld_volumerot" />
+        </physvol>
+        <physvol name="al_pipe_across_bottom1_1">
+          <volumeref ref="al_pipe_across_bottom1" />
+          <positionref ref="al_pipe_across_bottom1_1inworld_volumepos" />
+          <rotationref ref="al_pipe_across_bottom1_1inworld_volumerot" />
+        </physvol>
+        <physvol name="al_pipe_across_bottom2_1">
+          <volumeref ref="al_pipe_across_bottom2" />
+          <positionref ref="al_pipe_across_bottom2_1inworld_volumepos" />
+          <rotationref ref="al_pipe_across_bottom2_1inworld_volumerot" />
+        </physvol>
+        <physvol name="cu_plate_top_left_1">
+          <volumeref ref="cu_plate_top_left" />
+          <positionref ref="cu_plate_top_left_1inworld_volumepos" />
+        </physvol>
+        <physvol name="cu_plate_bottom_left_1">
+          <volumeref ref="cu_plate_bottom_left" />
+          <positionref ref="cu_plate_bottom_left_1inworld_volumepos" />
+        </physvol>
+        <physvol name="cu_plate_top_right_1">
+          <volumeref ref="cu_plate_top_right" />
+          <positionref ref="cu_plate_top_right_1inworld_volumepos" />
+        </physvol>
+        <physvol name="cu_plate_bottom_right_1">
+          <volumeref ref="cu_plate_bottom_right" />
+          <positionref ref="cu_plate_bottom_right_1inworld_volumepos" />
+        </physvol>
+        <physvol name="cu_plate_top_middle_1">
+          <volumeref ref="cu_plate_top_middle" />
+          <positionref ref="cu_plate_top_middle_1inworld_volumepos" />
+        </physvol>
+        <physvol name="cu_plate_bottom_middle_1">
+          <volumeref ref="cu_plate_bottom_middle" />
+          <positionref ref="cu_plate_bottom_middle_1inworld_volumepos" />
+        </physvol>
+        <visref ref="WorldVis" />
+      </volume>
+    </structure>
+    <setup name="Default" version="1.0">
+      <world ref="world_volume" />
+    </setup>
+  </gdml>
+  <fields>
+    <field_map_3d name="HPSDipoleFieldMap3D" lunit="mm" funit="tesla" filename="fieldmap/418acm2_10kg_corrected_unfolded_scaled_1.0319.dat" xoffset="21.17" yoffset="0.0" zoffset="457.2" />
+  </fields>
+</lcdd>
+

--- a/detector-data/detectors/HPS_PhysicsRun2019_Pass2_fixed/SamplingFractions/Ecal.properties
+++ b/detector-data/detectors/HPS_PhysicsRun2019_Pass2_fixed/SamplingFractions/Ecal.properties
@@ -1,0 +1,1 @@
+samplingFraction: 1.0

--- a/detector-data/detectors/HPS_PhysicsRun2019_Pass2_fixed/SamplingFractions/Hodoscope.properties
+++ b/detector-data/detectors/HPS_PhysicsRun2019_Pass2_fixed/SamplingFractions/Hodoscope.properties
@@ -1,0 +1,1 @@
+samplingFraction: 1.0

--- a/detector-data/detectors/HPS_PhysicsRun2019_Pass2_fixed/compact.xml
+++ b/detector-data/detectors/HPS_PhysicsRun2019_Pass2_fixed/compact.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <lccdd xmlns:compact="http://www.lcsim.org/schemas/compact/1.0" xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/compact/1.0/compact.xsd">
 
-<info name="HPS_PhysicsRun2019_Pass2">
+<info name="HPS_PhysicsRun2019_Pass2_fixed">
     <comment>HPS detector for 2019 run with fieldmap,
     Tracker at nominal opening angle.
     SVT Survey for back of the detector from 2016.
@@ -213,12 +213,12 @@
           <unitvec name="Y" x="7.6453e-05" y="1.0000e+00" z="-3.0945e-05" />
           <unitvec name="Z" x="3.0082e-02" y="2.8631e-05" z="9.9955e-01" />
         </SurveyVolume>
-        <!-- <SurveyVolume name="support_top_L46" desc="T46 ball basis in box fiducial frame:">
+        <SurveyVolume name="support_top_L46" desc="T46 ball basis in box fiducial frame:">
           <origin x="-6.3106" y="8.462" z="773.7906" />
           <unitvec name="X" x="9.9954e-01" y="7.3687e-05" z="-3.0209e-02" />
           <unitvec name="Y" x="-7.2695e-05" y="1.0000e+00" z="3.3946e-05" />
           <unitvec name="Z" x="3.0209e-02" y="-3.1734e-05" z="9.9954e-01" />
-        </SurveyVolume> -->
+        </SurveyVolume>
 
         <!-- Originally the x of the bottom was 0.0 +1.0, but that seems like a hack -->
 
@@ -806,14 +806,14 @@
         <millepede_constant name="22362" value="0.0" /> <!-- rw -->
 
         <!-- L3 Top/Bottom translations and angles -->
-        <millepede_constant name="11163" value="0.0 + 0.018801 + 0.000277 + -0.001333 + -0.000319 + -0.7" /> <!-- u  -> global Y   -->
+        <millepede_constant name="11163" value="0.0 + 0.018801 + 0.000277 + -0.001333 + -0.000319" /> <!-- u  -> global Y   -->
         <millepede_constant name="11263" value="0.0" /> <!-- v  -> X+svtAngle -->
         <millepede_constant name="11363" value="0.0" /> <!-- w  -> Z+svtAngle -->
         <millepede_constant name="12163" value="0.0" /> <!-- ru -->
         <millepede_constant name="12263" value="0.0" /> <!-- rv -->
         <millepede_constant name="12363" value="0.0" /> <!-- rw -->
 
-        <millepede_constant name="21163" value="0.0 + 0.002791 + -0.7" /> <!-- u -->
+        <millepede_constant name="21163" value="0.0 + 0.002791" /> <!-- u -->
         <millepede_constant name="21263" value="0.0" /> <!-- v -->
         <millepede_constant name="21363" value="0.0" /> <!-- w -->
         <millepede_constant name="22163" value="0.0" /> <!-- ru -->
@@ -821,14 +821,14 @@
         <millepede_constant name="22363" value="0.0" /> <!-- rw -->
 
         <!-- L4 Top/Bottom translations and angles -->
-        <millepede_constant name="11164" value="0.0 + 0.022586 + -0.004495 + -0.004089 + -0.000772 + -0.7" /> <!-- u  -> global Y   -->
+        <millepede_constant name="11164" value="0.0 + 0.022586 + -0.004495 + -0.004089 + -0.000772" /> <!-- u  -> global Y   -->
         <millepede_constant name="11264" value="0.0" /> <!-- v  -> X+svtAngle -->
         <millepede_constant name="11364" value="0.0" /> <!-- w  -> Z+svtAngle -->
         <millepede_constant name="12164" value="0.0" /> <!-- ru -->
         <millepede_constant name="12264" value="0.0" /> <!-- rv -->
         <millepede_constant name="12364" value="0.0" /> <!-- rw -->
 
-        <millepede_constant name="21164" value="0.0 + 0.003839 + -0.7" /> <!-- u -->
+        <millepede_constant name="21164" value="0.0 + 0.003839" /> <!-- u -->
         <millepede_constant name="21264" value="0.0" /> <!-- v -->
         <millepede_constant name="21364" value="0.0" /> <!-- w -->
         <millepede_constant name="22164" value="0.0" /> <!-- ru -->

--- a/detector-data/detectors/HPS_PhysicsRun2019_Pass2_fixed/detector.properties
+++ b/detector-data/detectors/HPS_PhysicsRun2019_Pass2_fixed/detector.properties
@@ -1,0 +1,1 @@
+name: HPS_PhysicsRun2019_Pass2_fixed

--- a/detector-data/detectors/HPS_Run2021Pass0_v1/HPS_Run2021Pass0_v1.lcdd
+++ b/detector-data/detectors/HPS_Run2021Pass0_v1/HPS_Run2021Pass0_v1.lcdd
@@ -2,7 +2,7 @@
 <lcdd xmlns:lcdd="http://www.lcsim.org/schemas/lcdd/1.0" xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/lcdd/1.0/lcdd.xsd">
   <header>
     <detector name="HPS_Run2021Pass0_v1" />
-    <generator name="lcsim" version="1.0" file="/sdf/group/hps/users/sgaiser/src/hps-java/detector-data/detectors/HPS_Run2021Pass0_v1/compact.xml" checksum="38842783" />
+    <generator name="lcsim" version="1.0" file="/sdf/group/hps/users/sgaiser/src/hps-java/detector-data/detectors/HPS_Run2021Pass0_v1/compact.xml" checksum="1210858853" />
     <author name="NONE" />
     <comment>HPS detector for 2021 run with fieldmap, Tracker at nominal opening angle, no SVT survey, this detector uses the corrected fieldmap scaled for 3.74 GeV beam. Includes L0 and Hodoscope. ECAL with survey alignment for HPSEcal3 (global y/z translations). This detector has the full hierarchical alignment structure</comment>
   </header>
@@ -274,7 +274,7 @@
       <rotation name="module_L2t_halfmodule_stereo_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
       <position name="module_L2t_halfmodule_stereo_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
       <rotation name="module_L2t_halfmodule_stereo_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
-      <position name="module_L3b_halfmodule_axial_position" x="-44.86653535485047" y="137.05267003736043" z="-25.672413778892928" unit="mm" />
+      <position name="module_L3b_halfmodule_axial_position" x="-44.86653535485047" y="137.053647237043" z="-24.972414460978417" unit="mm" />
       <rotation name="module_L3b_halfmodule_axial_rotation" x="-1.5694003267948962" y="-0.030540399450088122" z="1.5707963267948963" unit="radian" />
       <position name="module_L3b_halfmodule_axial_sensor_position" x="-3.414999999999999" y="30.0" z="-0.50725" unit="mm" />
       <rotation name="module_L3b_halfmodule_axial_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
@@ -286,7 +286,7 @@
       <rotation name="module_L3b_halfmodule_axial_cf_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
       <position name="module_L3b_halfmodule_axial_hybrid_position" x="-3.414999999999999" y="-55.0" z="0.12649999999999995" unit="mm" />
       <rotation name="module_L3b_halfmodule_axial_hybrid_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
-      <position name="module_L3b_halfmodule_stereo_position" x="-45.31762685506874" y="145.4286365754165" z="-21.854831478310007" unit="mm" />
+      <position name="module_L3b_halfmodule_stereo_position" x="-45.31762685506874" y="145.42961377509909" z="-21.154832160395497" unit="mm" />
       <rotation name="module_L3b_halfmodule_stereo_rotation" x="1.5721923267948963" y="0.03054039945008801" z="1.6707963267948964" unit="radian" />
       <position name="module_L3b_halfmodule_stereo_sensor_position" x="-3.414999999999999" y="30.0" z="-0.50725" unit="mm" />
       <rotation name="module_L3b_halfmodule_stereo_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
@@ -298,7 +298,7 @@
       <rotation name="module_L3b_halfmodule_stereo_cf_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
       <position name="module_L3b_halfmodule_stereo_hybrid_position" x="-3.414999999999999" y="-55.0" z="0.12649999999999995" unit="mm" />
       <rotation name="module_L3b_halfmodule_stereo_hybrid_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
-      <position name="module_L3t_halfmodule_axial_position" x="-45.61670040744279" y="161.22559183511078" z="25.61125900534158" unit="mm" />
+      <position name="module_L3t_halfmodule_axial_position" x="-45.61670040744279" y="161.2253174351178" z="24.911259059123978" unit="mm" />
       <rotation name="module_L3t_halfmodule_axial_rotation" x="1.5711883267948965" y="0.03043330642417559" z="1.5707963267948966" unit="radian" />
       <position name="module_L3t_halfmodule_axial_sensor_position" x="-3.414999999999999" y="30.0" z="-0.50725" unit="mm" />
       <rotation name="module_L3t_halfmodule_axial_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
@@ -310,7 +310,7 @@
       <rotation name="module_L3t_halfmodule_axial_cf_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
       <position name="module_L3t_halfmodule_axial_hybrid_position" x="-3.414999999999999" y="-55.0" z="0.12649999999999995" unit="mm" />
       <rotation name="module_L3t_halfmodule_axial_hybrid_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
-      <position name="module_L3t_halfmodule_stereo_position" x="-45.54676173869666" y="152.84185549481725" z="21.829706065586" unit="mm" />
+      <position name="module_L3t_halfmodule_stereo_position" x="-45.54676173869666" y="152.84158109482428" z="21.129706119368397" unit="mm" />
       <rotation name="module_L3t_halfmodule_stereo_rotation" x="-1.5704043267948962" y="-0.030433306424175535" z="1.6707963267948964" unit="radian" />
       <position name="module_L3t_halfmodule_stereo_sensor_position" x="-3.414999999999999" y="30.0" z="-0.50725" unit="mm" />
       <rotation name="module_L3t_halfmodule_stereo_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
@@ -322,7 +322,7 @@
       <rotation name="module_L3t_halfmodule_stereo_cf_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
       <position name="module_L3t_halfmodule_stereo_hybrid_position" x="-3.414999999999999" y="-55.0" z="0.12649999999999995" unit="mm" />
       <rotation name="module_L3t_halfmodule_stereo_hybrid_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
-      <position name="module_L4b_halfmodule_axial_position" x="-41.81297014635422" y="37.09720378439058" z="-27.105817390045754" unit="mm" />
+      <position name="module_L4b_halfmodule_axial_position" x="-41.81297014635422" y="37.09818098407319" z="-26.405818072131243" unit="mm" />
       <rotation name="module_L4b_halfmodule_axial_rotation" x="-1.5694003267948962" y="-0.030540399450088122" z="1.5707963267948963" unit="radian" />
       <position name="module_L4b_halfmodule_axial_sensor_position" x="-3.414999999999999" y="30.0" z="-0.50725" unit="mm" />
       <rotation name="module_L4b_halfmodule_axial_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
@@ -334,7 +334,7 @@
       <rotation name="module_L4b_halfmodule_axial_cf_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
       <position name="module_L4b_halfmodule_axial_hybrid_position" x="-3.414999999999999" y="-55.0" z="0.12649999999999995" unit="mm" />
       <rotation name="module_L4b_halfmodule_axial_hybrid_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
-      <position name="module_L4b_halfmodule_stereo_position" x="-42.266005594434105" y="45.47317236141525" z="-23.244233373289834" unit="mm" />
+      <position name="module_L4b_halfmodule_stereo_position" x="-42.266005594434105" y="45.47414956109785" z="-22.544234055375323" unit="mm" />
       <rotation name="module_L4b_halfmodule_stereo_rotation" x="1.5721923267948963" y="0.03054039945008801" z="1.6707963267948964" unit="radian" />
       <position name="module_L4b_halfmodule_stereo_sensor_position" x="-3.414999999999999" y="30.0" z="-0.50725" unit="mm" />
       <rotation name="module_L4b_halfmodule_stereo_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
@@ -346,7 +346,7 @@
       <rotation name="module_L4b_halfmodule_stereo_cf_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
       <position name="module_L4b_halfmodule_stereo_hybrid_position" x="-3.414999999999999" y="-55.0" z="0.12649999999999995" unit="mm" />
       <rotation name="module_L4b_halfmodule_stereo_hybrid_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
-      <position name="module_L4t_halfmodule_axial_position" x="-42.57383952504715" y="61.27246976169503" z="27.090527741846074" unit="mm" />
+      <position name="module_L4t_halfmodule_axial_position" x="-42.57383952504715" y="61.27219536170206" z="26.390527795628472" unit="mm" />
       <rotation name="module_L4t_halfmodule_axial_rotation" x="1.5711883267948965" y="0.03043330642417559" z="1.5707963267948966" unit="radian" />
       <position name="module_L4t_halfmodule_axial_sensor_position" x="-3.414999999999999" y="30.0" z="-0.50725" unit="mm" />
       <rotation name="module_L4t_halfmodule_axial_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
@@ -358,7 +358,7 @@
       <rotation name="module_L4t_halfmodule_axial_cf_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
       <position name="module_L4t_halfmodule_axial_hybrid_position" x="-3.414999999999999" y="-55.0" z="0.12649999999999995" unit="mm" />
       <rotation name="module_L4t_halfmodule_axial_hybrid_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
-      <position name="module_L4t_halfmodule_stereo_position" x="-42.51021339381717" y="52.88854680495761" z="23.323143912837278" unit="mm" />
+      <position name="module_L4t_halfmodule_stereo_position" x="-42.51021339381717" y="52.888272404964646" z="22.623143966619676" unit="mm" />
       <rotation name="module_L4t_halfmodule_stereo_rotation" x="-1.5704043267948962" y="-0.030433306424175535" z="1.6707963267948964" unit="radian" />
       <position name="module_L4t_halfmodule_stereo_sensor_position" x="-3.414999999999999" y="30.0" z="-0.50725" unit="mm" />
       <rotation name="module_L4t_halfmodule_stereo_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />

--- a/detector-data/detectors/HPS_Run2021Pass0_v1/compact.xml
+++ b/detector-data/detectors/HPS_Run2021Pass0_v1/compact.xml
@@ -534,14 +534,14 @@
         <millepede_constant name="22362" value="0.0" /> <!-- rw -->
 
         <!-- L3 Top/Bottom translations and angles -->
-        <millepede_constant name="11163" value="0.0 + 0.000678 - -0.059459 - 0.012216 - 0.006668 - 0.002504" /> <!-- u  -> global Y   -->
+        <millepede_constant name="11163" value="0.0 + 0.000678 - -0.059459 - 0.012216 - 0.006668 - 0.002504 + -0.7" /> <!-- u  -> global Y   -->
         <millepede_constant name="11263" value="0.0" /> <!-- v  -> X+svtAngle -->
         <millepede_constant name="11363" value="0.0" /> <!-- w  -> Z+svtAngle -->
         <millepede_constant name="12163" value="0.0" /> <!-- ru -->
         <millepede_constant name="12263" value="0.0" /> <!-- rv -->
         <millepede_constant name="12363" value="0.0" /> <!-- rw -->
 
-        <millepede_constant name="21163" value="0.0 + -0.046884 + -0.010228 - 0.075913 - 0.001767 - 0.023862" /> <!-- u -->
+        <millepede_constant name="21163" value="0.0 + -0.046884 + -0.010228 - 0.075913 - 0.001767 - 0.023862 + -0.7" /> <!-- u -->
         <millepede_constant name="21263" value="0.0" /> <!-- v -->
         <millepede_constant name="21363" value="0.0" /> <!-- w -->
         <millepede_constant name="22163" value="0.0" /> <!-- ru -->
@@ -549,14 +549,14 @@
         <millepede_constant name="22363" value="0.0" /> <!-- rw -->
 
         <!-- L4 Top/Bottom translations and angles -->
-        <millepede_constant name="11164" value="0.0 + -0.007361 - -0.033468 - -0.017968 - -0.013564 - 0.001690" /> <!-- u  -> global Y   -->
+        <millepede_constant name="11164" value="0.0 + -0.007361 - -0.033468 - -0.017968 - -0.013564 - 0.001690 + -0.7" /> <!-- u  -> global Y   -->
         <millepede_constant name="11264" value="0.0" /> <!-- v  -> X+svtAngle -->
         <millepede_constant name="11364" value="0.0" /> <!-- w  -> Z+svtAngle -->
         <millepede_constant name="12164" value="0.0" /> <!-- ru -->
         <millepede_constant name="12264" value="0.0" /> <!-- rv -->
         <millepede_constant name="12364" value="0.0" /> <!-- rw -->
 
-        <millepede_constant name="21164" value="0.0 + -0.033974 + -0.006749 - 0.051528 - -0.004088 - 0.021074 - 0.001095" /> <!-- u -->
+        <millepede_constant name="21164" value="0.0 + -0.033974 + -0.006749 - 0.051528 - -0.004088 - 0.021074 - 0.001095 + -0.7" /> <!-- u -->
         <millepede_constant name="21264" value="0.0" /> <!-- v -->
         <millepede_constant name="21364" value="0.0" /> <!-- w -->
         <millepede_constant name="22164" value="0.0" /> <!-- ru -->

--- a/detector-data/detectors/HPS_Run2021Pass0_v1_1pt92GeV/HPS_Run2021Pass0_v1_1pt92GeV.lcdd
+++ b/detector-data/detectors/HPS_Run2021Pass0_v1_1pt92GeV/HPS_Run2021Pass0_v1_1pt92GeV.lcdd
@@ -2,7 +2,7 @@
 <lcdd xmlns:lcdd="http://www.lcsim.org/schemas/lcdd/1.0" xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/lcdd/1.0/lcdd.xsd">
   <header>
     <detector name="HPS_Run2021Pass0_v1_1pt92GeV" />
-    <generator name="lcsim" version="1.0" file="/sdf/group/hps/users/sgaiser/src/hps-java/detector-data/detectors/HPS_Run2021Pass0_v1_1pt92GeV/compact.xml" checksum="935991574" />
+    <generator name="lcsim" version="1.0" file="/sdf/group/hps/users/sgaiser/src/hps-java/detector-data/detectors/HPS_Run2021Pass0_v1_1pt92GeV/compact.xml" checksum="3403357450" />
     <author name="NONE" />
     <comment>HPS detector for 2021 run with fieldmap, Tracker at nominal opening angle, no SVT survey, this detector uses the corrected fieldmap scaled for 3.74 GeV beam. Includes L0 and Hodoscope. ECAL with survey alignment for HPSEcal3 (global y/z translations). This detector has the full hierarchical alignment structure</comment>
   </header>
@@ -274,7 +274,7 @@
       <rotation name="module_L2t_halfmodule_stereo_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
       <position name="module_L2t_halfmodule_stereo_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
       <rotation name="module_L2t_halfmodule_stereo_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
-      <position name="module_L3b_halfmodule_axial_position" x="-44.86653535485047" y="137.05267003736043" z="-25.672413778892928" unit="mm" />
+      <position name="module_L3b_halfmodule_axial_position" x="-44.86653535485047" y="137.053647237043" z="-24.972414460978417" unit="mm" />
       <rotation name="module_L3b_halfmodule_axial_rotation" x="-1.5694003267948962" y="-0.030540399450088122" z="1.5707963267948963" unit="radian" />
       <position name="module_L3b_halfmodule_axial_sensor_position" x="-3.414999999999999" y="30.0" z="-0.50725" unit="mm" />
       <rotation name="module_L3b_halfmodule_axial_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
@@ -286,7 +286,7 @@
       <rotation name="module_L3b_halfmodule_axial_cf_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
       <position name="module_L3b_halfmodule_axial_hybrid_position" x="-3.414999999999999" y="-55.0" z="0.12649999999999995" unit="mm" />
       <rotation name="module_L3b_halfmodule_axial_hybrid_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
-      <position name="module_L3b_halfmodule_stereo_position" x="-45.31762685506874" y="145.4286365754165" z="-21.854831478310007" unit="mm" />
+      <position name="module_L3b_halfmodule_stereo_position" x="-45.31762685506874" y="145.42961377509909" z="-21.154832160395497" unit="mm" />
       <rotation name="module_L3b_halfmodule_stereo_rotation" x="1.5721923267948963" y="0.03054039945008801" z="1.6707963267948964" unit="radian" />
       <position name="module_L3b_halfmodule_stereo_sensor_position" x="-3.414999999999999" y="30.0" z="-0.50725" unit="mm" />
       <rotation name="module_L3b_halfmodule_stereo_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
@@ -298,7 +298,7 @@
       <rotation name="module_L3b_halfmodule_stereo_cf_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
       <position name="module_L3b_halfmodule_stereo_hybrid_position" x="-3.414999999999999" y="-55.0" z="0.12649999999999995" unit="mm" />
       <rotation name="module_L3b_halfmodule_stereo_hybrid_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
-      <position name="module_L3t_halfmodule_axial_position" x="-45.61670040744279" y="161.22559183511078" z="25.61125900534158" unit="mm" />
+      <position name="module_L3t_halfmodule_axial_position" x="-45.61670040744279" y="161.2253174351178" z="24.911259059123978" unit="mm" />
       <rotation name="module_L3t_halfmodule_axial_rotation" x="1.5711883267948965" y="0.03043330642417559" z="1.5707963267948966" unit="radian" />
       <position name="module_L3t_halfmodule_axial_sensor_position" x="-3.414999999999999" y="30.0" z="-0.50725" unit="mm" />
       <rotation name="module_L3t_halfmodule_axial_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
@@ -310,7 +310,7 @@
       <rotation name="module_L3t_halfmodule_axial_cf_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
       <position name="module_L3t_halfmodule_axial_hybrid_position" x="-3.414999999999999" y="-55.0" z="0.12649999999999995" unit="mm" />
       <rotation name="module_L3t_halfmodule_axial_hybrid_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
-      <position name="module_L3t_halfmodule_stereo_position" x="-45.54676173869666" y="152.84185549481725" z="21.829706065586" unit="mm" />
+      <position name="module_L3t_halfmodule_stereo_position" x="-45.54676173869666" y="152.84158109482428" z="21.129706119368397" unit="mm" />
       <rotation name="module_L3t_halfmodule_stereo_rotation" x="-1.5704043267948962" y="-0.030433306424175535" z="1.6707963267948964" unit="radian" />
       <position name="module_L3t_halfmodule_stereo_sensor_position" x="-3.414999999999999" y="30.0" z="-0.50725" unit="mm" />
       <rotation name="module_L3t_halfmodule_stereo_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
@@ -322,7 +322,7 @@
       <rotation name="module_L3t_halfmodule_stereo_cf_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
       <position name="module_L3t_halfmodule_stereo_hybrid_position" x="-3.414999999999999" y="-55.0" z="0.12649999999999995" unit="mm" />
       <rotation name="module_L3t_halfmodule_stereo_hybrid_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
-      <position name="module_L4b_halfmodule_axial_position" x="-41.81297014635422" y="37.09720378439058" z="-27.105817390045754" unit="mm" />
+      <position name="module_L4b_halfmodule_axial_position" x="-41.81297014635422" y="37.09818098407319" z="-26.405818072131243" unit="mm" />
       <rotation name="module_L4b_halfmodule_axial_rotation" x="-1.5694003267948962" y="-0.030540399450088122" z="1.5707963267948963" unit="radian" />
       <position name="module_L4b_halfmodule_axial_sensor_position" x="-3.414999999999999" y="30.0" z="-0.50725" unit="mm" />
       <rotation name="module_L4b_halfmodule_axial_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
@@ -334,7 +334,7 @@
       <rotation name="module_L4b_halfmodule_axial_cf_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
       <position name="module_L4b_halfmodule_axial_hybrid_position" x="-3.414999999999999" y="-55.0" z="0.12649999999999995" unit="mm" />
       <rotation name="module_L4b_halfmodule_axial_hybrid_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
-      <position name="module_L4b_halfmodule_stereo_position" x="-42.266005594434105" y="45.47317236141525" z="-23.244233373289834" unit="mm" />
+      <position name="module_L4b_halfmodule_stereo_position" x="-42.266005594434105" y="45.47414956109785" z="-22.544234055375323" unit="mm" />
       <rotation name="module_L4b_halfmodule_stereo_rotation" x="1.5721923267948963" y="0.03054039945008801" z="1.6707963267948964" unit="radian" />
       <position name="module_L4b_halfmodule_stereo_sensor_position" x="-3.414999999999999" y="30.0" z="-0.50725" unit="mm" />
       <rotation name="module_L4b_halfmodule_stereo_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
@@ -346,7 +346,7 @@
       <rotation name="module_L4b_halfmodule_stereo_cf_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
       <position name="module_L4b_halfmodule_stereo_hybrid_position" x="-3.414999999999999" y="-55.0" z="0.12649999999999995" unit="mm" />
       <rotation name="module_L4b_halfmodule_stereo_hybrid_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
-      <position name="module_L4t_halfmodule_axial_position" x="-42.57383952504715" y="61.27246976169503" z="27.090527741846074" unit="mm" />
+      <position name="module_L4t_halfmodule_axial_position" x="-42.57383952504715" y="61.27219536170206" z="26.390527795628472" unit="mm" />
       <rotation name="module_L4t_halfmodule_axial_rotation" x="1.5711883267948965" y="0.03043330642417559" z="1.5707963267948966" unit="radian" />
       <position name="module_L4t_halfmodule_axial_sensor_position" x="-3.414999999999999" y="30.0" z="-0.50725" unit="mm" />
       <rotation name="module_L4t_halfmodule_axial_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
@@ -358,7 +358,7 @@
       <rotation name="module_L4t_halfmodule_axial_cf_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
       <position name="module_L4t_halfmodule_axial_hybrid_position" x="-3.414999999999999" y="-55.0" z="0.12649999999999995" unit="mm" />
       <rotation name="module_L4t_halfmodule_axial_hybrid_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
-      <position name="module_L4t_halfmodule_stereo_position" x="-42.51021339381717" y="52.88854680495761" z="23.323143912837278" unit="mm" />
+      <position name="module_L4t_halfmodule_stereo_position" x="-42.51021339381717" y="52.888272404964646" z="22.623143966619676" unit="mm" />
       <rotation name="module_L4t_halfmodule_stereo_rotation" x="-1.5704043267948962" y="-0.030433306424175535" z="1.6707963267948964" unit="radian" />
       <position name="module_L4t_halfmodule_stereo_sensor_position" x="-3.414999999999999" y="30.0" z="-0.50725" unit="mm" />
       <rotation name="module_L4t_halfmodule_stereo_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />

--- a/detector-data/detectors/HPS_Run2021Pass0_v1_1pt92GeV_fixed/HPS_Run2021Pass0_v1_1pt92GeV_fixed.lcdd
+++ b/detector-data/detectors/HPS_Run2021Pass0_v1_1pt92GeV_fixed/HPS_Run2021Pass0_v1_1pt92GeV_fixed.lcdd
@@ -1,0 +1,10070 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lcdd xmlns:lcdd="http://www.lcsim.org/schemas/lcdd/1.0" xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/lcdd/1.0/lcdd.xsd">
+  <header>
+    <detector name="HPS_Run2021Pass0_v1_1pt92GeV_fixed" />
+    <generator name="lcsim" version="1.0" file="/sdf/group/hps/users/sgaiser/src/hps-java/detector-data/detectors/HPS_Run2021Pass0_v1_1pt92GeV/compact.xml" checksum="935991574" />
+    <author name="NONE" />
+    <comment>HPS detector for 2021 run with fieldmap, Tracker at nominal opening angle, no SVT survey, this detector uses the corrected fieldmap scaled for 3.74 GeV beam. Includes L0 and Hodoscope. ECAL with survey alignment for HPSEcal3 (global y/z translations). This detector has the full hierarchical alignment structure</comment>
+  </header>
+  <iddict>
+    <idspec name="HodoscopeForeHits" length="46">
+      <idfield signed="false" label="system" length="6" start="0" />
+      <idfield signed="false" label="barrel" length="3" start="6" />
+      <idfield signed="false" label="layer" length="4" start="9" />
+      <idfield signed="false" label="module" length="12" start="13" />
+      <idfield signed="false" label="sensor" length="1" start="25" />
+      <idfield signed="true" label="side" length="2" start="32" />
+      <idfield signed="false" label="strip" length="12" start="34" />
+    </idspec>
+    <idspec name="TrackerHitsFieldDef" length="46">
+      <idfield signed="false" label="system" length="6" start="0" />
+      <idfield signed="false" label="barrel" length="3" start="6" />
+      <idfield signed="false" label="layer" length="4" start="9" />
+      <idfield signed="false" label="module" length="12" start="13" />
+      <idfield signed="false" label="sensor" length="1" start="25" />
+      <idfield signed="true" label="side" length="2" start="32" />
+      <idfield signed="false" label="strip" length="12" start="34" />
+    </idspec>
+    <idspec name="TrackerHits" length="46">
+      <idfield signed="false" label="system" length="6" start="0" />
+      <idfield signed="false" label="barrel" length="3" start="6" />
+      <idfield signed="false" label="layer" length="4" start="9" />
+      <idfield signed="false" label="module" length="12" start="13" />
+      <idfield signed="false" label="sensor" length="1" start="25" />
+      <idfield signed="true" label="side" length="2" start="32" />
+      <idfield signed="false" label="strip" length="12" start="34" />
+    </idspec>
+    <idspec name="HodoscopeHits" length="23">
+      <idfield signed="false" label="system" length="6" start="0" />
+      <idfield signed="false" label="barrel" length="3" start="6" />
+      <idfield signed="false" label="layer" length="4" start="9" />
+      <idfield signed="false" label="ix" length="4" start="13" />
+      <idfield signed="true" label="iy" length="3" start="17" />
+      <idfield signed="true" label="hole" length="3" start="20" />
+    </idspec>
+    <idspec name="EcalHits" length="22">
+      <idfield signed="false" label="system" length="6" start="0" />
+      <idfield signed="false" label="layer" length="2" start="6" />
+      <idfield signed="true" label="ix" length="8" start="8" />
+      <idfield signed="true" label="iy" length="6" start="16" />
+    </idspec>
+    <idspec name="TrackerHitsECal" length="46">
+      <idfield signed="false" label="system" length="6" start="0" />
+      <idfield signed="false" label="barrel" length="3" start="6" />
+      <idfield signed="false" label="layer" length="4" start="9" />
+      <idfield signed="false" label="module" length="12" start="13" />
+      <idfield signed="false" label="sensor" length="1" start="25" />
+      <idfield signed="true" label="side" length="2" start="32" />
+      <idfield signed="false" label="strip" length="12" start="34" />
+    </idspec>
+  </iddict>
+  <sensitive_detectors>
+    <tracker name="Tracker" ecut="0.0" eunit="MeV" verbose="0" hits_collection="TrackerHits">
+      <idspecref ref="TrackerHits" />
+    </tracker>
+    <tracker name="ECalScoring" ecut="0.0" eunit="MeV" verbose="0" hits_collection="TrackerHitsECal">
+      <idspecref ref="TrackerHitsECal" />
+      <hit_processor type="ScoringTrackerHitProcessor" />
+    </tracker>
+    <calorimeter name="Ecal" ecut="0.0" eunit="MeV" verbose="0" hits_collection="EcalHits">
+      <idspecref ref="EcalHits" />
+      <grid_xyz grid_size_x="0.0" grid_size_y="0.0" grid_size_z="0.0" />
+    </calorimeter>
+    <tracker name="Hodoscope" ecut="0.0" eunit="MeV" verbose="0" hits_collection="HodoscopeHits">
+      <idspecref ref="HodoscopeHits" />
+    </tracker>
+  </sensitive_detectors>
+  <limits />
+  <regions>
+    <region name="TrackingRegion" store_secondaries="true" kill_tracks="false" cut="10.0" lunit="mm" threshold="1.0" eunit="MeV" />
+  </regions>
+  <display>
+    <vis name="InvisibleWithDaughters" line_style="unbroken" drawing_style="wireframe" show_daughters="true" visible="false">
+      <color R="0.0" G="0.0" B="0.0" alpha="0.0" />
+    </vis>
+    <vis name="SensorVis" line_style="unbroken" drawing_style="wireframe" show_daughters="true" visible="true">
+      <color R="1.0" G="0.0" B="0.0" alpha="1.0" />
+    </vis>
+    <vis name="SvtBoxVis" line_style="unbroken" drawing_style="wireframe" show_daughters="true" visible="true">
+      <color R="1.0" G="1.0" B="0.0" alpha="1.0" />
+    </vis>
+    <vis name="ComponentVis" line_style="unbroken" drawing_style="solid" show_daughters="false" visible="false">
+      <color R="0.0" G="0.2" B="0.4" alpha="0.0" />
+    </vis>
+    <vis name="HybridVis" line_style="unbroken" drawing_style="solid" show_daughters="true" visible="true">
+      <color R="0.0" G="1.0" B="0.0" alpha="1.0" />
+    </vis>
+    <vis name="ColdBlockVis" line_style="dashed" drawing_style="solid" show_daughters="true" visible="true">
+      <color R="0.75" G="0.73" B="0.75" alpha="1.0" />
+    </vis>
+    <vis name="ECALVis" line_style="unbroken" drawing_style="wireframe" show_daughters="true" visible="true">
+      <color R="0.8" G="0.5" B="0.1" alpha="1.0" />
+    </vis>
+    <vis name="HodoscopeVis" line_style="unbroken" drawing_style="solid" show_daughters="true" visible="true">
+      <color R="0.0" G="0.3372549" B="0.50980395" alpha="1.0" />
+    </vis>
+    <vis name="BasePlateVis" line_style="dashed" drawing_style="solid" show_daughters="true" visible="true">
+      <color R="0.35" G="0.35" B="0.35" alpha="1.0" />
+    </vis>
+    <vis name="BeamPlaneVis" line_style="unbroken" drawing_style="solid" show_daughters="false" visible="true">
+      <color R="1.0" G="1.0" B="1.0" alpha="1.0" />
+    </vis>
+    <vis name="HalfModuleVis" line_style="dashed" drawing_style="wireframe" show_daughters="true" visible="true">
+      <color R="1.0" G="1.0" B="1.0" alpha="1.0" />
+    </vis>
+    <vis name="CarbonFiberVis" line_style="unbroken" drawing_style="solid" show_daughters="true" visible="true">
+      <color R="0.88" G="0.88" B="0.88" alpha="1.0" />
+    </vis>
+    <vis name="ModuleVis" line_style="dotted" drawing_style="wireframe" show_daughters="true" visible="true">
+      <color R="1.0" G="1.0" B="1.0" alpha="1.0" />
+    </vis>
+    <vis name="SupportPlateVis" line_style="dashed" drawing_style="solid" show_daughters="true" visible="true">
+      <color R="0.45" G="0.45" B="0.45" alpha="1.0" />
+    </vis>
+    <vis name="LayerVis" line_style="unbroken" drawing_style="wireframe" show_daughters="true" visible="false">
+      <color R="0.0" G="0.0" B="1.0" alpha="0.0" />
+    </vis>
+    <vis name="ChamberVis" line_style="unbroken" drawing_style="wireframe" show_daughters="true" visible="true">
+      <color R="1.0" G="0.0" B="1.0" alpha="1.0" />
+    </vis>
+    <vis name="InvisibleNoDaughters" line_style="unbroken" drawing_style="wireframe" show_daughters="false" visible="false">
+      <color R="0.0" G="0.0" B="0.0" alpha="0.0" />
+    </vis>
+    <vis name="ActiveSensorVis" line_style="unbroken" drawing_style="solid" show_daughters="true" visible="true">
+      <color R="1.0" G="0.0" B="0.0" alpha="1.0" />
+    </vis>
+    <vis name="KaptonVis" line_style="unbroken" drawing_style="solid" show_daughters="true" visible="true">
+      <color R="0.91" G="0.77" B="0.06" alpha="1.0" />
+    </vis>
+    <vis name="SupportVolumeVis" line_style="dashed" drawing_style="wireframe" show_daughters="true" visible="true">
+      <color R="0.75" G="0.73" B="0.75" alpha="1.0" />
+    </vis>
+    <vis name="WorldVis" line_style="unbroken" drawing_style="wireframe" show_daughters="true" visible="false">
+      <color R="1.0" G="1.0" B="1.0" alpha="1.0" />
+    </vis>
+    <vis name="TrackingVis" line_style="unbroken" drawing_style="wireframe" show_daughters="true" visible="false">
+      <color R="1.0" G="1.0" B="1.0" alpha="1.0" />
+    </vis>
+  </display>
+  <gdml>
+    <define>
+      <rotation name="identity_rot" x="0.0" y="0.0" z="0.0" unit="radian" />
+      <rotation name="reflect_rot" x="3.141592653589793" y="0.0" z="0.0" unit="radian" />
+      <position name="identity_pos" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <constant name="bot_tr_x" value="-0.405" />
+      <constant name="x_rot_top" value="0.0" />
+      <constant name="hodoscopeXMin2" value="48.0" />
+      <constant name="hodoscopeXMin1" value="43.548" />
+      <constant name="scoringThickness" value="0.001" />
+      <constant name="ecal_back" value="8.0" />
+      <constant name="pivot" value="791.0" />
+      <constant name="bot_tr_y" value="-0.9125" />
+      <constant name="hodoscopeThickness" value="10.0" />
+      <constant name="bot_tr_z" value="2.6225" />
+      <constant name="bot_rot_beta" value="0.0" />
+      <constant name="dipoleMagnetWidth" value="1000.0" />
+      <constant name="top_rot_beta" value="0.0" />
+      <constant name="SA1" value="0.1" />
+      <constant name="x_rot_top_add" value="0.0" />
+      <constant name="SA2" value="0.05" />
+      <constant name="tracking_region_min" value="50.0" />
+      <constant name="y02t" value="21.419865625949214" />
+      <constant name="world_side" value="5000.0" />
+      <constant name="sensorLength" value="98.33" />
+      <constant name="sensorWidth" value="38.3399" />
+      <constant name="y02b" value="-21.419865625949214" />
+      <constant name="bot_rot_gamma" value="0.0013469727279283583" />
+      <constant name="x_rot_bot" value="0.0" />
+      <constant name="dipoleMagnetHeight" value="1000.0" />
+      <constant name="z02t" value="146.185" />
+      <constant name="top_rot_alpha" value="6.4964212772E-4" />
+      <constant name="y_rot" value="0.03052" />
+      <constant name="tracking_region_zmax" value="1368.0" />
+      <constant name="constBFieldY" value="-0.437" />
+      <constant name="top_tr_z" value="4.9375" />
+      <constant name="top_tr_y" value="2.725" />
+      <constant name="top_tr_x" value="-0.71" />
+      <constant name="dipoleMagnetLength" value="1080.0" />
+      <constant name="top_rot_gamma" value="-4.6882347412E-4" />
+      <constant name="y01t" value="21.419865625949214" />
+      <constant name="x_rot_bot_add" value="0.0" />
+      <constant name="zst" value="1.0" />
+      <constant name="bot_rot_alpha" value="5.150274940439E-4" />
+      <constant name="hodoscopePixelHeight" value="59.225" />
+      <constant name="beam_angle" value="0.03052" />
+      <constant name="z02b" value="161.185" />
+      <constant name="y01b" value="-21.419865625949214" />
+      <constant name="electronGapLeftEdge" value="382.492" />
+      <constant name="ecal_front" value="6.65" />
+      <constant name="z01t" value="138.815" />
+      <constant name="world_x" value="5000.0" />
+      <constant name="hodoscopeScoreDisplacement" value="1.0" />
+      <constant name="world_y" value="5000.0" />
+      <constant name="dipoleMagnetPositionX" value="21.17" />
+      <constant name="world_z" value="5000.0" />
+      <constant name="dipoleMagnetPositionZ" value="457.2" />
+      <constant name="tracking_region_radius" value="2000.0" />
+      <constant name="moduleWidth" value="40.34" />
+      <constant name="x_off" value="0.0" />
+      <constant name="electronGapRightEdge" value="474.962" />
+      <constant name="hodoscopeZ" value="1098.5" />
+      <constant name="moduleLength" value="100.0" />
+      <constant name="PI" value="3.14159265359" />
+      <constant name="ecal_dface" value="1448.0" />
+      <constant name="ecal_z" value="80.0" />
+      <constant name="z01b" value="153.815" />
+      <position name="tracking_region_pos" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <position name="base_position" x="21.336" y="0.0" z="349.9358" unit="mm" />
+      <rotation name="base_rotation" x="1.5707963267948963" y="-0.0" z="0.0" unit="radian" />
+      <position name="base_plate_position" x="0.0" y="0.0" z="-82.423" unit="mm" />
+      <rotation name="base_plate_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="support_plate_bottom_L14_position" x="-43.91306765955236" y="158.27805970493353" z="-64.29618504855034" unit="mm" />
+      <rotation name="support_plate_bottom_L14_rotation" x="0.0013959999999999999" y="3.3881317890172014E-21" z="3.111052254139705" unit="radian" />
+      <position name="support_plate_top_L14_position" x="-43.92289273297252" y="158.275538638572" z="63.9526433720102" unit="mm" />
+      <rotation name="support_plate_top_L14_rotation" x="-3.1412006535897934" y="4.235164736271502E-21" z="0.030433306424175563" unit="radian" />
+      <position name="support_plate_bottom_L46_position" x="0.14270823091617224" y="-354.5345474665431" z="-65.573" unit="mm" />
+      <rotation name="support_plate_bottom_L46_rotation" x="0.0" y="-0.0" z="3.1111093540316292" unit="radian" />
+      <position name="support_plate_top_L46_position" x="0.14255566889328364" y="-354.53517226223204" z="65.573" unit="mm" />
+      <rotation name="support_plate_top_L46_rotation" x="3.141592653589793" y="-0.0" z="0.030483299558163937" unit="radian" />
+      <position name="module_L1b_halfmodule_axial_position" x="-19.4763620296784" y="288.4308408110862" z="-7.8439612644705505" unit="mm" />
+      <rotation name="module_L1b_halfmodule_axial_rotation" x="-1.5694003267948962" y="-0.0305403994500879" z="1.5622113267948965" unit="radian" />
+      <position name="module_L1b_halfmodule_axial_sensor_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L1b_halfmodule_axial_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L1b_halfmodule_axial_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L1b_halfmodule_axial_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L1b_halfmodule_stereo_position" x="-18.951361692806728" y="296.04519371827337" z="-7.726768223078636" unit="mm" />
+      <rotation name="module_L1b_halfmodule_stereo_rotation" x="1.5721923267948965" y="0.030540399450088455" z="-1.4591623267948968" unit="radian" />
+      <position name="module_L1b_halfmodule_stereo_sensor_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L1b_halfmodule_stereo_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L1b_halfmodule_stereo_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L1b_halfmodule_stereo_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L1t_halfmodule_axial_position" x="-20.1794485390661" y="311.5550157182415" z="7.82498750613383" unit="mm" />
+      <rotation name="module_L1t_halfmodule_axial_rotation" x="1.5711883267948965" y="0.03043330642417559" z="1.5707963267948966" unit="radian" />
+      <position name="module_L1t_halfmodule_axial_sensor_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L1t_halfmodule_axial_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L1t_halfmodule_axial_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L1t_halfmodule_axial_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L1t_halfmodule_stereo_position" x="-19.16125214862157" y="303.98788379354727" z="7.800416579843663" unit="mm" />
+      <rotation name="module_L1t_halfmodule_stereo_rotation" x="-1.5704043267948966" y="-0.030433306424175424" z="-1.4707963267948967" unit="radian" />
+      <position name="module_L1t_halfmodule_stereo_sensor_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L1t_halfmodule_stereo_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L1t_halfmodule_stereo_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L1t_halfmodule_stereo_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L2b_halfmodule_axial_position" x="-18.19946284499224" y="238.4459152303712" z="-8.244426721240949" unit="mm" />
+      <rotation name="module_L2b_halfmodule_axial_rotation" x="-1.5694003267948966" y="-0.030540399450088455" z="1.5693003267948964" unit="radian" />
+      <position name="module_L2b_halfmodule_axial_sensor_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L2b_halfmodule_axial_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L2b_halfmodule_axial_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L2b_halfmodule_axial_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L2b_halfmodule_stereo_position" x="-17.669068629073763" y="246.06042408603088" z="-8.133561858869193" unit="mm" />
+      <rotation name="module_L2b_halfmodule_stereo_rotation" x="1.5721923267948965" y="0.0305403994500884" z="-1.4656833267948968" unit="radian" />
+      <position name="module_L2b_halfmodule_stereo_sensor_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L2b_halfmodule_stereo_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L2b_halfmodule_stereo_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L2b_halfmodule_stereo_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L2t_halfmodule_axial_position" x="-18.90790233353613" y="261.57064286534535" z="8.042521396503915" unit="mm" />
+      <rotation name="module_L2t_halfmodule_axial_rotation" x="1.5711883267948965" y="0.03043330642417559" z="1.5707963267948966" unit="radian" />
+      <position name="module_L2t_halfmodule_axial_sensor_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L2t_halfmodule_axial_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L2t_halfmodule_axial_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L2t_halfmodule_axial_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L2t_halfmodule_stereo_position" x="-17.891118829887205" y="254.00348918739766" z="8.072182218931573" unit="mm" />
+      <rotation name="module_L2t_halfmodule_stereo_rotation" x="-1.5704043267948966" y="-0.030433306424175424" z="-1.4707963267948967" unit="radian" />
+      <position name="module_L2t_halfmodule_stereo_sensor_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L2t_halfmodule_stereo_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L2t_halfmodule_stereo_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L2t_halfmodule_stereo_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3b_halfmodule_axial_position" x="-44.86653535485047" y="137.05267003736043" z="-25.672413778892928" unit="mm" />
+      <rotation name="module_L3b_halfmodule_axial_rotation" x="-1.5694003267948962" y="-0.030540399450088122" z="1.5707963267948963" unit="radian" />
+      <position name="module_L3b_halfmodule_axial_sensor_position" x="-3.414999999999999" y="30.0" z="-0.50725" unit="mm" />
+      <rotation name="module_L3b_halfmodule_axial_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3b_halfmodule_axial_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L3b_halfmodule_axial_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3b_halfmodule_axial_lamination_position" x="-3.414999999999999" y="30.0" z="-0.69225" unit="mm" />
+      <rotation name="module_L3b_halfmodule_axial_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3b_halfmodule_axial_cf_position" x="-3.414999999999999" y="30.0" z="-0.81875" unit="mm" />
+      <rotation name="module_L3b_halfmodule_axial_cf_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3b_halfmodule_axial_hybrid_position" x="-3.414999999999999" y="-55.0" z="0.12649999999999995" unit="mm" />
+      <rotation name="module_L3b_halfmodule_axial_hybrid_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3b_halfmodule_stereo_position" x="-45.31762685506874" y="145.4286365754165" z="-21.854831478310007" unit="mm" />
+      <rotation name="module_L3b_halfmodule_stereo_rotation" x="1.5721923267948963" y="0.03054039945008801" z="1.6707963267948964" unit="radian" />
+      <position name="module_L3b_halfmodule_stereo_sensor_position" x="-3.414999999999999" y="30.0" z="-0.50725" unit="mm" />
+      <rotation name="module_L3b_halfmodule_stereo_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3b_halfmodule_stereo_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L3b_halfmodule_stereo_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3b_halfmodule_stereo_lamination_position" x="-3.414999999999999" y="30.0" z="-0.69225" unit="mm" />
+      <rotation name="module_L3b_halfmodule_stereo_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3b_halfmodule_stereo_cf_position" x="-3.414999999999999" y="30.0" z="-0.81875" unit="mm" />
+      <rotation name="module_L3b_halfmodule_stereo_cf_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3b_halfmodule_stereo_hybrid_position" x="-3.414999999999999" y="-55.0" z="0.12649999999999995" unit="mm" />
+      <rotation name="module_L3b_halfmodule_stereo_hybrid_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3t_halfmodule_axial_position" x="-45.61670040744279" y="161.22559183511078" z="25.61125900534158" unit="mm" />
+      <rotation name="module_L3t_halfmodule_axial_rotation" x="1.5711883267948965" y="0.03043330642417559" z="1.5707963267948966" unit="radian" />
+      <position name="module_L3t_halfmodule_axial_sensor_position" x="-3.414999999999999" y="30.0" z="-0.50725" unit="mm" />
+      <rotation name="module_L3t_halfmodule_axial_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3t_halfmodule_axial_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L3t_halfmodule_axial_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3t_halfmodule_axial_lamination_position" x="-3.414999999999999" y="30.0" z="-0.69225" unit="mm" />
+      <rotation name="module_L3t_halfmodule_axial_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3t_halfmodule_axial_cf_position" x="-3.414999999999999" y="30.0" z="-0.81875" unit="mm" />
+      <rotation name="module_L3t_halfmodule_axial_cf_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3t_halfmodule_axial_hybrid_position" x="-3.414999999999999" y="-55.0" z="0.12649999999999995" unit="mm" />
+      <rotation name="module_L3t_halfmodule_axial_hybrid_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3t_halfmodule_stereo_position" x="-45.54676173869666" y="152.84185549481725" z="21.829706065586" unit="mm" />
+      <rotation name="module_L3t_halfmodule_stereo_rotation" x="-1.5704043267948962" y="-0.030433306424175535" z="1.6707963267948964" unit="radian" />
+      <position name="module_L3t_halfmodule_stereo_sensor_position" x="-3.414999999999999" y="30.0" z="-0.50725" unit="mm" />
+      <rotation name="module_L3t_halfmodule_stereo_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3t_halfmodule_stereo_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L3t_halfmodule_stereo_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3t_halfmodule_stereo_lamination_position" x="-3.414999999999999" y="30.0" z="-0.69225" unit="mm" />
+      <rotation name="module_L3t_halfmodule_stereo_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3t_halfmodule_stereo_cf_position" x="-3.414999999999999" y="30.0" z="-0.81875" unit="mm" />
+      <rotation name="module_L3t_halfmodule_stereo_cf_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3t_halfmodule_stereo_hybrid_position" x="-3.414999999999999" y="-55.0" z="0.12649999999999995" unit="mm" />
+      <rotation name="module_L3t_halfmodule_stereo_hybrid_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4b_halfmodule_axial_position" x="-41.81297014635422" y="37.09720378439058" z="-27.105817390045754" unit="mm" />
+      <rotation name="module_L4b_halfmodule_axial_rotation" x="-1.5694003267948962" y="-0.030540399450088122" z="1.5707963267948963" unit="radian" />
+      <position name="module_L4b_halfmodule_axial_sensor_position" x="-3.414999999999999" y="30.0" z="-0.50725" unit="mm" />
+      <rotation name="module_L4b_halfmodule_axial_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4b_halfmodule_axial_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L4b_halfmodule_axial_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4b_halfmodule_axial_lamination_position" x="-3.414999999999999" y="30.0" z="-0.69225" unit="mm" />
+      <rotation name="module_L4b_halfmodule_axial_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4b_halfmodule_axial_cf_position" x="-3.414999999999999" y="30.0" z="-0.81875" unit="mm" />
+      <rotation name="module_L4b_halfmodule_axial_cf_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4b_halfmodule_axial_hybrid_position" x="-3.414999999999999" y="-55.0" z="0.12649999999999995" unit="mm" />
+      <rotation name="module_L4b_halfmodule_axial_hybrid_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4b_halfmodule_stereo_position" x="-42.266005594434105" y="45.47317236141525" z="-23.244233373289834" unit="mm" />
+      <rotation name="module_L4b_halfmodule_stereo_rotation" x="1.5721923267948963" y="0.03054039945008801" z="1.6707963267948964" unit="radian" />
+      <position name="module_L4b_halfmodule_stereo_sensor_position" x="-3.414999999999999" y="30.0" z="-0.50725" unit="mm" />
+      <rotation name="module_L4b_halfmodule_stereo_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4b_halfmodule_stereo_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L4b_halfmodule_stereo_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4b_halfmodule_stereo_lamination_position" x="-3.414999999999999" y="30.0" z="-0.69225" unit="mm" />
+      <rotation name="module_L4b_halfmodule_stereo_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4b_halfmodule_stereo_cf_position" x="-3.414999999999999" y="30.0" z="-0.81875" unit="mm" />
+      <rotation name="module_L4b_halfmodule_stereo_cf_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4b_halfmodule_stereo_hybrid_position" x="-3.414999999999999" y="-55.0" z="0.12649999999999995" unit="mm" />
+      <rotation name="module_L4b_halfmodule_stereo_hybrid_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4t_halfmodule_axial_position" x="-42.57383952504715" y="61.27246976169503" z="27.090527741846074" unit="mm" />
+      <rotation name="module_L4t_halfmodule_axial_rotation" x="1.5711883267948965" y="0.03043330642417559" z="1.5707963267948966" unit="radian" />
+      <position name="module_L4t_halfmodule_axial_sensor_position" x="-3.414999999999999" y="30.0" z="-0.50725" unit="mm" />
+      <rotation name="module_L4t_halfmodule_axial_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4t_halfmodule_axial_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L4t_halfmodule_axial_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4t_halfmodule_axial_lamination_position" x="-3.414999999999999" y="30.0" z="-0.69225" unit="mm" />
+      <rotation name="module_L4t_halfmodule_axial_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4t_halfmodule_axial_cf_position" x="-3.414999999999999" y="30.0" z="-0.81875" unit="mm" />
+      <rotation name="module_L4t_halfmodule_axial_cf_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4t_halfmodule_axial_hybrid_position" x="-3.414999999999999" y="-55.0" z="0.12649999999999995" unit="mm" />
+      <rotation name="module_L4t_halfmodule_axial_hybrid_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4t_halfmodule_stereo_position" x="-42.51021339381717" y="52.88854680495761" z="23.323143912837278" unit="mm" />
+      <rotation name="module_L4t_halfmodule_stereo_rotation" x="-1.5704043267948962" y="-0.030433306424175535" z="1.6707963267948964" unit="radian" />
+      <position name="module_L4t_halfmodule_stereo_sensor_position" x="-3.414999999999999" y="30.0" z="-0.50725" unit="mm" />
+      <rotation name="module_L4t_halfmodule_stereo_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4t_halfmodule_stereo_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L4t_halfmodule_stereo_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4t_halfmodule_stereo_lamination_position" x="-3.414999999999999" y="30.0" z="-0.69225" unit="mm" />
+      <rotation name="module_L4t_halfmodule_stereo_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4t_halfmodule_stereo_cf_position" x="-3.414999999999999" y="30.0" z="-0.81875" unit="mm" />
+      <rotation name="module_L4t_halfmodule_stereo_cf_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4t_halfmodule_stereo_hybrid_position" x="-3.414999999999999" y="-55.0" z="0.12649999999999995" unit="mm" />
+      <rotation name="module_L4t_halfmodule_stereo_hybrid_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5b_halfmodule_axial_hole_position" x="-56.217250308986" y="-162.97132249781242" z="-26.654184000000008" unit="mm" />
+      <rotation name="module_L5b_halfmodule_axial_hole_rotation" x="-1.5707963267948966" y="-0.030483299558163958" z="1.5707963267948963" unit="radian" />
+      <position name="module_L5b_halfmodule_axial_hole_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L5b_halfmodule_axial_hole_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5b_halfmodule_axial_hole_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L5b_halfmodule_axial_hole_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5b_halfmodule_axial_hole_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L5b_halfmodule_axial_hole_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5b_halfmodule_axial_slot_position" x="44.72623159126889" y="-159.89327863637723" z="-26.792147000000007" unit="mm" />
+      <rotation name="module_L5b_halfmodule_axial_slot_rotation" x="-1.5707963267948963" y="-0.030483299558164013" z="-1.5718113267948963" unit="radian" />
+      <position name="module_L5b_halfmodule_axial_slot_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L5b_halfmodule_axial_slot_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5b_halfmodule_axial_slot_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L5b_halfmodule_axial_slot_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5b_halfmodule_axial_slot_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L5b_halfmodule_axial_slot_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5b_halfmodule_stereo_hole_position" x="-56.38945519192267" y="-155.65717305182127" z="-29.194184000000007" unit="mm" />
+      <rotation name="module_L5b_halfmodule_stereo_hole_rotation" x="1.5707963267948963" y="0.030483299558163958" z="1.6207963267948968" unit="radian" />
+      <position name="module_L5b_halfmodule_stereo_hole_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L5b_halfmodule_stereo_hole_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5b_halfmodule_stereo_hole_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L5b_halfmodule_stereo_hole_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5b_halfmodule_stereo_hole_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L5b_halfmodule_stereo_hole_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5b_halfmodule_stereo_slot_position" x="44.45375947605603" y="-152.58218661354013" z="-24.165285839201005" unit="mm" />
+      <rotation name="module_L5b_halfmodule_stereo_slot_rotation" x="1.5707963267948963" y="0.030483299558163958" z="-1.5200143267948967" unit="radian" />
+      <position name="module_L5b_halfmodule_stereo_slot_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L5b_halfmodule_stereo_slot_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5b_halfmodule_stereo_slot_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L5b_halfmodule_stereo_slot_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5b_halfmodule_stereo_slot_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L5b_halfmodule_stereo_slot_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5t_halfmodule_axial_hole_position" x="-56.924231591268885" y="-139.79172136362277" z="26.541470000000004" unit="mm" />
+      <rotation name="module_L5t_halfmodule_axial_hole_rotation" x="1.5707963267948966" y="0.030483299558164013" z="1.5707993267948968" unit="radian" />
+      <position name="module_L5t_halfmodule_axial_hole_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L5t_halfmodule_axial_hole_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5t_halfmodule_axial_hole_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L5t_halfmodule_axial_hole_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5t_halfmodule_axial_hole_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L5t_halfmodule_axial_hole_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5t_halfmodule_axial_slot_position" x="44.01925030898598" y="-136.71367750218758" z="26.432303000000005" unit="mm" />
+      <rotation name="module_L5t_halfmodule_axial_slot_rotation" x="1.5707963267948966" y="0.030483299558164013" z="-1.5733703267948964" unit="radian" />
+      <position name="module_L5t_halfmodule_axial_slot_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L5t_halfmodule_axial_slot_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5t_halfmodule_axial_slot_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L5t_halfmodule_axial_slot_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5t_halfmodule_axial_slot_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L5t_halfmodule_axial_slot_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5t_halfmodule_stereo_hole_position" x="-56.64679240590764" y="-147.10266192685603" z="29.177405900439815" unit="mm" />
+      <rotation name="module_L5t_halfmodule_stereo_hole_rotation" x="-1.5707963267948963" y="-0.030483299558164013" z="1.6201163267948966" unit="radian" />
+      <position name="module_L5t_halfmodule_stereo_hole_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L5t_halfmodule_stereo_hole_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5t_halfmodule_stereo_hole_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L5t_halfmodule_stereo_hole_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5t_halfmodule_stereo_hole_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L5t_halfmodule_stereo_hole_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5t_halfmodule_stereo_slot_position" x="44.19357232508188" y="-144.027762390977" z="24.091530036035536" unit="mm" />
+      <rotation name="module_L5t_halfmodule_stereo_slot_rotation" x="-1.5707963267948968" y="-0.030483299558163958" z="-1.5177933267948966" unit="radian" />
+      <position name="module_L5t_halfmodule_stereo_slot_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L5t_halfmodule_stereo_slot_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5t_halfmodule_stereo_slot_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L5t_halfmodule_stereo_slot_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5t_halfmodule_stereo_slot_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L5t_halfmodule_stereo_slot_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6b_halfmodule_axial_hole_position" x="-50.12153455494366" y="-362.8784065379883" z="-29.852538000000017" unit="mm" />
+      <rotation name="module_L6b_halfmodule_axial_hole_rotation" x="-1.5707963267948966" y="-0.030483299558163958" z="1.5724713267948967" unit="radian" />
+      <position name="module_L6b_halfmodule_axial_hole_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L6b_halfmodule_axial_hole_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6b_halfmodule_axial_hole_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L6b_halfmodule_axial_hole_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6b_halfmodule_axial_hole_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L6b_halfmodule_axial_hole_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6b_halfmodule_axial_slot_position" x="50.82194734531124" y="-359.8003626765531" z="-29.84663300000002" unit="mm" />
+      <rotation name="module_L6b_halfmodule_axial_slot_rotation" x="-1.5707963267948966" y="-0.030483299558163902" z="-1.5728073267948965" unit="radian" />
+      <position name="module_L6b_halfmodule_axial_slot_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L6b_halfmodule_axial_slot_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6b_halfmodule_axial_slot_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L6b_halfmodule_axial_slot_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6b_halfmodule_axial_slot_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L6b_halfmodule_axial_slot_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6b_halfmodule_stereo_hole_position" x="-50.28756533206903" y="-355.5640688265625" z="-32.29936354343249" unit="mm" />
+      <rotation name="module_L6b_halfmodule_stereo_hole_rotation" x="1.5707963267948968" y="0.030483299558163902" z="1.6204373267948966" unit="radian" />
+      <position name="module_L6b_halfmodule_stereo_hole_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L6b_halfmodule_stereo_hole_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6b_halfmodule_stereo_hole_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L6b_halfmodule_stereo_hole_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6b_halfmodule_stereo_hole_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L6b_halfmodule_stereo_hole_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6b_halfmodule_stereo_slot_position" x="50.55307230827514" y="-352.4891609689281" z="-27.21894385170075" unit="mm" />
+      <rotation name="module_L6b_halfmodule_stereo_slot_rotation" x="1.5707963267948963" y="0.03048329955816407" z="-1.5190973267948966" unit="radian" />
+      <position name="module_L6b_halfmodule_stereo_slot_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L6b_halfmodule_stereo_slot_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6b_halfmodule_stereo_slot_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L6b_halfmodule_stereo_slot_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6b_halfmodule_stereo_slot_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L6b_halfmodule_stereo_slot_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6t_halfmodule_axial_hole_position" x="-50.82851583722654" y="-339.6988054037986" z="29.535058000000006" unit="mm" />
+      <rotation name="module_L6t_halfmodule_axial_hole_rotation" x="1.5707963267948966" y="0.030483299558164013" z="1.5720093267948967" unit="radian" />
+      <position name="module_L6t_halfmodule_axial_hole_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L6t_halfmodule_axial_hole_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6t_halfmodule_axial_hole_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L6t_halfmodule_axial_hole_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6t_halfmodule_axial_hole_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L6t_halfmodule_axial_hole_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6t_halfmodule_axial_slot_position" x="50.11496606302833" y="-336.6207615423634" z="29.453632000000006" unit="mm" />
+      <rotation name="module_L6t_halfmodule_axial_slot_rotation" x="1.5707963267948966" y="0.030483299558163847" z="-1.5747723267948965" unit="radian" />
+      <position name="module_L6t_halfmodule_axial_slot_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L6t_halfmodule_axial_slot_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6t_halfmodule_axial_slot_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L6t_halfmodule_axial_slot_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6t_halfmodule_axial_slot_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L6t_halfmodule_axial_slot_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6t_halfmodule_stereo_hole_position" x="-50.54759087554505" y="-347.00963967614314" z="32.213967697359394" unit="mm" />
+      <rotation name="module_L6t_halfmodule_stereo_hole_rotation" x="-1.5707963267948963" y="-0.03048329955816379" z="1.6191823267948964" unit="radian" />
+      <position name="module_L6t_halfmodule_stereo_hole_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L6t_halfmodule_stereo_hole_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6t_halfmodule_stereo_hole_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L6t_halfmodule_stereo_hole_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6t_halfmodule_stereo_hole_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L6t_halfmodule_stereo_hole_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6t_halfmodule_stereo_slot_position" x="50.29296603598397" y="-343.9347342801519" z="27.13193402520686" unit="mm" />
+      <rotation name="module_L6t_halfmodule_stereo_slot_rotation" x="-1.5707963267948966" y="-0.030483299558163847" z="-1.517512326794897" unit="radian" />
+      <position name="module_L6t_halfmodule_stereo_slot_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L6t_halfmodule_stereo_slot_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6t_halfmodule_stereo_slot_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L6t_halfmodule_stereo_slot_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6t_halfmodule_stereo_slot_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L6t_halfmodule_stereo_slot_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7b_halfmodule_axial_hole_position" x="-44.02581880090134" y="-562.7854905781641" z="-33.05875100000001" unit="mm" />
+      <rotation name="module_L7b_halfmodule_axial_hole_rotation" x="-1.5707963267948966" y="-0.030483299558163902" z="1.5728003267948967" unit="radian" />
+      <position name="module_L7b_halfmodule_axial_hole_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L7b_halfmodule_axial_hole_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7b_halfmodule_axial_hole_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L7b_halfmodule_axial_hole_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7b_halfmodule_axial_hole_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L7b_halfmodule_axial_hole_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7b_halfmodule_axial_slot_position" x="56.917663099353554" y="-559.7074467167289" z="-33.00230400000001" unit="mm" />
+      <rotation name="module_L7b_halfmodule_axial_slot_rotation" x="-1.5707963267948968" y="-0.030483299558163736" z="-1.5736323267948966" unit="radian" />
+      <position name="module_L7b_halfmodule_axial_slot_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L7b_halfmodule_axial_slot_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7b_halfmodule_axial_slot_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L7b_halfmodule_axial_slot_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7b_halfmodule_axial_slot_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L7b_halfmodule_axial_slot_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7b_halfmodule_stereo_hole_position" x="-44.18806111860568" y="-555.4710373462109" z="-35.340047768179794" unit="mm" />
+      <rotation name="module_L7b_halfmodule_stereo_hole_rotation" x="1.5707963267948966" y="0.030483299558163958" z="1.6197933267948967" unit="radian" />
+      <position name="module_L7b_halfmodule_stereo_hole_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L7b_halfmodule_stereo_hole_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7b_halfmodule_stereo_hole_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L7b_halfmodule_stereo_hole_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7b_halfmodule_stereo_hole_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L7b_halfmodule_stereo_hole_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7b_halfmodule_stereo_slot_position" x="56.65264561081727" y="-552.3961273818608" z="-30.26100934805818" unit="mm" />
+      <rotation name="module_L7b_halfmodule_stereo_slot_rotation" x="1.5707963267948963" y="0.030483299558163958" z="-1.5181053267948965" unit="radian" />
+      <position name="module_L7b_halfmodule_stereo_slot_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L7b_halfmodule_stereo_slot_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7b_halfmodule_stereo_slot_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L7b_halfmodule_stereo_slot_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7b_halfmodule_stereo_slot_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L7b_halfmodule_stereo_slot_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7t_halfmodule_axial_hole_position" x="-44.732800083184195" y="-539.6058894439745" z="32.57358800000001" unit="mm" />
+      <rotation name="module_L7t_halfmodule_axial_hole_rotation" x="1.5707963267948966" y="0.030483299558163902" z="1.5725343267948966" unit="radian" />
+      <position name="module_L7t_halfmodule_axial_hole_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L7t_halfmodule_axial_hole_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7t_halfmodule_axial_hole_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L7t_halfmodule_axial_hole_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7t_halfmodule_axial_hole_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L7t_halfmodule_axial_hole_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7t_halfmodule_axial_slot_position" x="56.21068181707067" y="-536.5278455825394" z="32.48724600000001" unit="mm" />
+      <rotation name="module_L7t_halfmodule_axial_slot_rotation" x="1.5707963267948966" y="0.03048329955816407" z="-1.5754243267948964" unit="radian" />
+      <position name="module_L7t_halfmodule_axial_slot_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L7t_halfmodule_axial_slot_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7t_halfmodule_axial_slot_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L7t_halfmodule_axial_slot_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7t_halfmodule_axial_slot_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L7t_halfmodule_axial_slot_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7t_halfmodule_stereo_hole_position" x="-44.4520482188693" y="-546.916728994533" z="35.187660027707125" unit="mm" />
+      <rotation name="module_L7t_halfmodule_stereo_hole_rotation" x="-1.5707963267948966" y="-0.030483299558163958" z="1.6198633267948965" unit="radian" />
+      <position name="module_L7t_halfmodule_stereo_hole_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L7t_halfmodule_stereo_hole_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7t_halfmodule_stereo_hole_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L7t_halfmodule_stereo_hole_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7t_halfmodule_stereo_hole_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L7t_halfmodule_stereo_hole_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7t_halfmodule_stereo_slot_position" x="56.38605165921695" y="-543.8418985202362" z="30.056503822747324" unit="mm" />
+      <rotation name="module_L7t_halfmodule_stereo_slot_rotation" x="-1.5707963267948966" y="-0.030483299558163847" z="-1.5161223267948967" unit="radian" />
+      <position name="module_L7t_halfmodule_stereo_slot_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L7t_halfmodule_stereo_slot_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7t_halfmodule_stereo_slot_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L7t_halfmodule_stereo_slot_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7t_halfmodule_stereo_slot_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L7t_halfmodule_stereo_slot_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="BeamLeftVolume_component0_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="BeamLeftVolume_component0_rotation" x="0.0" y="0.0" z="0.0" unit="radian" />
+      <position name="BeamLeftVolume_component0Sensor0Position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="BeamLeftVolume_component0Sensor0Rotation" x="0.0" y="0.0" z="0.0" unit="radian" />
+      <position name="ElectronGapVolume_component0_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="ElectronGapVolume_component0_rotation" x="0.0" y="0.0" z="0.0" unit="radian" />
+      <position name="ElectronGapVolume_component0Sensor0Position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="ElectronGapVolume_component0Sensor0Rotation" x="0.0" y="0.0" z="0.0" unit="radian" />
+      <position name="BeamRightVolume_component0_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="BeamRightVolume_component0_rotation" x="0.0" y="0.0" z="0.0" unit="radian" />
+      <position name="BeamRightVolume_component0Sensor0Position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="BeamRightVolume_component0Sensor0Rotation" x="0.0" y="0.0" z="0.0" unit="radian" />
+      <position name="ECalScoring_BeamLeft_layer1_module0_position" x="214.099" y="122.8" z="1443.001" unit="mm" />
+      <rotation name="ECalScoring_BeamLeft_layer1_module0_rotation" x="0.0" y="0.0" z="-1.570796326795" unit="radian" />
+      <position name="ECalScoring_ElectronGap_layer1_module0_position" x="-23.38199999999999" y="130.465" z="1443.001" unit="mm" />
+      <rotation name="ECalScoring_ElectronGap_layer1_module0_rotation" x="0.0" y="0.0" z="-1.570796326795" unit="radian" />
+      <position name="ECalScoring_BeamRight_layer1_module0_position" x="-216.31099999999998" y="121.3" z="1443.001" unit="mm" />
+      <rotation name="ECalScoring_BeamRight_layer1_module0_rotation" x="0.0" y="0.0" z="-1.570796326795" unit="radian" />
+      <position name="ECalScoring_BeamLeft_layer2_module0_position" x="214.099" y="-122.8" z="1443.001" unit="mm" />
+      <rotation name="ECalScoring_BeamLeft_layer2_module0_rotation" x="0.0" y="0.0" z="-4.7123889803850005" unit="radian" />
+      <position name="ECalScoring_ElectronGap_layer2_module0_position" x="-23.38199999999999" y="-130.465" z="1443.001" unit="mm" />
+      <rotation name="ECalScoring_ElectronGap_layer2_module0_rotation" x="0.0" y="0.0" z="-4.7123889803850005" unit="radian" />
+      <position name="ECalScoring_BeamRight_layer2_module0_position" x="-216.31099999999998" y="-121.3" z="1443.001" unit="mm" />
+      <rotation name="ECalScoring_BeamRight_layer2_module0_rotation" x="0.0" y="0.0" z="-4.7123889803850005" unit="radian" />
+      <position name="crystal1-1_pos_pos_bot" x="50.20495188328156" y="-29.07473927539554" z="1528.1626281236922" unit="mm" />
+      <rotation name="crystal1-1_rot_pos_bot" x="-0.0084372997827221" y="-0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal1-1_pos_neg_bot" x="35.15547333249048" y="-29.07473927539554" z="1528.1626281236922" unit="mm" />
+      <rotation name="crystal1-1_rot_neg_bot" x="-0.0084372997827221" y="0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal1-1_pos_pos_top" x="50.20495188328156" y="29.974739275395542" z="1528.1626281236922" unit="mm" />
+      <rotation name="crystal1-1_rot_pos_top" x="0.0084372997827221" y="-0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal1-1_pos_neg_top" x="35.15547333249048" y="29.974739275395542" z="1528.1626281236922" unit="mm" />
+      <rotation name="crystal1-1_rot_neg_top" x="0.0084372997827221" y="0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal2-1_pos_pos_bot" x="65.05802548582456" y="-29.07473927539554" z="1528.2520480856124" unit="mm" />
+      <rotation name="crystal2-1_rot_pos_bot" x="-0.0084372997827221" y="-0.0253118993481663" z="0.0" unit="radian" />
+      <position name="crystal2-1_pos_pos_top" x="65.05802548582456" y="29.974739275395542" z="1528.2520480856124" unit="mm" />
+      <rotation name="crystal2-1_rot_pos_top" x="0.0084372997827221" y="-0.0253118993481663" z="0.0" unit="radian" />
+      <position name="crystal3-1_pos_pos_bot" x="79.9180994782841" y="-29.07473927539554" z="1528.3186477918262" unit="mm" />
+      <rotation name="crystal3-1_rot_pos_bot" x="-0.0084372997827221" y="-0.042186498913610496" z="0.0" unit="radian" />
+      <position name="crystal3-1_pos_pos_top" x="79.9180994782841" y="29.974739275395542" z="1528.3186477918262" unit="mm" />
+      <rotation name="crystal3-1_rot_pos_top" x="0.0084372997827221" y="-0.042186498913610496" z="0.0" unit="radian" />
+      <position name="crystal4-1_pos_pos_bot" x="94.78858692586502" y="-29.07473927539554" z="1528.3624082783765" unit="mm" />
+      <rotation name="crystal4-1_rot_pos_bot" x="-0.0084372997827221" y="-0.0590610984790547" z="0.0" unit="radian" />
+      <position name="crystal4-1_pos_pos_top" x="94.78858692586502" y="29.974739275395542" z="1528.3624082783765" unit="mm" />
+      <rotation name="crystal4-1_rot_pos_top" x="0.0084372997827221" y="-0.0590610984790547" z="0.0" unit="radian" />
+      <position name="crystal5-1_pos_pos_bot" x="109.67291416309662" y="-29.07473927539554" z="1528.3833170846683" unit="mm" />
+      <rotation name="crystal5-1_rot_pos_bot" x="-0.0084372997827221" y="-0.0759356980444989" z="0.0" unit="radian" />
+      <position name="crystal5-1_pos_pos_top" x="109.67291416309662" y="29.974739275395542" z="1528.3833170846683" unit="mm" />
+      <rotation name="crystal5-1_rot_pos_top" x="0.0084372997827221" y="-0.0759356980444989" z="0.0" unit="radian" />
+      <position name="crystal6-1_pos_pos_bot" x="124.57452638340096" y="-29.07473927539554" z="1528.381368257016" unit="mm" />
+      <rotation name="crystal6-1_rot_pos_bot" x="-0.0084372997827221" y="-0.0928102976099431" z="0.0" unit="radian" />
+      <position name="crystal6-1_pos_pos_top" x="124.57452638340096" y="29.974739275395542" z="1528.381368257016" unit="mm" />
+      <rotation name="crystal6-1_rot_pos_top" x="0.0084372997827221" y="-0.0928102976099431" z="0.0" unit="radian" />
+      <position name="crystal7-1_pos_pos_bot" x="139.4968932952259" y="-29.07473927539554" z="1528.3565623503396" unit="mm" />
+      <rotation name="crystal7-1_rot_pos_bot" x="-0.0084372997827221" y="-0.10968489717538729" z="0.0" unit="radian" />
+      <position name="crystal7-1_pos_pos_top" x="139.4968932952259" y="29.974739275395542" z="1528.3565623503396" unit="mm" />
+      <rotation name="crystal7-1_rot_pos_top" x="0.0084372997827221" y="-0.10968489717538729" z="0.0" unit="radian" />
+      <position name="crystal8-1_pos_pos_bot" x="154.44351486445828" y="-29.07473927539554" z="1528.3089064280052" unit="mm" />
+      <rotation name="crystal8-1_rot_pos_bot" x="-0.0084372997827221" y="-0.1265594967408315" z="0.0" unit="radian" />
+      <position name="crystal8-1_pos_pos_top" x="154.44351486445828" y="29.974739275395542" z="1528.3089064280052" unit="mm" />
+      <rotation name="crystal8-1_rot_pos_top" x="0.0084372997827221" y="-0.1265594967408315" z="0.0" unit="radian" />
+      <position name="crystal9-1_pos_pos_bot" x="169.41792716339802" y="-29.07473927539554" z="1528.2384140598156" unit="mm" />
+      <rotation name="crystal9-1_rot_pos_bot" x="-0.0084372997827221" y="-0.14343409630627568" z="0.0" unit="radian" />
+      <position name="crystal9-1_pos_pos_top" x="169.41792716339802" y="29.974739275395542" z="1528.2384140598156" unit="mm" />
+      <rotation name="crystal9-1_rot_pos_top" x="0.0084372997827221" y="-0.14343409630627568" z="0.0" unit="radian" />
+      <position name="crystal10-1_pos_pos_bot" x="184.42370834727978" y="-29.07473927539554" z="1528.1451053181452" unit="mm" />
+      <rotation name="crystal10-1_rot_pos_bot" x="-0.0084372997827221" y="-0.1603086958717199" z="0.0" unit="radian" />
+      <position name="crystal10-1_pos_pos_top" x="184.42370834727978" y="29.974739275395542" z="1528.1451053181452" unit="mm" />
+      <rotation name="crystal10-1_rot_pos_top" x="0.0084372997827221" y="-0.1603086958717199" z="0.0" unit="radian" />
+      <position name="crystal11-1_pos_pos_bot" x="199.46448478017476" y="-29.07473927539554" z="1528.0290067722244" unit="mm" />
+      <rotation name="crystal11-1_rot_pos_bot" x="-0.0084372997827221" y="-0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal11-1_pos_neg_bot" x="-114.1040595644027" y="-29.07473927539554" z="1528.0290067722244" unit="mm" />
+      <rotation name="crystal11-1_rot_neg_bot" x="-0.0084372997827221" y="0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal11-1_pos_pos_top" x="199.46448478017476" y="29.974739275395542" z="1528.0290067722244" unit="mm" />
+      <rotation name="crystal11-1_rot_pos_top" x="0.0084372997827221" y="-0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal11-1_pos_neg_top" x="-114.1040595644027" y="29.974739275395542" z="1528.0290067722244" unit="mm" />
+      <rotation name="crystal11-1_rot_neg_top" x="0.0084372997827221" y="0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal12-1_pos_pos_bot" x="214.5439373331128" y="-29.07473927539554" z="1527.8901514805746" unit="mm" />
+      <rotation name="crystal12-1_rot_pos_bot" x="-0.0084372997827221" y="-0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal12-1_pos_neg_bot" x="-129.1835121173408" y="-29.07473927539554" z="1527.8901514805746" unit="mm" />
+      <rotation name="crystal12-1_rot_neg_bot" x="-0.0084372997827221" y="0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal12-1_pos_pos_top" x="214.5439373331128" y="29.974739275395542" z="1527.8901514805746" unit="mm" />
+      <rotation name="crystal12-1_rot_pos_top" x="0.0084372997827221" y="-0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal12-1_pos_neg_top" x="-129.1835121173408" y="29.974739275395542" z="1527.8901514805746" unit="mm" />
+      <rotation name="crystal12-1_rot_neg_top" x="0.0084372997827221" y="0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal13-1_pos_pos_bot" x="229.66580787843168" y="-29.07473927539554" z="1527.7285789815953" unit="mm" />
+      <rotation name="crystal13-1_rot_pos_bot" x="-0.0084372997827221" y="-0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal13-1_pos_neg_bot" x="-144.30538266265967" y="-29.07473927539554" z="1527.7285789815953" unit="mm" />
+      <rotation name="crystal13-1_rot_neg_bot" x="-0.0084372997827221" y="0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal13-1_pos_pos_top" x="229.66580787843168" y="29.974739275395542" z="1527.7285789815953" unit="mm" />
+      <rotation name="crystal13-1_rot_pos_top" x="0.0084372997827221" y="-0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal13-1_pos_neg_top" x="-144.30538266265967" y="29.974739275395542" z="1527.7285789815953" unit="mm" />
+      <rotation name="crystal13-1_rot_neg_top" x="0.0084372997827221" y="0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal14-1_pos_pos_bot" x="244.83390600570817" y="-29.07473927539554" z="1527.5443352823047" unit="mm" />
+      <rotation name="crystal14-1_rot_pos_bot" x="-0.0084372997827221" y="-0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal14-1_pos_neg_bot" x="-159.47348078993616" y="-29.07473927539554" z="1527.5443352823047" unit="mm" />
+      <rotation name="crystal14-1_rot_neg_bot" x="-0.0084372997827221" y="0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal14-1_pos_pos_top" x="244.83390600570817" y="29.974739275395542" z="1527.5443352823047" unit="mm" />
+      <rotation name="crystal14-1_rot_pos_top" x="0.0084372997827221" y="-0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal14-1_pos_neg_top" x="-159.47348078993616" y="29.974739275395542" z="1527.5443352823047" unit="mm" />
+      <rotation name="crystal14-1_rot_neg_top" x="0.0084372997827221" y="0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal15-1_pos_pos_bot" x="260.0521159861688" y="-29.07473927539554" z="1527.3374728452397" unit="mm" />
+      <rotation name="crystal15-1_rot_pos_bot" x="-0.0084372997827221" y="-0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal15-1_pos_neg_bot" x="-174.6916907703968" y="-29.07473927539554" z="1527.3374728452397" unit="mm" />
+      <rotation name="crystal15-1_rot_neg_bot" x="-0.0084372997827221" y="0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal15-1_pos_pos_top" x="260.0521159861688" y="29.974739275395542" z="1527.3374728452397" unit="mm" />
+      <rotation name="crystal15-1_rot_pos_top" x="0.0084372997827221" y="-0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal15-1_pos_neg_top" x="-174.6916907703968" y="29.974739275395542" z="1527.3374728452397" unit="mm" />
+      <rotation name="crystal15-1_rot_neg_top" x="0.0084372997827221" y="0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal16-1_pos_pos_bot" x="275.32440401422616" y="-29.07473927539554" z="1527.108050573519" unit="mm" />
+      <rotation name="crystal16-1_rot_pos_bot" x="-0.0084372997827221" y="-0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal16-1_pos_neg_bot" x="-189.96397879845415" y="-29.07473927539554" z="1527.108050573519" unit="mm" />
+      <rotation name="crystal16-1_rot_neg_bot" x="-0.0084372997827221" y="0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal16-1_pos_pos_top" x="275.32440401422616" y="29.974739275395542" z="1527.108050573519" unit="mm" />
+      <rotation name="crystal16-1_rot_pos_top" x="0.0084372997827221" y="-0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal16-1_pos_neg_top" x="-189.96397879845415" y="29.974739275395542" z="1527.108050573519" unit="mm" />
+      <rotation name="crystal16-1_rot_neg_top" x="0.0084372997827221" y="0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal17-1_pos_pos_bot" x="290.6548257567732" y="-29.07473927539554" z="1526.8561337940675" unit="mm" />
+      <rotation name="crystal17-1_rot_pos_bot" x="-0.0084372997827221" y="-0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal17-1_pos_neg_bot" x="-205.2944005410012" y="-29.07473927539554" z="1526.8561337940675" unit="mm" />
+      <rotation name="crystal17-1_rot_neg_bot" x="-0.0084372997827221" y="0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal17-1_pos_pos_top" x="290.6548257567732" y="29.974739275395542" z="1526.8561337940675" unit="mm" />
+      <rotation name="crystal17-1_rot_pos_top" x="0.0084372997827221" y="-0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal17-1_pos_neg_top" x="-205.2944005410012" y="29.974739275395542" z="1526.8561337940675" unit="mm" />
+      <rotation name="crystal17-1_rot_neg_top" x="0.0084372997827221" y="0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal18-1_pos_pos_bot" x="306.0475342431027" y="-29.07473927539554" z="1526.581794239018" unit="mm" />
+      <rotation name="crystal18-1_rot_pos_bot" x="-0.0084372997827221" y="-0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal18-1_pos_neg_bot" x="-220.68710902733068" y="-29.07473927539554" z="1526.581794239018" unit="mm" />
+      <rotation name="crystal18-1_rot_neg_bot" x="-0.0084372997827221" y="0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal18-1_pos_pos_top" x="306.0475342431027" y="29.974739275395542" z="1526.581794239018" unit="mm" />
+      <rotation name="crystal18-1_rot_pos_top" x="0.0084372997827221" y="-0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal18-1_pos_neg_top" x="-220.68710902733068" y="29.974739275395542" z="1526.581794239018" unit="mm" />
+      <rotation name="crystal18-1_rot_neg_top" x="0.0084372997827221" y="0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal19-1_pos_pos_bot" x="321.5067881308382" y="-29.07473927539554" z="1526.2851100252847" unit="mm" />
+      <rotation name="crystal19-1_rot_pos_bot" x="-0.0084372997827221" y="-0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal19-1_pos_neg_bot" x="-236.14636291506616" y="-29.07473927539554" z="1526.2851100252847" unit="mm" />
+      <rotation name="crystal19-1_rot_neg_bot" x="-0.0084372997827221" y="0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal19-1_pos_pos_top" x="321.5067881308382" y="29.974739275395542" z="1526.2851100252847" unit="mm" />
+      <rotation name="crystal19-1_rot_pos_top" x="0.0084372997827221" y="-0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal19-1_pos_neg_top" x="-236.14636291506616" y="29.974739275395542" z="1526.2851100252847" unit="mm" />
+      <rotation name="crystal19-1_rot_neg_top" x="0.0084372997827221" y="0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal20-1_pos_pos_bot" x="337.03696038609246" y="-29.07473927539554" z="1525.9661656323178" unit="mm" />
+      <rotation name="crystal20-1_rot_pos_bot" x="-0.0084372997827221" y="-0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal20-1_pos_neg_bot" x="-251.67653517032045" y="-29.07473927539554" z="1525.9661656323178" unit="mm" />
+      <rotation name="crystal20-1_rot_neg_bot" x="-0.0084372997827221" y="0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal20-1_pos_pos_top" x="337.03696038609246" y="29.974739275395542" z="1525.9661656323178" unit="mm" />
+      <rotation name="crystal20-1_rot_pos_top" x="0.0084372997827221" y="-0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal20-1_pos_neg_top" x="-251.67653517032045" y="29.974739275395542" z="1525.9661656323178" unit="mm" />
+      <rotation name="crystal20-1_rot_neg_top" x="0.0084372997827221" y="0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal21-1_pos_pos_bot" x="352.64254741924634" y="-29.07473927539554" z="1525.625051878052" unit="mm" />
+      <rotation name="crystal21-1_rot_pos_bot" x="-0.0084372997827221" y="-0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal21-1_pos_neg_bot" x="-267.28212220347433" y="-29.07473927539554" z="1525.625051878052" unit="mm" />
+      <rotation name="crystal21-1_rot_neg_bot" x="-0.0084372997827221" y="0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal21-1_pos_pos_top" x="352.64254741924634" y="29.974739275395542" z="1525.625051878052" unit="mm" />
+      <rotation name="crystal21-1_rot_pos_top" x="0.0084372997827221" y="-0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal21-1_pos_neg_top" x="-267.28212220347433" y="29.974739275395542" z="1525.625051878052" unit="mm" />
+      <rotation name="crystal21-1_rot_neg_top" x="0.0084372997827221" y="0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal22-1_pos_pos_bot" x="368.32817872130425" y="-29.07473927539554" z="1525.2618658930442" unit="mm" />
+      <rotation name="crystal22-1_rot_pos_bot" x="-0.0084372997827221" y="-0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal22-1_pos_neg_bot" x="-282.96775350553224" y="-29.07473927539554" z="1525.2618658930442" unit="mm" />
+      <rotation name="crystal22-1_rot_neg_bot" x="-0.0084372997827221" y="0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal22-1_pos_pos_top" x="368.32817872130425" y="29.974739275395542" z="1525.2618658930442" unit="mm" />
+      <rotation name="crystal22-1_rot_pos_top" x="0.0084372997827221" y="-0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal22-1_pos_neg_top" x="-282.96775350553224" y="29.974739275395542" z="1525.2618658930442" unit="mm" />
+      <rotation name="crystal22-1_rot_neg_top" x="0.0084372997827221" y="0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal23-1_pos_pos_bot" x="384.09862704978" y="-29.07473927539554" z="1524.8767110928152" unit="mm" />
+      <rotation name="crystal23-1_rot_pos_bot" x="-0.0084372997827221" y="-0.3796784902224945" z="0.0" unit="radian" />
+      <position name="crystal23-1_pos_neg_bot" x="-298.738201834008" y="-29.07473927539554" z="1524.8767110928152" unit="mm" />
+      <rotation name="crystal23-1_rot_neg_bot" x="-0.0084372997827221" y="0.3796784902224945" z="0.0" unit="radian" />
+      <position name="crystal23-1_pos_pos_top" x="384.09862704978" y="29.974739275395542" z="1524.8767110928152" unit="mm" />
+      <rotation name="crystal23-1_rot_pos_top" x="0.0084372997827221" y="-0.3796784902224945" z="0.0" unit="radian" />
+      <position name="crystal23-1_pos_neg_top" x="-298.738201834008" y="29.974739275395542" z="1524.8767110928152" unit="mm" />
+      <rotation name="crystal23-1_rot_neg_top" x="0.0084372997827221" y="0.3796784902224945" z="0.0" unit="radian" />
+      <position name="crystal1-2_pos_pos_bot" x="50.20495188328156" y="-44.077812877938534" z="1528.2520480856124" unit="mm" />
+      <rotation name="crystal1-2_rot_pos_bot" x="-0.0253118993481663" y="-0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal1-2_pos_neg_bot" x="35.15547333249048" y="-44.077812877938534" z="1528.2520480856124" unit="mm" />
+      <rotation name="crystal1-2_rot_neg_bot" x="-0.0253118993481663" y="0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal1-2_pos_pos_top" x="50.20495188328156" y="44.97781287793853" z="1528.2520480856124" unit="mm" />
+      <rotation name="crystal1-2_rot_pos_top" x="0.0253118993481663" y="-0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal1-2_pos_neg_top" x="35.15547333249048" y="44.97781287793853" z="1528.2520480856124" unit="mm" />
+      <rotation name="crystal1-2_rot_neg_top" x="0.0253118993481663" y="0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal2-2_pos_pos_bot" x="65.05802548582456" y="-44.077812877938534" z="1528.3414680475323" unit="mm" />
+      <rotation name="crystal2-2_rot_pos_bot" x="-0.0253118993481663" y="-0.0253118993481663" z="0.0" unit="radian" />
+      <position name="crystal2-2_pos_neg_bot" x="20.302399729947485" y="-44.077812877938534" z="1528.3414680475323" unit="mm" />
+      <rotation name="crystal2-2_rot_neg_bot" x="-0.0253118993481663" y="0.0253118993481663" z="0.0" unit="radian" />
+      <position name="crystal2-2_pos_pos_top" x="65.05802548582456" y="44.97781287793853" z="1528.3414680475323" unit="mm" />
+      <rotation name="crystal2-2_rot_pos_top" x="0.0253118993481663" y="-0.0253118993481663" z="0.0" unit="radian" />
+      <position name="crystal2-2_pos_neg_top" x="20.302399729947485" y="44.97781287793853" z="1528.3414680475323" unit="mm" />
+      <rotation name="crystal2-2_rot_neg_top" x="0.0253118993481663" y="0.0253118993481663" z="0.0" unit="radian" />
+      <position name="crystal3-2_pos_pos_bot" x="79.9180994782841" y="-44.077812877938534" z="1528.4080677537463" unit="mm" />
+      <rotation name="crystal3-2_rot_pos_bot" x="-0.0253118993481663" y="-0.042186498913610496" z="0.0" unit="radian" />
+      <position name="crystal3-2_pos_neg_bot" x="5.442325737487934" y="-44.077812877938534" z="1528.4080677537463" unit="mm" />
+      <rotation name="crystal3-2_rot_neg_bot" x="-0.0253118993481663" y="0.042186498913610496" z="0.0" unit="radian" />
+      <position name="crystal3-2_pos_pos_top" x="79.9180994782841" y="44.97781287793853" z="1528.4080677537463" unit="mm" />
+      <rotation name="crystal3-2_rot_pos_top" x="0.0253118993481663" y="-0.042186498913610496" z="0.0" unit="radian" />
+      <position name="crystal3-2_pos_neg_top" x="5.442325737487934" y="44.97781287793853" z="1528.4080677537463" unit="mm" />
+      <rotation name="crystal3-2_rot_neg_top" x="0.0253118993481663" y="0.042186498913610496" z="0.0" unit="radian" />
+      <position name="crystal4-2_pos_pos_bot" x="94.78858692586502" y="-44.077812877938534" z="1528.4518282402964" unit="mm" />
+      <rotation name="crystal4-2_rot_pos_bot" x="-0.0253118993481663" y="-0.0590610984790547" z="0.0" unit="radian" />
+      <position name="crystal4-2_pos_neg_bot" x="-9.42816171009298" y="-44.077812877938534" z="1528.4518282402964" unit="mm" />
+      <rotation name="crystal4-2_rot_neg_bot" x="-0.0253118993481663" y="0.0590610984790547" z="0.0" unit="radian" />
+      <position name="crystal4-2_pos_pos_top" x="94.78858692586502" y="44.97781287793853" z="1528.4518282402964" unit="mm" />
+      <rotation name="crystal4-2_rot_pos_top" x="0.0253118993481663" y="-0.0590610984790547" z="0.0" unit="radian" />
+      <position name="crystal4-2_pos_neg_top" x="-9.42816171009298" y="44.97781287793853" z="1528.4518282402964" unit="mm" />
+      <rotation name="crystal4-2_rot_neg_top" x="0.0253118993481663" y="0.0590610984790547" z="0.0" unit="radian" />
+      <position name="crystal5-2_pos_pos_bot" x="109.67291416309662" y="-44.077812877938534" z="1528.4727370465882" unit="mm" />
+      <rotation name="crystal5-2_rot_pos_bot" x="-0.0253118993481663" y="-0.0759356980444989" z="0.0" unit="radian" />
+      <position name="crystal5-2_pos_neg_bot" x="-24.31248894732458" y="-44.077812877938534" z="1528.4727370465882" unit="mm" />
+      <rotation name="crystal5-2_rot_neg_bot" x="-0.0253118993481663" y="0.0759356980444989" z="0.0" unit="radian" />
+      <position name="crystal5-2_pos_pos_top" x="109.67291416309662" y="44.97781287793853" z="1528.4727370465882" unit="mm" />
+      <rotation name="crystal5-2_rot_pos_top" x="0.0253118993481663" y="-0.0759356980444989" z="0.0" unit="radian" />
+      <position name="crystal5-2_pos_neg_top" x="-24.31248894732458" y="44.97781287793853" z="1528.4727370465882" unit="mm" />
+      <rotation name="crystal5-2_rot_neg_top" x="0.0253118993481663" y="0.0759356980444989" z="0.0" unit="radian" />
+      <position name="crystal6-2_pos_pos_bot" x="124.57452638340096" y="-44.077812877938534" z="1528.4707882189361" unit="mm" />
+      <rotation name="crystal6-2_rot_pos_bot" x="-0.0253118993481663" y="-0.0928102976099431" z="0.0" unit="radian" />
+      <position name="crystal6-2_pos_neg_bot" x="-39.214101167628925" y="-44.077812877938534" z="1528.4707882189361" unit="mm" />
+      <rotation name="crystal6-2_rot_neg_bot" x="-0.0253118993481663" y="0.0928102976099431" z="0.0" unit="radian" />
+      <position name="crystal6-2_pos_pos_top" x="124.57452638340096" y="44.97781287793853" z="1528.4707882189361" unit="mm" />
+      <rotation name="crystal6-2_rot_pos_top" x="0.0253118993481663" y="-0.0928102976099431" z="0.0" unit="radian" />
+      <position name="crystal6-2_pos_neg_top" x="-39.214101167628925" y="44.97781287793853" z="1528.4707882189361" unit="mm" />
+      <rotation name="crystal6-2_rot_neg_top" x="0.0253118993481663" y="0.0928102976099431" z="0.0" unit="radian" />
+      <position name="crystal7-2_pos_pos_bot" x="139.4968932952259" y="-44.077812877938534" z="1528.4459823122595" unit="mm" />
+      <rotation name="crystal7-2_rot_pos_bot" x="-0.0253118993481663" y="-0.10968489717538729" z="0.0" unit="radian" />
+      <position name="crystal7-2_pos_neg_bot" x="-54.13646807945388" y="-44.077812877938534" z="1528.4459823122595" unit="mm" />
+      <rotation name="crystal7-2_rot_neg_bot" x="-0.0253118993481663" y="0.10968489717538729" z="0.0" unit="radian" />
+      <position name="crystal7-2_pos_pos_top" x="139.4968932952259" y="44.97781287793853" z="1528.4459823122595" unit="mm" />
+      <rotation name="crystal7-2_rot_pos_top" x="0.0253118993481663" y="-0.10968489717538729" z="0.0" unit="radian" />
+      <position name="crystal7-2_pos_neg_top" x="-54.13646807945388" y="44.97781287793853" z="1528.4459823122595" unit="mm" />
+      <rotation name="crystal7-2_rot_neg_top" x="0.0253118993481663" y="0.10968489717538729" z="0.0" unit="radian" />
+      <position name="crystal8-2_pos_pos_bot" x="154.44351486445828" y="-44.077812877938534" z="1528.3983263899254" unit="mm" />
+      <rotation name="crystal8-2_rot_pos_bot" x="-0.0253118993481663" y="-0.1265594967408315" z="0.0" unit="radian" />
+      <position name="crystal8-2_pos_neg_bot" x="-69.08308964868624" y="-44.077812877938534" z="1528.3983263899254" unit="mm" />
+      <rotation name="crystal8-2_rot_neg_bot" x="-0.0253118993481663" y="0.1265594967408315" z="0.0" unit="radian" />
+      <position name="crystal8-2_pos_pos_top" x="154.44351486445828" y="44.97781287793853" z="1528.3983263899254" unit="mm" />
+      <rotation name="crystal8-2_rot_pos_top" x="0.0253118993481663" y="-0.1265594967408315" z="0.0" unit="radian" />
+      <position name="crystal8-2_pos_neg_top" x="-69.08308964868624" y="44.97781287793853" z="1528.3983263899254" unit="mm" />
+      <rotation name="crystal8-2_rot_neg_top" x="0.0253118993481663" y="0.1265594967408315" z="0.0" unit="radian" />
+      <position name="crystal9-2_pos_pos_bot" x="169.41792716339802" y="-44.077812877938534" z="1528.3278340217357" unit="mm" />
+      <rotation name="crystal9-2_rot_pos_bot" x="-0.0253118993481663" y="-0.14343409630627568" z="0.0" unit="radian" />
+      <position name="crystal9-2_pos_neg_bot" x="-84.057501947626" y="-44.077812877938534" z="1528.3278340217357" unit="mm" />
+      <rotation name="crystal9-2_rot_neg_bot" x="-0.0253118993481663" y="0.14343409630627568" z="0.0" unit="radian" />
+      <position name="crystal9-2_pos_pos_top" x="169.41792716339802" y="44.97781287793853" z="1528.3278340217357" unit="mm" />
+      <rotation name="crystal9-2_rot_pos_top" x="0.0253118993481663" y="-0.14343409630627568" z="0.0" unit="radian" />
+      <position name="crystal9-2_pos_neg_top" x="-84.057501947626" y="44.97781287793853" z="1528.3278340217357" unit="mm" />
+      <rotation name="crystal9-2_rot_neg_top" x="0.0253118993481663" y="0.14343409630627568" z="0.0" unit="radian" />
+      <position name="crystal10-2_pos_pos_bot" x="184.42370834727978" y="-44.077812877938534" z="1528.2345252800653" unit="mm" />
+      <rotation name="crystal10-2_rot_pos_bot" x="-0.0253118993481663" y="-0.1603086958717199" z="0.0" unit="radian" />
+      <position name="crystal10-2_pos_neg_bot" x="-99.06328313150773" y="-44.077812877938534" z="1528.2345252800653" unit="mm" />
+      <rotation name="crystal10-2_rot_neg_bot" x="-0.0253118993481663" y="0.1603086958717199" z="0.0" unit="radian" />
+      <position name="crystal10-2_pos_pos_top" x="184.42370834727978" y="44.97781287793853" z="1528.2345252800653" unit="mm" />
+      <rotation name="crystal10-2_rot_pos_top" x="0.0253118993481663" y="-0.1603086958717199" z="0.0" unit="radian" />
+      <position name="crystal10-2_pos_neg_top" x="-99.06328313150773" y="44.97781287793853" z="1528.2345252800653" unit="mm" />
+      <rotation name="crystal10-2_rot_neg_top" x="0.0253118993481663" y="0.1603086958717199" z="0.0" unit="radian" />
+      <position name="crystal11-2_pos_pos_bot" x="199.46448478017476" y="-44.077812877938534" z="1528.1184267341444" unit="mm" />
+      <rotation name="crystal11-2_rot_pos_bot" x="-0.0253118993481663" y="-0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal11-2_pos_neg_bot" x="-114.1040595644027" y="-44.077812877938534" z="1528.1184267341444" unit="mm" />
+      <rotation name="crystal11-2_rot_neg_bot" x="-0.0253118993481663" y="0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal11-2_pos_pos_top" x="199.46448478017476" y="44.97781287793853" z="1528.1184267341444" unit="mm" />
+      <rotation name="crystal11-2_rot_pos_top" x="0.0253118993481663" y="-0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal11-2_pos_neg_top" x="-114.1040595644027" y="44.97781287793853" z="1528.1184267341444" unit="mm" />
+      <rotation name="crystal11-2_rot_neg_top" x="0.0253118993481663" y="0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal12-2_pos_pos_bot" x="214.5439373331128" y="-44.077812877938534" z="1527.9795714424947" unit="mm" />
+      <rotation name="crystal12-2_rot_pos_bot" x="-0.0253118993481663" y="-0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal12-2_pos_neg_bot" x="-129.1835121173408" y="-44.077812877938534" z="1527.9795714424947" unit="mm" />
+      <rotation name="crystal12-2_rot_neg_bot" x="-0.0253118993481663" y="0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal12-2_pos_pos_top" x="214.5439373331128" y="44.97781287793853" z="1527.9795714424947" unit="mm" />
+      <rotation name="crystal12-2_rot_pos_top" x="0.0253118993481663" y="-0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal12-2_pos_neg_top" x="-129.1835121173408" y="44.97781287793853" z="1527.9795714424947" unit="mm" />
+      <rotation name="crystal12-2_rot_neg_top" x="0.0253118993481663" y="0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal13-2_pos_pos_bot" x="229.66580787843168" y="-44.077812877938534" z="1527.8179989435152" unit="mm" />
+      <rotation name="crystal13-2_rot_pos_bot" x="-0.0253118993481663" y="-0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal13-2_pos_neg_bot" x="-144.30538266265967" y="-44.077812877938534" z="1527.8179989435152" unit="mm" />
+      <rotation name="crystal13-2_rot_neg_bot" x="-0.0253118993481663" y="0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal13-2_pos_pos_top" x="229.66580787843168" y="44.97781287793853" z="1527.8179989435152" unit="mm" />
+      <rotation name="crystal13-2_rot_pos_top" x="0.0253118993481663" y="-0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal13-2_pos_neg_top" x="-144.30538266265967" y="44.97781287793853" z="1527.8179989435152" unit="mm" />
+      <rotation name="crystal13-2_rot_neg_top" x="0.0253118993481663" y="0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal14-2_pos_pos_bot" x="244.83390600570817" y="-44.077812877938534" z="1527.6337552442246" unit="mm" />
+      <rotation name="crystal14-2_rot_pos_bot" x="-0.0253118993481663" y="-0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal14-2_pos_neg_bot" x="-159.47348078993616" y="-44.077812877938534" z="1527.6337552442246" unit="mm" />
+      <rotation name="crystal14-2_rot_neg_bot" x="-0.0253118993481663" y="0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal14-2_pos_pos_top" x="244.83390600570817" y="44.97781287793853" z="1527.6337552442246" unit="mm" />
+      <rotation name="crystal14-2_rot_pos_top" x="0.0253118993481663" y="-0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal14-2_pos_neg_top" x="-159.47348078993616" y="44.97781287793853" z="1527.6337552442246" unit="mm" />
+      <rotation name="crystal14-2_rot_neg_top" x="0.0253118993481663" y="0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal15-2_pos_pos_bot" x="260.0521159861688" y="-44.077812877938534" z="1527.42689280716" unit="mm" />
+      <rotation name="crystal15-2_rot_pos_bot" x="-0.0253118993481663" y="-0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal15-2_pos_neg_bot" x="-174.6916907703968" y="-44.077812877938534" z="1527.42689280716" unit="mm" />
+      <rotation name="crystal15-2_rot_neg_bot" x="-0.0253118993481663" y="0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal15-2_pos_pos_top" x="260.0521159861688" y="44.97781287793853" z="1527.42689280716" unit="mm" />
+      <rotation name="crystal15-2_rot_pos_top" x="0.0253118993481663" y="-0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal15-2_pos_neg_top" x="-174.6916907703968" y="44.97781287793853" z="1527.42689280716" unit="mm" />
+      <rotation name="crystal15-2_rot_neg_top" x="0.0253118993481663" y="0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal16-2_pos_pos_bot" x="275.32440401422616" y="-44.077812877938534" z="1527.1974705354392" unit="mm" />
+      <rotation name="crystal16-2_rot_pos_bot" x="-0.0253118993481663" y="-0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal16-2_pos_neg_bot" x="-189.96397879845415" y="-44.077812877938534" z="1527.1974705354392" unit="mm" />
+      <rotation name="crystal16-2_rot_neg_bot" x="-0.0253118993481663" y="0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal16-2_pos_pos_top" x="275.32440401422616" y="44.97781287793853" z="1527.1974705354392" unit="mm" />
+      <rotation name="crystal16-2_rot_pos_top" x="0.0253118993481663" y="-0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal16-2_pos_neg_top" x="-189.96397879845415" y="44.97781287793853" z="1527.1974705354392" unit="mm" />
+      <rotation name="crystal16-2_rot_neg_top" x="0.0253118993481663" y="0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal17-2_pos_pos_bot" x="290.6548257567732" y="-44.077812877938534" z="1526.9455537559877" unit="mm" />
+      <rotation name="crystal17-2_rot_pos_bot" x="-0.0253118993481663" y="-0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal17-2_pos_neg_bot" x="-205.2944005410012" y="-44.077812877938534" z="1526.9455537559877" unit="mm" />
+      <rotation name="crystal17-2_rot_neg_bot" x="-0.0253118993481663" y="0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal17-2_pos_pos_top" x="290.6548257567732" y="44.97781287793853" z="1526.9455537559877" unit="mm" />
+      <rotation name="crystal17-2_rot_pos_top" x="0.0253118993481663" y="-0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal17-2_pos_neg_top" x="-205.2944005410012" y="44.97781287793853" z="1526.9455537559877" unit="mm" />
+      <rotation name="crystal17-2_rot_neg_top" x="0.0253118993481663" y="0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal18-2_pos_pos_bot" x="306.0475342431027" y="-44.077812877938534" z="1526.6712142009383" unit="mm" />
+      <rotation name="crystal18-2_rot_pos_bot" x="-0.0253118993481663" y="-0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal18-2_pos_neg_bot" x="-220.68710902733068" y="-44.077812877938534" z="1526.6712142009383" unit="mm" />
+      <rotation name="crystal18-2_rot_neg_bot" x="-0.0253118993481663" y="0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal18-2_pos_pos_top" x="306.0475342431027" y="44.97781287793853" z="1526.6712142009383" unit="mm" />
+      <rotation name="crystal18-2_rot_pos_top" x="0.0253118993481663" y="-0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal18-2_pos_neg_top" x="-220.68710902733068" y="44.97781287793853" z="1526.6712142009383" unit="mm" />
+      <rotation name="crystal18-2_rot_neg_top" x="0.0253118993481663" y="0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal19-2_pos_pos_bot" x="321.5067881308382" y="-44.077812877938534" z="1526.3745299872046" unit="mm" />
+      <rotation name="crystal19-2_rot_pos_bot" x="-0.0253118993481663" y="-0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal19-2_pos_neg_bot" x="-236.14636291506616" y="-44.077812877938534" z="1526.3745299872046" unit="mm" />
+      <rotation name="crystal19-2_rot_neg_bot" x="-0.0253118993481663" y="0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal19-2_pos_pos_top" x="321.5067881308382" y="44.97781287793853" z="1526.3745299872046" unit="mm" />
+      <rotation name="crystal19-2_rot_pos_top" x="0.0253118993481663" y="-0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal19-2_pos_neg_top" x="-236.14636291506616" y="44.97781287793853" z="1526.3745299872046" unit="mm" />
+      <rotation name="crystal19-2_rot_neg_top" x="0.0253118993481663" y="0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal20-2_pos_pos_bot" x="337.03696038609246" y="-44.077812877938534" z="1526.055585594238" unit="mm" />
+      <rotation name="crystal20-2_rot_pos_bot" x="-0.0253118993481663" y="-0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal20-2_pos_neg_bot" x="-251.67653517032045" y="-44.077812877938534" z="1526.055585594238" unit="mm" />
+      <rotation name="crystal20-2_rot_neg_bot" x="-0.0253118993481663" y="0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal20-2_pos_pos_top" x="337.03696038609246" y="44.97781287793853" z="1526.055585594238" unit="mm" />
+      <rotation name="crystal20-2_rot_pos_top" x="0.0253118993481663" y="-0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal20-2_pos_neg_top" x="-251.67653517032045" y="44.97781287793853" z="1526.055585594238" unit="mm" />
+      <rotation name="crystal20-2_rot_neg_top" x="0.0253118993481663" y="0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal21-2_pos_pos_bot" x="352.64254741924634" y="-44.077812877938534" z="1525.7144718399722" unit="mm" />
+      <rotation name="crystal21-2_rot_pos_bot" x="-0.0253118993481663" y="-0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal21-2_pos_neg_bot" x="-267.28212220347433" y="-44.077812877938534" z="1525.7144718399722" unit="mm" />
+      <rotation name="crystal21-2_rot_neg_bot" x="-0.0253118993481663" y="0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal21-2_pos_pos_top" x="352.64254741924634" y="44.97781287793853" z="1525.7144718399722" unit="mm" />
+      <rotation name="crystal21-2_rot_pos_top" x="0.0253118993481663" y="-0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal21-2_pos_neg_top" x="-267.28212220347433" y="44.97781287793853" z="1525.7144718399722" unit="mm" />
+      <rotation name="crystal21-2_rot_neg_top" x="0.0253118993481663" y="0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal22-2_pos_pos_bot" x="368.32817872130425" y="-44.077812877938534" z="1525.351285854964" unit="mm" />
+      <rotation name="crystal22-2_rot_pos_bot" x="-0.0253118993481663" y="-0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal22-2_pos_neg_bot" x="-282.96775350553224" y="-44.077812877938534" z="1525.351285854964" unit="mm" />
+      <rotation name="crystal22-2_rot_neg_bot" x="-0.0253118993481663" y="0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal22-2_pos_pos_top" x="368.32817872130425" y="44.97781287793853" z="1525.351285854964" unit="mm" />
+      <rotation name="crystal22-2_rot_pos_top" x="0.0253118993481663" y="-0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal22-2_pos_neg_top" x="-282.96775350553224" y="44.97781287793853" z="1525.351285854964" unit="mm" />
+      <rotation name="crystal22-2_rot_neg_top" x="0.0253118993481663" y="0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal23-2_pos_pos_bot" x="384.09862704978" y="-44.077812877938534" z="1524.9661310547353" unit="mm" />
+      <rotation name="crystal23-2_rot_pos_bot" x="-0.0253118993481663" y="-0.3796784902224945" z="0.0" unit="radian" />
+      <position name="crystal23-2_pos_neg_bot" x="-298.738201834008" y="-44.077812877938534" z="1524.9661310547353" unit="mm" />
+      <rotation name="crystal23-2_rot_neg_bot" x="-0.0253118993481663" y="0.3796784902224945" z="0.0" unit="radian" />
+      <position name="crystal23-2_pos_pos_top" x="384.09862704978" y="44.97781287793853" z="1524.9661310547353" unit="mm" />
+      <rotation name="crystal23-2_rot_pos_top" x="0.0253118993481663" y="-0.3796784902224945" z="0.0" unit="radian" />
+      <position name="crystal23-2_pos_neg_top" x="-298.738201834008" y="44.97781287793853" z="1524.9661310547353" unit="mm" />
+      <rotation name="crystal23-2_rot_neg_top" x="0.0253118993481663" y="0.3796784902224945" z="0.0" unit="radian" />
+      <position name="crystal1-3_pos_pos_bot" x="50.20495188328156" y="-59.08788687039808" z="1528.3186477918262" unit="mm" />
+      <rotation name="crystal1-3_rot_pos_bot" x="-0.042186498913610496" y="-0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal1-3_pos_neg_bot" x="35.15547333249048" y="-59.08788687039808" z="1528.3186477918262" unit="mm" />
+      <rotation name="crystal1-3_rot_neg_bot" x="-0.042186498913610496" y="0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal1-3_pos_pos_top" x="50.20495188328156" y="59.987886870398086" z="1528.3186477918262" unit="mm" />
+      <rotation name="crystal1-3_rot_pos_top" x="0.042186498913610496" y="-0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal1-3_pos_neg_top" x="35.15547333249048" y="59.987886870398086" z="1528.3186477918262" unit="mm" />
+      <rotation name="crystal1-3_rot_neg_top" x="0.042186498913610496" y="0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal2-3_pos_pos_bot" x="65.05802548582456" y="-59.08788687039808" z="1528.4080677537463" unit="mm" />
+      <rotation name="crystal2-3_rot_pos_bot" x="-0.042186498913610496" y="-0.0253118993481663" z="0.0" unit="radian" />
+      <position name="crystal2-3_pos_neg_bot" x="20.302399729947485" y="-59.08788687039808" z="1528.4080677537463" unit="mm" />
+      <rotation name="crystal2-3_rot_neg_bot" x="-0.042186498913610496" y="0.0253118993481663" z="0.0" unit="radian" />
+      <position name="crystal2-3_pos_pos_top" x="65.05802548582456" y="59.987886870398086" z="1528.4080677537463" unit="mm" />
+      <rotation name="crystal2-3_rot_pos_top" x="0.042186498913610496" y="-0.0253118993481663" z="0.0" unit="radian" />
+      <position name="crystal2-3_pos_neg_top" x="20.302399729947485" y="59.987886870398086" z="1528.4080677537463" unit="mm" />
+      <rotation name="crystal2-3_rot_neg_top" x="0.042186498913610496" y="0.0253118993481663" z="0.0" unit="radian" />
+      <position name="crystal3-3_pos_pos_bot" x="79.9180994782841" y="-59.08788687039808" z="1528.47466745996" unit="mm" />
+      <rotation name="crystal3-3_rot_pos_bot" x="-0.042186498913610496" y="-0.042186498913610496" z="0.0" unit="radian" />
+      <position name="crystal3-3_pos_neg_bot" x="5.442325737487934" y="-59.08788687039808" z="1528.47466745996" unit="mm" />
+      <rotation name="crystal3-3_rot_neg_bot" x="-0.042186498913610496" y="0.042186498913610496" z="0.0" unit="radian" />
+      <position name="crystal3-3_pos_pos_top" x="79.9180994782841" y="59.987886870398086" z="1528.47466745996" unit="mm" />
+      <rotation name="crystal3-3_rot_pos_top" x="0.042186498913610496" y="-0.042186498913610496" z="0.0" unit="radian" />
+      <position name="crystal3-3_pos_neg_top" x="5.442325737487934" y="59.987886870398086" z="1528.47466745996" unit="mm" />
+      <rotation name="crystal3-3_rot_neg_top" x="0.042186498913610496" y="0.042186498913610496" z="0.0" unit="radian" />
+      <position name="crystal4-3_pos_pos_bot" x="94.78858692586502" y="-59.08788687039808" z="1528.5184279465104" unit="mm" />
+      <rotation name="crystal4-3_rot_pos_bot" x="-0.042186498913610496" y="-0.0590610984790547" z="0.0" unit="radian" />
+      <position name="crystal4-3_pos_neg_bot" x="-9.42816171009298" y="-59.08788687039808" z="1528.5184279465104" unit="mm" />
+      <rotation name="crystal4-3_rot_neg_bot" x="-0.042186498913610496" y="0.0590610984790547" z="0.0" unit="radian" />
+      <position name="crystal4-3_pos_pos_top" x="94.78858692586502" y="59.987886870398086" z="1528.5184279465104" unit="mm" />
+      <rotation name="crystal4-3_rot_pos_top" x="0.042186498913610496" y="-0.0590610984790547" z="0.0" unit="radian" />
+      <position name="crystal4-3_pos_neg_top" x="-9.42816171009298" y="59.987886870398086" z="1528.5184279465104" unit="mm" />
+      <rotation name="crystal4-3_rot_neg_top" x="0.042186498913610496" y="0.0590610984790547" z="0.0" unit="radian" />
+      <position name="crystal5-3_pos_pos_bot" x="109.67291416309662" y="-59.08788687039808" z="1528.5393367528022" unit="mm" />
+      <rotation name="crystal5-3_rot_pos_bot" x="-0.042186498913610496" y="-0.0759356980444989" z="0.0" unit="radian" />
+      <position name="crystal5-3_pos_neg_bot" x="-24.31248894732458" y="-59.08788687039808" z="1528.5393367528022" unit="mm" />
+      <rotation name="crystal5-3_rot_neg_bot" x="-0.042186498913610496" y="0.0759356980444989" z="0.0" unit="radian" />
+      <position name="crystal5-3_pos_pos_top" x="109.67291416309662" y="59.987886870398086" z="1528.5393367528022" unit="mm" />
+      <rotation name="crystal5-3_rot_pos_top" x="0.042186498913610496" y="-0.0759356980444989" z="0.0" unit="radian" />
+      <position name="crystal5-3_pos_neg_top" x="-24.31248894732458" y="59.987886870398086" z="1528.5393367528022" unit="mm" />
+      <rotation name="crystal5-3_rot_neg_top" x="0.042186498913610496" y="0.0759356980444989" z="0.0" unit="radian" />
+      <position name="crystal6-3_pos_pos_bot" x="124.57452638340096" y="-59.08788687039808" z="1528.53738792515" unit="mm" />
+      <rotation name="crystal6-3_rot_pos_bot" x="-0.042186498913610496" y="-0.0928102976099431" z="0.0" unit="radian" />
+      <position name="crystal6-3_pos_neg_bot" x="-39.214101167628925" y="-59.08788687039808" z="1528.53738792515" unit="mm" />
+      <rotation name="crystal6-3_rot_neg_bot" x="-0.042186498913610496" y="0.0928102976099431" z="0.0" unit="radian" />
+      <position name="crystal6-3_pos_pos_top" x="124.57452638340096" y="59.987886870398086" z="1528.53738792515" unit="mm" />
+      <rotation name="crystal6-3_rot_pos_top" x="0.042186498913610496" y="-0.0928102976099431" z="0.0" unit="radian" />
+      <position name="crystal6-3_pos_neg_top" x="-39.214101167628925" y="59.987886870398086" z="1528.53738792515" unit="mm" />
+      <rotation name="crystal6-3_rot_neg_top" x="0.042186498913610496" y="0.0928102976099431" z="0.0" unit="radian" />
+      <position name="crystal7-3_pos_pos_bot" x="139.4968932952259" y="-59.08788687039808" z="1528.5125820184735" unit="mm" />
+      <rotation name="crystal7-3_rot_pos_bot" x="-0.042186498913610496" y="-0.10968489717538729" z="0.0" unit="radian" />
+      <position name="crystal7-3_pos_neg_bot" x="-54.13646807945388" y="-59.08788687039808" z="1528.5125820184735" unit="mm" />
+      <rotation name="crystal7-3_rot_neg_bot" x="-0.042186498913610496" y="0.10968489717538729" z="0.0" unit="radian" />
+      <position name="crystal7-3_pos_pos_top" x="139.4968932952259" y="59.987886870398086" z="1528.5125820184735" unit="mm" />
+      <rotation name="crystal7-3_rot_pos_top" x="0.042186498913610496" y="-0.10968489717538729" z="0.0" unit="radian" />
+      <position name="crystal7-3_pos_neg_top" x="-54.13646807945388" y="59.987886870398086" z="1528.5125820184735" unit="mm" />
+      <rotation name="crystal7-3_rot_neg_top" x="0.042186498913610496" y="0.10968489717538729" z="0.0" unit="radian" />
+      <position name="crystal8-3_pos_pos_bot" x="154.44351486445828" y="-59.08788687039808" z="1528.4649260961392" unit="mm" />
+      <rotation name="crystal8-3_rot_pos_bot" x="-0.042186498913610496" y="-0.1265594967408315" z="0.0" unit="radian" />
+      <position name="crystal8-3_pos_neg_bot" x="-69.08308964868624" y="-59.08788687039808" z="1528.4649260961392" unit="mm" />
+      <rotation name="crystal8-3_rot_neg_bot" x="-0.042186498913610496" y="0.1265594967408315" z="0.0" unit="radian" />
+      <position name="crystal8-3_pos_pos_top" x="154.44351486445828" y="59.987886870398086" z="1528.4649260961392" unit="mm" />
+      <rotation name="crystal8-3_rot_pos_top" x="0.042186498913610496" y="-0.1265594967408315" z="0.0" unit="radian" />
+      <position name="crystal8-3_pos_neg_top" x="-69.08308964868624" y="59.987886870398086" z="1528.4649260961392" unit="mm" />
+      <rotation name="crystal8-3_rot_neg_top" x="0.042186498913610496" y="0.1265594967408315" z="0.0" unit="radian" />
+      <position name="crystal9-3_pos_pos_bot" x="169.41792716339802" y="-59.08788687039808" z="1528.3944337279495" unit="mm" />
+      <rotation name="crystal9-3_rot_pos_bot" x="-0.042186498913610496" y="-0.14343409630627568" z="0.0" unit="radian" />
+      <position name="crystal9-3_pos_neg_bot" x="-84.057501947626" y="-59.08788687039808" z="1528.3944337279495" unit="mm" />
+      <rotation name="crystal9-3_rot_neg_bot" x="-0.042186498913610496" y="0.14343409630627568" z="0.0" unit="radian" />
+      <position name="crystal9-3_pos_pos_top" x="169.41792716339802" y="59.987886870398086" z="1528.3944337279495" unit="mm" />
+      <rotation name="crystal9-3_rot_pos_top" x="0.042186498913610496" y="-0.14343409630627568" z="0.0" unit="radian" />
+      <position name="crystal9-3_pos_neg_top" x="-84.057501947626" y="59.987886870398086" z="1528.3944337279495" unit="mm" />
+      <rotation name="crystal9-3_rot_neg_top" x="0.042186498913610496" y="0.14343409630627568" z="0.0" unit="radian" />
+      <position name="crystal10-3_pos_pos_bot" x="184.42370834727978" y="-59.08788687039808" z="1528.301124986279" unit="mm" />
+      <rotation name="crystal10-3_rot_pos_bot" x="-0.042186498913610496" y="-0.1603086958717199" z="0.0" unit="radian" />
+      <position name="crystal10-3_pos_neg_bot" x="-99.06328313150773" y="-59.08788687039808" z="1528.301124986279" unit="mm" />
+      <rotation name="crystal10-3_rot_neg_bot" x="-0.042186498913610496" y="0.1603086958717199" z="0.0" unit="radian" />
+      <position name="crystal10-3_pos_pos_top" x="184.42370834727978" y="59.987886870398086" z="1528.301124986279" unit="mm" />
+      <rotation name="crystal10-3_rot_pos_top" x="0.042186498913610496" y="-0.1603086958717199" z="0.0" unit="radian" />
+      <position name="crystal10-3_pos_neg_top" x="-99.06328313150773" y="59.987886870398086" z="1528.301124986279" unit="mm" />
+      <rotation name="crystal10-3_rot_neg_top" x="0.042186498913610496" y="0.1603086958717199" z="0.0" unit="radian" />
+      <position name="crystal11-3_pos_pos_bot" x="199.46448478017476" y="-59.08788687039808" z="1528.1850264403583" unit="mm" />
+      <rotation name="crystal11-3_rot_pos_bot" x="-0.042186498913610496" y="-0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal11-3_pos_neg_bot" x="-114.1040595644027" y="-59.08788687039808" z="1528.1850264403583" unit="mm" />
+      <rotation name="crystal11-3_rot_neg_bot" x="-0.042186498913610496" y="0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal11-3_pos_pos_top" x="199.46448478017476" y="59.987886870398086" z="1528.1850264403583" unit="mm" />
+      <rotation name="crystal11-3_rot_pos_top" x="0.042186498913610496" y="-0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal11-3_pos_neg_top" x="-114.1040595644027" y="59.987886870398086" z="1528.1850264403583" unit="mm" />
+      <rotation name="crystal11-3_rot_neg_top" x="0.042186498913610496" y="0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal12-3_pos_pos_bot" x="214.5439373331128" y="-59.08788687039808" z="1528.0461711487085" unit="mm" />
+      <rotation name="crystal12-3_rot_pos_bot" x="-0.042186498913610496" y="-0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal12-3_pos_neg_bot" x="-129.1835121173408" y="-59.08788687039808" z="1528.0461711487085" unit="mm" />
+      <rotation name="crystal12-3_rot_neg_bot" x="-0.042186498913610496" y="0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal12-3_pos_pos_top" x="214.5439373331128" y="59.987886870398086" z="1528.0461711487085" unit="mm" />
+      <rotation name="crystal12-3_rot_pos_top" x="0.042186498913610496" y="-0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal12-3_pos_neg_top" x="-129.1835121173408" y="59.987886870398086" z="1528.0461711487085" unit="mm" />
+      <rotation name="crystal12-3_rot_neg_top" x="0.042186498913610496" y="0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal13-3_pos_pos_bot" x="229.66580787843168" y="-59.08788687039808" z="1527.8845986497292" unit="mm" />
+      <rotation name="crystal13-3_rot_pos_bot" x="-0.042186498913610496" y="-0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal13-3_pos_neg_bot" x="-144.30538266265967" y="-59.08788687039808" z="1527.8845986497292" unit="mm" />
+      <rotation name="crystal13-3_rot_neg_bot" x="-0.042186498913610496" y="0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal13-3_pos_pos_top" x="229.66580787843168" y="59.987886870398086" z="1527.8845986497292" unit="mm" />
+      <rotation name="crystal13-3_rot_pos_top" x="0.042186498913610496" y="-0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal13-3_pos_neg_top" x="-144.30538266265967" y="59.987886870398086" z="1527.8845986497292" unit="mm" />
+      <rotation name="crystal13-3_rot_neg_top" x="0.042186498913610496" y="0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal14-3_pos_pos_bot" x="244.83390600570817" y="-59.08788687039808" z="1527.7003549504386" unit="mm" />
+      <rotation name="crystal14-3_rot_pos_bot" x="-0.042186498913610496" y="-0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal14-3_pos_neg_bot" x="-159.47348078993616" y="-59.08788687039808" z="1527.7003549504386" unit="mm" />
+      <rotation name="crystal14-3_rot_neg_bot" x="-0.042186498913610496" y="0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal14-3_pos_pos_top" x="244.83390600570817" y="59.987886870398086" z="1527.7003549504386" unit="mm" />
+      <rotation name="crystal14-3_rot_pos_top" x="0.042186498913610496" y="-0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal14-3_pos_neg_top" x="-159.47348078993616" y="59.987886870398086" z="1527.7003549504386" unit="mm" />
+      <rotation name="crystal14-3_rot_neg_top" x="0.042186498913610496" y="0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal15-3_pos_pos_bot" x="260.0521159861688" y="-59.08788687039808" z="1527.4934925133737" unit="mm" />
+      <rotation name="crystal15-3_rot_pos_bot" x="-0.042186498913610496" y="-0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal15-3_pos_neg_bot" x="-174.6916907703968" y="-59.08788687039808" z="1527.4934925133737" unit="mm" />
+      <rotation name="crystal15-3_rot_neg_bot" x="-0.042186498913610496" y="0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal15-3_pos_pos_top" x="260.0521159861688" y="59.987886870398086" z="1527.4934925133737" unit="mm" />
+      <rotation name="crystal15-3_rot_pos_top" x="0.042186498913610496" y="-0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal15-3_pos_neg_top" x="-174.6916907703968" y="59.987886870398086" z="1527.4934925133737" unit="mm" />
+      <rotation name="crystal15-3_rot_neg_top" x="0.042186498913610496" y="0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal16-3_pos_pos_bot" x="275.32440401422616" y="-59.08788687039808" z="1527.264070241653" unit="mm" />
+      <rotation name="crystal16-3_rot_pos_bot" x="-0.042186498913610496" y="-0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal16-3_pos_neg_bot" x="-189.96397879845415" y="-59.08788687039808" z="1527.264070241653" unit="mm" />
+      <rotation name="crystal16-3_rot_neg_bot" x="-0.042186498913610496" y="0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal16-3_pos_pos_top" x="275.32440401422616" y="59.987886870398086" z="1527.264070241653" unit="mm" />
+      <rotation name="crystal16-3_rot_pos_top" x="0.042186498913610496" y="-0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal16-3_pos_neg_top" x="-189.96397879845415" y="59.987886870398086" z="1527.264070241653" unit="mm" />
+      <rotation name="crystal16-3_rot_neg_top" x="0.042186498913610496" y="0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal17-3_pos_pos_bot" x="290.6548257567732" y="-59.08788687039808" z="1527.0121534622015" unit="mm" />
+      <rotation name="crystal17-3_rot_pos_bot" x="-0.042186498913610496" y="-0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal17-3_pos_neg_bot" x="-205.2944005410012" y="-59.08788687039808" z="1527.0121534622015" unit="mm" />
+      <rotation name="crystal17-3_rot_neg_bot" x="-0.042186498913610496" y="0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal17-3_pos_pos_top" x="290.6548257567732" y="59.987886870398086" z="1527.0121534622015" unit="mm" />
+      <rotation name="crystal17-3_rot_pos_top" x="0.042186498913610496" y="-0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal17-3_pos_neg_top" x="-205.2944005410012" y="59.987886870398086" z="1527.0121534622015" unit="mm" />
+      <rotation name="crystal17-3_rot_neg_top" x="0.042186498913610496" y="0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal18-3_pos_pos_bot" x="306.0475342431027" y="-59.08788687039808" z="1526.737813907152" unit="mm" />
+      <rotation name="crystal18-3_rot_pos_bot" x="-0.042186498913610496" y="-0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal18-3_pos_neg_bot" x="-220.68710902733068" y="-59.08788687039808" z="1526.737813907152" unit="mm" />
+      <rotation name="crystal18-3_rot_neg_bot" x="-0.042186498913610496" y="0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal18-3_pos_pos_top" x="306.0475342431027" y="59.987886870398086" z="1526.737813907152" unit="mm" />
+      <rotation name="crystal18-3_rot_pos_top" x="0.042186498913610496" y="-0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal18-3_pos_neg_top" x="-220.68710902733068" y="59.987886870398086" z="1526.737813907152" unit="mm" />
+      <rotation name="crystal18-3_rot_neg_top" x="0.042186498913610496" y="0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal19-3_pos_pos_bot" x="321.5067881308382" y="-59.08788687039808" z="1526.4411296934186" unit="mm" />
+      <rotation name="crystal19-3_rot_pos_bot" x="-0.042186498913610496" y="-0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal19-3_pos_neg_bot" x="-236.14636291506616" y="-59.08788687039808" z="1526.4411296934186" unit="mm" />
+      <rotation name="crystal19-3_rot_neg_bot" x="-0.042186498913610496" y="0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal19-3_pos_pos_top" x="321.5067881308382" y="59.987886870398086" z="1526.4411296934186" unit="mm" />
+      <rotation name="crystal19-3_rot_pos_top" x="0.042186498913610496" y="-0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal19-3_pos_neg_top" x="-236.14636291506616" y="59.987886870398086" z="1526.4411296934186" unit="mm" />
+      <rotation name="crystal19-3_rot_neg_top" x="0.042186498913610496" y="0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal20-3_pos_pos_bot" x="337.03696038609246" y="-59.08788687039808" z="1526.1221853004517" unit="mm" />
+      <rotation name="crystal20-3_rot_pos_bot" x="-0.042186498913610496" y="-0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal20-3_pos_neg_bot" x="-251.67653517032045" y="-59.08788687039808" z="1526.1221853004517" unit="mm" />
+      <rotation name="crystal20-3_rot_neg_bot" x="-0.042186498913610496" y="0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal20-3_pos_pos_top" x="337.03696038609246" y="59.987886870398086" z="1526.1221853004517" unit="mm" />
+      <rotation name="crystal20-3_rot_pos_top" x="0.042186498913610496" y="-0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal20-3_pos_neg_top" x="-251.67653517032045" y="59.987886870398086" z="1526.1221853004517" unit="mm" />
+      <rotation name="crystal20-3_rot_neg_top" x="0.042186498913610496" y="0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal21-3_pos_pos_bot" x="352.64254741924634" y="-59.08788687039808" z="1525.781071546186" unit="mm" />
+      <rotation name="crystal21-3_rot_pos_bot" x="-0.042186498913610496" y="-0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal21-3_pos_neg_bot" x="-267.28212220347433" y="-59.08788687039808" z="1525.781071546186" unit="mm" />
+      <rotation name="crystal21-3_rot_neg_bot" x="-0.042186498913610496" y="0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal21-3_pos_pos_top" x="352.64254741924634" y="59.987886870398086" z="1525.781071546186" unit="mm" />
+      <rotation name="crystal21-3_rot_pos_top" x="0.042186498913610496" y="-0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal21-3_pos_neg_top" x="-267.28212220347433" y="59.987886870398086" z="1525.781071546186" unit="mm" />
+      <rotation name="crystal21-3_rot_neg_top" x="0.042186498913610496" y="0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal22-3_pos_pos_bot" x="368.32817872130425" y="-59.08788687039808" z="1525.417885561178" unit="mm" />
+      <rotation name="crystal22-3_rot_pos_bot" x="-0.042186498913610496" y="-0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal22-3_pos_neg_bot" x="-282.96775350553224" y="-59.08788687039808" z="1525.417885561178" unit="mm" />
+      <rotation name="crystal22-3_rot_neg_bot" x="-0.042186498913610496" y="0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal22-3_pos_pos_top" x="368.32817872130425" y="59.987886870398086" z="1525.417885561178" unit="mm" />
+      <rotation name="crystal22-3_rot_pos_top" x="0.042186498913610496" y="-0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal22-3_pos_neg_top" x="-282.96775350553224" y="59.987886870398086" z="1525.417885561178" unit="mm" />
+      <rotation name="crystal22-3_rot_neg_top" x="0.042186498913610496" y="0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal23-3_pos_pos_bot" x="384.09862704978" y="-59.08788687039808" z="1525.032730760949" unit="mm" />
+      <rotation name="crystal23-3_rot_pos_bot" x="-0.042186498913610496" y="-0.3796784902224945" z="0.0" unit="radian" />
+      <position name="crystal23-3_pos_neg_bot" x="-298.738201834008" y="-59.08788687039808" z="1525.032730760949" unit="mm" />
+      <rotation name="crystal23-3_rot_neg_bot" x="-0.042186498913610496" y="0.3796784902224945" z="0.0" unit="radian" />
+      <position name="crystal23-3_pos_pos_top" x="384.09862704978" y="59.987886870398086" z="1525.032730760949" unit="mm" />
+      <rotation name="crystal23-3_rot_pos_top" x="0.042186498913610496" y="-0.3796784902224945" z="0.0" unit="radian" />
+      <position name="crystal23-3_pos_neg_top" x="-298.738201834008" y="59.987886870398086" z="1525.032730760949" unit="mm" />
+      <rotation name="crystal23-3_rot_neg_top" x="0.042186498913610496" y="0.3796784902224945" z="0.0" unit="radian" />
+      <position name="crystal1-4_pos_pos_bot" x="50.20495188328156" y="-74.108374317979" z="1528.3624082783765" unit="mm" />
+      <rotation name="crystal1-4_rot_pos_bot" x="-0.0590610984790547" y="-0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal1-4_pos_neg_bot" x="35.15547333249048" y="-74.108374317979" z="1528.3624082783765" unit="mm" />
+      <rotation name="crystal1-4_rot_neg_bot" x="-0.0590610984790547" y="0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal1-4_pos_pos_top" x="50.20495188328156" y="75.008374317979" z="1528.3624082783765" unit="mm" />
+      <rotation name="crystal1-4_rot_pos_top" x="0.0590610984790547" y="-0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal1-4_pos_neg_top" x="35.15547333249048" y="75.008374317979" z="1528.3624082783765" unit="mm" />
+      <rotation name="crystal1-4_rot_neg_top" x="0.0590610984790547" y="0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal2-4_pos_pos_bot" x="65.05802548582456" y="-74.108374317979" z="1528.4518282402964" unit="mm" />
+      <rotation name="crystal2-4_rot_pos_bot" x="-0.0590610984790547" y="-0.0253118993481663" z="0.0" unit="radian" />
+      <position name="crystal2-4_pos_neg_bot" x="20.302399729947485" y="-74.108374317979" z="1528.4518282402964" unit="mm" />
+      <rotation name="crystal2-4_rot_neg_bot" x="-0.0590610984790547" y="0.0253118993481663" z="0.0" unit="radian" />
+      <position name="crystal2-4_pos_pos_top" x="65.05802548582456" y="75.008374317979" z="1528.4518282402964" unit="mm" />
+      <rotation name="crystal2-4_rot_pos_top" x="0.0590610984790547" y="-0.0253118993481663" z="0.0" unit="radian" />
+      <position name="crystal2-4_pos_neg_top" x="20.302399729947485" y="75.008374317979" z="1528.4518282402964" unit="mm" />
+      <rotation name="crystal2-4_rot_neg_top" x="0.0590610984790547" y="0.0253118993481663" z="0.0" unit="radian" />
+      <position name="crystal3-4_pos_pos_bot" x="79.9180994782841" y="-74.108374317979" z="1528.5184279465104" unit="mm" />
+      <rotation name="crystal3-4_rot_pos_bot" x="-0.0590610984790547" y="-0.042186498913610496" z="0.0" unit="radian" />
+      <position name="crystal3-4_pos_neg_bot" x="5.442325737487934" y="-74.108374317979" z="1528.5184279465104" unit="mm" />
+      <rotation name="crystal3-4_rot_neg_bot" x="-0.0590610984790547" y="0.042186498913610496" z="0.0" unit="radian" />
+      <position name="crystal3-4_pos_pos_top" x="79.9180994782841" y="75.008374317979" z="1528.5184279465104" unit="mm" />
+      <rotation name="crystal3-4_rot_pos_top" x="0.0590610984790547" y="-0.042186498913610496" z="0.0" unit="radian" />
+      <position name="crystal3-4_pos_neg_top" x="5.442325737487934" y="75.008374317979" z="1528.5184279465104" unit="mm" />
+      <rotation name="crystal3-4_rot_neg_top" x="0.0590610984790547" y="0.042186498913610496" z="0.0" unit="radian" />
+      <position name="crystal4-4_pos_pos_bot" x="94.78858692586502" y="-74.108374317979" z="1528.5621884330608" unit="mm" />
+      <rotation name="crystal4-4_rot_pos_bot" x="-0.0590610984790547" y="-0.0590610984790547" z="0.0" unit="radian" />
+      <position name="crystal4-4_pos_neg_bot" x="-9.42816171009298" y="-74.108374317979" z="1528.5621884330608" unit="mm" />
+      <rotation name="crystal4-4_rot_neg_bot" x="-0.0590610984790547" y="0.0590610984790547" z="0.0" unit="radian" />
+      <position name="crystal4-4_pos_pos_top" x="94.78858692586502" y="75.008374317979" z="1528.5621884330608" unit="mm" />
+      <rotation name="crystal4-4_rot_pos_top" x="0.0590610984790547" y="-0.0590610984790547" z="0.0" unit="radian" />
+      <position name="crystal4-4_pos_neg_top" x="-9.42816171009298" y="75.008374317979" z="1528.5621884330608" unit="mm" />
+      <rotation name="crystal4-4_rot_neg_top" x="0.0590610984790547" y="0.0590610984790547" z="0.0" unit="radian" />
+      <position name="crystal5-4_pos_pos_bot" x="109.67291416309662" y="-74.108374317979" z="1528.5830972393524" unit="mm" />
+      <rotation name="crystal5-4_rot_pos_bot" x="-0.0590610984790547" y="-0.0759356980444989" z="0.0" unit="radian" />
+      <position name="crystal5-4_pos_neg_bot" x="-24.31248894732458" y="-74.108374317979" z="1528.5830972393524" unit="mm" />
+      <rotation name="crystal5-4_rot_neg_bot" x="-0.0590610984790547" y="0.0759356980444989" z="0.0" unit="radian" />
+      <position name="crystal5-4_pos_pos_top" x="109.67291416309662" y="75.008374317979" z="1528.5830972393524" unit="mm" />
+      <rotation name="crystal5-4_rot_pos_top" x="0.0590610984790547" y="-0.0759356980444989" z="0.0" unit="radian" />
+      <position name="crystal5-4_pos_neg_top" x="-24.31248894732458" y="75.008374317979" z="1528.5830972393524" unit="mm" />
+      <rotation name="crystal5-4_rot_neg_top" x="0.0590610984790547" y="0.0759356980444989" z="0.0" unit="radian" />
+      <position name="crystal6-4_pos_pos_bot" x="124.57452638340096" y="-74.108374317979" z="1528.5811484117003" unit="mm" />
+      <rotation name="crystal6-4_rot_pos_bot" x="-0.0590610984790547" y="-0.0928102976099431" z="0.0" unit="radian" />
+      <position name="crystal6-4_pos_neg_bot" x="-39.214101167628925" y="-74.108374317979" z="1528.5811484117003" unit="mm" />
+      <rotation name="crystal6-4_rot_neg_bot" x="-0.0590610984790547" y="0.0928102976099431" z="0.0" unit="radian" />
+      <position name="crystal6-4_pos_pos_top" x="124.57452638340096" y="75.008374317979" z="1528.5811484117003" unit="mm" />
+      <rotation name="crystal6-4_rot_pos_top" x="0.0590610984790547" y="-0.0928102976099431" z="0.0" unit="radian" />
+      <position name="crystal6-4_pos_neg_top" x="-39.214101167628925" y="75.008374317979" z="1528.5811484117003" unit="mm" />
+      <rotation name="crystal6-4_rot_neg_top" x="0.0590610984790547" y="0.0928102976099431" z="0.0" unit="radian" />
+      <position name="crystal7-4_pos_pos_bot" x="139.4968932952259" y="-74.108374317979" z="1528.5563425050236" unit="mm" />
+      <rotation name="crystal7-4_rot_pos_bot" x="-0.0590610984790547" y="-0.10968489717538729" z="0.0" unit="radian" />
+      <position name="crystal7-4_pos_neg_bot" x="-54.13646807945388" y="-74.108374317979" z="1528.5563425050236" unit="mm" />
+      <rotation name="crystal7-4_rot_neg_bot" x="-0.0590610984790547" y="0.10968489717538729" z="0.0" unit="radian" />
+      <position name="crystal7-4_pos_pos_top" x="139.4968932952259" y="75.008374317979" z="1528.5563425050236" unit="mm" />
+      <rotation name="crystal7-4_rot_pos_top" x="0.0590610984790547" y="-0.10968489717538729" z="0.0" unit="radian" />
+      <position name="crystal7-4_pos_neg_top" x="-54.13646807945388" y="75.008374317979" z="1528.5563425050236" unit="mm" />
+      <rotation name="crystal7-4_rot_neg_top" x="0.0590610984790547" y="0.10968489717538729" z="0.0" unit="radian" />
+      <position name="crystal8-4_pos_pos_bot" x="154.44351486445828" y="-74.108374317979" z="1528.5086865826895" unit="mm" />
+      <rotation name="crystal8-4_rot_pos_bot" x="-0.0590610984790547" y="-0.1265594967408315" z="0.0" unit="radian" />
+      <position name="crystal8-4_pos_neg_bot" x="-69.08308964868624" y="-74.108374317979" z="1528.5086865826895" unit="mm" />
+      <rotation name="crystal8-4_rot_neg_bot" x="-0.0590610984790547" y="0.1265594967408315" z="0.0" unit="radian" />
+      <position name="crystal8-4_pos_pos_top" x="154.44351486445828" y="75.008374317979" z="1528.5086865826895" unit="mm" />
+      <rotation name="crystal8-4_rot_pos_top" x="0.0590610984790547" y="-0.1265594967408315" z="0.0" unit="radian" />
+      <position name="crystal8-4_pos_neg_top" x="-69.08308964868624" y="75.008374317979" z="1528.5086865826895" unit="mm" />
+      <rotation name="crystal8-4_rot_neg_top" x="0.0590610984790547" y="0.1265594967408315" z="0.0" unit="radian" />
+      <position name="crystal9-4_pos_pos_bot" x="169.41792716339802" y="-74.108374317979" z="1528.4381942144998" unit="mm" />
+      <rotation name="crystal9-4_rot_pos_bot" x="-0.0590610984790547" y="-0.14343409630627568" z="0.0" unit="radian" />
+      <position name="crystal9-4_pos_neg_bot" x="-84.057501947626" y="-74.108374317979" z="1528.4381942144998" unit="mm" />
+      <rotation name="crystal9-4_rot_neg_bot" x="-0.0590610984790547" y="0.14343409630627568" z="0.0" unit="radian" />
+      <position name="crystal9-4_pos_pos_top" x="169.41792716339802" y="75.008374317979" z="1528.4381942144998" unit="mm" />
+      <rotation name="crystal9-4_rot_pos_top" x="0.0590610984790547" y="-0.14343409630627568" z="0.0" unit="radian" />
+      <position name="crystal9-4_pos_neg_top" x="-84.057501947626" y="75.008374317979" z="1528.4381942144998" unit="mm" />
+      <rotation name="crystal9-4_rot_neg_top" x="0.0590610984790547" y="0.14343409630627568" z="0.0" unit="radian" />
+      <position name="crystal10-4_pos_pos_bot" x="184.42370834727978" y="-74.108374317979" z="1528.3448854728294" unit="mm" />
+      <rotation name="crystal10-4_rot_pos_bot" x="-0.0590610984790547" y="-0.1603086958717199" z="0.0" unit="radian" />
+      <position name="crystal10-4_pos_neg_bot" x="-99.06328313150773" y="-74.108374317979" z="1528.3448854728294" unit="mm" />
+      <rotation name="crystal10-4_rot_neg_bot" x="-0.0590610984790547" y="0.1603086958717199" z="0.0" unit="radian" />
+      <position name="crystal10-4_pos_pos_top" x="184.42370834727978" y="75.008374317979" z="1528.3448854728294" unit="mm" />
+      <rotation name="crystal10-4_rot_pos_top" x="0.0590610984790547" y="-0.1603086958717199" z="0.0" unit="radian" />
+      <position name="crystal10-4_pos_neg_top" x="-99.06328313150773" y="75.008374317979" z="1528.3448854728294" unit="mm" />
+      <rotation name="crystal10-4_rot_neg_top" x="0.0590610984790547" y="0.1603086958717199" z="0.0" unit="radian" />
+      <position name="crystal11-4_pos_pos_bot" x="199.46448478017476" y="-74.108374317979" z="1528.2287869269085" unit="mm" />
+      <rotation name="crystal11-4_rot_pos_bot" x="-0.0590610984790547" y="-0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal11-4_pos_neg_bot" x="-114.1040595644027" y="-74.108374317979" z="1528.2287869269085" unit="mm" />
+      <rotation name="crystal11-4_rot_neg_bot" x="-0.0590610984790547" y="0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal11-4_pos_pos_top" x="199.46448478017476" y="75.008374317979" z="1528.2287869269085" unit="mm" />
+      <rotation name="crystal11-4_rot_pos_top" x="0.0590610984790547" y="-0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal11-4_pos_neg_top" x="-114.1040595644027" y="75.008374317979" z="1528.2287869269085" unit="mm" />
+      <rotation name="crystal11-4_rot_neg_top" x="0.0590610984790547" y="0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal12-4_pos_pos_bot" x="214.5439373331128" y="-74.108374317979" z="1528.0899316352588" unit="mm" />
+      <rotation name="crystal12-4_rot_pos_bot" x="-0.0590610984790547" y="-0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal12-4_pos_neg_bot" x="-129.1835121173408" y="-74.108374317979" z="1528.0899316352588" unit="mm" />
+      <rotation name="crystal12-4_rot_neg_bot" x="-0.0590610984790547" y="0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal12-4_pos_pos_top" x="214.5439373331128" y="75.008374317979" z="1528.0899316352588" unit="mm" />
+      <rotation name="crystal12-4_rot_pos_top" x="0.0590610984790547" y="-0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal12-4_pos_neg_top" x="-129.1835121173408" y="75.008374317979" z="1528.0899316352588" unit="mm" />
+      <rotation name="crystal12-4_rot_neg_top" x="0.0590610984790547" y="0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal13-4_pos_pos_bot" x="229.66580787843168" y="-74.108374317979" z="1527.9283591362796" unit="mm" />
+      <rotation name="crystal13-4_rot_pos_bot" x="-0.0590610984790547" y="-0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal13-4_pos_neg_bot" x="-144.30538266265967" y="-74.108374317979" z="1527.9283591362796" unit="mm" />
+      <rotation name="crystal13-4_rot_neg_bot" x="-0.0590610984790547" y="0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal13-4_pos_pos_top" x="229.66580787843168" y="75.008374317979" z="1527.9283591362796" unit="mm" />
+      <rotation name="crystal13-4_rot_pos_top" x="0.0590610984790547" y="-0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal13-4_pos_neg_top" x="-144.30538266265967" y="75.008374317979" z="1527.9283591362796" unit="mm" />
+      <rotation name="crystal13-4_rot_neg_top" x="0.0590610984790547" y="0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal14-4_pos_pos_bot" x="244.83390600570817" y="-74.108374317979" z="1527.744115436989" unit="mm" />
+      <rotation name="crystal14-4_rot_pos_bot" x="-0.0590610984790547" y="-0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal14-4_pos_neg_bot" x="-159.47348078993616" y="-74.108374317979" z="1527.744115436989" unit="mm" />
+      <rotation name="crystal14-4_rot_neg_bot" x="-0.0590610984790547" y="0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal14-4_pos_pos_top" x="244.83390600570817" y="75.008374317979" z="1527.744115436989" unit="mm" />
+      <rotation name="crystal14-4_rot_pos_top" x="0.0590610984790547" y="-0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal14-4_pos_neg_top" x="-159.47348078993616" y="75.008374317979" z="1527.744115436989" unit="mm" />
+      <rotation name="crystal14-4_rot_neg_top" x="0.0590610984790547" y="0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal15-4_pos_pos_bot" x="260.0521159861688" y="-74.108374317979" z="1527.537252999924" unit="mm" />
+      <rotation name="crystal15-4_rot_pos_bot" x="-0.0590610984790547" y="-0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal15-4_pos_neg_bot" x="-174.6916907703968" y="-74.108374317979" z="1527.537252999924" unit="mm" />
+      <rotation name="crystal15-4_rot_neg_bot" x="-0.0590610984790547" y="0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal15-4_pos_pos_top" x="260.0521159861688" y="75.008374317979" z="1527.537252999924" unit="mm" />
+      <rotation name="crystal15-4_rot_pos_top" x="0.0590610984790547" y="-0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal15-4_pos_neg_top" x="-174.6916907703968" y="75.008374317979" z="1527.537252999924" unit="mm" />
+      <rotation name="crystal15-4_rot_neg_top" x="0.0590610984790547" y="0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal16-4_pos_pos_bot" x="275.32440401422616" y="-74.108374317979" z="1527.3078307282033" unit="mm" />
+      <rotation name="crystal16-4_rot_pos_bot" x="-0.0590610984790547" y="-0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal16-4_pos_neg_bot" x="-189.96397879845415" y="-74.108374317979" z="1527.3078307282033" unit="mm" />
+      <rotation name="crystal16-4_rot_neg_bot" x="-0.0590610984790547" y="0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal16-4_pos_pos_top" x="275.32440401422616" y="75.008374317979" z="1527.3078307282033" unit="mm" />
+      <rotation name="crystal16-4_rot_pos_top" x="0.0590610984790547" y="-0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal16-4_pos_neg_top" x="-189.96397879845415" y="75.008374317979" z="1527.3078307282033" unit="mm" />
+      <rotation name="crystal16-4_rot_neg_top" x="0.0590610984790547" y="0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal17-4_pos_pos_bot" x="290.6548257567732" y="-74.108374317979" z="1527.0559139487518" unit="mm" />
+      <rotation name="crystal17-4_rot_pos_bot" x="-0.0590610984790547" y="-0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal17-4_pos_neg_bot" x="-205.2944005410012" y="-74.108374317979" z="1527.0559139487518" unit="mm" />
+      <rotation name="crystal17-4_rot_neg_bot" x="-0.0590610984790547" y="0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal17-4_pos_pos_top" x="290.6548257567732" y="75.008374317979" z="1527.0559139487518" unit="mm" />
+      <rotation name="crystal17-4_rot_pos_top" x="0.0590610984790547" y="-0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal17-4_pos_neg_top" x="-205.2944005410012" y="75.008374317979" z="1527.0559139487518" unit="mm" />
+      <rotation name="crystal17-4_rot_neg_top" x="0.0590610984790547" y="0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal18-4_pos_pos_bot" x="306.0475342431027" y="-74.108374317979" z="1526.7815743937024" unit="mm" />
+      <rotation name="crystal18-4_rot_pos_bot" x="-0.0590610984790547" y="-0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal18-4_pos_neg_bot" x="-220.68710902733068" y="-74.108374317979" z="1526.7815743937024" unit="mm" />
+      <rotation name="crystal18-4_rot_neg_bot" x="-0.0590610984790547" y="0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal18-4_pos_pos_top" x="306.0475342431027" y="75.008374317979" z="1526.7815743937024" unit="mm" />
+      <rotation name="crystal18-4_rot_pos_top" x="0.0590610984790547" y="-0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal18-4_pos_neg_top" x="-220.68710902733068" y="75.008374317979" z="1526.7815743937024" unit="mm" />
+      <rotation name="crystal18-4_rot_neg_top" x="0.0590610984790547" y="0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal19-4_pos_pos_bot" x="321.5067881308382" y="-74.108374317979" z="1526.4848901799687" unit="mm" />
+      <rotation name="crystal19-4_rot_pos_bot" x="-0.0590610984790547" y="-0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal19-4_pos_neg_bot" x="-236.14636291506616" y="-74.108374317979" z="1526.4848901799687" unit="mm" />
+      <rotation name="crystal19-4_rot_neg_bot" x="-0.0590610984790547" y="0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal19-4_pos_pos_top" x="321.5067881308382" y="75.008374317979" z="1526.4848901799687" unit="mm" />
+      <rotation name="crystal19-4_rot_pos_top" x="0.0590610984790547" y="-0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal19-4_pos_neg_top" x="-236.14636291506616" y="75.008374317979" z="1526.4848901799687" unit="mm" />
+      <rotation name="crystal19-4_rot_neg_top" x="0.0590610984790547" y="0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal20-4_pos_pos_bot" x="337.03696038609246" y="-74.108374317979" z="1526.165945787002" unit="mm" />
+      <rotation name="crystal20-4_rot_pos_bot" x="-0.0590610984790547" y="-0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal20-4_pos_neg_bot" x="-251.67653517032045" y="-74.108374317979" z="1526.165945787002" unit="mm" />
+      <rotation name="crystal20-4_rot_neg_bot" x="-0.0590610984790547" y="0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal20-4_pos_pos_top" x="337.03696038609246" y="75.008374317979" z="1526.165945787002" unit="mm" />
+      <rotation name="crystal20-4_rot_pos_top" x="0.0590610984790547" y="-0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal20-4_pos_neg_top" x="-251.67653517032045" y="75.008374317979" z="1526.165945787002" unit="mm" />
+      <rotation name="crystal20-4_rot_neg_top" x="0.0590610984790547" y="0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal21-4_pos_pos_bot" x="352.64254741924634" y="-74.108374317979" z="1525.8248320327364" unit="mm" />
+      <rotation name="crystal21-4_rot_pos_bot" x="-0.0590610984790547" y="-0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal21-4_pos_neg_bot" x="-267.28212220347433" y="-74.108374317979" z="1525.8248320327364" unit="mm" />
+      <rotation name="crystal21-4_rot_neg_bot" x="-0.0590610984790547" y="0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal21-4_pos_pos_top" x="352.64254741924634" y="75.008374317979" z="1525.8248320327364" unit="mm" />
+      <rotation name="crystal21-4_rot_pos_top" x="0.0590610984790547" y="-0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal21-4_pos_neg_top" x="-267.28212220347433" y="75.008374317979" z="1525.8248320327364" unit="mm" />
+      <rotation name="crystal21-4_rot_neg_top" x="0.0590610984790547" y="0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal22-4_pos_pos_bot" x="368.32817872130425" y="-74.108374317979" z="1525.4616460477282" unit="mm" />
+      <rotation name="crystal22-4_rot_pos_bot" x="-0.0590610984790547" y="-0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal22-4_pos_neg_bot" x="-282.96775350553224" y="-74.108374317979" z="1525.4616460477282" unit="mm" />
+      <rotation name="crystal22-4_rot_neg_bot" x="-0.0590610984790547" y="0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal22-4_pos_pos_top" x="368.32817872130425" y="75.008374317979" z="1525.4616460477282" unit="mm" />
+      <rotation name="crystal22-4_rot_pos_top" x="0.0590610984790547" y="-0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal22-4_pos_neg_top" x="-282.96775350553224" y="75.008374317979" z="1525.4616460477282" unit="mm" />
+      <rotation name="crystal22-4_rot_neg_top" x="0.0590610984790547" y="0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal23-4_pos_pos_bot" x="384.09862704978" y="-74.108374317979" z="1525.0764912474995" unit="mm" />
+      <rotation name="crystal23-4_rot_pos_bot" x="-0.0590610984790547" y="-0.3796784902224945" z="0.0" unit="radian" />
+      <position name="crystal23-4_pos_neg_bot" x="-298.738201834008" y="-74.108374317979" z="1525.0764912474995" unit="mm" />
+      <rotation name="crystal23-4_rot_neg_bot" x="-0.0590610984790547" y="0.3796784902224945" z="0.0" unit="radian" />
+      <position name="crystal23-4_pos_pos_top" x="384.09862704978" y="75.008374317979" z="1525.0764912474995" unit="mm" />
+      <rotation name="crystal23-4_rot_pos_top" x="0.0590610984790547" y="-0.3796784902224945" z="0.0" unit="radian" />
+      <position name="crystal23-4_pos_neg_top" x="-298.738201834008" y="75.008374317979" z="1525.0764912474995" unit="mm" />
+      <rotation name="crystal23-4_rot_neg_top" x="0.0590610984790547" y="0.3796784902224945" z="0.0" unit="radian" />
+      <position name="crystal1-5_pos_pos_bot" x="50.20495188328156" y="-89.1427015552106" z="1528.3833170846683" unit="mm" />
+      <rotation name="crystal1-5_rot_pos_bot" x="-0.0759356980444989" y="-0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal1-5_pos_neg_bot" x="35.15547333249048" y="-89.1427015552106" z="1528.3833170846683" unit="mm" />
+      <rotation name="crystal1-5_rot_neg_bot" x="-0.0759356980444989" y="0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal1-5_pos_pos_top" x="50.20495188328156" y="90.0427015552106" z="1528.3833170846683" unit="mm" />
+      <rotation name="crystal1-5_rot_pos_top" x="0.0759356980444989" y="-0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal1-5_pos_neg_top" x="35.15547333249048" y="90.0427015552106" z="1528.3833170846683" unit="mm" />
+      <rotation name="crystal1-5_rot_neg_top" x="0.0759356980444989" y="0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal2-5_pos_pos_bot" x="65.05802548582456" y="-89.1427015552106" z="1528.4727370465882" unit="mm" />
+      <rotation name="crystal2-5_rot_pos_bot" x="-0.0759356980444989" y="-0.0253118993481663" z="0.0" unit="radian" />
+      <position name="crystal2-5_pos_neg_bot" x="20.302399729947485" y="-89.1427015552106" z="1528.4727370465882" unit="mm" />
+      <rotation name="crystal2-5_rot_neg_bot" x="-0.0759356980444989" y="0.0253118993481663" z="0.0" unit="radian" />
+      <position name="crystal2-5_pos_pos_top" x="65.05802548582456" y="90.0427015552106" z="1528.4727370465882" unit="mm" />
+      <rotation name="crystal2-5_rot_pos_top" x="0.0759356980444989" y="-0.0253118993481663" z="0.0" unit="radian" />
+      <position name="crystal2-5_pos_neg_top" x="20.302399729947485" y="90.0427015552106" z="1528.4727370465882" unit="mm" />
+      <rotation name="crystal2-5_rot_neg_top" x="0.0759356980444989" y="0.0253118993481663" z="0.0" unit="radian" />
+      <position name="crystal3-5_pos_pos_bot" x="79.9180994782841" y="-89.1427015552106" z="1528.5393367528022" unit="mm" />
+      <rotation name="crystal3-5_rot_pos_bot" x="-0.0759356980444989" y="-0.042186498913610496" z="0.0" unit="radian" />
+      <position name="crystal3-5_pos_neg_bot" x="5.442325737487934" y="-89.1427015552106" z="1528.5393367528022" unit="mm" />
+      <rotation name="crystal3-5_rot_neg_bot" x="-0.0759356980444989" y="0.042186498913610496" z="0.0" unit="radian" />
+      <position name="crystal3-5_pos_pos_top" x="79.9180994782841" y="90.0427015552106" z="1528.5393367528022" unit="mm" />
+      <rotation name="crystal3-5_rot_pos_top" x="0.0759356980444989" y="-0.042186498913610496" z="0.0" unit="radian" />
+      <position name="crystal3-5_pos_neg_top" x="5.442325737487934" y="90.0427015552106" z="1528.5393367528022" unit="mm" />
+      <rotation name="crystal3-5_rot_neg_top" x="0.0759356980444989" y="0.042186498913610496" z="0.0" unit="radian" />
+      <position name="crystal4-5_pos_pos_bot" x="94.78858692586502" y="-89.1427015552106" z="1528.5830972393524" unit="mm" />
+      <rotation name="crystal4-5_rot_pos_bot" x="-0.0759356980444989" y="-0.0590610984790547" z="0.0" unit="radian" />
+      <position name="crystal4-5_pos_neg_bot" x="-9.42816171009298" y="-89.1427015552106" z="1528.5830972393524" unit="mm" />
+      <rotation name="crystal4-5_rot_neg_bot" x="-0.0759356980444989" y="0.0590610984790547" z="0.0" unit="radian" />
+      <position name="crystal4-5_pos_pos_top" x="94.78858692586502" y="90.0427015552106" z="1528.5830972393524" unit="mm" />
+      <rotation name="crystal4-5_rot_pos_top" x="0.0759356980444989" y="-0.0590610984790547" z="0.0" unit="radian" />
+      <position name="crystal4-5_pos_neg_top" x="-9.42816171009298" y="90.0427015552106" z="1528.5830972393524" unit="mm" />
+      <rotation name="crystal4-5_rot_neg_top" x="0.0759356980444989" y="0.0590610984790547" z="0.0" unit="radian" />
+      <position name="crystal5-5_pos_pos_bot" x="109.67291416309662" y="-89.1427015552106" z="1528.6040060456442" unit="mm" />
+      <rotation name="crystal5-5_rot_pos_bot" x="-0.0759356980444989" y="-0.0759356980444989" z="0.0" unit="radian" />
+      <position name="crystal5-5_pos_neg_bot" x="-24.31248894732458" y="-89.1427015552106" z="1528.6040060456442" unit="mm" />
+      <rotation name="crystal5-5_rot_neg_bot" x="-0.0759356980444989" y="0.0759356980444989" z="0.0" unit="radian" />
+      <position name="crystal5-5_pos_pos_top" x="109.67291416309662" y="90.0427015552106" z="1528.6040060456442" unit="mm" />
+      <rotation name="crystal5-5_rot_pos_top" x="0.0759356980444989" y="-0.0759356980444989" z="0.0" unit="radian" />
+      <position name="crystal5-5_pos_neg_top" x="-24.31248894732458" y="90.0427015552106" z="1528.6040060456442" unit="mm" />
+      <rotation name="crystal5-5_rot_neg_top" x="0.0759356980444989" y="0.0759356980444989" z="0.0" unit="radian" />
+      <position name="crystal6-5_pos_pos_bot" x="124.57452638340096" y="-89.1427015552106" z="1528.602057217992" unit="mm" />
+      <rotation name="crystal6-5_rot_pos_bot" x="-0.0759356980444989" y="-0.0928102976099431" z="0.0" unit="radian" />
+      <position name="crystal6-5_pos_neg_bot" x="-39.214101167628925" y="-89.1427015552106" z="1528.602057217992" unit="mm" />
+      <rotation name="crystal6-5_rot_neg_bot" x="-0.0759356980444989" y="0.0928102976099431" z="0.0" unit="radian" />
+      <position name="crystal6-5_pos_pos_top" x="124.57452638340096" y="90.0427015552106" z="1528.602057217992" unit="mm" />
+      <rotation name="crystal6-5_rot_pos_top" x="0.0759356980444989" y="-0.0928102976099431" z="0.0" unit="radian" />
+      <position name="crystal6-5_pos_neg_top" x="-39.214101167628925" y="90.0427015552106" z="1528.602057217992" unit="mm" />
+      <rotation name="crystal6-5_rot_neg_top" x="0.0759356980444989" y="0.0928102976099431" z="0.0" unit="radian" />
+      <position name="crystal7-5_pos_pos_bot" x="139.4968932952259" y="-89.1427015552106" z="1528.5772513113154" unit="mm" />
+      <rotation name="crystal7-5_rot_pos_bot" x="-0.0759356980444989" y="-0.10968489717538729" z="0.0" unit="radian" />
+      <position name="crystal7-5_pos_neg_bot" x="-54.13646807945388" y="-89.1427015552106" z="1528.5772513113154" unit="mm" />
+      <rotation name="crystal7-5_rot_neg_bot" x="-0.0759356980444989" y="0.10968489717538729" z="0.0" unit="radian" />
+      <position name="crystal7-5_pos_pos_top" x="139.4968932952259" y="90.0427015552106" z="1528.5772513113154" unit="mm" />
+      <rotation name="crystal7-5_rot_pos_top" x="0.0759356980444989" y="-0.10968489717538729" z="0.0" unit="radian" />
+      <position name="crystal7-5_pos_neg_top" x="-54.13646807945388" y="90.0427015552106" z="1528.5772513113154" unit="mm" />
+      <rotation name="crystal7-5_rot_neg_top" x="0.0759356980444989" y="0.10968489717538729" z="0.0" unit="radian" />
+      <position name="crystal8-5_pos_pos_bot" x="154.44351486445828" y="-89.1427015552106" z="1528.5295953889813" unit="mm" />
+      <rotation name="crystal8-5_rot_pos_bot" x="-0.0759356980444989" y="-0.1265594967408315" z="0.0" unit="radian" />
+      <position name="crystal8-5_pos_neg_bot" x="-69.08308964868624" y="-89.1427015552106" z="1528.5295953889813" unit="mm" />
+      <rotation name="crystal8-5_rot_neg_bot" x="-0.0759356980444989" y="0.1265594967408315" z="0.0" unit="radian" />
+      <position name="crystal8-5_pos_pos_top" x="154.44351486445828" y="90.0427015552106" z="1528.5295953889813" unit="mm" />
+      <rotation name="crystal8-5_rot_pos_top" x="0.0759356980444989" y="-0.1265594967408315" z="0.0" unit="radian" />
+      <position name="crystal8-5_pos_neg_top" x="-69.08308964868624" y="90.0427015552106" z="1528.5295953889813" unit="mm" />
+      <rotation name="crystal8-5_rot_neg_top" x="0.0759356980444989" y="0.1265594967408315" z="0.0" unit="radian" />
+      <position name="crystal9-5_pos_pos_bot" x="169.41792716339802" y="-89.1427015552106" z="1528.4591030207916" unit="mm" />
+      <rotation name="crystal9-5_rot_pos_bot" x="-0.0759356980444989" y="-0.14343409630627568" z="0.0" unit="radian" />
+      <position name="crystal9-5_pos_neg_bot" x="-84.057501947626" y="-89.1427015552106" z="1528.4591030207916" unit="mm" />
+      <rotation name="crystal9-5_rot_neg_bot" x="-0.0759356980444989" y="0.14343409630627568" z="0.0" unit="radian" />
+      <position name="crystal9-5_pos_pos_top" x="169.41792716339802" y="90.0427015552106" z="1528.4591030207916" unit="mm" />
+      <rotation name="crystal9-5_rot_pos_top" x="0.0759356980444989" y="-0.14343409630627568" z="0.0" unit="radian" />
+      <position name="crystal9-5_pos_neg_top" x="-84.057501947626" y="90.0427015552106" z="1528.4591030207916" unit="mm" />
+      <rotation name="crystal9-5_rot_neg_top" x="0.0759356980444989" y="0.14343409630627568" z="0.0" unit="radian" />
+      <position name="crystal10-5_pos_pos_bot" x="184.42370834727978" y="-89.1427015552106" z="1528.3657942791212" unit="mm" />
+      <rotation name="crystal10-5_rot_pos_bot" x="-0.0759356980444989" y="-0.1603086958717199" z="0.0" unit="radian" />
+      <position name="crystal10-5_pos_neg_bot" x="-99.06328313150773" y="-89.1427015552106" z="1528.3657942791212" unit="mm" />
+      <rotation name="crystal10-5_rot_neg_bot" x="-0.0759356980444989" y="0.1603086958717199" z="0.0" unit="radian" />
+      <position name="crystal10-5_pos_pos_top" x="184.42370834727978" y="90.0427015552106" z="1528.3657942791212" unit="mm" />
+      <rotation name="crystal10-5_rot_pos_top" x="0.0759356980444989" y="-0.1603086958717199" z="0.0" unit="radian" />
+      <position name="crystal10-5_pos_neg_top" x="-99.06328313150773" y="90.0427015552106" z="1528.3657942791212" unit="mm" />
+      <rotation name="crystal10-5_rot_neg_top" x="0.0759356980444989" y="0.1603086958717199" z="0.0" unit="radian" />
+      <position name="crystal11-5_pos_pos_bot" x="199.46448478017476" y="-89.1427015552106" z="1528.2496957332003" unit="mm" />
+      <rotation name="crystal11-5_rot_pos_bot" x="-0.0759356980444989" y="-0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal11-5_pos_neg_bot" x="-114.1040595644027" y="-89.1427015552106" z="1528.2496957332003" unit="mm" />
+      <rotation name="crystal11-5_rot_neg_bot" x="-0.0759356980444989" y="0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal11-5_pos_pos_top" x="199.46448478017476" y="90.0427015552106" z="1528.2496957332003" unit="mm" />
+      <rotation name="crystal11-5_rot_pos_top" x="0.0759356980444989" y="-0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal11-5_pos_neg_top" x="-114.1040595644027" y="90.0427015552106" z="1528.2496957332003" unit="mm" />
+      <rotation name="crystal11-5_rot_neg_top" x="0.0759356980444989" y="0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal12-5_pos_pos_bot" x="214.5439373331128" y="-89.1427015552106" z="1528.1108404415506" unit="mm" />
+      <rotation name="crystal12-5_rot_pos_bot" x="-0.0759356980444989" y="-0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal12-5_pos_neg_bot" x="-129.1835121173408" y="-89.1427015552106" z="1528.1108404415506" unit="mm" />
+      <rotation name="crystal12-5_rot_neg_bot" x="-0.0759356980444989" y="0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal12-5_pos_pos_top" x="214.5439373331128" y="90.0427015552106" z="1528.1108404415506" unit="mm" />
+      <rotation name="crystal12-5_rot_pos_top" x="0.0759356980444989" y="-0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal12-5_pos_neg_top" x="-129.1835121173408" y="90.0427015552106" z="1528.1108404415506" unit="mm" />
+      <rotation name="crystal12-5_rot_neg_top" x="0.0759356980444989" y="0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal13-5_pos_pos_bot" x="229.66580787843168" y="-89.1427015552106" z="1527.9492679425712" unit="mm" />
+      <rotation name="crystal13-5_rot_pos_bot" x="-0.0759356980444989" y="-0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal13-5_pos_neg_bot" x="-144.30538266265967" y="-89.1427015552106" z="1527.9492679425712" unit="mm" />
+      <rotation name="crystal13-5_rot_neg_bot" x="-0.0759356980444989" y="0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal13-5_pos_pos_top" x="229.66580787843168" y="90.0427015552106" z="1527.9492679425712" unit="mm" />
+      <rotation name="crystal13-5_rot_pos_top" x="0.0759356980444989" y="-0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal13-5_pos_neg_top" x="-144.30538266265967" y="90.0427015552106" z="1527.9492679425712" unit="mm" />
+      <rotation name="crystal13-5_rot_neg_top" x="0.0759356980444989" y="0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal14-5_pos_pos_bot" x="244.83390600570817" y="-89.1427015552106" z="1527.7650242432805" unit="mm" />
+      <rotation name="crystal14-5_rot_pos_bot" x="-0.0759356980444989" y="-0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal14-5_pos_neg_bot" x="-159.47348078993616" y="-89.1427015552106" z="1527.7650242432805" unit="mm" />
+      <rotation name="crystal14-5_rot_neg_bot" x="-0.0759356980444989" y="0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal14-5_pos_pos_top" x="244.83390600570817" y="90.0427015552106" z="1527.7650242432805" unit="mm" />
+      <rotation name="crystal14-5_rot_pos_top" x="0.0759356980444989" y="-0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal14-5_pos_neg_top" x="-159.47348078993616" y="90.0427015552106" z="1527.7650242432805" unit="mm" />
+      <rotation name="crystal14-5_rot_neg_top" x="0.0759356980444989" y="0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal15-5_pos_pos_bot" x="260.0521159861688" y="-89.1427015552106" z="1527.5581618062158" unit="mm" />
+      <rotation name="crystal15-5_rot_pos_bot" x="-0.0759356980444989" y="-0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal15-5_pos_neg_bot" x="-174.6916907703968" y="-89.1427015552106" z="1527.5581618062158" unit="mm" />
+      <rotation name="crystal15-5_rot_neg_bot" x="-0.0759356980444989" y="0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal15-5_pos_pos_top" x="260.0521159861688" y="90.0427015552106" z="1527.5581618062158" unit="mm" />
+      <rotation name="crystal15-5_rot_pos_top" x="0.0759356980444989" y="-0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal15-5_pos_neg_top" x="-174.6916907703968" y="90.0427015552106" z="1527.5581618062158" unit="mm" />
+      <rotation name="crystal15-5_rot_neg_top" x="0.0759356980444989" y="0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal16-5_pos_pos_bot" x="275.32440401422616" y="-89.1427015552106" z="1527.328739534495" unit="mm" />
+      <rotation name="crystal16-5_rot_pos_bot" x="-0.0759356980444989" y="-0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal16-5_pos_neg_bot" x="-189.96397879845415" y="-89.1427015552106" z="1527.328739534495" unit="mm" />
+      <rotation name="crystal16-5_rot_neg_bot" x="-0.0759356980444989" y="0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal16-5_pos_pos_top" x="275.32440401422616" y="90.0427015552106" z="1527.328739534495" unit="mm" />
+      <rotation name="crystal16-5_rot_pos_top" x="0.0759356980444989" y="-0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal16-5_pos_neg_top" x="-189.96397879845415" y="90.0427015552106" z="1527.328739534495" unit="mm" />
+      <rotation name="crystal16-5_rot_neg_top" x="0.0759356980444989" y="0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal17-5_pos_pos_bot" x="290.6548257567732" y="-89.1427015552106" z="1527.0768227550436" unit="mm" />
+      <rotation name="crystal17-5_rot_pos_bot" x="-0.0759356980444989" y="-0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal17-5_pos_neg_bot" x="-205.2944005410012" y="-89.1427015552106" z="1527.0768227550436" unit="mm" />
+      <rotation name="crystal17-5_rot_neg_bot" x="-0.0759356980444989" y="0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal17-5_pos_pos_top" x="290.6548257567732" y="90.0427015552106" z="1527.0768227550436" unit="mm" />
+      <rotation name="crystal17-5_rot_pos_top" x="0.0759356980444989" y="-0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal17-5_pos_neg_top" x="-205.2944005410012" y="90.0427015552106" z="1527.0768227550436" unit="mm" />
+      <rotation name="crystal17-5_rot_neg_top" x="0.0759356980444989" y="0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal18-5_pos_pos_bot" x="306.0475342431027" y="-89.1427015552106" z="1526.8024831999942" unit="mm" />
+      <rotation name="crystal18-5_rot_pos_bot" x="-0.0759356980444989" y="-0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal18-5_pos_neg_bot" x="-220.68710902733068" y="-89.1427015552106" z="1526.8024831999942" unit="mm" />
+      <rotation name="crystal18-5_rot_neg_bot" x="-0.0759356980444989" y="0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal18-5_pos_pos_top" x="306.0475342431027" y="90.0427015552106" z="1526.8024831999942" unit="mm" />
+      <rotation name="crystal18-5_rot_pos_top" x="0.0759356980444989" y="-0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal18-5_pos_neg_top" x="-220.68710902733068" y="90.0427015552106" z="1526.8024831999942" unit="mm" />
+      <rotation name="crystal18-5_rot_neg_top" x="0.0759356980444989" y="0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal19-5_pos_pos_bot" x="321.5067881308382" y="-89.1427015552106" z="1526.5057989862605" unit="mm" />
+      <rotation name="crystal19-5_rot_pos_bot" x="-0.0759356980444989" y="-0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal19-5_pos_neg_bot" x="-236.14636291506616" y="-89.1427015552106" z="1526.5057989862605" unit="mm" />
+      <rotation name="crystal19-5_rot_neg_bot" x="-0.0759356980444989" y="0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal19-5_pos_pos_top" x="321.5067881308382" y="90.0427015552106" z="1526.5057989862605" unit="mm" />
+      <rotation name="crystal19-5_rot_pos_top" x="0.0759356980444989" y="-0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal19-5_pos_neg_top" x="-236.14636291506616" y="90.0427015552106" z="1526.5057989862605" unit="mm" />
+      <rotation name="crystal19-5_rot_neg_top" x="0.0759356980444989" y="0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal20-5_pos_pos_bot" x="337.03696038609246" y="-89.1427015552106" z="1526.186854593294" unit="mm" />
+      <rotation name="crystal20-5_rot_pos_bot" x="-0.0759356980444989" y="-0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal20-5_pos_neg_bot" x="-251.67653517032045" y="-89.1427015552106" z="1526.186854593294" unit="mm" />
+      <rotation name="crystal20-5_rot_neg_bot" x="-0.0759356980444989" y="0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal20-5_pos_pos_top" x="337.03696038609246" y="90.0427015552106" z="1526.186854593294" unit="mm" />
+      <rotation name="crystal20-5_rot_pos_top" x="0.0759356980444989" y="-0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal20-5_pos_neg_top" x="-251.67653517032045" y="90.0427015552106" z="1526.186854593294" unit="mm" />
+      <rotation name="crystal20-5_rot_neg_top" x="0.0759356980444989" y="0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal21-5_pos_pos_bot" x="352.64254741924634" y="-89.1427015552106" z="1525.8457408390282" unit="mm" />
+      <rotation name="crystal21-5_rot_pos_bot" x="-0.0759356980444989" y="-0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal21-5_pos_neg_bot" x="-267.28212220347433" y="-89.1427015552106" z="1525.8457408390282" unit="mm" />
+      <rotation name="crystal21-5_rot_neg_bot" x="-0.0759356980444989" y="0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal21-5_pos_pos_top" x="352.64254741924634" y="90.0427015552106" z="1525.8457408390282" unit="mm" />
+      <rotation name="crystal21-5_rot_pos_top" x="0.0759356980444989" y="-0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal21-5_pos_neg_top" x="-267.28212220347433" y="90.0427015552106" z="1525.8457408390282" unit="mm" />
+      <rotation name="crystal21-5_rot_neg_top" x="0.0759356980444989" y="0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal22-5_pos_pos_bot" x="368.32817872130425" y="-89.1427015552106" z="1525.48255485402" unit="mm" />
+      <rotation name="crystal22-5_rot_pos_bot" x="-0.0759356980444989" y="-0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal22-5_pos_neg_bot" x="-282.96775350553224" y="-89.1427015552106" z="1525.48255485402" unit="mm" />
+      <rotation name="crystal22-5_rot_neg_bot" x="-0.0759356980444989" y="0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal22-5_pos_pos_top" x="368.32817872130425" y="90.0427015552106" z="1525.48255485402" unit="mm" />
+      <rotation name="crystal22-5_rot_pos_top" x="0.0759356980444989" y="-0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal22-5_pos_neg_top" x="-282.96775350553224" y="90.0427015552106" z="1525.48255485402" unit="mm" />
+      <rotation name="crystal22-5_rot_neg_top" x="0.0759356980444989" y="0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal23-5_pos_pos_bot" x="384.09862704978" y="-89.1427015552106" z="1525.0974000537913" unit="mm" />
+      <rotation name="crystal23-5_rot_pos_bot" x="-0.0759356980444989" y="-0.3796784902224945" z="0.0" unit="radian" />
+      <position name="crystal23-5_pos_neg_bot" x="-298.738201834008" y="-89.1427015552106" z="1525.0974000537913" unit="mm" />
+      <rotation name="crystal23-5_rot_neg_bot" x="-0.0759356980444989" y="0.3796784902224945" z="0.0" unit="radian" />
+      <position name="crystal23-5_pos_pos_top" x="384.09862704978" y="90.0427015552106" z="1525.0974000537913" unit="mm" />
+      <rotation name="crystal23-5_rot_pos_top" x="0.0759356980444989" y="-0.3796784902224945" z="0.0" unit="radian" />
+      <position name="crystal23-5_pos_neg_top" x="-298.738201834008" y="90.0427015552106" z="1525.0974000537913" unit="mm" />
+      <rotation name="crystal23-5_rot_neg_top" x="0.0759356980444989" y="0.3796784902224945" z="0.0" unit="radian" />
+      <rotation name="hodo_rot" x="0.0" y="0.0" z="0.0" unit="radian" />
+      <position name="hodo_pos_L1TP0" x="73.63" y="44.2" z="1103.5" unit="mm" />
+      <position name="hodo_forecover_pos_L1TP0" x="73.63" y="44.2" z="1098.625" unit="mm" />
+      <position name="hodo_postcover_pos_L1TP0" x="73.63" y="44.2" z="1108.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L1TP0" x="65.75500000000001" y="44.2" z="1103.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L1TP0" x="81.50500000000001" y="44.2" z="1103.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L1TP0" x="73.63" y="74.17500000000001" z="1103.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L1TP0" x="73.63" y="14.225000000000003" z="1103.5" unit="mm" />
+      <position name="hodo_pos_L1BP0" x="73.63" y="-44.2" z="1103.5" unit="mm" />
+      <position name="hodo_forecover_pos_L1BP0" x="73.63" y="-44.2" z="1098.625" unit="mm" />
+      <position name="hodo_postcover_pos_L1BP0" x="73.63" y="-44.2" z="1108.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L1BP0" x="65.75500000000001" y="-44.2" z="1103.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L1BP0" x="81.50500000000001" y="-44.2" z="1103.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L1BP0" x="73.63" y="-14.225000000000003" z="1103.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L1BP0" x="73.63" y="-74.17500000000001" z="1103.5" unit="mm" />
+      <position name="hodo_pos_L1TP1" x="98.63" y="44.2" z="1103.5" unit="mm" />
+      <position name="hodo_forecover_pos_L1TP1" x="98.63" y="44.2" z="1098.625" unit="mm" />
+      <position name="hodo_postcover_pos_L1TP1" x="98.63" y="44.2" z="1108.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L1TP1" x="81.555" y="44.2" z="1103.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L1TP1" x="115.70500000000001" y="44.2" z="1103.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L1TP1" x="98.63" y="74.17500000000001" z="1103.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L1TP1" x="98.63" y="14.225000000000003" z="1103.5" unit="mm" />
+      <position name="hodo_pos_L1BP1" x="98.63" y="-44.2" z="1103.5" unit="mm" />
+      <position name="hodo_forecover_pos_L1BP1" x="98.63" y="-44.2" z="1098.625" unit="mm" />
+      <position name="hodo_postcover_pos_L1BP1" x="98.63" y="-44.2" z="1108.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L1BP1" x="81.555" y="-44.2" z="1103.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L1BP1" x="115.70500000000001" y="-44.2" z="1103.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L1BP1" x="98.63" y="-14.225000000000003" z="1103.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L1BP1" x="98.63" y="-74.17500000000001" z="1103.5" unit="mm" />
+      <position name="hodo_pos_L1TP2" x="137.78" y="44.2" z="1103.5" unit="mm" />
+      <position name="hodo_forecover_pos_L1TP2" x="137.78" y="44.2" z="1098.625" unit="mm" />
+      <position name="hodo_postcover_pos_L1TP2" x="137.78" y="44.2" z="1108.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L1TP2" x="115.75500000000001" y="44.2" z="1103.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L1TP2" x="159.805" y="44.2" z="1103.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L1TP2" x="137.78" y="74.17500000000001" z="1103.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L1TP2" x="137.78" y="14.225000000000003" z="1103.5" unit="mm" />
+      <position name="hodo_pos_L1BP2" x="137.78" y="-44.2" z="1103.5" unit="mm" />
+      <position name="hodo_forecover_pos_L1BP2" x="137.78" y="-44.2" z="1098.625" unit="mm" />
+      <position name="hodo_postcover_pos_L1BP2" x="137.78" y="-44.2" z="1108.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L1BP2" x="115.75500000000001" y="-44.2" z="1103.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L1BP2" x="159.805" y="-44.2" z="1103.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L1BP2" x="137.78" y="-14.225000000000003" z="1103.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L1BP2" x="137.78" y="-74.17500000000001" z="1103.5" unit="mm" />
+      <position name="hodo_pos_L1TP3" x="181.88" y="44.2" z="1103.5" unit="mm" />
+      <position name="hodo_forecover_pos_L1TP3" x="181.88" y="44.2" z="1098.625" unit="mm" />
+      <position name="hodo_postcover_pos_L1TP3" x="181.88" y="44.2" z="1108.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L1TP3" x="159.855" y="44.2" z="1103.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L1TP3" x="203.905" y="44.2" z="1103.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L1TP3" x="181.88" y="74.17500000000001" z="1103.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L1TP3" x="181.88" y="14.225000000000003" z="1103.5" unit="mm" />
+      <position name="hodo_pos_L1BP3" x="181.88" y="-44.2" z="1103.5" unit="mm" />
+      <position name="hodo_forecover_pos_L1BP3" x="181.88" y="-44.2" z="1098.625" unit="mm" />
+      <position name="hodo_postcover_pos_L1BP3" x="181.88" y="-44.2" z="1108.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L1BP3" x="159.855" y="-44.2" z="1103.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L1BP3" x="203.905" y="-44.2" z="1103.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L1BP3" x="181.88" y="-14.225000000000003" z="1103.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L1BP3" x="181.88" y="-74.17500000000001" z="1103.5" unit="mm" />
+      <position name="hodo_pos_L1TP4" x="225.98000000000002" y="44.2" z="1103.5" unit="mm" />
+      <position name="hodo_forecover_pos_L1TP4" x="225.98000000000002" y="44.2" z="1098.625" unit="mm" />
+      <position name="hodo_postcover_pos_L1TP4" x="225.98000000000002" y="44.2" z="1108.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L1TP4" x="203.955" y="44.2" z="1103.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L1TP4" x="248.00500000000002" y="44.2" z="1103.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L1TP4" x="225.98000000000002" y="74.17500000000001" z="1103.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L1TP4" x="225.98000000000002" y="14.225000000000003" z="1103.5" unit="mm" />
+      <position name="hodo_pos_L1BP4" x="225.98000000000002" y="-44.2" z="1103.5" unit="mm" />
+      <position name="hodo_forecover_pos_L1BP4" x="225.98000000000002" y="-44.2" z="1098.625" unit="mm" />
+      <position name="hodo_postcover_pos_L1BP4" x="225.98000000000002" y="-44.2" z="1108.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L1BP4" x="203.955" y="-44.2" z="1103.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L1BP4" x="248.00500000000002" y="-44.2" z="1103.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L1BP4" x="225.98000000000002" y="-14.225000000000003" z="1103.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L1BP4" x="225.98000000000002" y="-74.17500000000001" z="1103.5" unit="mm" />
+      <position name="hodo_pos_L2TP0" x="78.61999999999999" y="44.2" z="1115.5" unit="mm" />
+      <position name="hodo_forecover_pos_L2TP0" x="78.61999999999999" y="44.2" z="1110.625" unit="mm" />
+      <position name="hodo_postcover_pos_L2TP0" x="78.61999999999999" y="44.2" z="1120.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L2TP0" x="69.095" y="44.2" z="1115.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L2TP0" x="88.145" y="44.2" z="1115.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L2TP0" x="78.61999999999999" y="74.17500000000001" z="1115.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L2TP0" x="78.61999999999999" y="14.225000000000003" z="1115.5" unit="mm" />
+      <position name="hodo_pos_L2BP0" x="78.61999999999999" y="-44.2" z="1115.5" unit="mm" />
+      <position name="hodo_forecover_pos_L2BP0" x="78.61999999999999" y="-44.2" z="1110.625" unit="mm" />
+      <position name="hodo_postcover_pos_L2BP0" x="78.61999999999999" y="-44.2" z="1120.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L2BP0" x="69.095" y="-44.2" z="1115.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L2BP0" x="88.145" y="-44.2" z="1115.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L2BP0" x="78.61999999999999" y="-14.225000000000003" z="1115.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L2BP0" x="78.61999999999999" y="-74.17500000000001" z="1115.5" unit="mm" />
+      <position name="hodo_pos_L2TP1" x="110.22" y="44.2" z="1115.5" unit="mm" />
+      <position name="hodo_forecover_pos_L2TP1" x="110.22" y="44.2" z="1110.625" unit="mm" />
+      <position name="hodo_postcover_pos_L2TP1" x="110.22" y="44.2" z="1120.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L2TP1" x="88.19500000000001" y="44.2" z="1115.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L2TP1" x="132.245" y="44.2" z="1115.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L2TP1" x="110.22" y="74.17500000000001" z="1115.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L2TP1" x="110.22" y="14.225000000000003" z="1115.5" unit="mm" />
+      <position name="hodo_pos_L2BP1" x="110.22" y="-44.2" z="1115.5" unit="mm" />
+      <position name="hodo_forecover_pos_L2BP1" x="110.22" y="-44.2" z="1110.625" unit="mm" />
+      <position name="hodo_postcover_pos_L2BP1" x="110.22" y="-44.2" z="1120.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L2BP1" x="88.19500000000001" y="-44.2" z="1115.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L2BP1" x="132.245" y="-44.2" z="1115.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L2BP1" x="110.22" y="-14.225000000000003" z="1115.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L2BP1" x="110.22" y="-74.17500000000001" z="1115.5" unit="mm" />
+      <position name="hodo_pos_L2TP2" x="154.32000000000002" y="44.2" z="1115.5" unit="mm" />
+      <position name="hodo_forecover_pos_L2TP2" x="154.32000000000002" y="44.2" z="1110.625" unit="mm" />
+      <position name="hodo_postcover_pos_L2TP2" x="154.32000000000002" y="44.2" z="1120.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L2TP2" x="132.29500000000002" y="44.2" z="1115.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L2TP2" x="176.34500000000003" y="44.2" z="1115.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L2TP2" x="154.32000000000002" y="74.17500000000001" z="1115.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L2TP2" x="154.32000000000002" y="14.225000000000003" z="1115.5" unit="mm" />
+      <position name="hodo_pos_L2BP2" x="154.32000000000002" y="-44.2" z="1115.5" unit="mm" />
+      <position name="hodo_forecover_pos_L2BP2" x="154.32000000000002" y="-44.2" z="1110.625" unit="mm" />
+      <position name="hodo_postcover_pos_L2BP2" x="154.32000000000002" y="-44.2" z="1120.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L2BP2" x="132.29500000000002" y="-44.2" z="1115.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L2BP2" x="176.34500000000003" y="-44.2" z="1115.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L2BP2" x="154.32000000000002" y="-14.225000000000003" z="1115.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L2BP2" x="154.32000000000002" y="-74.17500000000001" z="1115.5" unit="mm" />
+      <position name="hodo_pos_L2TP3" x="198.42000000000004" y="44.2" z="1115.5" unit="mm" />
+      <position name="hodo_forecover_pos_L2TP3" x="198.42000000000004" y="44.2" z="1110.625" unit="mm" />
+      <position name="hodo_postcover_pos_L2TP3" x="198.42000000000004" y="44.2" z="1120.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L2TP3" x="176.39500000000004" y="44.2" z="1115.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L2TP3" x="220.44500000000005" y="44.2" z="1115.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L2TP3" x="198.42000000000004" y="74.17500000000001" z="1115.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L2TP3" x="198.42000000000004" y="14.225000000000003" z="1115.5" unit="mm" />
+      <position name="hodo_pos_L2BP3" x="198.42000000000004" y="-44.2" z="1115.5" unit="mm" />
+      <position name="hodo_forecover_pos_L2BP3" x="198.42000000000004" y="-44.2" z="1110.625" unit="mm" />
+      <position name="hodo_postcover_pos_L2BP3" x="198.42000000000004" y="-44.2" z="1120.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L2BP3" x="176.39500000000004" y="-44.2" z="1115.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L2BP3" x="220.44500000000005" y="-44.2" z="1115.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L2BP3" x="198.42000000000004" y="-14.225000000000003" z="1115.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L2BP3" x="198.42000000000004" y="-74.17500000000001" z="1115.5" unit="mm" />
+      <position name="hodo_pos_L2TP4" x="235.92000000000002" y="44.2" z="1115.5" unit="mm" />
+      <position name="hodo_forecover_pos_L2TP4" x="235.92000000000002" y="44.2" z="1110.625" unit="mm" />
+      <position name="hodo_postcover_pos_L2TP4" x="235.92000000000002" y="44.2" z="1120.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L2TP4" x="220.495" y="44.2" z="1115.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L2TP4" x="251.34500000000003" y="44.2" z="1115.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L2TP4" x="235.92000000000002" y="74.17500000000001" z="1115.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L2TP4" x="235.92000000000002" y="14.225000000000003" z="1115.5" unit="mm" />
+      <position name="hodo_pos_L2BP4" x="235.92000000000002" y="-44.2" z="1115.5" unit="mm" />
+      <position name="hodo_forecover_pos_L2BP4" x="235.92000000000002" y="-44.2" z="1110.625" unit="mm" />
+      <position name="hodo_postcover_pos_L2BP4" x="235.92000000000002" y="-44.2" z="1120.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L2BP4" x="220.495" y="-44.2" z="1115.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L2BP4" x="251.34500000000003" y="-44.2" z="1115.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L2BP4" x="235.92000000000002" y="-14.225000000000003" z="1115.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L2BP4" x="235.92000000000002" y="-74.17500000000001" z="1115.5" unit="mm" />
+      <position name="hodo_bufferT_pos" x="153.99" y="54.2" z="1109.5" unit="mm" />
+      <position name="hodo_bufferB_pos" x="153.99" y="-54.2" z="1109.5" unit="mm" />
+      <position name="front_flange_1inworld_volumepos" x="2.1420000000000003" y="0" z="137.80000000000001" unit="cm" />
+      <position name="back_flange_1inworld_volumepos" x="-12.608499999999999" y="0" z="180.80000000000001" unit="cm" />
+      <position name="ECAL_chamber_1inworld_volumepos" x="-11.940800000000001" y="0" z="159.30000000000001" unit="cm" />
+      <position name="al_honeycomb_1inworld_volumepos" x="-18.858000000000001" y="0" z="155.80000000000001" unit="cm" />
+      <position name="layer_1_top_1inworld_volumepos" x="4.1920000000000002" y="8.0999999999999996" z="152.80000000000001" unit="cm" />
+      <position name="layer_2_top_1inworld_volumepos" x="4.1920000000000002" y="6.6899999999999995" z="152.80000000000001" unit="cm" />
+      <position name="layer_3_top_1inworld_volumepos" x="4.1920000000000002" y="5.2799999999999994" z="152.80000000000001" unit="cm" />
+      <position name="layer_4_top_1inworld_volumepos" x="4.1920000000000002" y="3.8699999999999992" z="152.80000000000001" unit="cm" />
+      <position name="layer_1_bottom_1inworld_volumepos" x="4.1920000000000002" y="-4.0999999999999996" z="152.80000000000001" unit="cm" />
+      <position name="layer_2_bottom_1inworld_volumepos" x="4.1920000000000002" y="-5.5099999999999998" z="152.80000000000001" unit="cm" />
+      <position name="layer_3_bottom_1inworld_volumepos" x="4.1920000000000002" y="-6.9199999999999999" z="152.80000000000001" unit="cm" />
+      <position name="layer_4_bottom_1inworld_volumepos" x="4.1920000000000002" y="-8.3300000000000001" z="152.80000000000001" unit="cm" />
+      <position name="layer_5T_left_1inworld_volumepos" x="4.1920000000000002" y="2.46" z="152.80000000000001" unit="cm" />
+      <position name="layer_5B_left_1inworld_volumepos" x="4.1920000000000002" y="-2.6899999999999995" z="152.80000000000001" unit="cm" />
+      <position name="steel_bar_1inworld_volumepos" x="-35.357999999999997" y="0.90000000000000002" z="152.80000000000001" unit="cm" />
+      <position name="cu_Tpipe_inner_left_1inworld_volumepos" x="1.6420000000000003" y="2.7000000000000002" z="152.80000000000001" unit="cm" />
+      <rotation name="cu_Tpipe_inner_left_1inworld_volumerot" x="0" y="-0.95599999999999996" z="0" unit="deg" />
+      <position name="cu_Tpipe_inner_right_1inworld_volumepos" x="-9.1580000000000013" y="2.7000000000000002" z="152.80000000000001" unit="cm" />
+      <rotation name="cu_Tpipe_inner_right_1inworld_volumerot" x="0" y="9.6799999999999997" z="0" unit="deg" />
+      <position name="cu_Bpipe_inner_left_1inworld_volumepos" x="1.6420000000000003" y="-2.7000000000000002" z="152.80000000000001" unit="cm" />
+      <rotation name="cu_Bpipe_inner_left_1inworld_volumerot" x="0" y="-0.95599999999999996" z="0" unit="deg" />
+      <position name="cu_Bpipe_inner_right_1inworld_volumepos" x="-9.1580000000000013" y="-2.7000000000000002" z="152.80000000000001" unit="cm" />
+      <rotation name="cu_Bpipe_inner_right_1inworld_volumerot" x="0" y="9.6799999999999997" z="0" unit="deg" />
+      <position name="cu_Tpipe_outer_right1_1inworld_volumepos" x="-10.858000000000001" y="1.3999999999999999" z="154.30000000000001" unit="cm" />
+      <rotation name="cu_Tpipe_outer_right1_1inworld_volumerot" x="0" y="10" z="0" unit="deg" />
+      <position name="cu_Tpipe_outer_right2_1inworld_volumepos" x="-27.858000000000001" y="1.3999999999999999" z="154.30000000000001" unit="cm" />
+      <position name="cu_Tpipe_outer_right3_1inworld_volumepos" x="-34.857999999999997" y="1.5" z="142.10000000000002" unit="cm" />
+      <rotation name="cu_Tpipe_outer_right3_1inworld_volumerot" x="-0" y="90" z="0" unit="deg" />
+      <position name="cu_Bpipe_outer_right_1inworld_volumepos" x="-34.857999999999997" y="-1.5" z="142.10000000000002" unit="cm" />
+      <rotation name="cu_Bpipe_outer_right_1inworld_volumerot" x="-0" y="90" z="0" unit="deg" />
+      <position name="cu_Bpipe_outer_right1_1inworld_volumepos" x="-10.858000000000001" y="-1.3999999999999999" z="154.30000000000001" unit="cm" />
+      <rotation name="cu_Bpipe_outer_right1_1inworld_volumerot" x="0" y="10" z="0" unit="deg" />
+      <position name="cu_Bpipe_outer_right2_1inworld_volumepos" x="-27.858000000000001" y="-1.3999999999999999" z="154.30000000000001" unit="cm" />
+      <position name="al_pipe_across_top1_1inworld_volumepos" x="2.1420000000000003" y="9" z="142.10000000000002" unit="cm" />
+      <rotation name="al_pipe_across_top1_1inworld_volumerot" x="-90" y="86.999999999999957" z="180" unit="deg" />
+      <position name="al_pipe_across_top2_1inworld_volumepos" x="2.1420000000000003" y="4" z="142.10000000000002" unit="cm" />
+      <rotation name="al_pipe_across_top2_1inworld_volumerot" x="-90" y="89.000000000000099" z="180" unit="deg" />
+      <position name="al_pipe_across_bottom1_1inworld_volumepos" x="2.1420000000000003" y="-9" z="142.10000000000002" unit="cm" />
+      <rotation name="al_pipe_across_bottom1_1inworld_volumerot" x="90" y="86.999999999999957" z="0" unit="deg" />
+      <position name="al_pipe_across_bottom2_1inworld_volumepos" x="2.1420000000000003" y="-4" z="142.10000000000002" unit="cm" />
+      <rotation name="al_pipe_across_bottom2_1inworld_volumerot" x="90" y="89.000000000000099" z="0" unit="deg" />
+      <position name="cu_plate_top_left_1inworld_volumepos" x="22.141999999999999" y="1.6000000000000001" z="152.80000000000001" unit="cm" />
+      <position name="cu_plate_bottom_left_1inworld_volumepos" x="22.141999999999999" y="-1.6000000000000001" z="152.80000000000001" unit="cm" />
+      <position name="cu_plate_top_right_1inworld_volumepos" x="-20.858000000000001" y="1.6000000000000001" z="152.80000000000001" unit="cm" />
+      <position name="cu_plate_bottom_right_1inworld_volumepos" x="-20.858000000000001" y="-1.6000000000000001" z="152.80000000000001" unit="cm" />
+      <position name="cu_plate_top_middle_1inworld_volumepos" x="-3.3579999999999997" y="3.1000000000000001" z="152.80000000000001" unit="cm" />
+      <position name="cu_plate_bottom_middle_1inworld_volumepos" x="-3.3579999999999997" y="-3.1000000000000001" z="152.80000000000001" unit="cm" />
+      <position name="hodo_flange_1intracking_volumepos" x="2.1170000000000004" y="0" z="134.30000000000001" unit="cm" />
+      <position name="arms1_block1_1intracking_volumepos" x="21.517000000000003" y="14.938225000000001" z="132.70000000000002" unit="cm" />
+      <position name="arms1_block2_1intracking_volumepos" x="9.5170000000000012" y="14.938225000000001" z="132.70000000000002" unit="cm" />
+      <position name="arms1_block3_1intracking_volumepos" x="21.517000000000003" y="-14.938225000000001" z="132.70000000000002" unit="cm" />
+      <position name="arms1_block4_1intracking_volumepos" x="9.5170000000000012" y="-14.938225000000001" z="132.70000000000002" unit="cm" />
+      <position name="cross_bar_top_1intracking_volumepos" x="15.517000000000003" y="16.34" z="132.70000000000002" unit="cm" />
+      <position name="cross_bar_bottom_1intracking_volumepos" x="15.517000000000003" y="-16.34" z="132.70000000000002" unit="cm" />
+      <position name="support_arm_bottom_left_plus_block_1intracking_volumepos" x="21.517000000000003" y="-12.771562277258594" z="121.10000000000001" unit="cm" />
+      <position name="support_arm_bottom_right_1intracking_volumepos" x="9.5170000000000012" y="-12.771562277258594" z="121.10000000000001" unit="cm" />
+      <position name="support_arm_top_left_1intracking_volumepos" x="21.517000000000003" y="12.771562277258594" z="121.10000000000001" unit="cm" />
+      <rotation name="support_arm_top_left_1intracking_volumerot" x="0" y="-0" z="180" unit="deg" />
+      <position name="support_arm_top_right_1intracking_volumepos" x="9.5170000000000012" y="12.771562277258594" z="121.10000000000001" unit="cm" />
+      <rotation name="support_arm_top_right_1intracking_volumerot" x="0" y="-0" z="180" unit="deg" />
+      <position name="u_support_bar_bottom_1intracking_volumepos" x="15.517000000000003" y="-9.8400000000000034" z="110.899" unit="cm" />
+      <position name="u_support_bar_upper1_1intracking_volumepos" x="15.517000000000003" y="-8.5400000000000027" z="110.65000000000001" unit="cm" />
+      <position name="u_support_bar_upper2_1intracking_volumepos" x="15.517000000000003" y="-8.5400000000000027" z="111.2" unit="cm" />
+      <position name="u_support_bar_top_1intracking_volumepos" x="15.517000000000003" y="9.8400000000000034" z="110.899" unit="cm" />
+      <position name="u_support_bar_upper3_1intracking_volumepos" x="15.517000000000003" y="8.5400000000000027" z="110.65000000000001" unit="cm" />
+      <position name="u_support_bar_upper4_1intracking_volumepos" x="15.517000000000003" y="8.5400000000000027" z="111.2" unit="cm" />
+      <constant name="svt_chamber_box_z" value="609.6" />
+      <constant name="svt_chamber_flare1_z" value="1285.621" />
+      <constant name="svt_chamber_flare2_z" value="1478.407" />
+      <constant name="svt_chamber_flange_z" value="1614.297" />
+      <constant name="svt_chamber_x" value="21.17" />
+      <constant name="svt_chamber_z" value="1318-1623.822" />
+    </define>
+    <materials>
+      <element Z="1" formula="H" name="H">
+        <atom type="A" unit="g/mol" value="1.00794" />
+      </element>
+      <element Z="82" formula="Pb" name="Pb">
+        <atom type="A" unit="g/mol" value="207.217" />
+      </element>
+      <element Z="74" formula="W" name="W">
+        <atom type="A" unit="g/mol" value="183.842" />
+      </element>
+      <element Z="8" formula="O" name="O">
+        <atom type="A" unit="g/mol" value="15.9994" />
+      </element>
+      <element Z="6" formula="C" name="C">
+        <atom type="A" unit="g/mol" value="12.0107" />
+      </element>
+      <element Z="22" formula="Ti" name="Ti">
+        <atom type="A" unit="g/mol" value="47.8667" />
+      </element>
+      <material name="Vacuum">
+        <D type="density" unit="g/cm3" value="0.00000001" />
+        <fraction n="1" ref="H" />
+      </material>
+      <material name="WorldMaterial">
+        <D type="density" unit="g/cm3" value="0.0000000000000001" />
+        <fraction n="1.0" ref="Vacuum" />
+      </material>
+      <material name="TrackingMaterial">
+        <D type="density" unit="g/cm3" value="0.0000000000000001" />
+        <fraction n="1.0" ref="Vacuum" />
+      </material>
+      <material name="LeadTungstate">
+        <D value="8.28" unit="g/cm3" type="density" />
+        <composite n="1" ref="Pb" />
+        <composite n="1" ref="W" />
+        <composite n="4" ref="O" />
+      </material>
+      <material name="EJ204_PlasticScintillator">
+        <D value="1.032" unit="g/cm3" type="density" />
+        <fraction n="0.523618" ref="H" />
+        <fraction n="0.476382" ref="C" />
+      </material>
+      <material name="TitaniumDioxide">
+        <D value="4.23" unit="g/cm3" type="density" />
+        <composite n="1" ref="Ti" />
+        <composite n="2" ref="O" />
+      </material>
+      <material name="Mylar">
+        <D value="1.4" unit="g/cm3" type="density" />
+        <fraction n="0.041958" ref="H" />
+        <fraction n="0.625017" ref="C" />
+        <fraction n="0.333025" ref="O" />
+      </material>
+      <material name="GenericFoam">
+        <D value="0.052" unit="g/cm3" type="density" />
+        <fraction n="0.5" ref="H" />
+        <fraction n="0.5" ref="C" />
+      </material>
+      <element name="Al" formula="Al" Z="13">
+        <atom type="A" unit="g/mol" value="26.9815" />
+      </element>
+      <material name="Aluminum">
+        <RL type="X0" unit="cm" value="8.89632" />
+        <NIL type="lambda" unit="cm" value="38.8766" />
+        <D type="density" unit="g/cm3" value="2.699" />
+        <composite n="1" ref="Al" />
+      </material>
+      <element name="Si" formula="Si" Z="14">
+        <atom type="A" unit="g/mol" value="28.0854" />
+      </element>
+      <material name="Silicon">
+        <RL type="X0" unit="cm" value="9.36607" />
+        <NIL type="lambda" unit="cm" value="45.7531" />
+        <D type="density" unit="g/cm3" value="2.33" />
+        <composite n="1" ref="Si" />
+      </material>
+      <element name="N" formula="N" Z="7">
+        <atom type="A" unit="g/mol" value="14.0068" />
+      </element>
+      <material name="Kapton">
+        <D value="1.43" unit="g/cm3" />
+        <composite n="22" ref="C" />
+        <composite n="10" ref="H" />
+        <composite n="2" ref="N" />
+        <composite n="5" ref="O" />
+      </material>
+      <material name="Epoxy">
+        <D type="density" value="1.3" unit="g/cm3" />
+        <composite n="44" ref="H" />
+        <composite n="15" ref="C" />
+        <composite n="7" ref="O" />
+      </material>
+      <material name="CarbonFiber">
+        <D type="density" value="1.5" unit="g/cm3" />
+        <fraction n="0.65" ref="C" />
+        <fraction n="0.35" ref="Epoxy" />
+      </material>
+      <element name="Cl" formula="Cl" Z="17">
+        <atom type="A" unit="g/mol" value="35.4526" />
+      </element>
+      <material name="Quartz">
+        <D type="density" value="2.2" unit="g/cm3" />
+        <composite n="1" ref="Si" />
+        <composite n="2" ref="O" />
+      </material>
+      <material name="G10">
+        <D type="density" value="1.7" unit="g/cm3" />
+        <fraction n="0.08" ref="Cl" />
+        <fraction n="0.773" ref="Quartz" />
+        <fraction n="0.147" ref="Epoxy" />
+      </material>
+      <material name="Polystyrene">
+        <D value="1.032" unit="g/cm3" />
+        <composite n="19" ref="C" />
+        <composite n="21" ref="H" />
+      </material>
+      <material name="Carbon">
+        <RL type="X0" unit="cm" value="21.3485" />
+        <NIL type="lambda" unit="cm" value="40.1008" />
+        <D type="density" unit="g/cm3" value="2" />
+        <composite n="1" ref="C" />
+      </material>
+      <material name="G4_Al" Z="13">
+        <D unit="g/cm3" value="2.6989999999999998" />
+        <atom unit="g/mole" value="26.981538" />
+      </material>
+      <material name="AlHoneycomb" Z="13">
+        <D unit="g/cm3" value="0.13" />
+        <atom unit="g/mole" value="26.981538" />
+      </material>
+      <element name="MANGANESE_elm" formula="MN" Z="25">
+        <atom unit="g/mole" value="54.938048999999999" />
+      </element>
+      <element name="SILICON_elm" formula="SI" Z="14">
+        <atom unit="g/mole" value="28.0855" />
+      </element>
+      <element name="CHROMIUM_elm" formula="CR" Z="24">
+        <atom unit="g/mole" value="51.996099999999998" />
+      </element>
+      <element name="NICKEL_elm" formula="NI" Z="28">
+        <atom unit="g/mole" value="58.693399999999997" />
+      </element>
+      <element name="IRON_elm" formula="FE" Z="26">
+        <atom unit="g/mole" value="55.844999999999999" />
+      </element>
+      <material name="StainlessSteel">
+        <D unit="g/cm3" value="8.0199999999999996" />
+        <fraction n="0.18999999761581421" ref="CHROMIUM_elm" />
+        <fraction n="0.68000000715255737" ref="IRON_elm" />
+        <fraction n="0.019999999552965164" ref="MANGANESE_elm" />
+        <fraction n="0.10000000149011612" ref="NICKEL_elm" />
+        <fraction n="0.0099999997764825821" ref="SILICON_elm" />
+      </material>
+      <material name="G4_Cu" Z="29">
+        <D unit="g/cm3" value="8.9600000000000009" />
+        <atom unit="g/mole" value="63.545645059999998" />
+      </material>
+      <element name="OXYGEN_elm" formula="O" Z="8">
+        <atom unit="g/mole" value="15.9994" />
+      </element>
+      <element name="CARBON_elm" formula="C" Z="6">
+        <atom unit="g/mole" value="12.0107" />
+      </element>
+      <element name="HYDROGEN_elm" formula="H" Z="1">
+        <atom unit="g/mole" value="1.0079400000000001" />
+      </element>
+      <material name="G10_FR4">
+        <D unit="g/cm3" value="1.8500000000000001" />
+        <fraction n="0.40416482090950012" ref="CARBON_elm" />
+        <fraction n="0.067835167050361633" ref="HYDROGEN_elm" />
+        <fraction n="0.28119435906410217" ref="OXYGEN_elm" />
+        <fraction n="0.24680563807487488" ref="SILICON_elm" />
+      </material>
+      <material name="SiO2">
+        <D unit="g/cm3" value="2.2000000000000002" />
+        <fraction n="0.53256505727767944" ref="OXYGEN_elm" />
+        <fraction n="0.46743491291999817" ref="SILICON_elm" />
+      </material>
+      <element Z="26" formula="Fe" name="Iron">
+        <atom value="55.845" />
+      </element>
+      <element Z="24" formula="Cr" name="Chromium">
+        <atom value="51.9961" />
+      </element>
+      <element Z="28" formula="Ni" name="Nickel">
+        <atom value="58.6934" />
+      </element>
+      <material formula=" " name="Stainless_304">
+        <D value="8.00" />
+        <fraction n="0.733078" ref="Iron" />
+        <fraction n="0.191516" ref="Chromium" />
+        <fraction n="0.075406" ref="Nickel" />
+      </material>
+      <material Z="1" name="G4_Galactic" state="gas">
+        <T unit="K" value="2.73" />
+        <P unit="pascal" value="3e-18" />
+        <!-- <MEE unit="eV" value="21.8"/> -->
+        <D unit="g/cm3" value="2e-25" />
+        <atom unit="g/mole" value="1.01" />
+      </material>
+    </materials>
+    <solids>
+      <box name="world_box" x="world_x" y="world_y" z="world_z" />
+      <tube name="tracking_cylinder" deltaphi="6.283185307179586" rmin="0.0" rmax="tracking_region_radius" z="2*tracking_region_zmax" />
+      <box name="baseBox" x="406.4" y="1282.6999999999998" z="171.196" />
+      <box name="base_plateBox" x="406.4" y="1282.6999999999998" z="6.35" />
+      <box name="support_plate_bottom_L14Box" x="234.95" y="456.4" z="9.524999999999999" />
+      <box name="support_plate_top_L14Box" x="234.95" y="456.4" z="9.524999999999999" />
+      <box name="support_plate_bottom_L46Box" x="342.9" y="533.4" z="12.7" />
+      <box name="support_plate_top_L46Box" x="342.9" y="533.4" z="12.7" />
+      <box name="module_L1b_halfmodule_axialBox" x="14.525" y="30.0" z="0.2" />
+      <box name="module_L1b_halfmodule_axial_sensorBox" x="14.525" y="30.0" z="0.2" />
+      <box name="module_L1b_halfmodule_axial_sensor_activeBox" x="14.025" y="30.0" z="0.2" />
+      <box name="module_L1b_halfmodule_stereoBox" x="14.525" y="30.0" z="0.2" />
+      <box name="module_L1b_halfmodule_stereo_sensorBox" x="14.525" y="30.0" z="0.2" />
+      <box name="module_L1b_halfmodule_stereo_sensor_activeBox" x="14.025" y="30.0" z="0.2" />
+      <box name="module_L1t_halfmodule_axialBox" x="14.525" y="30.0" z="0.2" />
+      <box name="module_L1t_halfmodule_axial_sensorBox" x="14.525" y="30.0" z="0.2" />
+      <box name="module_L1t_halfmodule_axial_sensor_activeBox" x="14.025" y="30.0" z="0.2" />
+      <box name="module_L1t_halfmodule_stereoBox" x="14.525" y="30.0" z="0.2" />
+      <box name="module_L1t_halfmodule_stereo_sensorBox" x="14.525" y="30.0" z="0.2" />
+      <box name="module_L1t_halfmodule_stereo_sensor_activeBox" x="14.025" y="30.0" z="0.2" />
+      <box name="module_L2b_halfmodule_axialBox" x="14.525" y="30.0" z="0.2" />
+      <box name="module_L2b_halfmodule_axial_sensorBox" x="14.525" y="30.0" z="0.2" />
+      <box name="module_L2b_halfmodule_axial_sensor_activeBox" x="14.025" y="30.0" z="0.2" />
+      <box name="module_L2b_halfmodule_stereoBox" x="14.525" y="30.0" z="0.2" />
+      <box name="module_L2b_halfmodule_stereo_sensorBox" x="14.525" y="30.0" z="0.2" />
+      <box name="module_L2b_halfmodule_stereo_sensor_activeBox" x="14.025" y="30.0" z="0.2" />
+      <box name="module_L2t_halfmodule_axialBox" x="14.525" y="30.0" z="0.2" />
+      <box name="module_L2t_halfmodule_axial_sensorBox" x="14.525" y="30.0" z="0.2" />
+      <box name="module_L2t_halfmodule_axial_sensor_activeBox" x="14.025" y="30.0" z="0.2" />
+      <box name="module_L2t_halfmodule_stereoBox" x="14.525" y="30.0" z="0.2" />
+      <box name="module_L2t_halfmodule_stereo_sensorBox" x="14.525" y="30.0" z="0.2" />
+      <box name="module_L2t_halfmodule_stereo_sensor_activeBox" x="14.025" y="30.0" z="0.2" />
+      <box name="module_L3b_halfmodule_axialBox" x="47.17" y="200.0" z="1.8405" />
+      <box name="module_L3b_halfmodule_axial_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L3b_halfmodule_axial_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L3b_halfmodule_axial_laminationBox" x="38.0" y="100.0" z="0.05" />
+      <box name="module_L3b_halfmodule_axial_cfBox" x="36.02" y="100.0" z="0.203" />
+      <box name="module_L3b_halfmodule_axial_hybridBox" x="40.34" y="70.0" z="1.5875" />
+      <box name="module_L3b_halfmodule_stereoBox" x="47.17" y="200.0" z="1.8405" />
+      <box name="module_L3b_halfmodule_stereo_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L3b_halfmodule_stereo_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L3b_halfmodule_stereo_laminationBox" x="38.0" y="100.0" z="0.05" />
+      <box name="module_L3b_halfmodule_stereo_cfBox" x="36.02" y="100.0" z="0.203" />
+      <box name="module_L3b_halfmodule_stereo_hybridBox" x="40.34" y="70.0" z="1.5875" />
+      <box name="module_L3t_halfmodule_axialBox" x="47.17" y="200.0" z="1.8405" />
+      <box name="module_L3t_halfmodule_axial_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L3t_halfmodule_axial_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L3t_halfmodule_axial_laminationBox" x="38.0" y="100.0" z="0.05" />
+      <box name="module_L3t_halfmodule_axial_cfBox" x="36.02" y="100.0" z="0.203" />
+      <box name="module_L3t_halfmodule_axial_hybridBox" x="40.34" y="70.0" z="1.5875" />
+      <box name="module_L3t_halfmodule_stereoBox" x="47.17" y="200.0" z="1.8405" />
+      <box name="module_L3t_halfmodule_stereo_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L3t_halfmodule_stereo_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L3t_halfmodule_stereo_laminationBox" x="38.0" y="100.0" z="0.05" />
+      <box name="module_L3t_halfmodule_stereo_cfBox" x="36.02" y="100.0" z="0.203" />
+      <box name="module_L3t_halfmodule_stereo_hybridBox" x="40.34" y="70.0" z="1.5875" />
+      <box name="module_L4b_halfmodule_axialBox" x="47.17" y="200.0" z="1.8405" />
+      <box name="module_L4b_halfmodule_axial_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L4b_halfmodule_axial_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L4b_halfmodule_axial_laminationBox" x="38.0" y="100.0" z="0.05" />
+      <box name="module_L4b_halfmodule_axial_cfBox" x="36.02" y="100.0" z="0.203" />
+      <box name="module_L4b_halfmodule_axial_hybridBox" x="40.34" y="70.0" z="1.5875" />
+      <box name="module_L4b_halfmodule_stereoBox" x="47.17" y="200.0" z="1.8405" />
+      <box name="module_L4b_halfmodule_stereo_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L4b_halfmodule_stereo_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L4b_halfmodule_stereo_laminationBox" x="38.0" y="100.0" z="0.05" />
+      <box name="module_L4b_halfmodule_stereo_cfBox" x="36.02" y="100.0" z="0.203" />
+      <box name="module_L4b_halfmodule_stereo_hybridBox" x="40.34" y="70.0" z="1.5875" />
+      <box name="module_L4t_halfmodule_axialBox" x="47.17" y="200.0" z="1.8405" />
+      <box name="module_L4t_halfmodule_axial_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L4t_halfmodule_axial_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L4t_halfmodule_axial_laminationBox" x="38.0" y="100.0" z="0.05" />
+      <box name="module_L4t_halfmodule_axial_cfBox" x="36.02" y="100.0" z="0.203" />
+      <box name="module_L4t_halfmodule_axial_hybridBox" x="40.34" y="70.0" z="1.5875" />
+      <box name="module_L4t_halfmodule_stereoBox" x="47.17" y="200.0" z="1.8405" />
+      <box name="module_L4t_halfmodule_stereo_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L4t_halfmodule_stereo_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L4t_halfmodule_stereo_laminationBox" x="38.0" y="100.0" z="0.05" />
+      <box name="module_L4t_halfmodule_stereo_cfBox" x="36.02" y="100.0" z="0.203" />
+      <box name="module_L4t_halfmodule_stereo_hybridBox" x="40.34" y="70.0" z="1.5875" />
+      <box name="module_L5b_halfmodule_axial_holeBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L5b_halfmodule_axial_hole_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L5b_halfmodule_axial_hole_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L5b_halfmodule_axial_hole_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L5b_halfmodule_axial_slotBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L5b_halfmodule_axial_slot_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L5b_halfmodule_axial_slot_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L5b_halfmodule_axial_slot_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L5b_halfmodule_stereo_holeBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L5b_halfmodule_stereo_hole_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L5b_halfmodule_stereo_hole_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L5b_halfmodule_stereo_hole_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L5b_halfmodule_stereo_slotBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L5b_halfmodule_stereo_slot_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L5b_halfmodule_stereo_slot_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L5b_halfmodule_stereo_slot_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L5t_halfmodule_axial_holeBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L5t_halfmodule_axial_hole_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L5t_halfmodule_axial_hole_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L5t_halfmodule_axial_hole_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L5t_halfmodule_axial_slotBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L5t_halfmodule_axial_slot_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L5t_halfmodule_axial_slot_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L5t_halfmodule_axial_slot_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L5t_halfmodule_stereo_holeBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L5t_halfmodule_stereo_hole_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L5t_halfmodule_stereo_hole_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L5t_halfmodule_stereo_hole_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L5t_halfmodule_stereo_slotBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L5t_halfmodule_stereo_slot_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L5t_halfmodule_stereo_slot_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L5t_halfmodule_stereo_slot_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L6b_halfmodule_axial_holeBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L6b_halfmodule_axial_hole_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L6b_halfmodule_axial_hole_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L6b_halfmodule_axial_hole_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L6b_halfmodule_axial_slotBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L6b_halfmodule_axial_slot_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L6b_halfmodule_axial_slot_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L6b_halfmodule_axial_slot_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L6b_halfmodule_stereo_holeBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L6b_halfmodule_stereo_hole_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L6b_halfmodule_stereo_hole_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L6b_halfmodule_stereo_hole_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L6b_halfmodule_stereo_slotBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L6b_halfmodule_stereo_slot_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L6b_halfmodule_stereo_slot_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L6b_halfmodule_stereo_slot_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L6t_halfmodule_axial_holeBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L6t_halfmodule_axial_hole_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L6t_halfmodule_axial_hole_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L6t_halfmodule_axial_hole_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L6t_halfmodule_axial_slotBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L6t_halfmodule_axial_slot_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L6t_halfmodule_axial_slot_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L6t_halfmodule_axial_slot_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L6t_halfmodule_stereo_holeBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L6t_halfmodule_stereo_hole_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L6t_halfmodule_stereo_hole_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L6t_halfmodule_stereo_hole_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L6t_halfmodule_stereo_slotBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L6t_halfmodule_stereo_slot_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L6t_halfmodule_stereo_slot_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L6t_halfmodule_stereo_slot_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L7b_halfmodule_axial_holeBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L7b_halfmodule_axial_hole_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L7b_halfmodule_axial_hole_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L7b_halfmodule_axial_hole_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L7b_halfmodule_axial_slotBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L7b_halfmodule_axial_slot_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L7b_halfmodule_axial_slot_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L7b_halfmodule_axial_slot_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L7b_halfmodule_stereo_holeBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L7b_halfmodule_stereo_hole_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L7b_halfmodule_stereo_hole_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L7b_halfmodule_stereo_hole_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L7b_halfmodule_stereo_slotBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L7b_halfmodule_stereo_slot_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L7b_halfmodule_stereo_slot_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L7b_halfmodule_stereo_slot_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L7t_halfmodule_axial_holeBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L7t_halfmodule_axial_hole_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L7t_halfmodule_axial_hole_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L7t_halfmodule_axial_hole_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L7t_halfmodule_axial_slotBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L7t_halfmodule_axial_slot_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L7t_halfmodule_axial_slot_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L7t_halfmodule_axial_slot_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L7t_halfmodule_stereo_holeBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L7t_halfmodule_stereo_hole_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L7t_halfmodule_stereo_hole_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L7t_halfmodule_stereo_hole_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L7t_halfmodule_stereo_slotBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L7t_halfmodule_stereo_slot_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L7t_halfmodule_stereo_slot_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L7t_halfmodule_stereo_slot_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="BeamLeftBox" x="211.6" y="382.492" z="0.001" />
+      <box name="BeamLeftVolume_component0Box" x="211.6" y="382.492" z="0.001" />
+      <box name="BeamLeftVolume_component0Sensor0Box" x="211.6" y="382.492" z="0.001" />
+      <box name="ElectronGapBox" x="196.26999999999998" y="92.46999999999997" z="0.001" />
+      <box name="ElectronGapVolume_component0Box" x="196.26999999999998" y="92.46999999999997" z="0.001" />
+      <box name="ElectronGapVolume_component0Sensor0Box" x="196.26999999999998" y="92.46999999999997" z="0.001" />
+      <box name="BeamRightBox" x="214.6" y="293.38800000000003" z="0.001" />
+      <box name="BeamRightVolume_component0Box" x="214.6" y="293.38800000000003" z="0.001" />
+      <box name="BeamRightVolume_component0Sensor0Box" x="214.6" y="293.38800000000003" z="0.001" />
+      <trd name="crystal_trap" x1="13.3" x2="16.0" y1="13.3" y2="16.0" z="160.0" />
+      <box name="hodo_pixel_L1TP0" x="15.7" y="59.9" z="9.5" />
+      <box name="hodo_cover_L1TP0" x="15.7" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L1TP0" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L1TP0" x="15.799999999999999" y="0.05" z="10.0" />
+      <box name="hodo_pixel_L1BP0" x="15.7" y="59.9" z="9.5" />
+      <box name="hodo_cover_L1BP0" x="15.7" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L1BP0" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L1BP0" x="15.799999999999999" y="0.05" z="10.0" />
+      <box name="hodo_pixel_L1TP1" x="34.1" y="59.9" z="9.5" />
+      <box name="hodo_cover_L1TP1" x="34.1" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L1TP1" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L1TP1" x="34.2" y="0.05" z="10.0" />
+      <box name="hodo_pixel_L1BP1" x="34.1" y="59.9" z="9.5" />
+      <box name="hodo_cover_L1BP1" x="34.1" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L1BP1" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L1BP1" x="34.2" y="0.05" z="10.0" />
+      <box name="hodo_pixel_L1TP2" x="44.0" y="59.9" z="9.5" />
+      <box name="hodo_cover_L1TP2" x="44.0" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L1TP2" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L1TP2" x="44.1" y="0.05" z="10.0" />
+      <box name="hodo_pixel_L1BP2" x="44.0" y="59.9" z="9.5" />
+      <box name="hodo_cover_L1BP2" x="44.0" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L1BP2" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L1BP2" x="44.1" y="0.05" z="10.0" />
+      <box name="hodo_pixel_L1TP3" x="44.0" y="59.9" z="9.5" />
+      <box name="hodo_cover_L1TP3" x="44.0" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L1TP3" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L1TP3" x="44.1" y="0.05" z="10.0" />
+      <box name="hodo_pixel_L1BP3" x="44.0" y="59.9" z="9.5" />
+      <box name="hodo_cover_L1BP3" x="44.0" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L1BP3" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L1BP3" x="44.1" y="0.05" z="10.0" />
+      <box name="hodo_pixel_L1TP4" x="44.0" y="59.9" z="9.5" />
+      <box name="hodo_cover_L1TP4" x="44.0" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L1TP4" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L1TP4" x="44.1" y="0.05" z="10.0" />
+      <box name="hodo_pixel_L1BP4" x="44.0" y="59.9" z="9.5" />
+      <box name="hodo_cover_L1BP4" x="44.0" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L1BP4" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L1BP4" x="44.1" y="0.05" z="10.0" />
+      <box name="hodo_pixel_L2TP0" x="19.0" y="59.9" z="9.5" />
+      <box name="hodo_cover_L2TP0" x="19.0" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L2TP0" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L2TP0" x="19.1" y="0.05" z="10.0" />
+      <box name="hodo_pixel_L2BP0" x="19.0" y="59.9" z="9.5" />
+      <box name="hodo_cover_L2BP0" x="19.0" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L2BP0" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L2BP0" x="19.1" y="0.05" z="10.0" />
+      <box name="hodo_pixel_L2TP1" x="44.0" y="59.9" z="9.5" />
+      <box name="hodo_cover_L2TP1" x="44.0" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L2TP1" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L2TP1" x="44.1" y="0.05" z="10.0" />
+      <box name="hodo_pixel_L2BP1" x="44.0" y="59.9" z="9.5" />
+      <box name="hodo_cover_L2BP1" x="44.0" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L2BP1" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L2BP1" x="44.1" y="0.05" z="10.0" />
+      <box name="hodo_pixel_L2TP2" x="44.0" y="59.9" z="9.5" />
+      <box name="hodo_cover_L2TP2" x="44.0" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L2TP2" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L2TP2" x="44.1" y="0.05" z="10.0" />
+      <box name="hodo_pixel_L2BP2" x="44.0" y="59.9" z="9.5" />
+      <box name="hodo_cover_L2BP2" x="44.0" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L2BP2" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L2BP2" x="44.1" y="0.05" z="10.0" />
+      <box name="hodo_pixel_L2TP3" x="44.0" y="59.9" z="9.5" />
+      <box name="hodo_cover_L2TP3" x="44.0" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L2TP3" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L2TP3" x="44.1" y="0.05" z="10.0" />
+      <box name="hodo_pixel_L2BP3" x="44.0" y="59.9" z="9.5" />
+      <box name="hodo_cover_L2BP3" x="44.0" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L2BP3" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L2BP3" x="44.1" y="0.05" z="10.0" />
+      <box name="hodo_pixel_L2TP4" x="30.8" y="59.9" z="9.5" />
+      <box name="hodo_cover_L2TP4" x="30.8" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L2TP4" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L2TP4" x="30.900000000000002" y="0.05" z="10.0" />
+      <box name="hodo_pixel_L2BP4" x="30.8" y="59.9" z="9.5" />
+      <box name="hodo_cover_L2BP4" x="30.8" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L2BP4" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L2BP4" x="30.900000000000002" y="0.05" z="10.0" />
+      <box name="hodo_buffer" x="187.64" y="80.0" z="2.0" />
+      <box name="world_volume_solid" x="2000" y="2000" z="2000" lunit="cm" />
+      <box name="front_flange_box_shape" x="76.835000000000008" y="45.719999999999999" z="2" lunit="cm" />
+      <trap name="front_chamber_trap_shape" z="3" theta="-0.98799999999999999" phi="0" x1="33.119799999999998" x2="33.119799999999998" x3="33.406400000000005" x4="33.406400000000005" y1="1.6000000000000001" y2="1.6000000000000001" alpha1="0" alpha2="0" aunit="deg" lunit="cm" />
+      <subtraction name="front_minus_chamber_shape">
+        <first ref="front_flange_box_shape" />
+        <second ref="front_chamber_trap_shape" />
+        <position name="front_minus_chamber_shapefront_chamber_trap_shapepos" x="-14.6309" y="0" z="0" unit="cm" />
+      </subtraction>
+      <eltube name="flange_photontube_inside_shape" dx="1.1000000000000001" dy="1.1000000000000001" dz="3" lunit="cm" />
+      <subtraction name="front_minus_photontube_shape">
+        <first ref="front_minus_chamber_shape" />
+        <second ref="flange_photontube_inside_shape" />
+        <position name="front_minus_photontube_shapeflange_photontube_inside_shapepos" x="2.0007000000000001" y="0" z="0" unit="cm" />
+        <rotation name="front_minus_photontube_shapeflange_photontube_inside_shaperot" x="0" y="1.7480000000000002" z="0" unit="deg" />
+      </subtraction>
+      <trap name="front_egap_trap_shape" z="3" theta="-4.7960000000000003" phi="0" x1="2.5683000000000002" x2="2.5683000000000002" x3="2.9716000000000005" x4="2.9716000000000005" y1="5.266" y2="5.266" alpha1="0" alpha2="0" aunit="deg" lunit="cm" />
+      <subtraction name="front_minus_egap_shape">
+        <first ref="front_minus_photontube_shape" />
+        <second ref="front_egap_trap_shape" />
+        <position name="front_minus_egap_shapefront_egap_trap_shapepos" x="-4.4683000000000002" y="0" z="0" unit="cm" />
+      </subtraction>
+      <eltube name="flange_egap_inside_tube_shape" dx="2.633" dy="2.633" dz="3" lunit="cm" />
+      <subtraction name="front_minus_egapleft_shape">
+        <first ref="front_minus_egap_shape" />
+        <second ref="flange_egap_inside_tube_shape" />
+        <position name="front_minus_egapleft_shapeflange_egap_inside_tube_shapepos" x="-3.0832999999999999" y="0" z="0" unit="cm" />
+        <rotation name="front_minus_egapleft_shapeflange_egap_inside_tube_shaperot" x="0" y="-0.95599999999999996" z="0" unit="deg" />
+      </subtraction>
+      <eltube name="flange_egap_inside_tube2_shape" dx="2.633" dy="2.633" dz="3" lunit="cm" />
+      <subtraction name="front_flange_shape">
+        <first ref="front_minus_egapleft_shape" />
+        <second ref="flange_egap_inside_tube2_shape" />
+        <position name="front_flange_shapeflange_egap_inside_tube2_shapepos" x="-5.8532000000000002" y="0" z="0" unit="cm" />
+        <rotation name="front_flange_shapeflange_egap_inside_tube2_shaperot" x="0" y="-8.5939999999999994" z="0" unit="deg" />
+      </subtraction>
+      <box name="back_flange_box_shape" x="50.5" y="16" z="2" lunit="cm" />
+      <trap name="back_chamber_trap_shape" z="3" theta="-0.98799999999999999" phi="0" x1="37.227899999999998" x2="37.227899999999998" x3="37.514499999999998" x4="37.514499999999998" y1="1.6000000000000001" y2="1.6000000000000001" alpha1="0" alpha2="0" aunit="deg" lunit="cm" />
+      <subtraction name="back_minus_chamber_shape">
+        <first ref="back_flange_box_shape" />
+        <second ref="back_chamber_trap_shape" />
+        <position name="back_minus_chamber_shapeback_chamber_trap_shapepos" x="-0.62210000000000043" y="0" z="0" unit="cm" />
+      </subtraction>
+      <eltube name="flange_photontube_inside2_shape" dx="1.1000000000000001" dy="1.1000000000000001" dz="3" lunit="cm" />
+      <subtraction name="back_minus_photontube_shape">
+        <first ref="back_minus_chamber_shape" />
+        <second ref="flange_photontube_inside2_shape" />
+        <position name="back_minus_photontube_shapeflange_photontube_inside2_shapepos" x="18.063500000000001" y="0" z="0" unit="cm" />
+        <rotation name="back_minus_photontube_shapeflange_photontube_inside2_shaperot" x="0" y="1.7480000000000002" z="0" unit="deg" />
+      </subtraction>
+      <trap name="back_egap_trap_shape" z="3" theta="-4.7960000000000003" phi="0" x1="8.3492999999999995" x2="8.3492999999999995" x3="8.7525999999999993" x4="8.7525999999999993" y1="5.266" y2="5.266" alpha1="0" alpha2="0" aunit="deg" lunit="cm" />
+      <subtraction name="back_minus_egap_shape">
+        <first ref="back_minus_photontube_shape" />
+        <second ref="back_egap_trap_shape" />
+        <position name="back_minus_egap_shapeback_egap_trap_shapepos" x="6.674199999999999" y="0" z="0" unit="cm" />
+      </subtraction>
+      <eltube name="flange_egap_inside_tube3_shape" dx="2.633" dy="2.633" dz="3" lunit="cm" />
+      <subtraction name="back_minus_egapleft_shape">
+        <first ref="back_minus_egap_shape" />
+        <second ref="flange_egap_inside_tube3_shape" />
+        <position name="back_minus_egapleft_shapeflange_egap_inside_tube3_shapepos" x="10.9497" y="0" z="0" unit="cm" />
+        <rotation name="back_minus_egapleft_shapeflange_egap_inside_tube3_shaperot" x="0" y="-0.95599999999999996" z="0" unit="deg" />
+      </subtraction>
+      <eltube name="flange_egap_inside_tube4_shape" dx="2.633" dy="2.633" dz="3" lunit="cm" />
+      <subtraction name="back_flange_shape">
+        <first ref="back_minus_egapleft_shape" />
+        <second ref="flange_egap_inside_tube4_shape" />
+        <position name="back_flange_shapeflange_egap_inside_tube4_shapepos" x="2.3986999999999994" y="0" z="0" unit="cm" />
+        <rotation name="back_flange_shapeflange_egap_inside_tube4_shaperot" x="0" y="-8.5939999999999994" z="0" unit="deg" />
+      </subtraction>
+      <trap name="chamber_trap_shape" z="45" theta="-1.8640000000000001" phi="0" x1="37.700000000000003" x2="37.700000000000003" x3="40.629000000000005" x4="40.629000000000005" y1="2.8000000000000003" y2="2.8000000000000003" alpha1="0" alpha2="0" aunit="deg" lunit="cm" />
+      <box name="chamber_cutaway_box_shape" x="50" y="1" z="30" lunit="cm" />
+      <subtraction name="chamber_trim1_shape">
+        <first ref="chamber_trap_shape" />
+        <second ref="chamber_cutaway_box_shape" />
+        <position name="chamber_trim1_shapechamber_cutaway_box_shapepos" x="0" y="1.6000000000000001" z="-9" unit="cm" />
+      </subtraction>
+      <box name="chamber_cutaway_box2_shape" x="50" y="1" z="30" lunit="cm" />
+      <subtraction name="chamber_trim2_shape">
+        <first ref="chamber_trim1_shape" />
+        <second ref="chamber_cutaway_box2_shape" />
+        <position name="chamber_trim2_shapechamber_cutaway_box2_shapepos" x="0" y="-1.6000000000000001" z="-9" unit="cm" />
+      </subtraction>
+      <eltube name="photontube_outside_shape" dx="1.3" dy="1.3" dz="23.5" lunit="cm" />
+      <union name="chamber_with_photontube_shape">
+        <first ref="chamber_trim2_shape" />
+        <second ref="photontube_outside_shape" />
+        <position name="chamber_with_photontube_shapephotontube_outside_shapepos" x="16.739699999999999" y="0" z="0" unit="cm" />
+        <rotation name="chamber_with_photontube_shapephotontube_outside_shaperot" x="0" y="1.7480000000000002" z="0" unit="deg" />
+      </union>
+      <trap name="egap_outside_trap_upper_shape" z="45" theta="-4.7960000000000003" phi="0" x1="10.691200000000002" x2="5.2344000000000008" x3="16.741099999999999" x4="11.284300000000002" y1="3.2330000000000001" y2="3.2330000000000001" alpha1="0.26900000000000002" alpha2="0.26900000000000002" aunit="deg" lunit="cm" />
+      <union name="chamber_with_egap_upper_shape">
+        <first ref="chamber_with_photontube_shape" />
+        <second ref="egap_outside_trap_upper_shape" />
+        <position name="chamber_with_egap_upper_shapeegap_outside_trap_upper_shapepos" x="7.7018000000000004" y="1.6165" z="0" unit="cm" />
+      </union>
+      <trap name="egap_outside_trap_lower_shape" z="45" theta="-4.7960000000000003" phi="0" x1="5.2344000000000008" x2="10.691200000000002" x3="11.284300000000002" x4="16.741099999999999" y1="3.2330000000000001" y2="3.2330000000000001" alpha1="-0.26900000000000002" alpha2="-0.26900000000000002" aunit="deg" lunit="cm" />
+      <union name="chamber_with_egap_lower_shape">
+        <first ref="chamber_with_egap_upper_shape" />
+        <second ref="egap_outside_trap_lower_shape" />
+        <position name="chamber_with_egap_lower_shapeegap_outside_trap_lower_shapepos" x="7.7018000000000004" y="-1.6165" z="0" unit="cm" />
+      </union>
+      <box name="chamber_cutaway_box3_shape" x="50" y="1" z="30" lunit="cm" />
+      <subtraction name="chamber_with_egap_trimtop_shape">
+        <first ref="chamber_with_egap_lower_shape" />
+        <second ref="chamber_cutaway_box3_shape" />
+        <position name="chamber_with_egap_trimtop_shapechamber_cutaway_box3_shapepos" x="0" y="3.4329999999999998" z="-9" unit="cm" />
+      </subtraction>
+      <box name="chamber_cutaway_box4_shape" x="50" y="1" z="30" lunit="cm" />
+      <subtraction name="chamber_with_egap_trimbot_shape">
+        <first ref="chamber_with_egap_trimtop_shape" />
+        <second ref="chamber_cutaway_box4_shape" />
+        <position name="chamber_with_egap_trimbot_shapechamber_cutaway_box4_shapepos" x="0" y="-3.4329999999999998" z="-9" unit="cm" />
+      </subtraction>
+      <box name="back_end_box_shape" x="76.835000000000008" y="45.719999999999999" z="5" lunit="cm" />
+      <subtraction name="chamber_outside_trim1_shape">
+        <first ref="chamber_with_egap_trimbot_shape" />
+        <second ref="back_end_box_shape" />
+        <position name="chamber_outside_trim1_shapeback_end_box_shapepos" x="0" y="0" z="-23" unit="cm" />
+      </subtraction>
+      <box name="back_end_box2_shape" x="76.835000000000008" y="45.719999999999999" z="5" lunit="cm" />
+      <subtraction name="chamber_outside_trim2_shape">
+        <first ref="chamber_outside_trim1_shape" />
+        <second ref="back_end_box2_shape" />
+        <position name="chamber_outside_trim2_shapeback_end_box2_shapepos" x="0" y="0" z="23" unit="cm" />
+      </subtraction>
+      <eltube name="photontube_inside_shape" dx="1.1000000000000001" dy="1.1000000000000001" dz="23.5" lunit="cm" />
+      <subtraction name="chamber_minus_photontube_shape">
+        <first ref="chamber_outside_trim2_shape" />
+        <second ref="photontube_inside_shape" />
+        <position name="chamber_minus_photontube_shapephotontube_inside_shapepos" x="16.739699999999999" y="0" z="0" unit="cm" />
+        <rotation name="chamber_minus_photontube_shapephotontube_inside_shaperot" x="0" y="1.7480000000000002" z="0" unit="deg" />
+      </subtraction>
+      <trap name="chamber_inside_trap_shape" z="45.000100000000003" theta="-0.98799999999999999" phi="0" x1="33.1676" x2="33.1676" x3="37.466699999999996" x4="37.466699999999996" y1="1.6000000000000001" y2="1.6000000000000001" alpha1="0" alpha2="0" aunit="deg" lunit="cm" />
+      <subtraction name="chamber_minus_inside_shape">
+        <first ref="chamber_minus_photontube_shape" />
+        <second ref="chamber_inside_trap_shape" />
+        <position name="chamber_minus_inside_shapechamber_inside_trap_shapepos" x="-0.91889999999999938" y="0" z="0" unit="cm" />
+      </subtraction>
+      <trap name="egap_inside_trap_shape" z="45.000100000000003" theta="-4.7960000000000003" phi="0" x1="2.6355000000000004" x2="2.6355000000000004" x3="8.6853999999999996" x4="8.6853999999999996" y1="5.266" y2="5.266" alpha1="0" alpha2="0" aunit="deg" lunit="cm" />
+      <subtraction name="chamber_minus_egapinside_shape">
+        <first ref="chamber_minus_inside_shape" />
+        <second ref="egap_inside_trap_shape" />
+        <position name="chamber_minus_egapinside_shapeegap_inside_trap_shapepos" x="7.8105000000000011" y="0" z="0" unit="cm" />
+      </subtraction>
+      <eltube name="egap_inside_tube_shape" dx="2.633" dy="2.633" dz="24" lunit="cm" />
+      <subtraction name="chamber_minus_egap_left_shape">
+        <first ref="chamber_minus_egapinside_shape" />
+        <second ref="egap_inside_tube_shape" />
+        <position name="chamber_minus_egap_left_shapeegap_inside_tube_shapepos" x="10.640750000000001" y="0" z="0" unit="cm" />
+        <rotation name="chamber_minus_egap_left_shapeegap_inside_tube_shaperot" x="0" y="-0.95599999999999996" z="0" unit="deg" />
+      </subtraction>
+      <tube name="egap_inside_tube2_shape" rmin="0" rmax="2.633" z="48" startphi="0" deltaphi="360" aunit="deg" lunit="cm" />
+      <subtraction name="ECAL_chamber_shape">
+        <first ref="chamber_minus_egap_left_shape" />
+        <second ref="egap_inside_tube2_shape" />
+        <position name="ECAL_chamber_shapeegap_inside_tube2_shapepos" x="4.9802999999999997" y="0" z="0" unit="cm" />
+        <rotation name="ECAL_chamber_shapeegap_inside_tube2_shaperot" x="0" y="-8.5939999999999994" z="0" unit="deg" />
+      </subtraction>
+      <box name="al_honeycomb_shape" x="6" y="1.6000000000000001" z="6" lunit="cm" />
+      <box name="ecal_box_outer1_shape" x="80" y="1.3999999999999999" z="20.100000000000001" lunit="cm" />
+      <box name="ecal_box_inner1_shape" x="78" y="2" z="21" lunit="cm" />
+      <subtraction name="ecal_box_minus_inner1_shape">
+        <first ref="ecal_box_outer1_shape" />
+        <second ref="ecal_box_inner1_shape" />
+        <position name="ecal_box_minus_inner1_shapeecal_box_inner1_shapepos" x="0" y="0.16" z="1.8500000000000001" unit="cm" />
+      </subtraction>
+      <box name="ecal_box_inner2_shape" x="68" y="1.2" z="7.4199999999999999" lunit="cm" />
+      <subtraction name="ecal_box_minus_inner2_shape">
+        <first ref="ecal_box_minus_inner1_shape" />
+        <second ref="ecal_box_inner2_shape" />
+        <position name="ecal_box_minus_inner2_shapeecal_box_inner2_shapepos" x="0" y="0.16" z="-10.050000000000001" unit="cm" />
+      </subtraction>
+      <para name="ppd_0_shape" x="0.59999999999999998" y="1.3999999999999999" z="1.5" alpha="0" theta="0" phi="0" aunit="deg" lunit="cm" />
+      <union name="box_with_ppd_shape">
+        <first ref="ecal_box_minus_inner2_shape" />
+        <second ref="ppd_0_shape" />
+        <position name="box_with_ppd_shapeppd_0_shapepos" x="0" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <para name="ppd_1_shape" x="0.59999999999999998" y="1.3999999999999999" z="1.5" alpha="0" theta="-3.8700000000000001" phi="0" aunit="deg" lunit="cm" />
+      <union name="box_with_ppd1_shape">
+        <first ref="box_with_ppd_shape" />
+        <second ref="ppd_1_shape" />
+        <position name="box_with_ppd1_shapeppd_1_shapepos" x="-5.2400000000000002" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <para name="ppd_2_shape" x="0.59999999999999998" y="1.3999999999999999" z="1.5" alpha="0" theta="-7.7400000000000002" phi="0" aunit="deg" lunit="cm" />
+      <union name="box_with_ppd2_shape">
+        <first ref="box_with_ppd1_shape" />
+        <second ref="ppd_2_shape" />
+        <position name="box_with_ppd2_shapeppd_2_shapepos" x="-10.5" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <para name="ppd_3_shape" x="0.59999999999999998" y="1.3999999999999999" z="1.5" alpha="0" theta="-11.619999999999999" phi="0" aunit="deg" lunit="cm" />
+      <union name="box_with_ppd3_shape">
+        <first ref="box_with_ppd2_shape" />
+        <second ref="ppd_3_shape" />
+        <position name="box_with_ppd3_shapeppd_3_shapepos" x="-15.800000000000001" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <para name="ppd_4_shape" x="0.59999999999999998" y="1.3999999999999999" z="1.5" alpha="0" theta="-15.49" phi="0" aunit="deg" lunit="cm" />
+      <union name="box_with_ppd4_shape">
+        <first ref="box_with_ppd3_shape" />
+        <second ref="ppd_4_shape" />
+        <position name="box_with_ppd4_shapeppd_4_shapepos" x="-21.170000000000002" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <para name="ppd_5_shape" x="0.59999999999999998" y="1.3999999999999999" z="1.5" alpha="0" theta="-19.359999999999999" phi="0" aunit="deg" lunit="cm" />
+      <union name="box_with_ppd5_shape">
+        <first ref="box_with_ppd4_shape" />
+        <second ref="ppd_5_shape" />
+        <position name="box_with_ppd5_shapeppd_5_shapepos" x="-26.640000000000001" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <para name="ppd_6_shape" x="0.59999999999999998" y="1.3999999999999999" z="1.5" alpha="0" theta="3.8700000000000001" phi="0" aunit="deg" lunit="cm" />
+      <union name="box_with_ppd6_shape">
+        <first ref="box_with_ppd5_shape" />
+        <second ref="ppd_6_shape" />
+        <position name="box_with_ppd6_shapeppd_6_shapepos" x="5.2400000000000002" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <para name="ppd_7_shape" x="0.59999999999999998" y="1.3999999999999999" z="1.5" alpha="0" theta="7.7400000000000002" phi="0" aunit="deg" lunit="cm" />
+      <union name="box_with_ppd7_shape">
+        <first ref="box_with_ppd6_shape" />
+        <second ref="ppd_7_shape" />
+        <position name="box_with_ppd7_shapeppd_7_shapepos" x="10.5" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <para name="ppd_8_shape" x="0.59999999999999998" y="1.3999999999999999" z="1.5" alpha="0" theta="11.619999999999999" phi="0" aunit="deg" lunit="cm" />
+      <union name="box_with_ppd8_shape">
+        <first ref="box_with_ppd7_shape" />
+        <second ref="ppd_8_shape" />
+        <position name="box_with_ppd8_shapeppd_8_shapepos" x="15.800000000000001" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <para name="ppd_9_shape" x="0.59999999999999998" y="1.3999999999999999" z="1.5" alpha="0" theta="15.49" phi="0" aunit="deg" lunit="cm" />
+      <union name="box_with_ppd9_shape">
+        <first ref="box_with_ppd8_shape" />
+        <second ref="ppd_9_shape" />
+        <position name="box_with_ppd9_shapeppd_9_shapepos" x="21.170000000000002" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <para name="ppd_10_shape" x="0.59999999999999998" y="1.3999999999999999" z="1.5" alpha="0" theta="19.359999999999999" phi="0" aunit="deg" lunit="cm" />
+      <union name="layer_1_top_shape">
+        <first ref="box_with_ppd9_shape" />
+        <second ref="ppd_10_shape" />
+        <position name="layer_1_top_shapeppd_10_shapepos" x="26.640000000000001" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <union name="layer_2_top_shape">
+        <first ref="box_with_ppd9_shape" />
+        <second ref="ppd_10_shape" />
+        <position name="layer_2_top_shapeppd_10_shapepos" x="26.640000000000001" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <union name="layer_3_top_shape">
+        <first ref="box_with_ppd9_shape" />
+        <second ref="ppd_10_shape" />
+        <position name="layer_3_top_shapeppd_10_shapepos" x="26.640000000000001" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <union name="layer_4_top_shape">
+        <first ref="box_with_ppd9_shape" />
+        <second ref="ppd_10_shape" />
+        <position name="layer_4_top_shapeppd_10_shapepos" x="26.640000000000001" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <union name="layer_1_bottom_shape">
+        <first ref="box_with_ppd9_shape" />
+        <second ref="ppd_10_shape" />
+        <position name="layer_1_bottom_shapeppd_10_shapepos" x="26.640000000000001" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <union name="layer_2_bottom_shape">
+        <first ref="box_with_ppd9_shape" />
+        <second ref="ppd_10_shape" />
+        <position name="layer_2_bottom_shapeppd_10_shapepos" x="26.640000000000001" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <union name="layer_3_bottom_shape">
+        <first ref="box_with_ppd9_shape" />
+        <second ref="ppd_10_shape" />
+        <position name="layer_3_bottom_shapeppd_10_shapepos" x="26.640000000000001" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <union name="layer_4_bottom_shape">
+        <first ref="box_with_ppd9_shape" />
+        <second ref="ppd_10_shape" />
+        <position name="layer_4_bottom_shapeppd_10_shapepos" x="26.640000000000001" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <para name="ppd_left2_shape" x="0.40000000000000002" y="1.3999999999999999" z="20.100000000000001" alpha="0" theta="0.96999999999999997" phi="0" aunit="deg" lunit="cm" />
+      <union name="layer_5a1_1_shape">
+        <first ref="ecal_box_minus_inner2_shape" />
+        <second ref="ppd_left2_shape" />
+        <position name="layer_5a1_1_shapeppd_left2_shapepos" x="-1.903" y="0" z="0" unit="cm" />
+      </union>
+      <para name="ppd_left1_shape" x="0.502" y="1.3999999999999999" z="1.5" alpha="0" theta="0.96999999999999997" phi="0" aunit="deg" lunit="cm" />
+      <union name="layer_5a1_shape">
+        <first ref="layer_5a1_1_shape" />
+        <second ref="ppd_left1_shape" />
+        <position name="layer_5a1_shapeppd_left1_shapepos" x="-1.6499999999999999" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <trd name="electron_hole_left_shape" x1="38.177" x2="38.856999999999999" y1="4" y2="4" z="20.199999999999999" lunit="cm" />
+      <subtraction name="layer_5a2_shape">
+        <first ref="layer_5a1_shape" />
+        <second ref="electron_hole_left_shape" />
+        <position name="layer_5a2_shapeelectron_hole_left_shapepos" x="-21.361499999999999" y="0" z="0" unit="cm" />
+      </subtraction>
+      <union name="layer_5a3_shape">
+        <first ref="layer_5a2_shape" />
+        <second ref="ppd_6_shape" />
+        <position name="layer_5a3_shapeppd_6_shapepos" x="5.2400000000000002" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <union name="layer_5a4_shape">
+        <first ref="layer_5a3_shape" />
+        <second ref="ppd_7_shape" />
+        <position name="layer_5a4_shapeppd_7_shapepos" x="10.5" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <union name="layer_5a5_shape">
+        <first ref="layer_5a4_shape" />
+        <second ref="ppd_8_shape" />
+        <position name="layer_5a5_shapeppd_8_shapepos" x="15.800000000000001" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <union name="layer_5a6_shape">
+        <first ref="layer_5a5_shape" />
+        <second ref="ppd_9_shape" />
+        <position name="layer_5a6_shapeppd_9_shapepos" x="21.170000000000002" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <union name="layer_5a7_shape">
+        <first ref="layer_5a6_shape" />
+        <second ref="ppd_10_shape" />
+        <position name="layer_5a7_shapeppd_10_shapepos" x="26.640000000000001" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <union name="layer_5T_left_shape">
+        <first ref="layer_5a7_shape" />
+        <second ref="ppd_0_shape" />
+        <position name="layer_5T_left_shapeppd_0_shapepos" x="0" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <union name="layer_5B_left_shape">
+        <first ref="layer_5a7_shape" />
+        <second ref="ppd_0_shape" />
+        <position name="layer_5B_left_shapeppd_0_shapepos" x="0" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <box name="steel_bar_shape" x="3" y="1.5" z="20" lunit="cm" />
+      <tube name="cu_Tpipe_inner_left_shape" rmin="0.29999999999999999" rmax="0.40000000000000002" z="20.100000000000001" startphi="0" deltaphi="360" aunit="deg" lunit="cm" />
+      <tube name="cu_Tpipe_inner_right_shape" rmin="0.29999999999999999" rmax="0.40000000000000002" z="20.100000000000001" startphi="0" deltaphi="360" aunit="deg" lunit="cm" />
+      <tube name="cu_Bpipe_inner_left_shape" rmin="0.29999999999999999" rmax="0.40000000000000002" z="20.100000000000001" startphi="0" deltaphi="360" aunit="deg" lunit="cm" />
+      <tube name="cu_Bpipe_inner_right_shape" rmin="0.29999999999999999" rmax="0.40000000000000002" z="20.100000000000001" startphi="0" deltaphi="360" aunit="deg" lunit="cm" />
+      <eltube name="cu_Tpipe_outer_right1_shape" dx="0.5" dy="0.10000000000000001" dz="10" lunit="cm" />
+      <eltube name="cu_Tpipe_outer_right2_shape" dx="0.5" dy="0.10000000000000001" dz="10" lunit="cm" />
+      <tube name="cu_Tpipe_outer_right3_shape" rmin="0.29999999999999999" rmax="0.40000000000000002" z="8" startphi="0" deltaphi="360" aunit="deg" lunit="cm" />
+      <tube name="cu_Bpipe_outer_right_shape" rmin="0.29999999999999999" rmax="0.40000000000000002" z="8" startphi="0" deltaphi="360" aunit="deg" lunit="cm" />
+      <eltube name="cu_Bpipe_outer_right1_shape" dx="0.5" dy="0.10000000000000001" dz="10" lunit="cm" />
+      <eltube name="cu_Bpipe_outer_right2_shape" dx="0.5" dy="0.10000000000000001" dz="10" lunit="cm" />
+      <tube name="al_pipe_across_top1_shape" rmin="0.29999999999999999" rmax="0.40000000000000002" z="66" startphi="0" deltaphi="360" aunit="deg" lunit="cm" />
+      <tube name="al_pipe_across_top2_shape" rmin="0.29999999999999999" rmax="0.40000000000000002" z="74" startphi="0" deltaphi="360" aunit="deg" lunit="cm" />
+      <tube name="al_pipe_across_bottom1_shape" rmin="0.29999999999999999" rmax="0.40000000000000002" z="70" startphi="0" deltaphi="360" aunit="deg" lunit="cm" />
+      <tube name="al_pipe_across_bottom2_shape" rmin="0.29999999999999999" rmax="0.40000000000000002" z="78" startphi="0" deltaphi="360" aunit="deg" lunit="cm" />
+      <para name="cu_plate_top_left_shape" x="40" y="0.10000000000000001" z="20" alpha="0" theta="0.96999999999999997" phi="0" aunit="deg" lunit="cm" />
+      <para name="cu_plate_bottom_left_shape" x="40" y="0.10000000000000001" z="20" alpha="0" theta="0.96999999999999997" phi="0" aunit="deg" lunit="cm" />
+      <para name="cu_plate_top_right_shape" x="22" y="0.10000000000000001" z="20" alpha="0" theta="9.6799999999999997" phi="180" aunit="deg" lunit="cm" />
+      <para name="cu_plate_bottom_right_shape" x="22" y="0.10000000000000001" z="20" alpha="0" theta="-9.6799999999999997" phi="0" aunit="deg" lunit="cm" />
+      <trd name="cu_plate_top_middle_shape" x1="7" x2="9.8000000000000007" y1="0.10000000000000001" y2="0.10000000000000001" z="20" lunit="cm" />
+      <trd name="cu_plate_bottom_middle_shape" x1="7" x2="9.8000000000000007" y1="0.10000000000000001" y2="0.10000000000000001" z="20" lunit="cm" />
+      <box name="tracking_volume_solid" x="2000" y="2000" z="2000" lunit="cm" />
+      <box name="hodo_flange_outer_shape" x="76.835000000000008" y="45.719999999999999" z="5" lunit="cm" />
+      <box name="hodo_flange_inner_shape" x="65.035000000000011" y="33.480000000000004" z="5.0010000000000003" lunit="cm" />
+      <subtraction name="hodo_flange_only_shape">
+        <first ref="hodo_flange_outer_shape" />
+        <second ref="hodo_flange_inner_shape" />
+      </subtraction>
+      <box name="Flange_extrusion_1_shape" x="2.5" y="3.5" z="1.5" lunit="cm" />
+      <union name="hodo_flange_ex1_shape">
+        <first ref="hodo_flange_only_shape" />
+        <second ref="Flange_extrusion_1_shape" />
+        <position name="hodo_flange_ex1_shapeFlange_extrusion_1_shapepos" x="19.400000000000002" y="14.990000000000002" z="-0.10000000000000001" unit="cm" />
+      </union>
+      <box name="Flange_extrusion_2_shape" x="2.5" y="3.5" z="1.5" lunit="cm" />
+      <union name="hodo_flange_ex2_shape">
+        <first ref="hodo_flange_ex1_shape" />
+        <second ref="Flange_extrusion_2_shape" />
+        <position name="hodo_flange_ex2_shapeFlange_extrusion_2_shapepos" x="19.400000000000002" y="-14.990000000000002" z="-0.10000000000000001" unit="cm" />
+      </union>
+      <box name="Flange_extrusion_3_shape" x="2.5" y="3.5" z="1.5" lunit="cm" />
+      <union name="hodo_flange_ex3_shape">
+        <first ref="hodo_flange_ex2_shape" />
+        <second ref="Flange_extrusion_3_shape" />
+        <position name="hodo_flange_ex3_shapeFlange_extrusion_3_shapepos" x="7.4000000000000004" y="14.990000000000002" z="-0.10000000000000001" unit="cm" />
+      </union>
+      <box name="Flange_extrusion_4_shape" x="2.5" y="3.5" z="1.5" lunit="cm" />
+      <union name="hodo_flange_shape">
+        <first ref="hodo_flange_ex3_shape" />
+        <second ref="Flange_extrusion_4_shape" />
+        <position name="hodo_flange_shapeFlange_extrusion_4_shapepos" x="7.4000000000000004" y="-14.990000000000002" z="-0.10000000000000001" unit="cm" />
+      </union>
+      <trap name="arms1_block1_shape" z="1.5" theta="3.9490533936242498" phi="90" x1="2.5" x2="2.5" x3="2.5" x4="2.5" y1="3.7071000000000001" y2="3.5" alpha1="0" alpha2="0" aunit="deg" lunit="cm" />
+      <trap name="arms1_block2_shape" z="1.5" theta="3.9490533936242498" phi="90" x1="2.5" x2="2.5" x3="2.5" x4="2.5" y1="3.7071000000000001" y2="3.5" alpha1="0" alpha2="0" aunit="deg" lunit="cm" />
+      <trap name="arms1_block3_shape" z="1.5" theta="-3.9490533936242498" phi="90" x1="2.5" x2="2.5" x3="2.5" x4="2.5" y1="3.7071000000000001" y2="3.5" alpha1="0" alpha2="0" aunit="deg" lunit="cm" />
+      <trap name="arms1_block4_shape" z="1.5" theta="-3.9490533936242498" phi="90" x1="2.5" x2="2.5" x3="2.5" x4="2.5" y1="3.7071000000000001" y2="3.5" alpha1="0" alpha2="0" aunit="deg" lunit="cm" />
+      <box name="cross_bar_top_shape" x="9.5" y="0.80000000000000004" z="1.5" lunit="cm" />
+      <box name="cross_bar_bottom_shape" x="9.5" y="0.80000000000000004" z="1.5" lunit="cm" />
+      <trap name="support_arm_bottom_left_arm_shape" z="21.700000000000003" theta="-9.8039344658558196" phi="90" x1="0.60000000000000009" x2="0.60000000000000009" x3="0.60000000000000009" x4="0.60000000000000009" y1="2.2938300486668619" y2="3.2271000000000001" alpha1="0" alpha2="0" aunit="deg" lunit="cm" />
+      <box name="support_arm_bottom_left_notch_shape" x="2" y="1.7800000000000002" z="1.401" lunit="cm" />
+      <box name="end_block_bottom_left_block_shape" x="2" y="0.78000000000000003" z="1.4000000000000001" lunit="cm" />
+      <box name="end_block_bottom_left_subs_shape" x="2.0010000000000003" y="1" z="1.401" lunit="cm" />
+      <subtraction name="support_arm_bottom_left_with_notch_shape">
+        <first ref="support_arm_bottom_left_arm_shape" />
+        <second ref="support_arm_bottom_left_notch_shape" />
+        <position name="support_arm_bottom_left_with_notch_shapesupport_arm_bottom_left_notch_shapepos" x="0" y="2.9215622772585932" z="-10.151000000000002" unit="cm" />
+      </subtraction>
+      <subtraction name="end_block_bottom_left_shape">
+        <first ref="end_block_bottom_left_block_shape" />
+        <second ref="end_block_bottom_left_subs_shape" />
+        <position name="end_block_bottom_left_shapeend_block_bottom_left_subs_shapepos" x="0" y="0.60999999999999999" z="-0.30099999999999999" unit="cm" />
+      </subtraction>
+      <union name="support_arm_bottom_left_plus_block_shape">
+        <first ref="support_arm_bottom_left_with_notch_shape" />
+        <second ref="end_block_bottom_left_shape" />
+        <position name="support_arm_bottom_left_plus_block_shapeend_block_bottom_left_shapepos" x="0" y="2.4215622772585932" z="-10.15" unit="cm" />
+      </union>
+      <union name="support_arm_bottom_right_shape">
+        <first ref="support_arm_bottom_left_with_notch_shape" />
+        <second ref="end_block_bottom_left_shape" />
+        <position name="support_arm_bottom_right_shapeend_block_bottom_left_shapepos" x="0" y="2.4215622772585932" z="-10.15" unit="cm" />
+      </union>
+      <union name="support_arm_top_left_shape">
+        <first ref="support_arm_bottom_left_with_notch_shape" />
+        <second ref="end_block_bottom_left_shape" />
+        <position name="support_arm_top_left_shapeend_block_bottom_left_shapepos" x="0" y="2.4215622772585932" z="-10.15" unit="cm" />
+      </union>
+      <union name="support_arm_top_right_shape">
+        <first ref="support_arm_bottom_left_with_notch_shape" />
+        <second ref="end_block_bottom_left_shape" />
+        <position name="support_arm_top_right_shapeend_block_bottom_left_shapepos" x="0" y="2.4215622772585932" z="-10.15" unit="cm" />
+      </union>
+      <box name="u_support_bar_bottom_shape" x="16" y="0.80000000000000004" z="0.90000000000000002" lunit="cm" />
+      <box name="u_support_bar_upper1_shape" x="16" y="1.8" z="0.40000000000000002" lunit="cm" />
+      <box name="u_support_bar_upper2_shape" x="16" y="1.8" z="0.30000000000000004" lunit="cm" />
+      <box name="u_support_bar_top_shape" x="16" y="0.80000000000000004" z="0.90000000000000002" lunit="cm" />
+      <box name="u_support_bar_upper3_shape" x="16" y="1.8" z="0.40000000000000002" lunit="cm" />
+      <box name="u_support_bar_upper4_shape" x="16" y="1.8" z="0.30000000000000004" lunit="cm" />
+      <box lunit="mm" name="svt_chamber_outer_box" x="454.152" y="203.2" z="1219.2" />
+      <box lunit="mm" name="svt_chamber_inner_box" x="416.052" y="177.8" z="1221.2" />
+      <subtraction name="svt_chamber_box">
+        <first ref="svt_chamber_outer_box" />
+        <second ref="svt_chamber_inner_box" />
+      </subtraction>
+      <trd lunit="mm" name="svt_chamber_outer_flare1" x1="454.152" x2="454.152" y1="203.2" y2="254.832" z="132.842" />
+      <trd lunit="mm" name="svt_chamber_inner_flare1" x1="416.052" x2="416.052" y1="172.864" y2="234.368" z="158.242" />
+      <subtraction name="svt_chamber_flare1">
+        <first ref="svt_chamber_outer_flare1" />
+        <second ref="svt_chamber_inner_flare1" />
+      </subtraction>
+      <trd lunit="mm" name="svt_chamber_outer_flare2" x1="454.152" x2="679.704" y1="254.832" y2="353.06" z="252.73" />
+      <trd lunit="mm" name="svt_chamber_inner_flare2" x1="404.718" x2="652.938" y1="224.496" y2="332.596" z="278.13" />
+      <subtraction name="svt_chamber_flare2">
+        <first ref="svt_chamber_outer_flare2" />
+        <second ref="svt_chamber_inner_flare2" />
+      </subtraction>
+      <box lunit="mm" name="svt_chamber_outer_flange" x="768.35" y="457.2" z="19.05" />
+      <box lunit="mm" name="svt_chamber_inner_flange" x="654.05" y="342.9" z="25.4" />
+      <subtraction name="svt_chamber_flange">
+        <first ref="svt_chamber_outer_flange" />
+        <second ref="svt_chamber_inner_flange" />
+      </subtraction>
+      <box lunit="mm" name="WorldBox" x="80000" y="80000" z="80000" />
+    </solids>
+    <structure>
+      <volume name="base_plate_volume">
+        <materialref ref="Aluminum" />
+        <solidref ref="base_plateBox" />
+        <visref ref="BasePlateVis" />
+      </volume>
+      <volume name="support_plate_bottom_L14_volume">
+        <materialref ref="Aluminum" />
+        <solidref ref="support_plate_bottom_L14Box" />
+        <visref ref="SupportPlateVis" />
+      </volume>
+      <volume name="support_plate_top_L14_volume">
+        <materialref ref="Aluminum" />
+        <solidref ref="support_plate_top_L14Box" />
+        <visref ref="SupportPlateVis" />
+      </volume>
+      <volume name="support_plate_bottom_L46_volume">
+        <materialref ref="Aluminum" />
+        <solidref ref="support_plate_bottom_L46Box" />
+        <visref ref="SupportPlateVis" />
+      </volume>
+      <volume name="support_plate_top_L46_volume">
+        <materialref ref="Aluminum" />
+        <solidref ref="support_plate_top_L46Box" />
+        <visref ref="SupportPlateVis" />
+      </volume>
+      <volume name="module_L1b_halfmodule_axial_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L1b_halfmodule_axial_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L1b_halfmodule_axial_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L1b_halfmodule_axial_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L1b_halfmodule_axial_sensor_active_volume" />
+          <positionref ref="module_L1b_halfmodule_axial_sensor_active_position" />
+          <rotationref ref="module_L1b_halfmodule_axial_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L1b_halfmodule_axial_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L1b_halfmodule_axialBox" />
+        <physvol>
+          <volumeref ref="module_L1b_halfmodule_axial_sensor_volume" />
+          <positionref ref="module_L1b_halfmodule_axial_sensor_position" />
+          <rotationref ref="module_L1b_halfmodule_axial_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <visref ref="HalfModuleVis" />
+      </volume>
+      <volume name="module_L1b_halfmodule_stereo_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L1b_halfmodule_stereo_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L1b_halfmodule_stereo_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L1b_halfmodule_stereo_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L1b_halfmodule_stereo_sensor_active_volume" />
+          <positionref ref="module_L1b_halfmodule_stereo_sensor_active_position" />
+          <rotationref ref="module_L1b_halfmodule_stereo_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L1b_halfmodule_stereo_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L1b_halfmodule_stereoBox" />
+        <physvol>
+          <volumeref ref="module_L1b_halfmodule_stereo_sensor_volume" />
+          <positionref ref="module_L1b_halfmodule_stereo_sensor_position" />
+          <rotationref ref="module_L1b_halfmodule_stereo_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <visref ref="HalfModuleVis" />
+      </volume>
+      <volume name="module_L1t_halfmodule_axial_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L1t_halfmodule_axial_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L1t_halfmodule_axial_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L1t_halfmodule_axial_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L1t_halfmodule_axial_sensor_active_volume" />
+          <positionref ref="module_L1t_halfmodule_axial_sensor_active_position" />
+          <rotationref ref="module_L1t_halfmodule_axial_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L1t_halfmodule_axial_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L1t_halfmodule_axialBox" />
+        <physvol>
+          <volumeref ref="module_L1t_halfmodule_axial_sensor_volume" />
+          <positionref ref="module_L1t_halfmodule_axial_sensor_position" />
+          <rotationref ref="module_L1t_halfmodule_axial_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <visref ref="HalfModuleVis" />
+      </volume>
+      <volume name="module_L1t_halfmodule_stereo_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L1t_halfmodule_stereo_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L1t_halfmodule_stereo_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L1t_halfmodule_stereo_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L1t_halfmodule_stereo_sensor_active_volume" />
+          <positionref ref="module_L1t_halfmodule_stereo_sensor_active_position" />
+          <rotationref ref="module_L1t_halfmodule_stereo_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L1t_halfmodule_stereo_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L1t_halfmodule_stereoBox" />
+        <physvol>
+          <volumeref ref="module_L1t_halfmodule_stereo_sensor_volume" />
+          <positionref ref="module_L1t_halfmodule_stereo_sensor_position" />
+          <rotationref ref="module_L1t_halfmodule_stereo_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <visref ref="HalfModuleVis" />
+      </volume>
+      <volume name="module_L2b_halfmodule_axial_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L2b_halfmodule_axial_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L2b_halfmodule_axial_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L2b_halfmodule_axial_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L2b_halfmodule_axial_sensor_active_volume" />
+          <positionref ref="module_L2b_halfmodule_axial_sensor_active_position" />
+          <rotationref ref="module_L2b_halfmodule_axial_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L2b_halfmodule_axial_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L2b_halfmodule_axialBox" />
+        <physvol>
+          <volumeref ref="module_L2b_halfmodule_axial_sensor_volume" />
+          <positionref ref="module_L2b_halfmodule_axial_sensor_position" />
+          <rotationref ref="module_L2b_halfmodule_axial_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <visref ref="HalfModuleVis" />
+      </volume>
+      <volume name="module_L2b_halfmodule_stereo_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L2b_halfmodule_stereo_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L2b_halfmodule_stereo_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L2b_halfmodule_stereo_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L2b_halfmodule_stereo_sensor_active_volume" />
+          <positionref ref="module_L2b_halfmodule_stereo_sensor_active_position" />
+          <rotationref ref="module_L2b_halfmodule_stereo_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L2b_halfmodule_stereo_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L2b_halfmodule_stereoBox" />
+        <physvol>
+          <volumeref ref="module_L2b_halfmodule_stereo_sensor_volume" />
+          <positionref ref="module_L2b_halfmodule_stereo_sensor_position" />
+          <rotationref ref="module_L2b_halfmodule_stereo_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <visref ref="HalfModuleVis" />
+      </volume>
+      <volume name="module_L2t_halfmodule_axial_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L2t_halfmodule_axial_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L2t_halfmodule_axial_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L2t_halfmodule_axial_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L2t_halfmodule_axial_sensor_active_volume" />
+          <positionref ref="module_L2t_halfmodule_axial_sensor_active_position" />
+          <rotationref ref="module_L2t_halfmodule_axial_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L2t_halfmodule_axial_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L2t_halfmodule_axialBox" />
+        <physvol>
+          <volumeref ref="module_L2t_halfmodule_axial_sensor_volume" />
+          <positionref ref="module_L2t_halfmodule_axial_sensor_position" />
+          <rotationref ref="module_L2t_halfmodule_axial_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <visref ref="HalfModuleVis" />
+      </volume>
+      <volume name="module_L2t_halfmodule_stereo_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L2t_halfmodule_stereo_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L2t_halfmodule_stereo_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L2t_halfmodule_stereo_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L2t_halfmodule_stereo_sensor_active_volume" />
+          <positionref ref="module_L2t_halfmodule_stereo_sensor_active_position" />
+          <rotationref ref="module_L2t_halfmodule_stereo_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L2t_halfmodule_stereo_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L2t_halfmodule_stereoBox" />
+        <physvol>
+          <volumeref ref="module_L2t_halfmodule_stereo_sensor_volume" />
+          <positionref ref="module_L2t_halfmodule_stereo_sensor_position" />
+          <rotationref ref="module_L2t_halfmodule_stereo_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <visref ref="HalfModuleVis" />
+      </volume>
+      <volume name="module_L3b_halfmodule_axial_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L3b_halfmodule_axial_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L3b_halfmodule_axial_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L3b_halfmodule_axial_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L3b_halfmodule_axial_sensor_active_volume" />
+          <positionref ref="module_L3b_halfmodule_axial_sensor_active_position" />
+          <rotationref ref="module_L3b_halfmodule_axial_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L3b_halfmodule_axial_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L3b_halfmodule_axial_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L3b_halfmodule_axial_cf_volume">
+        <materialref ref="CarbonFiber" />
+        <solidref ref="module_L3b_halfmodule_axial_cfBox" />
+        <visref ref="CarbonFiberVis" />
+      </volume>
+      <volume name="module_L3b_halfmodule_axial_hybrid_volume">
+        <materialref ref="G10" />
+        <solidref ref="module_L3b_halfmodule_axial_hybridBox" />
+        <visref ref="HybridVis" />
+      </volume>
+      <volume name="module_L3b_halfmodule_axial_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L3b_halfmodule_axialBox" />
+        <physvol>
+          <volumeref ref="module_L3b_halfmodule_axial_sensor_volume" />
+          <positionref ref="module_L3b_halfmodule_axial_sensor_position" />
+          <rotationref ref="module_L3b_halfmodule_axial_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L3b_halfmodule_axial_lamination_volume" />
+          <positionref ref="module_L3b_halfmodule_axial_lamination_position" />
+          <rotationref ref="module_L3b_halfmodule_axial_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L3b_halfmodule_axial_cf_volume" />
+          <positionref ref="module_L3b_halfmodule_axial_cf_position" />
+          <rotationref ref="module_L3b_halfmodule_axial_cf_rotation" />
+          <physvolid field_name="component" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L3b_halfmodule_axial_hybrid_volume" />
+          <positionref ref="module_L3b_halfmodule_axial_hybrid_position" />
+          <rotationref ref="module_L3b_halfmodule_axial_hybrid_rotation" />
+          <physvolid field_name="component" value="3" />
+        </physvol>
+        <visref ref="HalfModuleVis" />
+      </volume>
+      <volume name="module_L3b_halfmodule_stereo_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L3b_halfmodule_stereo_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L3b_halfmodule_stereo_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L3b_halfmodule_stereo_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L3b_halfmodule_stereo_sensor_active_volume" />
+          <positionref ref="module_L3b_halfmodule_stereo_sensor_active_position" />
+          <rotationref ref="module_L3b_halfmodule_stereo_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L3b_halfmodule_stereo_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L3b_halfmodule_stereo_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L3b_halfmodule_stereo_cf_volume">
+        <materialref ref="CarbonFiber" />
+        <solidref ref="module_L3b_halfmodule_stereo_cfBox" />
+        <visref ref="CarbonFiberVis" />
+      </volume>
+      <volume name="module_L3b_halfmodule_stereo_hybrid_volume">
+        <materialref ref="G10" />
+        <solidref ref="module_L3b_halfmodule_stereo_hybridBox" />
+        <visref ref="HybridVis" />
+      </volume>
+      <volume name="module_L3b_halfmodule_stereo_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L3b_halfmodule_stereoBox" />
+        <physvol>
+          <volumeref ref="module_L3b_halfmodule_stereo_sensor_volume" />
+          <positionref ref="module_L3b_halfmodule_stereo_sensor_position" />
+          <rotationref ref="module_L3b_halfmodule_stereo_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L3b_halfmodule_stereo_lamination_volume" />
+          <positionref ref="module_L3b_halfmodule_stereo_lamination_position" />
+          <rotationref ref="module_L3b_halfmodule_stereo_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L3b_halfmodule_stereo_cf_volume" />
+          <positionref ref="module_L3b_halfmodule_stereo_cf_position" />
+          <rotationref ref="module_L3b_halfmodule_stereo_cf_rotation" />
+          <physvolid field_name="component" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L3b_halfmodule_stereo_hybrid_volume" />
+          <positionref ref="module_L3b_halfmodule_stereo_hybrid_position" />
+          <rotationref ref="module_L3b_halfmodule_stereo_hybrid_rotation" />
+          <physvolid field_name="component" value="3" />
+        </physvol>
+        <visref ref="HalfModuleVis" />
+      </volume>
+      <volume name="module_L3t_halfmodule_axial_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L3t_halfmodule_axial_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L3t_halfmodule_axial_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L3t_halfmodule_axial_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L3t_halfmodule_axial_sensor_active_volume" />
+          <positionref ref="module_L3t_halfmodule_axial_sensor_active_position" />
+          <rotationref ref="module_L3t_halfmodule_axial_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L3t_halfmodule_axial_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L3t_halfmodule_axial_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L3t_halfmodule_axial_cf_volume">
+        <materialref ref="CarbonFiber" />
+        <solidref ref="module_L3t_halfmodule_axial_cfBox" />
+        <visref ref="CarbonFiberVis" />
+      </volume>
+      <volume name="module_L3t_halfmodule_axial_hybrid_volume">
+        <materialref ref="G10" />
+        <solidref ref="module_L3t_halfmodule_axial_hybridBox" />
+        <visref ref="HybridVis" />
+      </volume>
+      <volume name="module_L3t_halfmodule_axial_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L3t_halfmodule_axialBox" />
+        <physvol>
+          <volumeref ref="module_L3t_halfmodule_axial_sensor_volume" />
+          <positionref ref="module_L3t_halfmodule_axial_sensor_position" />
+          <rotationref ref="module_L3t_halfmodule_axial_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L3t_halfmodule_axial_lamination_volume" />
+          <positionref ref="module_L3t_halfmodule_axial_lamination_position" />
+          <rotationref ref="module_L3t_halfmodule_axial_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L3t_halfmodule_axial_cf_volume" />
+          <positionref ref="module_L3t_halfmodule_axial_cf_position" />
+          <rotationref ref="module_L3t_halfmodule_axial_cf_rotation" />
+          <physvolid field_name="component" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L3t_halfmodule_axial_hybrid_volume" />
+          <positionref ref="module_L3t_halfmodule_axial_hybrid_position" />
+          <rotationref ref="module_L3t_halfmodule_axial_hybrid_rotation" />
+          <physvolid field_name="component" value="3" />
+        </physvol>
+        <visref ref="HalfModuleVis" />
+      </volume>
+      <volume name="module_L3t_halfmodule_stereo_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L3t_halfmodule_stereo_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L3t_halfmodule_stereo_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L3t_halfmodule_stereo_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L3t_halfmodule_stereo_sensor_active_volume" />
+          <positionref ref="module_L3t_halfmodule_stereo_sensor_active_position" />
+          <rotationref ref="module_L3t_halfmodule_stereo_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L3t_halfmodule_stereo_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L3t_halfmodule_stereo_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L3t_halfmodule_stereo_cf_volume">
+        <materialref ref="CarbonFiber" />
+        <solidref ref="module_L3t_halfmodule_stereo_cfBox" />
+        <visref ref="CarbonFiberVis" />
+      </volume>
+      <volume name="module_L3t_halfmodule_stereo_hybrid_volume">
+        <materialref ref="G10" />
+        <solidref ref="module_L3t_halfmodule_stereo_hybridBox" />
+        <visref ref="HybridVis" />
+      </volume>
+      <volume name="module_L3t_halfmodule_stereo_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L3t_halfmodule_stereoBox" />
+        <physvol>
+          <volumeref ref="module_L3t_halfmodule_stereo_sensor_volume" />
+          <positionref ref="module_L3t_halfmodule_stereo_sensor_position" />
+          <rotationref ref="module_L3t_halfmodule_stereo_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L3t_halfmodule_stereo_lamination_volume" />
+          <positionref ref="module_L3t_halfmodule_stereo_lamination_position" />
+          <rotationref ref="module_L3t_halfmodule_stereo_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L3t_halfmodule_stereo_cf_volume" />
+          <positionref ref="module_L3t_halfmodule_stereo_cf_position" />
+          <rotationref ref="module_L3t_halfmodule_stereo_cf_rotation" />
+          <physvolid field_name="component" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L3t_halfmodule_stereo_hybrid_volume" />
+          <positionref ref="module_L3t_halfmodule_stereo_hybrid_position" />
+          <rotationref ref="module_L3t_halfmodule_stereo_hybrid_rotation" />
+          <physvolid field_name="component" value="3" />
+        </physvol>
+        <visref ref="HalfModuleVis" />
+      </volume>
+      <volume name="module_L4b_halfmodule_axial_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L4b_halfmodule_axial_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L4b_halfmodule_axial_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L4b_halfmodule_axial_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L4b_halfmodule_axial_sensor_active_volume" />
+          <positionref ref="module_L4b_halfmodule_axial_sensor_active_position" />
+          <rotationref ref="module_L4b_halfmodule_axial_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L4b_halfmodule_axial_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L4b_halfmodule_axial_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L4b_halfmodule_axial_cf_volume">
+        <materialref ref="CarbonFiber" />
+        <solidref ref="module_L4b_halfmodule_axial_cfBox" />
+        <visref ref="CarbonFiberVis" />
+      </volume>
+      <volume name="module_L4b_halfmodule_axial_hybrid_volume">
+        <materialref ref="G10" />
+        <solidref ref="module_L4b_halfmodule_axial_hybridBox" />
+        <visref ref="HybridVis" />
+      </volume>
+      <volume name="module_L4b_halfmodule_axial_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L4b_halfmodule_axialBox" />
+        <physvol>
+          <volumeref ref="module_L4b_halfmodule_axial_sensor_volume" />
+          <positionref ref="module_L4b_halfmodule_axial_sensor_position" />
+          <rotationref ref="module_L4b_halfmodule_axial_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L4b_halfmodule_axial_lamination_volume" />
+          <positionref ref="module_L4b_halfmodule_axial_lamination_position" />
+          <rotationref ref="module_L4b_halfmodule_axial_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L4b_halfmodule_axial_cf_volume" />
+          <positionref ref="module_L4b_halfmodule_axial_cf_position" />
+          <rotationref ref="module_L4b_halfmodule_axial_cf_rotation" />
+          <physvolid field_name="component" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L4b_halfmodule_axial_hybrid_volume" />
+          <positionref ref="module_L4b_halfmodule_axial_hybrid_position" />
+          <rotationref ref="module_L4b_halfmodule_axial_hybrid_rotation" />
+          <physvolid field_name="component" value="3" />
+        </physvol>
+        <visref ref="HalfModuleVis" />
+      </volume>
+      <volume name="module_L4b_halfmodule_stereo_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L4b_halfmodule_stereo_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L4b_halfmodule_stereo_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L4b_halfmodule_stereo_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L4b_halfmodule_stereo_sensor_active_volume" />
+          <positionref ref="module_L4b_halfmodule_stereo_sensor_active_position" />
+          <rotationref ref="module_L4b_halfmodule_stereo_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L4b_halfmodule_stereo_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L4b_halfmodule_stereo_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L4b_halfmodule_stereo_cf_volume">
+        <materialref ref="CarbonFiber" />
+        <solidref ref="module_L4b_halfmodule_stereo_cfBox" />
+        <visref ref="CarbonFiberVis" />
+      </volume>
+      <volume name="module_L4b_halfmodule_stereo_hybrid_volume">
+        <materialref ref="G10" />
+        <solidref ref="module_L4b_halfmodule_stereo_hybridBox" />
+        <visref ref="HybridVis" />
+      </volume>
+      <volume name="module_L4b_halfmodule_stereo_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L4b_halfmodule_stereoBox" />
+        <physvol>
+          <volumeref ref="module_L4b_halfmodule_stereo_sensor_volume" />
+          <positionref ref="module_L4b_halfmodule_stereo_sensor_position" />
+          <rotationref ref="module_L4b_halfmodule_stereo_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L4b_halfmodule_stereo_lamination_volume" />
+          <positionref ref="module_L4b_halfmodule_stereo_lamination_position" />
+          <rotationref ref="module_L4b_halfmodule_stereo_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L4b_halfmodule_stereo_cf_volume" />
+          <positionref ref="module_L4b_halfmodule_stereo_cf_position" />
+          <rotationref ref="module_L4b_halfmodule_stereo_cf_rotation" />
+          <physvolid field_name="component" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L4b_halfmodule_stereo_hybrid_volume" />
+          <positionref ref="module_L4b_halfmodule_stereo_hybrid_position" />
+          <rotationref ref="module_L4b_halfmodule_stereo_hybrid_rotation" />
+          <physvolid field_name="component" value="3" />
+        </physvol>
+        <visref ref="HalfModuleVis" />
+      </volume>
+      <volume name="module_L4t_halfmodule_axial_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L4t_halfmodule_axial_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L4t_halfmodule_axial_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L4t_halfmodule_axial_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L4t_halfmodule_axial_sensor_active_volume" />
+          <positionref ref="module_L4t_halfmodule_axial_sensor_active_position" />
+          <rotationref ref="module_L4t_halfmodule_axial_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L4t_halfmodule_axial_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L4t_halfmodule_axial_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L4t_halfmodule_axial_cf_volume">
+        <materialref ref="CarbonFiber" />
+        <solidref ref="module_L4t_halfmodule_axial_cfBox" />
+        <visref ref="CarbonFiberVis" />
+      </volume>
+      <volume name="module_L4t_halfmodule_axial_hybrid_volume">
+        <materialref ref="G10" />
+        <solidref ref="module_L4t_halfmodule_axial_hybridBox" />
+        <visref ref="HybridVis" />
+      </volume>
+      <volume name="module_L4t_halfmodule_axial_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L4t_halfmodule_axialBox" />
+        <physvol>
+          <volumeref ref="module_L4t_halfmodule_axial_sensor_volume" />
+          <positionref ref="module_L4t_halfmodule_axial_sensor_position" />
+          <rotationref ref="module_L4t_halfmodule_axial_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L4t_halfmodule_axial_lamination_volume" />
+          <positionref ref="module_L4t_halfmodule_axial_lamination_position" />
+          <rotationref ref="module_L4t_halfmodule_axial_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L4t_halfmodule_axial_cf_volume" />
+          <positionref ref="module_L4t_halfmodule_axial_cf_position" />
+          <rotationref ref="module_L4t_halfmodule_axial_cf_rotation" />
+          <physvolid field_name="component" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L4t_halfmodule_axial_hybrid_volume" />
+          <positionref ref="module_L4t_halfmodule_axial_hybrid_position" />
+          <rotationref ref="module_L4t_halfmodule_axial_hybrid_rotation" />
+          <physvolid field_name="component" value="3" />
+        </physvol>
+        <visref ref="HalfModuleVis" />
+      </volume>
+      <volume name="module_L4t_halfmodule_stereo_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L4t_halfmodule_stereo_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L4t_halfmodule_stereo_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L4t_halfmodule_stereo_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L4t_halfmodule_stereo_sensor_active_volume" />
+          <positionref ref="module_L4t_halfmodule_stereo_sensor_active_position" />
+          <rotationref ref="module_L4t_halfmodule_stereo_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L4t_halfmodule_stereo_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L4t_halfmodule_stereo_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L4t_halfmodule_stereo_cf_volume">
+        <materialref ref="CarbonFiber" />
+        <solidref ref="module_L4t_halfmodule_stereo_cfBox" />
+        <visref ref="CarbonFiberVis" />
+      </volume>
+      <volume name="module_L4t_halfmodule_stereo_hybrid_volume">
+        <materialref ref="G10" />
+        <solidref ref="module_L4t_halfmodule_stereo_hybridBox" />
+        <visref ref="HybridVis" />
+      </volume>
+      <volume name="module_L4t_halfmodule_stereo_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L4t_halfmodule_stereoBox" />
+        <physvol>
+          <volumeref ref="module_L4t_halfmodule_stereo_sensor_volume" />
+          <positionref ref="module_L4t_halfmodule_stereo_sensor_position" />
+          <rotationref ref="module_L4t_halfmodule_stereo_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L4t_halfmodule_stereo_lamination_volume" />
+          <positionref ref="module_L4t_halfmodule_stereo_lamination_position" />
+          <rotationref ref="module_L4t_halfmodule_stereo_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L4t_halfmodule_stereo_cf_volume" />
+          <positionref ref="module_L4t_halfmodule_stereo_cf_position" />
+          <rotationref ref="module_L4t_halfmodule_stereo_cf_rotation" />
+          <physvolid field_name="component" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L4t_halfmodule_stereo_hybrid_volume" />
+          <positionref ref="module_L4t_halfmodule_stereo_hybrid_position" />
+          <rotationref ref="module_L4t_halfmodule_stereo_hybrid_rotation" />
+          <physvolid field_name="component" value="3" />
+        </physvol>
+        <visref ref="HalfModuleVis" />
+      </volume>
+      <volume name="module_L5b_halfmodule_axial_hole_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L5b_halfmodule_axial_hole_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L5b_halfmodule_axial_hole_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L5b_halfmodule_axial_hole_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L5b_halfmodule_axial_hole_sensor_active_volume" />
+          <positionref ref="module_L5b_halfmodule_axial_hole_sensor_active_position" />
+          <rotationref ref="module_L5b_halfmodule_axial_hole_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L5b_halfmodule_axial_hole_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L5b_halfmodule_axial_hole_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L5b_halfmodule_axial_hole_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L5b_halfmodule_axial_holeBox" />
+        <physvol>
+          <volumeref ref="module_L5b_halfmodule_axial_hole_sensor_volume" />
+          <positionref ref="module_L5b_halfmodule_axial_hole_sensor_position" />
+          <rotationref ref="module_L5b_halfmodule_axial_hole_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L5b_halfmodule_axial_hole_lamination_volume" />
+          <positionref ref="module_L5b_halfmodule_axial_hole_lamination_position" />
+          <rotationref ref="module_L5b_halfmodule_axial_hole_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L5b_halfmodule_axial_slot_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L5b_halfmodule_axial_slot_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L5b_halfmodule_axial_slot_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L5b_halfmodule_axial_slot_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L5b_halfmodule_axial_slot_sensor_active_volume" />
+          <positionref ref="module_L5b_halfmodule_axial_slot_sensor_active_position" />
+          <rotationref ref="module_L5b_halfmodule_axial_slot_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L5b_halfmodule_axial_slot_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L5b_halfmodule_axial_slot_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L5b_halfmodule_axial_slot_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L5b_halfmodule_axial_slotBox" />
+        <physvol>
+          <volumeref ref="module_L5b_halfmodule_axial_slot_sensor_volume" />
+          <positionref ref="module_L5b_halfmodule_axial_slot_sensor_position" />
+          <rotationref ref="module_L5b_halfmodule_axial_slot_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L5b_halfmodule_axial_slot_lamination_volume" />
+          <positionref ref="module_L5b_halfmodule_axial_slot_lamination_position" />
+          <rotationref ref="module_L5b_halfmodule_axial_slot_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L5b_halfmodule_stereo_hole_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L5b_halfmodule_stereo_hole_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L5b_halfmodule_stereo_hole_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L5b_halfmodule_stereo_hole_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L5b_halfmodule_stereo_hole_sensor_active_volume" />
+          <positionref ref="module_L5b_halfmodule_stereo_hole_sensor_active_position" />
+          <rotationref ref="module_L5b_halfmodule_stereo_hole_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L5b_halfmodule_stereo_hole_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L5b_halfmodule_stereo_hole_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L5b_halfmodule_stereo_hole_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L5b_halfmodule_stereo_holeBox" />
+        <physvol>
+          <volumeref ref="module_L5b_halfmodule_stereo_hole_sensor_volume" />
+          <positionref ref="module_L5b_halfmodule_stereo_hole_sensor_position" />
+          <rotationref ref="module_L5b_halfmodule_stereo_hole_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L5b_halfmodule_stereo_hole_lamination_volume" />
+          <positionref ref="module_L5b_halfmodule_stereo_hole_lamination_position" />
+          <rotationref ref="module_L5b_halfmodule_stereo_hole_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L5b_halfmodule_stereo_slot_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L5b_halfmodule_stereo_slot_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L5b_halfmodule_stereo_slot_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L5b_halfmodule_stereo_slot_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L5b_halfmodule_stereo_slot_sensor_active_volume" />
+          <positionref ref="module_L5b_halfmodule_stereo_slot_sensor_active_position" />
+          <rotationref ref="module_L5b_halfmodule_stereo_slot_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L5b_halfmodule_stereo_slot_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L5b_halfmodule_stereo_slot_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L5b_halfmodule_stereo_slot_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L5b_halfmodule_stereo_slotBox" />
+        <physvol>
+          <volumeref ref="module_L5b_halfmodule_stereo_slot_sensor_volume" />
+          <positionref ref="module_L5b_halfmodule_stereo_slot_sensor_position" />
+          <rotationref ref="module_L5b_halfmodule_stereo_slot_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L5b_halfmodule_stereo_slot_lamination_volume" />
+          <positionref ref="module_L5b_halfmodule_stereo_slot_lamination_position" />
+          <rotationref ref="module_L5b_halfmodule_stereo_slot_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L5t_halfmodule_axial_hole_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L5t_halfmodule_axial_hole_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L5t_halfmodule_axial_hole_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L5t_halfmodule_axial_hole_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L5t_halfmodule_axial_hole_sensor_active_volume" />
+          <positionref ref="module_L5t_halfmodule_axial_hole_sensor_active_position" />
+          <rotationref ref="module_L5t_halfmodule_axial_hole_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L5t_halfmodule_axial_hole_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L5t_halfmodule_axial_hole_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L5t_halfmodule_axial_hole_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L5t_halfmodule_axial_holeBox" />
+        <physvol>
+          <volumeref ref="module_L5t_halfmodule_axial_hole_sensor_volume" />
+          <positionref ref="module_L5t_halfmodule_axial_hole_sensor_position" />
+          <rotationref ref="module_L5t_halfmodule_axial_hole_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L5t_halfmodule_axial_hole_lamination_volume" />
+          <positionref ref="module_L5t_halfmodule_axial_hole_lamination_position" />
+          <rotationref ref="module_L5t_halfmodule_axial_hole_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L5t_halfmodule_axial_slot_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L5t_halfmodule_axial_slot_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L5t_halfmodule_axial_slot_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L5t_halfmodule_axial_slot_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L5t_halfmodule_axial_slot_sensor_active_volume" />
+          <positionref ref="module_L5t_halfmodule_axial_slot_sensor_active_position" />
+          <rotationref ref="module_L5t_halfmodule_axial_slot_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L5t_halfmodule_axial_slot_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L5t_halfmodule_axial_slot_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L5t_halfmodule_axial_slot_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L5t_halfmodule_axial_slotBox" />
+        <physvol>
+          <volumeref ref="module_L5t_halfmodule_axial_slot_sensor_volume" />
+          <positionref ref="module_L5t_halfmodule_axial_slot_sensor_position" />
+          <rotationref ref="module_L5t_halfmodule_axial_slot_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L5t_halfmodule_axial_slot_lamination_volume" />
+          <positionref ref="module_L5t_halfmodule_axial_slot_lamination_position" />
+          <rotationref ref="module_L5t_halfmodule_axial_slot_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L5t_halfmodule_stereo_hole_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L5t_halfmodule_stereo_hole_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L5t_halfmodule_stereo_hole_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L5t_halfmodule_stereo_hole_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L5t_halfmodule_stereo_hole_sensor_active_volume" />
+          <positionref ref="module_L5t_halfmodule_stereo_hole_sensor_active_position" />
+          <rotationref ref="module_L5t_halfmodule_stereo_hole_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L5t_halfmodule_stereo_hole_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L5t_halfmodule_stereo_hole_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L5t_halfmodule_stereo_hole_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L5t_halfmodule_stereo_holeBox" />
+        <physvol>
+          <volumeref ref="module_L5t_halfmodule_stereo_hole_sensor_volume" />
+          <positionref ref="module_L5t_halfmodule_stereo_hole_sensor_position" />
+          <rotationref ref="module_L5t_halfmodule_stereo_hole_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L5t_halfmodule_stereo_hole_lamination_volume" />
+          <positionref ref="module_L5t_halfmodule_stereo_hole_lamination_position" />
+          <rotationref ref="module_L5t_halfmodule_stereo_hole_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L5t_halfmodule_stereo_slot_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L5t_halfmodule_stereo_slot_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L5t_halfmodule_stereo_slot_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L5t_halfmodule_stereo_slot_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L5t_halfmodule_stereo_slot_sensor_active_volume" />
+          <positionref ref="module_L5t_halfmodule_stereo_slot_sensor_active_position" />
+          <rotationref ref="module_L5t_halfmodule_stereo_slot_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L5t_halfmodule_stereo_slot_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L5t_halfmodule_stereo_slot_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L5t_halfmodule_stereo_slot_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L5t_halfmodule_stereo_slotBox" />
+        <physvol>
+          <volumeref ref="module_L5t_halfmodule_stereo_slot_sensor_volume" />
+          <positionref ref="module_L5t_halfmodule_stereo_slot_sensor_position" />
+          <rotationref ref="module_L5t_halfmodule_stereo_slot_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L5t_halfmodule_stereo_slot_lamination_volume" />
+          <positionref ref="module_L5t_halfmodule_stereo_slot_lamination_position" />
+          <rotationref ref="module_L5t_halfmodule_stereo_slot_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L6b_halfmodule_axial_hole_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L6b_halfmodule_axial_hole_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L6b_halfmodule_axial_hole_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L6b_halfmodule_axial_hole_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L6b_halfmodule_axial_hole_sensor_active_volume" />
+          <positionref ref="module_L6b_halfmodule_axial_hole_sensor_active_position" />
+          <rotationref ref="module_L6b_halfmodule_axial_hole_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L6b_halfmodule_axial_hole_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L6b_halfmodule_axial_hole_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L6b_halfmodule_axial_hole_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L6b_halfmodule_axial_holeBox" />
+        <physvol>
+          <volumeref ref="module_L6b_halfmodule_axial_hole_sensor_volume" />
+          <positionref ref="module_L6b_halfmodule_axial_hole_sensor_position" />
+          <rotationref ref="module_L6b_halfmodule_axial_hole_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L6b_halfmodule_axial_hole_lamination_volume" />
+          <positionref ref="module_L6b_halfmodule_axial_hole_lamination_position" />
+          <rotationref ref="module_L6b_halfmodule_axial_hole_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L6b_halfmodule_axial_slot_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L6b_halfmodule_axial_slot_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L6b_halfmodule_axial_slot_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L6b_halfmodule_axial_slot_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L6b_halfmodule_axial_slot_sensor_active_volume" />
+          <positionref ref="module_L6b_halfmodule_axial_slot_sensor_active_position" />
+          <rotationref ref="module_L6b_halfmodule_axial_slot_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L6b_halfmodule_axial_slot_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L6b_halfmodule_axial_slot_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L6b_halfmodule_axial_slot_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L6b_halfmodule_axial_slotBox" />
+        <physvol>
+          <volumeref ref="module_L6b_halfmodule_axial_slot_sensor_volume" />
+          <positionref ref="module_L6b_halfmodule_axial_slot_sensor_position" />
+          <rotationref ref="module_L6b_halfmodule_axial_slot_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L6b_halfmodule_axial_slot_lamination_volume" />
+          <positionref ref="module_L6b_halfmodule_axial_slot_lamination_position" />
+          <rotationref ref="module_L6b_halfmodule_axial_slot_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L6b_halfmodule_stereo_hole_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L6b_halfmodule_stereo_hole_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L6b_halfmodule_stereo_hole_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L6b_halfmodule_stereo_hole_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L6b_halfmodule_stereo_hole_sensor_active_volume" />
+          <positionref ref="module_L6b_halfmodule_stereo_hole_sensor_active_position" />
+          <rotationref ref="module_L6b_halfmodule_stereo_hole_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L6b_halfmodule_stereo_hole_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L6b_halfmodule_stereo_hole_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L6b_halfmodule_stereo_hole_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L6b_halfmodule_stereo_holeBox" />
+        <physvol>
+          <volumeref ref="module_L6b_halfmodule_stereo_hole_sensor_volume" />
+          <positionref ref="module_L6b_halfmodule_stereo_hole_sensor_position" />
+          <rotationref ref="module_L6b_halfmodule_stereo_hole_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L6b_halfmodule_stereo_hole_lamination_volume" />
+          <positionref ref="module_L6b_halfmodule_stereo_hole_lamination_position" />
+          <rotationref ref="module_L6b_halfmodule_stereo_hole_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L6b_halfmodule_stereo_slot_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L6b_halfmodule_stereo_slot_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L6b_halfmodule_stereo_slot_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L6b_halfmodule_stereo_slot_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L6b_halfmodule_stereo_slot_sensor_active_volume" />
+          <positionref ref="module_L6b_halfmodule_stereo_slot_sensor_active_position" />
+          <rotationref ref="module_L6b_halfmodule_stereo_slot_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L6b_halfmodule_stereo_slot_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L6b_halfmodule_stereo_slot_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L6b_halfmodule_stereo_slot_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L6b_halfmodule_stereo_slotBox" />
+        <physvol>
+          <volumeref ref="module_L6b_halfmodule_stereo_slot_sensor_volume" />
+          <positionref ref="module_L6b_halfmodule_stereo_slot_sensor_position" />
+          <rotationref ref="module_L6b_halfmodule_stereo_slot_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L6b_halfmodule_stereo_slot_lamination_volume" />
+          <positionref ref="module_L6b_halfmodule_stereo_slot_lamination_position" />
+          <rotationref ref="module_L6b_halfmodule_stereo_slot_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L6t_halfmodule_axial_hole_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L6t_halfmodule_axial_hole_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L6t_halfmodule_axial_hole_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L6t_halfmodule_axial_hole_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L6t_halfmodule_axial_hole_sensor_active_volume" />
+          <positionref ref="module_L6t_halfmodule_axial_hole_sensor_active_position" />
+          <rotationref ref="module_L6t_halfmodule_axial_hole_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L6t_halfmodule_axial_hole_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L6t_halfmodule_axial_hole_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L6t_halfmodule_axial_hole_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L6t_halfmodule_axial_holeBox" />
+        <physvol>
+          <volumeref ref="module_L6t_halfmodule_axial_hole_sensor_volume" />
+          <positionref ref="module_L6t_halfmodule_axial_hole_sensor_position" />
+          <rotationref ref="module_L6t_halfmodule_axial_hole_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L6t_halfmodule_axial_hole_lamination_volume" />
+          <positionref ref="module_L6t_halfmodule_axial_hole_lamination_position" />
+          <rotationref ref="module_L6t_halfmodule_axial_hole_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L6t_halfmodule_axial_slot_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L6t_halfmodule_axial_slot_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L6t_halfmodule_axial_slot_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L6t_halfmodule_axial_slot_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L6t_halfmodule_axial_slot_sensor_active_volume" />
+          <positionref ref="module_L6t_halfmodule_axial_slot_sensor_active_position" />
+          <rotationref ref="module_L6t_halfmodule_axial_slot_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L6t_halfmodule_axial_slot_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L6t_halfmodule_axial_slot_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L6t_halfmodule_axial_slot_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L6t_halfmodule_axial_slotBox" />
+        <physvol>
+          <volumeref ref="module_L6t_halfmodule_axial_slot_sensor_volume" />
+          <positionref ref="module_L6t_halfmodule_axial_slot_sensor_position" />
+          <rotationref ref="module_L6t_halfmodule_axial_slot_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L6t_halfmodule_axial_slot_lamination_volume" />
+          <positionref ref="module_L6t_halfmodule_axial_slot_lamination_position" />
+          <rotationref ref="module_L6t_halfmodule_axial_slot_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L6t_halfmodule_stereo_hole_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L6t_halfmodule_stereo_hole_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L6t_halfmodule_stereo_hole_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L6t_halfmodule_stereo_hole_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L6t_halfmodule_stereo_hole_sensor_active_volume" />
+          <positionref ref="module_L6t_halfmodule_stereo_hole_sensor_active_position" />
+          <rotationref ref="module_L6t_halfmodule_stereo_hole_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L6t_halfmodule_stereo_hole_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L6t_halfmodule_stereo_hole_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L6t_halfmodule_stereo_hole_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L6t_halfmodule_stereo_holeBox" />
+        <physvol>
+          <volumeref ref="module_L6t_halfmodule_stereo_hole_sensor_volume" />
+          <positionref ref="module_L6t_halfmodule_stereo_hole_sensor_position" />
+          <rotationref ref="module_L6t_halfmodule_stereo_hole_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L6t_halfmodule_stereo_hole_lamination_volume" />
+          <positionref ref="module_L6t_halfmodule_stereo_hole_lamination_position" />
+          <rotationref ref="module_L6t_halfmodule_stereo_hole_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L6t_halfmodule_stereo_slot_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L6t_halfmodule_stereo_slot_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L6t_halfmodule_stereo_slot_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L6t_halfmodule_stereo_slot_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L6t_halfmodule_stereo_slot_sensor_active_volume" />
+          <positionref ref="module_L6t_halfmodule_stereo_slot_sensor_active_position" />
+          <rotationref ref="module_L6t_halfmodule_stereo_slot_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L6t_halfmodule_stereo_slot_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L6t_halfmodule_stereo_slot_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L6t_halfmodule_stereo_slot_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L6t_halfmodule_stereo_slotBox" />
+        <physvol>
+          <volumeref ref="module_L6t_halfmodule_stereo_slot_sensor_volume" />
+          <positionref ref="module_L6t_halfmodule_stereo_slot_sensor_position" />
+          <rotationref ref="module_L6t_halfmodule_stereo_slot_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L6t_halfmodule_stereo_slot_lamination_volume" />
+          <positionref ref="module_L6t_halfmodule_stereo_slot_lamination_position" />
+          <rotationref ref="module_L6t_halfmodule_stereo_slot_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L7b_halfmodule_axial_hole_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L7b_halfmodule_axial_hole_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L7b_halfmodule_axial_hole_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L7b_halfmodule_axial_hole_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L7b_halfmodule_axial_hole_sensor_active_volume" />
+          <positionref ref="module_L7b_halfmodule_axial_hole_sensor_active_position" />
+          <rotationref ref="module_L7b_halfmodule_axial_hole_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L7b_halfmodule_axial_hole_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L7b_halfmodule_axial_hole_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L7b_halfmodule_axial_hole_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L7b_halfmodule_axial_holeBox" />
+        <physvol>
+          <volumeref ref="module_L7b_halfmodule_axial_hole_sensor_volume" />
+          <positionref ref="module_L7b_halfmodule_axial_hole_sensor_position" />
+          <rotationref ref="module_L7b_halfmodule_axial_hole_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L7b_halfmodule_axial_hole_lamination_volume" />
+          <positionref ref="module_L7b_halfmodule_axial_hole_lamination_position" />
+          <rotationref ref="module_L7b_halfmodule_axial_hole_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L7b_halfmodule_axial_slot_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L7b_halfmodule_axial_slot_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L7b_halfmodule_axial_slot_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L7b_halfmodule_axial_slot_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L7b_halfmodule_axial_slot_sensor_active_volume" />
+          <positionref ref="module_L7b_halfmodule_axial_slot_sensor_active_position" />
+          <rotationref ref="module_L7b_halfmodule_axial_slot_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L7b_halfmodule_axial_slot_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L7b_halfmodule_axial_slot_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L7b_halfmodule_axial_slot_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L7b_halfmodule_axial_slotBox" />
+        <physvol>
+          <volumeref ref="module_L7b_halfmodule_axial_slot_sensor_volume" />
+          <positionref ref="module_L7b_halfmodule_axial_slot_sensor_position" />
+          <rotationref ref="module_L7b_halfmodule_axial_slot_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L7b_halfmodule_axial_slot_lamination_volume" />
+          <positionref ref="module_L7b_halfmodule_axial_slot_lamination_position" />
+          <rotationref ref="module_L7b_halfmodule_axial_slot_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L7b_halfmodule_stereo_hole_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L7b_halfmodule_stereo_hole_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L7b_halfmodule_stereo_hole_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L7b_halfmodule_stereo_hole_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L7b_halfmodule_stereo_hole_sensor_active_volume" />
+          <positionref ref="module_L7b_halfmodule_stereo_hole_sensor_active_position" />
+          <rotationref ref="module_L7b_halfmodule_stereo_hole_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L7b_halfmodule_stereo_hole_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L7b_halfmodule_stereo_hole_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L7b_halfmodule_stereo_hole_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L7b_halfmodule_stereo_holeBox" />
+        <physvol>
+          <volumeref ref="module_L7b_halfmodule_stereo_hole_sensor_volume" />
+          <positionref ref="module_L7b_halfmodule_stereo_hole_sensor_position" />
+          <rotationref ref="module_L7b_halfmodule_stereo_hole_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L7b_halfmodule_stereo_hole_lamination_volume" />
+          <positionref ref="module_L7b_halfmodule_stereo_hole_lamination_position" />
+          <rotationref ref="module_L7b_halfmodule_stereo_hole_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L7b_halfmodule_stereo_slot_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L7b_halfmodule_stereo_slot_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L7b_halfmodule_stereo_slot_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L7b_halfmodule_stereo_slot_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L7b_halfmodule_stereo_slot_sensor_active_volume" />
+          <positionref ref="module_L7b_halfmodule_stereo_slot_sensor_active_position" />
+          <rotationref ref="module_L7b_halfmodule_stereo_slot_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L7b_halfmodule_stereo_slot_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L7b_halfmodule_stereo_slot_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L7b_halfmodule_stereo_slot_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L7b_halfmodule_stereo_slotBox" />
+        <physvol>
+          <volumeref ref="module_L7b_halfmodule_stereo_slot_sensor_volume" />
+          <positionref ref="module_L7b_halfmodule_stereo_slot_sensor_position" />
+          <rotationref ref="module_L7b_halfmodule_stereo_slot_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L7b_halfmodule_stereo_slot_lamination_volume" />
+          <positionref ref="module_L7b_halfmodule_stereo_slot_lamination_position" />
+          <rotationref ref="module_L7b_halfmodule_stereo_slot_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L7t_halfmodule_axial_hole_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L7t_halfmodule_axial_hole_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L7t_halfmodule_axial_hole_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L7t_halfmodule_axial_hole_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L7t_halfmodule_axial_hole_sensor_active_volume" />
+          <positionref ref="module_L7t_halfmodule_axial_hole_sensor_active_position" />
+          <rotationref ref="module_L7t_halfmodule_axial_hole_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L7t_halfmodule_axial_hole_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L7t_halfmodule_axial_hole_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L7t_halfmodule_axial_hole_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L7t_halfmodule_axial_holeBox" />
+        <physvol>
+          <volumeref ref="module_L7t_halfmodule_axial_hole_sensor_volume" />
+          <positionref ref="module_L7t_halfmodule_axial_hole_sensor_position" />
+          <rotationref ref="module_L7t_halfmodule_axial_hole_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L7t_halfmodule_axial_hole_lamination_volume" />
+          <positionref ref="module_L7t_halfmodule_axial_hole_lamination_position" />
+          <rotationref ref="module_L7t_halfmodule_axial_hole_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L7t_halfmodule_axial_slot_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L7t_halfmodule_axial_slot_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L7t_halfmodule_axial_slot_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L7t_halfmodule_axial_slot_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L7t_halfmodule_axial_slot_sensor_active_volume" />
+          <positionref ref="module_L7t_halfmodule_axial_slot_sensor_active_position" />
+          <rotationref ref="module_L7t_halfmodule_axial_slot_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L7t_halfmodule_axial_slot_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L7t_halfmodule_axial_slot_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L7t_halfmodule_axial_slot_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L7t_halfmodule_axial_slotBox" />
+        <physvol>
+          <volumeref ref="module_L7t_halfmodule_axial_slot_sensor_volume" />
+          <positionref ref="module_L7t_halfmodule_axial_slot_sensor_position" />
+          <rotationref ref="module_L7t_halfmodule_axial_slot_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L7t_halfmodule_axial_slot_lamination_volume" />
+          <positionref ref="module_L7t_halfmodule_axial_slot_lamination_position" />
+          <rotationref ref="module_L7t_halfmodule_axial_slot_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L7t_halfmodule_stereo_hole_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L7t_halfmodule_stereo_hole_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L7t_halfmodule_stereo_hole_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L7t_halfmodule_stereo_hole_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L7t_halfmodule_stereo_hole_sensor_active_volume" />
+          <positionref ref="module_L7t_halfmodule_stereo_hole_sensor_active_position" />
+          <rotationref ref="module_L7t_halfmodule_stereo_hole_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L7t_halfmodule_stereo_hole_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L7t_halfmodule_stereo_hole_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L7t_halfmodule_stereo_hole_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L7t_halfmodule_stereo_holeBox" />
+        <physvol>
+          <volumeref ref="module_L7t_halfmodule_stereo_hole_sensor_volume" />
+          <positionref ref="module_L7t_halfmodule_stereo_hole_sensor_position" />
+          <rotationref ref="module_L7t_halfmodule_stereo_hole_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L7t_halfmodule_stereo_hole_lamination_volume" />
+          <positionref ref="module_L7t_halfmodule_stereo_hole_lamination_position" />
+          <rotationref ref="module_L7t_halfmodule_stereo_hole_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L7t_halfmodule_stereo_slot_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L7t_halfmodule_stereo_slot_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L7t_halfmodule_stereo_slot_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L7t_halfmodule_stereo_slot_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L7t_halfmodule_stereo_slot_sensor_active_volume" />
+          <positionref ref="module_L7t_halfmodule_stereo_slot_sensor_active_position" />
+          <rotationref ref="module_L7t_halfmodule_stereo_slot_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L7t_halfmodule_stereo_slot_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L7t_halfmodule_stereo_slot_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L7t_halfmodule_stereo_slot_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L7t_halfmodule_stereo_slotBox" />
+        <physvol>
+          <volumeref ref="module_L7t_halfmodule_stereo_slot_sensor_volume" />
+          <positionref ref="module_L7t_halfmodule_stereo_slot_sensor_position" />
+          <rotationref ref="module_L7t_halfmodule_stereo_slot_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L7t_halfmodule_stereo_slot_lamination_volume" />
+          <positionref ref="module_L7t_halfmodule_stereo_slot_lamination_position" />
+          <rotationref ref="module_L7t_halfmodule_stereo_slot_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="base_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="baseBox" />
+        <physvol>
+          <volumeref ref="base_plate_volume" />
+          <positionref ref="base_plate_position" />
+          <rotationref ref="base_plate_rotation" />
+        </physvol>
+        <physvol>
+          <volumeref ref="support_plate_bottom_L14_volume" />
+          <positionref ref="support_plate_bottom_L14_position" />
+          <rotationref ref="support_plate_bottom_L14_rotation" />
+        </physvol>
+        <physvol>
+          <volumeref ref="support_plate_top_L14_volume" />
+          <positionref ref="support_plate_top_L14_position" />
+          <rotationref ref="support_plate_top_L14_rotation" />
+        </physvol>
+        <physvol>
+          <volumeref ref="support_plate_bottom_L46_volume" />
+          <positionref ref="support_plate_bottom_L46_position" />
+          <rotationref ref="support_plate_bottom_L46_rotation" />
+        </physvol>
+        <physvol>
+          <volumeref ref="support_plate_top_L46_volume" />
+          <positionref ref="support_plate_top_L46_position" />
+          <rotationref ref="support_plate_top_L46_rotation" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L1b_halfmodule_axial_volume" />
+          <positionref ref="module_L1b_halfmodule_axial_position" />
+          <rotationref ref="module_L1b_halfmodule_axial_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="2" />
+          <physvolid field_name="module" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L1b_halfmodule_stereo_volume" />
+          <positionref ref="module_L1b_halfmodule_stereo_position" />
+          <rotationref ref="module_L1b_halfmodule_stereo_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="1" />
+          <physvolid field_name="module" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L1t_halfmodule_axial_volume" />
+          <positionref ref="module_L1t_halfmodule_axial_position" />
+          <rotationref ref="module_L1t_halfmodule_axial_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="1" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L1t_halfmodule_stereo_volume" />
+          <positionref ref="module_L1t_halfmodule_stereo_position" />
+          <rotationref ref="module_L1t_halfmodule_stereo_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="2" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L2b_halfmodule_axial_volume" />
+          <positionref ref="module_L2b_halfmodule_axial_position" />
+          <rotationref ref="module_L2b_halfmodule_axial_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="4" />
+          <physvolid field_name="module" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L2b_halfmodule_stereo_volume" />
+          <positionref ref="module_L2b_halfmodule_stereo_position" />
+          <rotationref ref="module_L2b_halfmodule_stereo_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="3" />
+          <physvolid field_name="module" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L2t_halfmodule_axial_volume" />
+          <positionref ref="module_L2t_halfmodule_axial_position" />
+          <rotationref ref="module_L2t_halfmodule_axial_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="3" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L2t_halfmodule_stereo_volume" />
+          <positionref ref="module_L2t_halfmodule_stereo_position" />
+          <rotationref ref="module_L2t_halfmodule_stereo_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="4" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L3b_halfmodule_axial_volume" />
+          <positionref ref="module_L3b_halfmodule_axial_position" />
+          <rotationref ref="module_L3b_halfmodule_axial_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="6" />
+          <physvolid field_name="module" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L3b_halfmodule_stereo_volume" />
+          <positionref ref="module_L3b_halfmodule_stereo_position" />
+          <rotationref ref="module_L3b_halfmodule_stereo_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="5" />
+          <physvolid field_name="module" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L3t_halfmodule_axial_volume" />
+          <positionref ref="module_L3t_halfmodule_axial_position" />
+          <rotationref ref="module_L3t_halfmodule_axial_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="5" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L3t_halfmodule_stereo_volume" />
+          <positionref ref="module_L3t_halfmodule_stereo_position" />
+          <rotationref ref="module_L3t_halfmodule_stereo_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="6" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L4b_halfmodule_axial_volume" />
+          <positionref ref="module_L4b_halfmodule_axial_position" />
+          <rotationref ref="module_L4b_halfmodule_axial_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="8" />
+          <physvolid field_name="module" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L4b_halfmodule_stereo_volume" />
+          <positionref ref="module_L4b_halfmodule_stereo_position" />
+          <rotationref ref="module_L4b_halfmodule_stereo_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="7" />
+          <physvolid field_name="module" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L4t_halfmodule_axial_volume" />
+          <positionref ref="module_L4t_halfmodule_axial_position" />
+          <rotationref ref="module_L4t_halfmodule_axial_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="7" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L4t_halfmodule_stereo_volume" />
+          <positionref ref="module_L4t_halfmodule_stereo_position" />
+          <rotationref ref="module_L4t_halfmodule_stereo_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="8" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L5b_halfmodule_axial_hole_volume" />
+          <positionref ref="module_L5b_halfmodule_axial_hole_position" />
+          <rotationref ref="module_L5b_halfmodule_axial_hole_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="10" />
+          <physvolid field_name="module" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L5b_halfmodule_axial_slot_volume" />
+          <positionref ref="module_L5b_halfmodule_axial_slot_position" />
+          <rotationref ref="module_L5b_halfmodule_axial_slot_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="10" />
+          <physvolid field_name="module" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L5b_halfmodule_stereo_hole_volume" />
+          <positionref ref="module_L5b_halfmodule_stereo_hole_position" />
+          <rotationref ref="module_L5b_halfmodule_stereo_hole_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="9" />
+          <physvolid field_name="module" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L5b_halfmodule_stereo_slot_volume" />
+          <positionref ref="module_L5b_halfmodule_stereo_slot_position" />
+          <rotationref ref="module_L5b_halfmodule_stereo_slot_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="9" />
+          <physvolid field_name="module" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L5t_halfmodule_axial_hole_volume" />
+          <positionref ref="module_L5t_halfmodule_axial_hole_position" />
+          <rotationref ref="module_L5t_halfmodule_axial_hole_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="9" />
+          <physvolid field_name="module" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L5t_halfmodule_axial_slot_volume" />
+          <positionref ref="module_L5t_halfmodule_axial_slot_position" />
+          <rotationref ref="module_L5t_halfmodule_axial_slot_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="9" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L5t_halfmodule_stereo_hole_volume" />
+          <positionref ref="module_L5t_halfmodule_stereo_hole_position" />
+          <rotationref ref="module_L5t_halfmodule_stereo_hole_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="10" />
+          <physvolid field_name="module" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L5t_halfmodule_stereo_slot_volume" />
+          <positionref ref="module_L5t_halfmodule_stereo_slot_position" />
+          <rotationref ref="module_L5t_halfmodule_stereo_slot_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="10" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L6b_halfmodule_axial_hole_volume" />
+          <positionref ref="module_L6b_halfmodule_axial_hole_position" />
+          <rotationref ref="module_L6b_halfmodule_axial_hole_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="12" />
+          <physvolid field_name="module" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L6b_halfmodule_axial_slot_volume" />
+          <positionref ref="module_L6b_halfmodule_axial_slot_position" />
+          <rotationref ref="module_L6b_halfmodule_axial_slot_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="12" />
+          <physvolid field_name="module" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L6b_halfmodule_stereo_hole_volume" />
+          <positionref ref="module_L6b_halfmodule_stereo_hole_position" />
+          <rotationref ref="module_L6b_halfmodule_stereo_hole_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="11" />
+          <physvolid field_name="module" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L6b_halfmodule_stereo_slot_volume" />
+          <positionref ref="module_L6b_halfmodule_stereo_slot_position" />
+          <rotationref ref="module_L6b_halfmodule_stereo_slot_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="11" />
+          <physvolid field_name="module" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L6t_halfmodule_axial_hole_volume" />
+          <positionref ref="module_L6t_halfmodule_axial_hole_position" />
+          <rotationref ref="module_L6t_halfmodule_axial_hole_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="11" />
+          <physvolid field_name="module" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L6t_halfmodule_axial_slot_volume" />
+          <positionref ref="module_L6t_halfmodule_axial_slot_position" />
+          <rotationref ref="module_L6t_halfmodule_axial_slot_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="11" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L6t_halfmodule_stereo_hole_volume" />
+          <positionref ref="module_L6t_halfmodule_stereo_hole_position" />
+          <rotationref ref="module_L6t_halfmodule_stereo_hole_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="12" />
+          <physvolid field_name="module" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L6t_halfmodule_stereo_slot_volume" />
+          <positionref ref="module_L6t_halfmodule_stereo_slot_position" />
+          <rotationref ref="module_L6t_halfmodule_stereo_slot_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="12" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L7b_halfmodule_axial_hole_volume" />
+          <positionref ref="module_L7b_halfmodule_axial_hole_position" />
+          <rotationref ref="module_L7b_halfmodule_axial_hole_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="14" />
+          <physvolid field_name="module" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L7b_halfmodule_axial_slot_volume" />
+          <positionref ref="module_L7b_halfmodule_axial_slot_position" />
+          <rotationref ref="module_L7b_halfmodule_axial_slot_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="14" />
+          <physvolid field_name="module" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L7b_halfmodule_stereo_hole_volume" />
+          <positionref ref="module_L7b_halfmodule_stereo_hole_position" />
+          <rotationref ref="module_L7b_halfmodule_stereo_hole_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="13" />
+          <physvolid field_name="module" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L7b_halfmodule_stereo_slot_volume" />
+          <positionref ref="module_L7b_halfmodule_stereo_slot_position" />
+          <rotationref ref="module_L7b_halfmodule_stereo_slot_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="13" />
+          <physvolid field_name="module" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L7t_halfmodule_axial_hole_volume" />
+          <positionref ref="module_L7t_halfmodule_axial_hole_position" />
+          <rotationref ref="module_L7t_halfmodule_axial_hole_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="13" />
+          <physvolid field_name="module" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L7t_halfmodule_axial_slot_volume" />
+          <positionref ref="module_L7t_halfmodule_axial_slot_position" />
+          <rotationref ref="module_L7t_halfmodule_axial_slot_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="13" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L7t_halfmodule_stereo_hole_volume" />
+          <positionref ref="module_L7t_halfmodule_stereo_hole_position" />
+          <rotationref ref="module_L7t_halfmodule_stereo_hole_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="14" />
+          <physvolid field_name="module" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L7t_halfmodule_stereo_slot_volume" />
+          <positionref ref="module_L7t_halfmodule_stereo_slot_position" />
+          <rotationref ref="module_L7t_halfmodule_stereo_slot_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="14" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <visref ref="SvtBoxVis" />
+      </volume>
+      <volume name="BeamLeftVolume_component0Sensor0">
+        <materialref ref="Vacuum" />
+        <solidref ref="BeamLeftVolume_component0Sensor0Box" />
+        <sdref ref="ECalScoring" />
+      </volume>
+      <volume name="BeamLeftVolume_component0">
+        <materialref ref="Vacuum" />
+        <solidref ref="BeamLeftVolume_component0Box" />
+        <physvol>
+          <volumeref ref="BeamLeftVolume_component0Sensor0" />
+          <positionref ref="BeamLeftVolume_component0Sensor0Position" />
+          <rotationref ref="BeamLeftVolume_component0Sensor0Rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+      </volume>
+      <volume name="BeamLeftVolume">
+        <materialref ref="Vacuum" />
+        <solidref ref="BeamLeftBox" />
+        <physvol>
+          <volumeref ref="BeamLeftVolume_component0" />
+          <positionref ref="BeamLeftVolume_component0_position" />
+          <rotationref ref="BeamLeftVolume_component0_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+      </volume>
+      <volume name="ElectronGapVolume_component0Sensor0">
+        <materialref ref="Vacuum" />
+        <solidref ref="ElectronGapVolume_component0Sensor0Box" />
+        <sdref ref="ECalScoring" />
+      </volume>
+      <volume name="ElectronGapVolume_component0">
+        <materialref ref="Vacuum" />
+        <solidref ref="ElectronGapVolume_component0Box" />
+        <physvol>
+          <volumeref ref="ElectronGapVolume_component0Sensor0" />
+          <positionref ref="ElectronGapVolume_component0Sensor0Position" />
+          <rotationref ref="ElectronGapVolume_component0Sensor0Rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+      </volume>
+      <volume name="ElectronGapVolume">
+        <materialref ref="Vacuum" />
+        <solidref ref="ElectronGapBox" />
+        <physvol>
+          <volumeref ref="ElectronGapVolume_component0" />
+          <positionref ref="ElectronGapVolume_component0_position" />
+          <rotationref ref="ElectronGapVolume_component0_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+      </volume>
+      <volume name="BeamRightVolume_component0Sensor0">
+        <materialref ref="Vacuum" />
+        <solidref ref="BeamRightVolume_component0Sensor0Box" />
+        <sdref ref="ECalScoring" />
+      </volume>
+      <volume name="BeamRightVolume_component0">
+        <materialref ref="Vacuum" />
+        <solidref ref="BeamRightVolume_component0Box" />
+        <physvol>
+          <volumeref ref="BeamRightVolume_component0Sensor0" />
+          <positionref ref="BeamRightVolume_component0Sensor0Position" />
+          <rotationref ref="BeamRightVolume_component0Sensor0Rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+      </volume>
+      <volume name="BeamRightVolume">
+        <materialref ref="Vacuum" />
+        <solidref ref="BeamRightBox" />
+        <physvol>
+          <volumeref ref="BeamRightVolume_component0" />
+          <positionref ref="BeamRightVolume_component0_position" />
+          <rotationref ref="BeamRightVolume_component0_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+      </volume>
+      <volume name="crystal_volume">
+        <materialref ref="LeadTungstate" />
+        <solidref ref="crystal_trap" />
+        <sdref ref="Ecal" />
+        <visref ref="ECALVis" />
+      </volume>
+      <volume name="hodo_vol_L1TP0">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L1TP0" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L1TP0">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L1TP0" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L1TP0">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L1TP0" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L1TP0">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L1TP0" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_vol_L1BP0">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L1BP0" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L1BP0">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L1BP0" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L1BP0">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L1BP0" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L1BP0">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L1BP0" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_vol_L1TP1">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L1TP1" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L1TP1">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L1TP1" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L1TP1">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L1TP1" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L1TP1">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L1TP1" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_vol_L1BP1">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L1BP1" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L1BP1">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L1BP1" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L1BP1">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L1BP1" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L1BP1">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L1BP1" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_vol_L1TP2">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L1TP2" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L1TP2">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L1TP2" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L1TP2">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L1TP2" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L1TP2">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L1TP2" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_vol_L1BP2">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L1BP2" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L1BP2">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L1BP2" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L1BP2">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L1BP2" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L1BP2">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L1BP2" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_vol_L1TP3">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L1TP3" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L1TP3">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L1TP3" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L1TP3">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L1TP3" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L1TP3">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L1TP3" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_vol_L1BP3">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L1BP3" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L1BP3">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L1BP3" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L1BP3">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L1BP3" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L1BP3">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L1BP3" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_vol_L1TP4">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L1TP4" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L1TP4">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L1TP4" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L1TP4">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L1TP4" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L1TP4">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L1TP4" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_vol_L1BP4">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L1BP4" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L1BP4">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L1BP4" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L1BP4">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L1BP4" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L1BP4">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L1BP4" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_vol_L2TP0">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L2TP0" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L2TP0">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L2TP0" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L2TP0">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L2TP0" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L2TP0">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L2TP0" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_vol_L2BP0">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L2BP0" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L2BP0">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L2BP0" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L2BP0">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L2BP0" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L2BP0">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L2BP0" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_vol_L2TP1">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L2TP1" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L2TP1">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L2TP1" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L2TP1">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L2TP1" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L2TP1">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L2TP1" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_vol_L2BP1">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L2BP1" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L2BP1">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L2BP1" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L2BP1">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L2BP1" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L2BP1">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L2BP1" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_vol_L2TP2">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L2TP2" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L2TP2">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L2TP2" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L2TP2">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L2TP2" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L2TP2">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L2TP2" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_vol_L2BP2">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L2BP2" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L2BP2">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L2BP2" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L2BP2">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L2BP2" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L2BP2">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L2BP2" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_vol_L2TP3">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L2TP3" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L2TP3">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L2TP3" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L2TP3">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L2TP3" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L2TP3">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L2TP3" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_vol_L2BP3">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L2BP3" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L2BP3">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L2BP3" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L2BP3">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L2BP3" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L2BP3">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L2BP3" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_vol_L2TP4">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L2TP4" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L2TP4">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L2TP4" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L2TP4">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L2TP4" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L2TP4">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L2TP4" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_vol_L2BP4">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L2BP4" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L2BP4">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L2BP4" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L2BP4">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L2BP4" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L2BP4">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L2BP4" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_buffer_vol">
+        <materialref ref="Carbon" />
+        <solidref ref="hodo_buffer" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="front_flange">
+        <materialref ref="G4_Al" />
+        <solidref ref="front_flange_shape" />
+      </volume>
+      <volume name="back_flange">
+        <materialref ref="G4_Al" />
+        <solidref ref="back_flange_shape" />
+      </volume>
+      <volume name="ECAL_chamber">
+        <materialref ref="G4_Al" />
+        <solidref ref="ECAL_chamber_shape" />
+      </volume>
+      <volume name="al_honeycomb">
+        <materialref ref="AlHoneycomb" />
+        <solidref ref="al_honeycomb_shape" />
+      </volume>
+      <volume name="layer_1_top">
+        <materialref ref="G4_Al" />
+        <solidref ref="layer_1_top_shape" />
+      </volume>
+      <volume name="layer_2_top">
+        <materialref ref="G4_Al" />
+        <solidref ref="layer_2_top_shape" />
+      </volume>
+      <volume name="layer_3_top">
+        <materialref ref="G4_Al" />
+        <solidref ref="layer_3_top_shape" />
+      </volume>
+      <volume name="layer_4_top">
+        <materialref ref="G4_Al" />
+        <solidref ref="layer_4_top_shape" />
+      </volume>
+      <volume name="layer_1_bottom">
+        <materialref ref="G4_Al" />
+        <solidref ref="layer_1_bottom_shape" />
+      </volume>
+      <volume name="layer_2_bottom">
+        <materialref ref="G4_Al" />
+        <solidref ref="layer_2_bottom_shape" />
+      </volume>
+      <volume name="layer_3_bottom">
+        <materialref ref="G4_Al" />
+        <solidref ref="layer_3_bottom_shape" />
+      </volume>
+      <volume name="layer_4_bottom">
+        <materialref ref="G4_Al" />
+        <solidref ref="layer_4_bottom_shape" />
+      </volume>
+      <volume name="layer_5T_left">
+        <materialref ref="G4_Al" />
+        <solidref ref="layer_5T_left_shape" />
+      </volume>
+      <volume name="layer_5B_left">
+        <materialref ref="G4_Al" />
+        <solidref ref="layer_5B_left_shape" />
+      </volume>
+      <volume name="steel_bar">
+        <materialref ref="StainlessSteel" />
+        <solidref ref="steel_bar_shape" />
+      </volume>
+      <volume name="cu_Tpipe_inner_left">
+        <materialref ref="G4_Cu" />
+        <solidref ref="cu_Tpipe_inner_left_shape" />
+      </volume>
+      <volume name="cu_Tpipe_inner_right">
+        <materialref ref="G4_Cu" />
+        <solidref ref="cu_Tpipe_inner_right_shape" />
+      </volume>
+      <volume name="cu_Bpipe_inner_left">
+        <materialref ref="G4_Cu" />
+        <solidref ref="cu_Bpipe_inner_left_shape" />
+      </volume>
+      <volume name="cu_Bpipe_inner_right">
+        <materialref ref="G4_Cu" />
+        <solidref ref="cu_Bpipe_inner_right_shape" />
+      </volume>
+      <volume name="cu_Tpipe_outer_right1">
+        <materialref ref="G4_Cu" />
+        <solidref ref="cu_Tpipe_outer_right1_shape" />
+      </volume>
+      <volume name="cu_Tpipe_outer_right2">
+        <materialref ref="G4_Cu" />
+        <solidref ref="cu_Tpipe_outer_right2_shape" />
+      </volume>
+      <volume name="cu_Tpipe_outer_right3">
+        <materialref ref="G4_Cu" />
+        <solidref ref="cu_Tpipe_outer_right3_shape" />
+      </volume>
+      <volume name="cu_Bpipe_outer_right">
+        <materialref ref="G4_Cu" />
+        <solidref ref="cu_Bpipe_outer_right_shape" />
+      </volume>
+      <volume name="cu_Bpipe_outer_right1">
+        <materialref ref="G4_Cu" />
+        <solidref ref="cu_Bpipe_outer_right1_shape" />
+      </volume>
+      <volume name="cu_Bpipe_outer_right2">
+        <materialref ref="G4_Cu" />
+        <solidref ref="cu_Bpipe_outer_right2_shape" />
+      </volume>
+      <volume name="al_pipe_across_top1">
+        <materialref ref="G4_Al" />
+        <solidref ref="al_pipe_across_top1_shape" />
+      </volume>
+      <volume name="al_pipe_across_top2">
+        <materialref ref="G4_Al" />
+        <solidref ref="al_pipe_across_top2_shape" />
+      </volume>
+      <volume name="al_pipe_across_bottom1">
+        <materialref ref="G4_Al" />
+        <solidref ref="al_pipe_across_bottom1_shape" />
+      </volume>
+      <volume name="al_pipe_across_bottom2">
+        <materialref ref="G4_Al" />
+        <solidref ref="al_pipe_across_bottom2_shape" />
+      </volume>
+      <volume name="cu_plate_top_left">
+        <materialref ref="G4_Cu" />
+        <solidref ref="cu_plate_top_left_shape" />
+      </volume>
+      <volume name="cu_plate_bottom_left">
+        <materialref ref="G4_Cu" />
+        <solidref ref="cu_plate_bottom_left_shape" />
+      </volume>
+      <volume name="cu_plate_top_right">
+        <materialref ref="G4_Cu" />
+        <solidref ref="cu_plate_top_right_shape" />
+      </volume>
+      <volume name="cu_plate_bottom_right">
+        <materialref ref="G4_Cu" />
+        <solidref ref="cu_plate_bottom_right_shape" />
+      </volume>
+      <volume name="cu_plate_top_middle">
+        <materialref ref="G4_Cu" />
+        <solidref ref="cu_plate_top_middle_shape" />
+      </volume>
+      <volume name="cu_plate_bottom_middle">
+        <materialref ref="G4_Cu" />
+        <solidref ref="cu_plate_bottom_middle_shape" />
+      </volume>
+      <volume name="hodo_flange">
+        <materialref ref="Aluminum" />
+        <solidref ref="hodo_flange_shape" />
+      </volume>
+      <volume name="arms1_block1">
+        <materialref ref="G10_FR4" />
+        <solidref ref="arms1_block1_shape" />
+      </volume>
+      <volume name="arms1_block2">
+        <materialref ref="G10_FR4" />
+        <solidref ref="arms1_block2_shape" />
+      </volume>
+      <volume name="arms1_block3">
+        <materialref ref="G10_FR4" />
+        <solidref ref="arms1_block3_shape" />
+      </volume>
+      <volume name="arms1_block4">
+        <materialref ref="G10_FR4" />
+        <solidref ref="arms1_block4_shape" />
+      </volume>
+      <volume name="cross_bar_top">
+        <materialref ref="G10_FR4" />
+        <solidref ref="cross_bar_top_shape" />
+      </volume>
+      <volume name="cross_bar_bottom">
+        <materialref ref="G10_FR4" />
+        <solidref ref="cross_bar_bottom_shape" />
+      </volume>
+      <volume name="support_arm_bottom_left_plus_block">
+        <materialref ref="G10_FR4" />
+        <solidref ref="support_arm_bottom_left_plus_block_shape" />
+      </volume>
+      <volume name="support_arm_bottom_right">
+        <materialref ref="G10_FR4" />
+        <solidref ref="support_arm_bottom_right_shape" />
+      </volume>
+      <volume name="support_arm_top_left">
+        <materialref ref="G10_FR4" />
+        <solidref ref="support_arm_top_left_shape" />
+      </volume>
+      <volume name="support_arm_top_right">
+        <materialref ref="G10_FR4" />
+        <solidref ref="support_arm_top_right_shape" />
+      </volume>
+      <volume name="u_support_bar_bottom">
+        <materialref ref="G10_FR4" />
+        <solidref ref="u_support_bar_bottom_shape" />
+      </volume>
+      <volume name="u_support_bar_upper1">
+        <materialref ref="G10_FR4" />
+        <solidref ref="u_support_bar_upper1_shape" />
+      </volume>
+      <volume name="u_support_bar_upper2">
+        <materialref ref="G10_FR4" />
+        <solidref ref="u_support_bar_upper2_shape" />
+      </volume>
+      <volume name="u_support_bar_top">
+        <materialref ref="G10_FR4" />
+        <solidref ref="u_support_bar_top_shape" />
+      </volume>
+      <volume name="u_support_bar_upper3">
+        <materialref ref="G10_FR4" />
+        <solidref ref="u_support_bar_upper3_shape" />
+      </volume>
+      <volume name="u_support_bar_upper4">
+        <materialref ref="G10_FR4" />
+        <solidref ref="u_support_bar_upper4_shape" />
+      </volume>
+      <volume name="svt_chamber_box_vol">
+        <materialref ref="Stainless_304" />
+        <solidref ref="svt_chamber_box" />
+      </volume>
+      <volume name="svt_chamber_flare1_vol">
+        <materialref ref="Stainless_304" />
+        <solidref ref="svt_chamber_flare1" />
+      </volume>
+      <volume name="svt_chamber_flare2_vol">
+        <materialref ref="Stainless_304" />
+        <solidref ref="svt_chamber_flare2" />
+      </volume>
+      <volume name="svt_chamber_flange_vol">
+        <materialref ref="Stainless_304" />
+        <solidref ref="svt_chamber_flange" />
+      </volume>
+      <volume name="tracking_volume">
+        <materialref ref="TrackingMaterial" />
+        <solidref ref="tracking_cylinder" />
+        <physvol>
+          <volumeref ref="base_volume" />
+          <positionref ref="base_position" />
+          <rotationref ref="base_rotation" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L1TP0" />
+          <positionref ref="hodo_pos_L1TP0" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="0" />
+          <physvolid field_name="ix" value="0" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1TP0" />
+          <positionref ref="hodo_forecover_pos_L1TP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1TP0" />
+          <positionref ref="hodo_postcover_pos_L1TP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1TP0" />
+          <positionref ref="hodo_sidereflR_pos_L1TP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1TP0" />
+          <positionref ref="hodo_siderefl2L_pos_L1TP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1TP0" />
+          <positionref ref="hodo_topreflT_pos_L1TP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1TP0" />
+          <positionref ref="hodo_toprefl2B_pos_L1TP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L1BP0" />
+          <positionref ref="hodo_pos_L1BP0" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="0" />
+          <physvolid field_name="ix" value="0" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1BP0" />
+          <positionref ref="hodo_forecover_pos_L1BP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1BP0" />
+          <positionref ref="hodo_postcover_pos_L1BP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1BP0" />
+          <positionref ref="hodo_sidereflR_pos_L1BP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1BP0" />
+          <positionref ref="hodo_siderefl2L_pos_L1BP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1BP0" />
+          <positionref ref="hodo_topreflT_pos_L1BP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1BP0" />
+          <positionref ref="hodo_toprefl2B_pos_L1BP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L1TP1" />
+          <positionref ref="hodo_pos_L1TP1" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="0" />
+          <physvolid field_name="ix" value="1" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1TP1" />
+          <positionref ref="hodo_forecover_pos_L1TP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1TP1" />
+          <positionref ref="hodo_postcover_pos_L1TP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1TP1" />
+          <positionref ref="hodo_sidereflR_pos_L1TP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1TP1" />
+          <positionref ref="hodo_siderefl2L_pos_L1TP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1TP1" />
+          <positionref ref="hodo_topreflT_pos_L1TP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1TP1" />
+          <positionref ref="hodo_toprefl2B_pos_L1TP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L1BP1" />
+          <positionref ref="hodo_pos_L1BP1" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="0" />
+          <physvolid field_name="ix" value="1" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1BP1" />
+          <positionref ref="hodo_forecover_pos_L1BP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1BP1" />
+          <positionref ref="hodo_postcover_pos_L1BP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1BP1" />
+          <positionref ref="hodo_sidereflR_pos_L1BP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1BP1" />
+          <positionref ref="hodo_siderefl2L_pos_L1BP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1BP1" />
+          <positionref ref="hodo_topreflT_pos_L1BP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1BP1" />
+          <positionref ref="hodo_toprefl2B_pos_L1BP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L1TP2" />
+          <positionref ref="hodo_pos_L1TP2" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="0" />
+          <physvolid field_name="ix" value="2" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1TP2" />
+          <positionref ref="hodo_forecover_pos_L1TP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1TP2" />
+          <positionref ref="hodo_postcover_pos_L1TP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1TP2" />
+          <positionref ref="hodo_sidereflR_pos_L1TP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1TP2" />
+          <positionref ref="hodo_siderefl2L_pos_L1TP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1TP2" />
+          <positionref ref="hodo_topreflT_pos_L1TP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1TP2" />
+          <positionref ref="hodo_toprefl2B_pos_L1TP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L1BP2" />
+          <positionref ref="hodo_pos_L1BP2" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="0" />
+          <physvolid field_name="ix" value="2" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1BP2" />
+          <positionref ref="hodo_forecover_pos_L1BP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1BP2" />
+          <positionref ref="hodo_postcover_pos_L1BP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1BP2" />
+          <positionref ref="hodo_sidereflR_pos_L1BP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1BP2" />
+          <positionref ref="hodo_siderefl2L_pos_L1BP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1BP2" />
+          <positionref ref="hodo_topreflT_pos_L1BP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1BP2" />
+          <positionref ref="hodo_toprefl2B_pos_L1BP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L1TP3" />
+          <positionref ref="hodo_pos_L1TP3" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="0" />
+          <physvolid field_name="ix" value="3" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1TP3" />
+          <positionref ref="hodo_forecover_pos_L1TP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1TP3" />
+          <positionref ref="hodo_postcover_pos_L1TP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1TP3" />
+          <positionref ref="hodo_sidereflR_pos_L1TP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1TP3" />
+          <positionref ref="hodo_siderefl2L_pos_L1TP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1TP3" />
+          <positionref ref="hodo_topreflT_pos_L1TP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1TP3" />
+          <positionref ref="hodo_toprefl2B_pos_L1TP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L1BP3" />
+          <positionref ref="hodo_pos_L1BP3" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="0" />
+          <physvolid field_name="ix" value="3" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1BP3" />
+          <positionref ref="hodo_forecover_pos_L1BP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1BP3" />
+          <positionref ref="hodo_postcover_pos_L1BP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1BP3" />
+          <positionref ref="hodo_sidereflR_pos_L1BP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1BP3" />
+          <positionref ref="hodo_siderefl2L_pos_L1BP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1BP3" />
+          <positionref ref="hodo_topreflT_pos_L1BP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1BP3" />
+          <positionref ref="hodo_toprefl2B_pos_L1BP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L1TP4" />
+          <positionref ref="hodo_pos_L1TP4" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="0" />
+          <physvolid field_name="ix" value="4" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1TP4" />
+          <positionref ref="hodo_forecover_pos_L1TP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1TP4" />
+          <positionref ref="hodo_postcover_pos_L1TP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1TP4" />
+          <positionref ref="hodo_sidereflR_pos_L1TP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1TP4" />
+          <positionref ref="hodo_siderefl2L_pos_L1TP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1TP4" />
+          <positionref ref="hodo_topreflT_pos_L1TP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1TP4" />
+          <positionref ref="hodo_toprefl2B_pos_L1TP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L1BP4" />
+          <positionref ref="hodo_pos_L1BP4" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="0" />
+          <physvolid field_name="ix" value="4" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1BP4" />
+          <positionref ref="hodo_forecover_pos_L1BP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1BP4" />
+          <positionref ref="hodo_postcover_pos_L1BP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1BP4" />
+          <positionref ref="hodo_sidereflR_pos_L1BP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1BP4" />
+          <positionref ref="hodo_siderefl2L_pos_L1BP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1BP4" />
+          <positionref ref="hodo_topreflT_pos_L1BP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1BP4" />
+          <positionref ref="hodo_toprefl2B_pos_L1BP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L2TP0" />
+          <positionref ref="hodo_pos_L2TP0" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="1" />
+          <physvolid field_name="ix" value="0" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2TP0" />
+          <positionref ref="hodo_forecover_pos_L2TP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2TP0" />
+          <positionref ref="hodo_postcover_pos_L2TP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2TP0" />
+          <positionref ref="hodo_sidereflR_pos_L2TP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2TP0" />
+          <positionref ref="hodo_siderefl2L_pos_L2TP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2TP0" />
+          <positionref ref="hodo_topreflT_pos_L2TP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2TP0" />
+          <positionref ref="hodo_toprefl2B_pos_L2TP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L2BP0" />
+          <positionref ref="hodo_pos_L2BP0" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="1" />
+          <physvolid field_name="ix" value="0" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2BP0" />
+          <positionref ref="hodo_forecover_pos_L2BP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2BP0" />
+          <positionref ref="hodo_postcover_pos_L2BP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2BP0" />
+          <positionref ref="hodo_sidereflR_pos_L2BP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2BP0" />
+          <positionref ref="hodo_siderefl2L_pos_L2BP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2BP0" />
+          <positionref ref="hodo_topreflT_pos_L2BP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2BP0" />
+          <positionref ref="hodo_toprefl2B_pos_L2BP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L2TP1" />
+          <positionref ref="hodo_pos_L2TP1" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="1" />
+          <physvolid field_name="ix" value="1" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2TP1" />
+          <positionref ref="hodo_forecover_pos_L2TP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2TP1" />
+          <positionref ref="hodo_postcover_pos_L2TP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2TP1" />
+          <positionref ref="hodo_sidereflR_pos_L2TP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2TP1" />
+          <positionref ref="hodo_siderefl2L_pos_L2TP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2TP1" />
+          <positionref ref="hodo_topreflT_pos_L2TP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2TP1" />
+          <positionref ref="hodo_toprefl2B_pos_L2TP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L2BP1" />
+          <positionref ref="hodo_pos_L2BP1" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="1" />
+          <physvolid field_name="ix" value="1" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2BP1" />
+          <positionref ref="hodo_forecover_pos_L2BP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2BP1" />
+          <positionref ref="hodo_postcover_pos_L2BP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2BP1" />
+          <positionref ref="hodo_sidereflR_pos_L2BP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2BP1" />
+          <positionref ref="hodo_siderefl2L_pos_L2BP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2BP1" />
+          <positionref ref="hodo_topreflT_pos_L2BP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2BP1" />
+          <positionref ref="hodo_toprefl2B_pos_L2BP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L2TP2" />
+          <positionref ref="hodo_pos_L2TP2" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="1" />
+          <physvolid field_name="ix" value="2" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2TP2" />
+          <positionref ref="hodo_forecover_pos_L2TP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2TP2" />
+          <positionref ref="hodo_postcover_pos_L2TP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2TP2" />
+          <positionref ref="hodo_sidereflR_pos_L2TP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2TP2" />
+          <positionref ref="hodo_siderefl2L_pos_L2TP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2TP2" />
+          <positionref ref="hodo_topreflT_pos_L2TP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2TP2" />
+          <positionref ref="hodo_toprefl2B_pos_L2TP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L2BP2" />
+          <positionref ref="hodo_pos_L2BP2" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="1" />
+          <physvolid field_name="ix" value="2" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2BP2" />
+          <positionref ref="hodo_forecover_pos_L2BP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2BP2" />
+          <positionref ref="hodo_postcover_pos_L2BP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2BP2" />
+          <positionref ref="hodo_sidereflR_pos_L2BP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2BP2" />
+          <positionref ref="hodo_siderefl2L_pos_L2BP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2BP2" />
+          <positionref ref="hodo_topreflT_pos_L2BP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2BP2" />
+          <positionref ref="hodo_toprefl2B_pos_L2BP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L2TP3" />
+          <positionref ref="hodo_pos_L2TP3" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="1" />
+          <physvolid field_name="ix" value="3" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2TP3" />
+          <positionref ref="hodo_forecover_pos_L2TP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2TP3" />
+          <positionref ref="hodo_postcover_pos_L2TP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2TP3" />
+          <positionref ref="hodo_sidereflR_pos_L2TP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2TP3" />
+          <positionref ref="hodo_siderefl2L_pos_L2TP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2TP3" />
+          <positionref ref="hodo_topreflT_pos_L2TP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2TP3" />
+          <positionref ref="hodo_toprefl2B_pos_L2TP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L2BP3" />
+          <positionref ref="hodo_pos_L2BP3" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="1" />
+          <physvolid field_name="ix" value="3" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2BP3" />
+          <positionref ref="hodo_forecover_pos_L2BP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2BP3" />
+          <positionref ref="hodo_postcover_pos_L2BP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2BP3" />
+          <positionref ref="hodo_sidereflR_pos_L2BP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2BP3" />
+          <positionref ref="hodo_siderefl2L_pos_L2BP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2BP3" />
+          <positionref ref="hodo_topreflT_pos_L2BP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2BP3" />
+          <positionref ref="hodo_toprefl2B_pos_L2BP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L2TP4" />
+          <positionref ref="hodo_pos_L2TP4" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="1" />
+          <physvolid field_name="ix" value="4" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2TP4" />
+          <positionref ref="hodo_forecover_pos_L2TP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2TP4" />
+          <positionref ref="hodo_postcover_pos_L2TP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2TP4" />
+          <positionref ref="hodo_sidereflR_pos_L2TP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2TP4" />
+          <positionref ref="hodo_siderefl2L_pos_L2TP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2TP4" />
+          <positionref ref="hodo_topreflT_pos_L2TP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2TP4" />
+          <positionref ref="hodo_toprefl2B_pos_L2TP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L2BP4" />
+          <positionref ref="hodo_pos_L2BP4" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="1" />
+          <physvolid field_name="ix" value="4" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2BP4" />
+          <positionref ref="hodo_forecover_pos_L2BP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2BP4" />
+          <positionref ref="hodo_postcover_pos_L2BP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2BP4" />
+          <positionref ref="hodo_sidereflR_pos_L2BP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2BP4" />
+          <positionref ref="hodo_siderefl2L_pos_L2BP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2BP4" />
+          <positionref ref="hodo_topreflT_pos_L2BP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2BP4" />
+          <positionref ref="hodo_toprefl2B_pos_L2BP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_buffer_vol" />
+          <positionref ref="hodo_bufferT_pos" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_buffer_vol" />
+          <positionref ref="hodo_bufferB_pos" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol name="hodo_flange_1">
+          <volumeref ref="hodo_flange" />
+          <positionref ref="hodo_flange_1intracking_volumepos" />
+        </physvol>
+        <physvol name="arms1_block1_1">
+          <volumeref ref="arms1_block1" />
+          <positionref ref="arms1_block1_1intracking_volumepos" />
+        </physvol>
+        <physvol name="arms1_block2_1">
+          <volumeref ref="arms1_block2" />
+          <positionref ref="arms1_block2_1intracking_volumepos" />
+        </physvol>
+        <physvol name="arms1_block3_1">
+          <volumeref ref="arms1_block3" />
+          <positionref ref="arms1_block3_1intracking_volumepos" />
+        </physvol>
+        <physvol name="arms1_block4_1">
+          <volumeref ref="arms1_block4" />
+          <positionref ref="arms1_block4_1intracking_volumepos" />
+        </physvol>
+        <physvol name="cross_bar_top_1">
+          <volumeref ref="cross_bar_top" />
+          <positionref ref="cross_bar_top_1intracking_volumepos" />
+        </physvol>
+        <physvol name="cross_bar_bottom_1">
+          <volumeref ref="cross_bar_bottom" />
+          <positionref ref="cross_bar_bottom_1intracking_volumepos" />
+        </physvol>
+        <physvol name="support_arm_bottom_left_plus_block_1">
+          <volumeref ref="support_arm_bottom_left_plus_block" />
+          <positionref ref="support_arm_bottom_left_plus_block_1intracking_volumepos" />
+        </physvol>
+        <physvol name="support_arm_bottom_right_1">
+          <volumeref ref="support_arm_bottom_right" />
+          <positionref ref="support_arm_bottom_right_1intracking_volumepos" />
+        </physvol>
+        <physvol name="support_arm_top_left_1">
+          <volumeref ref="support_arm_top_left" />
+          <positionref ref="support_arm_top_left_1intracking_volumepos" />
+          <rotationref ref="support_arm_top_left_1intracking_volumerot" />
+        </physvol>
+        <physvol name="support_arm_top_right_1">
+          <volumeref ref="support_arm_top_right" />
+          <positionref ref="support_arm_top_right_1intracking_volumepos" />
+          <rotationref ref="support_arm_top_right_1intracking_volumerot" />
+        </physvol>
+        <physvol name="u_support_bar_bottom_1">
+          <volumeref ref="u_support_bar_bottom" />
+          <positionref ref="u_support_bar_bottom_1intracking_volumepos" />
+        </physvol>
+        <physvol name="u_support_bar_upper1_1">
+          <volumeref ref="u_support_bar_upper1" />
+          <positionref ref="u_support_bar_upper1_1intracking_volumepos" />
+        </physvol>
+        <physvol name="u_support_bar_upper2_1">
+          <volumeref ref="u_support_bar_upper2" />
+          <positionref ref="u_support_bar_upper2_1intracking_volumepos" />
+        </physvol>
+        <physvol name="u_support_bar_top_1">
+          <volumeref ref="u_support_bar_top" />
+          <positionref ref="u_support_bar_top_1intracking_volumepos" />
+        </physvol>
+        <physvol name="u_support_bar_upper3_1">
+          <volumeref ref="u_support_bar_upper3" />
+          <positionref ref="u_support_bar_upper3_1intracking_volumepos" />
+        </physvol>
+        <physvol name="u_support_bar_upper4_1">
+          <volumeref ref="u_support_bar_upper4" />
+          <positionref ref="u_support_bar_upper4_1intracking_volumepos" />
+        </physvol>
+        <physvol>
+          <volumeref ref="svt_chamber_box_vol" />
+          <position name="svt_chamber_box_position" x="svt_chamber_x" y="0" z="svt_chamber_z+svt_chamber_box_z" />
+        </physvol>
+        <physvol>
+          <volumeref ref="svt_chamber_flare1_vol" />
+          <position name="svt_chamber_flare1_position" x="svt_chamber_x" y="0" z="svt_chamber_z+svt_chamber_flare1_z" />
+        </physvol>
+        <physvol>
+          <volumeref ref="svt_chamber_flare2_vol" />
+          <position name="svt_chamber_flare2_position" x="svt_chamber_x" y="0" z="svt_chamber_z+svt_chamber_flare2_z" />
+        </physvol>
+        <physvol>
+          <volumeref ref="svt_chamber_flange_vol" />
+          <position name="svt_chamber_flange_position" x="svt_chamber_x" y="0" z="svt_chamber_z+svt_chamber_flange_z" />
+        </physvol>
+        <regionref ref="TrackingRegion" />
+        <visref ref="TrackingVis" />
+      </volume>
+      <volume name="world_volume">
+        <materialref ref="WorldMaterial" />
+        <solidref ref="world_box" />
+        <physvol>
+          <volumeref ref="tracking_volume" />
+          <positionref ref="tracking_region_pos" />
+          <rotationref ref="identity_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="BeamLeftVolume" />
+          <positionref ref="ECalScoring_BeamLeft_layer1_module0_position" />
+          <rotationref ref="ECalScoring_BeamLeft_layer1_module0_rotation" />
+          <physvolid field_name="system" value="29" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="1" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="ElectronGapVolume" />
+          <positionref ref="ECalScoring_ElectronGap_layer1_module0_position" />
+          <rotationref ref="ECalScoring_ElectronGap_layer1_module0_rotation" />
+          <physvolid field_name="system" value="29" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="1" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="BeamRightVolume" />
+          <positionref ref="ECalScoring_BeamRight_layer1_module0_position" />
+          <rotationref ref="ECalScoring_BeamRight_layer1_module0_rotation" />
+          <physvolid field_name="system" value="29" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="1" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="BeamLeftVolume" />
+          <positionref ref="ECalScoring_BeamLeft_layer2_module0_position" />
+          <rotationref ref="ECalScoring_BeamLeft_layer2_module0_rotation" />
+          <physvolid field_name="system" value="29" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="2" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="ElectronGapVolume" />
+          <positionref ref="ECalScoring_ElectronGap_layer2_module0_position" />
+          <rotationref ref="ECalScoring_ElectronGap_layer2_module0_rotation" />
+          <physvolid field_name="system" value="29" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="2" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="BeamRightVolume" />
+          <positionref ref="ECalScoring_BeamRight_layer2_module0_position" />
+          <rotationref ref="ECalScoring_BeamRight_layer2_module0_rotation" />
+          <physvolid field_name="system" value="29" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="2" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-1_pos_pos_bot" />
+          <rotationref ref="crystal1-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="1" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-1_pos_neg_bot" />
+          <rotationref ref="crystal1-1_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-1" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-1_pos_pos_top" />
+          <rotationref ref="crystal1-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="1" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-1_pos_neg_top" />
+          <rotationref ref="crystal1-1_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-1" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal2-1_pos_pos_bot" />
+          <rotationref ref="crystal2-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="2" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal2-1_pos_pos_top" />
+          <rotationref ref="crystal2-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="2" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal3-1_pos_pos_bot" />
+          <rotationref ref="crystal3-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="3" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal3-1_pos_pos_top" />
+          <rotationref ref="crystal3-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="3" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal4-1_pos_pos_bot" />
+          <rotationref ref="crystal4-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="4" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal4-1_pos_pos_top" />
+          <rotationref ref="crystal4-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="4" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal5-1_pos_pos_bot" />
+          <rotationref ref="crystal5-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="5" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal5-1_pos_pos_top" />
+          <rotationref ref="crystal5-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="5" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal6-1_pos_pos_bot" />
+          <rotationref ref="crystal6-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="6" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal6-1_pos_pos_top" />
+          <rotationref ref="crystal6-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="6" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal7-1_pos_pos_bot" />
+          <rotationref ref="crystal7-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="7" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal7-1_pos_pos_top" />
+          <rotationref ref="crystal7-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="7" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal8-1_pos_pos_bot" />
+          <rotationref ref="crystal8-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="8" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal8-1_pos_pos_top" />
+          <rotationref ref="crystal8-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="8" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal9-1_pos_pos_bot" />
+          <rotationref ref="crystal9-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="9" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal9-1_pos_pos_top" />
+          <rotationref ref="crystal9-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="9" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal10-1_pos_pos_bot" />
+          <rotationref ref="crystal10-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="10" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal10-1_pos_pos_top" />
+          <rotationref ref="crystal10-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="10" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-1_pos_pos_bot" />
+          <rotationref ref="crystal11-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="11" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-1_pos_neg_bot" />
+          <rotationref ref="crystal11-1_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-11" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-1_pos_pos_top" />
+          <rotationref ref="crystal11-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="11" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-1_pos_neg_top" />
+          <rotationref ref="crystal11-1_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-11" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-1_pos_pos_bot" />
+          <rotationref ref="crystal12-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="12" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-1_pos_neg_bot" />
+          <rotationref ref="crystal12-1_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-12" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-1_pos_pos_top" />
+          <rotationref ref="crystal12-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="12" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-1_pos_neg_top" />
+          <rotationref ref="crystal12-1_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-12" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-1_pos_pos_bot" />
+          <rotationref ref="crystal13-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="13" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-1_pos_neg_bot" />
+          <rotationref ref="crystal13-1_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-13" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-1_pos_pos_top" />
+          <rotationref ref="crystal13-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="13" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-1_pos_neg_top" />
+          <rotationref ref="crystal13-1_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-13" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-1_pos_pos_bot" />
+          <rotationref ref="crystal14-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="14" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-1_pos_neg_bot" />
+          <rotationref ref="crystal14-1_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-14" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-1_pos_pos_top" />
+          <rotationref ref="crystal14-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="14" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-1_pos_neg_top" />
+          <rotationref ref="crystal14-1_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-14" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-1_pos_pos_bot" />
+          <rotationref ref="crystal15-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="15" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-1_pos_neg_bot" />
+          <rotationref ref="crystal15-1_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-15" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-1_pos_pos_top" />
+          <rotationref ref="crystal15-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="15" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-1_pos_neg_top" />
+          <rotationref ref="crystal15-1_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-15" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-1_pos_pos_bot" />
+          <rotationref ref="crystal16-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="16" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-1_pos_neg_bot" />
+          <rotationref ref="crystal16-1_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-16" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-1_pos_pos_top" />
+          <rotationref ref="crystal16-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="16" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-1_pos_neg_top" />
+          <rotationref ref="crystal16-1_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-16" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-1_pos_pos_bot" />
+          <rotationref ref="crystal17-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="17" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-1_pos_neg_bot" />
+          <rotationref ref="crystal17-1_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-17" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-1_pos_pos_top" />
+          <rotationref ref="crystal17-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="17" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-1_pos_neg_top" />
+          <rotationref ref="crystal17-1_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-17" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-1_pos_pos_bot" />
+          <rotationref ref="crystal18-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="18" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-1_pos_neg_bot" />
+          <rotationref ref="crystal18-1_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-18" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-1_pos_pos_top" />
+          <rotationref ref="crystal18-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="18" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-1_pos_neg_top" />
+          <rotationref ref="crystal18-1_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-18" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-1_pos_pos_bot" />
+          <rotationref ref="crystal19-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="19" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-1_pos_neg_bot" />
+          <rotationref ref="crystal19-1_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-19" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-1_pos_pos_top" />
+          <rotationref ref="crystal19-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="19" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-1_pos_neg_top" />
+          <rotationref ref="crystal19-1_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-19" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-1_pos_pos_bot" />
+          <rotationref ref="crystal20-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="20" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-1_pos_neg_bot" />
+          <rotationref ref="crystal20-1_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-20" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-1_pos_pos_top" />
+          <rotationref ref="crystal20-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="20" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-1_pos_neg_top" />
+          <rotationref ref="crystal20-1_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-20" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-1_pos_pos_bot" />
+          <rotationref ref="crystal21-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="21" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-1_pos_neg_bot" />
+          <rotationref ref="crystal21-1_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-21" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-1_pos_pos_top" />
+          <rotationref ref="crystal21-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="21" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-1_pos_neg_top" />
+          <rotationref ref="crystal21-1_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-21" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-1_pos_pos_bot" />
+          <rotationref ref="crystal22-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="22" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-1_pos_neg_bot" />
+          <rotationref ref="crystal22-1_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-22" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-1_pos_pos_top" />
+          <rotationref ref="crystal22-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="22" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-1_pos_neg_top" />
+          <rotationref ref="crystal22-1_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-22" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-1_pos_pos_bot" />
+          <rotationref ref="crystal23-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="23" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-1_pos_neg_bot" />
+          <rotationref ref="crystal23-1_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-23" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-1_pos_pos_top" />
+          <rotationref ref="crystal23-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="23" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-1_pos_neg_top" />
+          <rotationref ref="crystal23-1_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-23" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-2_pos_pos_bot" />
+          <rotationref ref="crystal1-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="1" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-2_pos_neg_bot" />
+          <rotationref ref="crystal1-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-1" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-2_pos_pos_top" />
+          <rotationref ref="crystal1-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="1" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-2_pos_neg_top" />
+          <rotationref ref="crystal1-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-1" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal2-2_pos_pos_bot" />
+          <rotationref ref="crystal2-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="2" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal2-2_pos_neg_bot" />
+          <rotationref ref="crystal2-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-2" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal2-2_pos_pos_top" />
+          <rotationref ref="crystal2-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="2" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal2-2_pos_neg_top" />
+          <rotationref ref="crystal2-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-2" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal3-2_pos_pos_bot" />
+          <rotationref ref="crystal3-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="3" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal3-2_pos_neg_bot" />
+          <rotationref ref="crystal3-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-3" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal3-2_pos_pos_top" />
+          <rotationref ref="crystal3-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="3" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal3-2_pos_neg_top" />
+          <rotationref ref="crystal3-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-3" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal4-2_pos_pos_bot" />
+          <rotationref ref="crystal4-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="4" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal4-2_pos_neg_bot" />
+          <rotationref ref="crystal4-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-4" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal4-2_pos_pos_top" />
+          <rotationref ref="crystal4-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="4" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal4-2_pos_neg_top" />
+          <rotationref ref="crystal4-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-4" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal5-2_pos_pos_bot" />
+          <rotationref ref="crystal5-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="5" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal5-2_pos_neg_bot" />
+          <rotationref ref="crystal5-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-5" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal5-2_pos_pos_top" />
+          <rotationref ref="crystal5-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="5" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal5-2_pos_neg_top" />
+          <rotationref ref="crystal5-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-5" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal6-2_pos_pos_bot" />
+          <rotationref ref="crystal6-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="6" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal6-2_pos_neg_bot" />
+          <rotationref ref="crystal6-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-6" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal6-2_pos_pos_top" />
+          <rotationref ref="crystal6-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="6" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal6-2_pos_neg_top" />
+          <rotationref ref="crystal6-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-6" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal7-2_pos_pos_bot" />
+          <rotationref ref="crystal7-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="7" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal7-2_pos_neg_bot" />
+          <rotationref ref="crystal7-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-7" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal7-2_pos_pos_top" />
+          <rotationref ref="crystal7-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="7" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal7-2_pos_neg_top" />
+          <rotationref ref="crystal7-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-7" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal8-2_pos_pos_bot" />
+          <rotationref ref="crystal8-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="8" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal8-2_pos_neg_bot" />
+          <rotationref ref="crystal8-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-8" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal8-2_pos_pos_top" />
+          <rotationref ref="crystal8-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="8" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal8-2_pos_neg_top" />
+          <rotationref ref="crystal8-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-8" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal9-2_pos_pos_bot" />
+          <rotationref ref="crystal9-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="9" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal9-2_pos_neg_bot" />
+          <rotationref ref="crystal9-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-9" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal9-2_pos_pos_top" />
+          <rotationref ref="crystal9-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="9" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal9-2_pos_neg_top" />
+          <rotationref ref="crystal9-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-9" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal10-2_pos_pos_bot" />
+          <rotationref ref="crystal10-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="10" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal10-2_pos_neg_bot" />
+          <rotationref ref="crystal10-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-10" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal10-2_pos_pos_top" />
+          <rotationref ref="crystal10-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="10" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal10-2_pos_neg_top" />
+          <rotationref ref="crystal10-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-10" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-2_pos_pos_bot" />
+          <rotationref ref="crystal11-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="11" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-2_pos_neg_bot" />
+          <rotationref ref="crystal11-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-11" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-2_pos_pos_top" />
+          <rotationref ref="crystal11-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="11" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-2_pos_neg_top" />
+          <rotationref ref="crystal11-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-11" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-2_pos_pos_bot" />
+          <rotationref ref="crystal12-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="12" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-2_pos_neg_bot" />
+          <rotationref ref="crystal12-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-12" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-2_pos_pos_top" />
+          <rotationref ref="crystal12-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="12" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-2_pos_neg_top" />
+          <rotationref ref="crystal12-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-12" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-2_pos_pos_bot" />
+          <rotationref ref="crystal13-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="13" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-2_pos_neg_bot" />
+          <rotationref ref="crystal13-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-13" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-2_pos_pos_top" />
+          <rotationref ref="crystal13-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="13" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-2_pos_neg_top" />
+          <rotationref ref="crystal13-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-13" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-2_pos_pos_bot" />
+          <rotationref ref="crystal14-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="14" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-2_pos_neg_bot" />
+          <rotationref ref="crystal14-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-14" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-2_pos_pos_top" />
+          <rotationref ref="crystal14-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="14" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-2_pos_neg_top" />
+          <rotationref ref="crystal14-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-14" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-2_pos_pos_bot" />
+          <rotationref ref="crystal15-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="15" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-2_pos_neg_bot" />
+          <rotationref ref="crystal15-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-15" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-2_pos_pos_top" />
+          <rotationref ref="crystal15-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="15" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-2_pos_neg_top" />
+          <rotationref ref="crystal15-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-15" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-2_pos_pos_bot" />
+          <rotationref ref="crystal16-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="16" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-2_pos_neg_bot" />
+          <rotationref ref="crystal16-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-16" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-2_pos_pos_top" />
+          <rotationref ref="crystal16-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="16" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-2_pos_neg_top" />
+          <rotationref ref="crystal16-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-16" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-2_pos_pos_bot" />
+          <rotationref ref="crystal17-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="17" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-2_pos_neg_bot" />
+          <rotationref ref="crystal17-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-17" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-2_pos_pos_top" />
+          <rotationref ref="crystal17-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="17" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-2_pos_neg_top" />
+          <rotationref ref="crystal17-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-17" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-2_pos_pos_bot" />
+          <rotationref ref="crystal18-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="18" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-2_pos_neg_bot" />
+          <rotationref ref="crystal18-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-18" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-2_pos_pos_top" />
+          <rotationref ref="crystal18-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="18" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-2_pos_neg_top" />
+          <rotationref ref="crystal18-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-18" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-2_pos_pos_bot" />
+          <rotationref ref="crystal19-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="19" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-2_pos_neg_bot" />
+          <rotationref ref="crystal19-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-19" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-2_pos_pos_top" />
+          <rotationref ref="crystal19-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="19" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-2_pos_neg_top" />
+          <rotationref ref="crystal19-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-19" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-2_pos_pos_bot" />
+          <rotationref ref="crystal20-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="20" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-2_pos_neg_bot" />
+          <rotationref ref="crystal20-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-20" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-2_pos_pos_top" />
+          <rotationref ref="crystal20-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="20" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-2_pos_neg_top" />
+          <rotationref ref="crystal20-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-20" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-2_pos_pos_bot" />
+          <rotationref ref="crystal21-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="21" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-2_pos_neg_bot" />
+          <rotationref ref="crystal21-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-21" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-2_pos_pos_top" />
+          <rotationref ref="crystal21-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="21" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-2_pos_neg_top" />
+          <rotationref ref="crystal21-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-21" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-2_pos_pos_bot" />
+          <rotationref ref="crystal22-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="22" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-2_pos_neg_bot" />
+          <rotationref ref="crystal22-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-22" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-2_pos_pos_top" />
+          <rotationref ref="crystal22-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="22" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-2_pos_neg_top" />
+          <rotationref ref="crystal22-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-22" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-2_pos_pos_bot" />
+          <rotationref ref="crystal23-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="23" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-2_pos_neg_bot" />
+          <rotationref ref="crystal23-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-23" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-2_pos_pos_top" />
+          <rotationref ref="crystal23-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="23" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-2_pos_neg_top" />
+          <rotationref ref="crystal23-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-23" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-3_pos_pos_bot" />
+          <rotationref ref="crystal1-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="1" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-3_pos_neg_bot" />
+          <rotationref ref="crystal1-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-1" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-3_pos_pos_top" />
+          <rotationref ref="crystal1-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="1" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-3_pos_neg_top" />
+          <rotationref ref="crystal1-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-1" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal2-3_pos_pos_bot" />
+          <rotationref ref="crystal2-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="2" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal2-3_pos_neg_bot" />
+          <rotationref ref="crystal2-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-2" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal2-3_pos_pos_top" />
+          <rotationref ref="crystal2-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="2" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal2-3_pos_neg_top" />
+          <rotationref ref="crystal2-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-2" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal3-3_pos_pos_bot" />
+          <rotationref ref="crystal3-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="3" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal3-3_pos_neg_bot" />
+          <rotationref ref="crystal3-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-3" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal3-3_pos_pos_top" />
+          <rotationref ref="crystal3-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="3" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal3-3_pos_neg_top" />
+          <rotationref ref="crystal3-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-3" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal4-3_pos_pos_bot" />
+          <rotationref ref="crystal4-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="4" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal4-3_pos_neg_bot" />
+          <rotationref ref="crystal4-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-4" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal4-3_pos_pos_top" />
+          <rotationref ref="crystal4-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="4" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal4-3_pos_neg_top" />
+          <rotationref ref="crystal4-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-4" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal5-3_pos_pos_bot" />
+          <rotationref ref="crystal5-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="5" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal5-3_pos_neg_bot" />
+          <rotationref ref="crystal5-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-5" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal5-3_pos_pos_top" />
+          <rotationref ref="crystal5-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="5" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal5-3_pos_neg_top" />
+          <rotationref ref="crystal5-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-5" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal6-3_pos_pos_bot" />
+          <rotationref ref="crystal6-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="6" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal6-3_pos_neg_bot" />
+          <rotationref ref="crystal6-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-6" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal6-3_pos_pos_top" />
+          <rotationref ref="crystal6-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="6" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal6-3_pos_neg_top" />
+          <rotationref ref="crystal6-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-6" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal7-3_pos_pos_bot" />
+          <rotationref ref="crystal7-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="7" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal7-3_pos_neg_bot" />
+          <rotationref ref="crystal7-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-7" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal7-3_pos_pos_top" />
+          <rotationref ref="crystal7-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="7" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal7-3_pos_neg_top" />
+          <rotationref ref="crystal7-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-7" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal8-3_pos_pos_bot" />
+          <rotationref ref="crystal8-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="8" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal8-3_pos_neg_bot" />
+          <rotationref ref="crystal8-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-8" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal8-3_pos_pos_top" />
+          <rotationref ref="crystal8-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="8" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal8-3_pos_neg_top" />
+          <rotationref ref="crystal8-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-8" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal9-3_pos_pos_bot" />
+          <rotationref ref="crystal9-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="9" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal9-3_pos_neg_bot" />
+          <rotationref ref="crystal9-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-9" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal9-3_pos_pos_top" />
+          <rotationref ref="crystal9-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="9" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal9-3_pos_neg_top" />
+          <rotationref ref="crystal9-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-9" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal10-3_pos_pos_bot" />
+          <rotationref ref="crystal10-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="10" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal10-3_pos_neg_bot" />
+          <rotationref ref="crystal10-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-10" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal10-3_pos_pos_top" />
+          <rotationref ref="crystal10-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="10" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal10-3_pos_neg_top" />
+          <rotationref ref="crystal10-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-10" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-3_pos_pos_bot" />
+          <rotationref ref="crystal11-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="11" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-3_pos_neg_bot" />
+          <rotationref ref="crystal11-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-11" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-3_pos_pos_top" />
+          <rotationref ref="crystal11-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="11" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-3_pos_neg_top" />
+          <rotationref ref="crystal11-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-11" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-3_pos_pos_bot" />
+          <rotationref ref="crystal12-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="12" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-3_pos_neg_bot" />
+          <rotationref ref="crystal12-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-12" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-3_pos_pos_top" />
+          <rotationref ref="crystal12-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="12" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-3_pos_neg_top" />
+          <rotationref ref="crystal12-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-12" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-3_pos_pos_bot" />
+          <rotationref ref="crystal13-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="13" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-3_pos_neg_bot" />
+          <rotationref ref="crystal13-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-13" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-3_pos_pos_top" />
+          <rotationref ref="crystal13-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="13" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-3_pos_neg_top" />
+          <rotationref ref="crystal13-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-13" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-3_pos_pos_bot" />
+          <rotationref ref="crystal14-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="14" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-3_pos_neg_bot" />
+          <rotationref ref="crystal14-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-14" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-3_pos_pos_top" />
+          <rotationref ref="crystal14-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="14" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-3_pos_neg_top" />
+          <rotationref ref="crystal14-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-14" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-3_pos_pos_bot" />
+          <rotationref ref="crystal15-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="15" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-3_pos_neg_bot" />
+          <rotationref ref="crystal15-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-15" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-3_pos_pos_top" />
+          <rotationref ref="crystal15-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="15" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-3_pos_neg_top" />
+          <rotationref ref="crystal15-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-15" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-3_pos_pos_bot" />
+          <rotationref ref="crystal16-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="16" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-3_pos_neg_bot" />
+          <rotationref ref="crystal16-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-16" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-3_pos_pos_top" />
+          <rotationref ref="crystal16-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="16" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-3_pos_neg_top" />
+          <rotationref ref="crystal16-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-16" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-3_pos_pos_bot" />
+          <rotationref ref="crystal17-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="17" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-3_pos_neg_bot" />
+          <rotationref ref="crystal17-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-17" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-3_pos_pos_top" />
+          <rotationref ref="crystal17-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="17" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-3_pos_neg_top" />
+          <rotationref ref="crystal17-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-17" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-3_pos_pos_bot" />
+          <rotationref ref="crystal18-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="18" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-3_pos_neg_bot" />
+          <rotationref ref="crystal18-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-18" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-3_pos_pos_top" />
+          <rotationref ref="crystal18-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="18" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-3_pos_neg_top" />
+          <rotationref ref="crystal18-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-18" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-3_pos_pos_bot" />
+          <rotationref ref="crystal19-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="19" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-3_pos_neg_bot" />
+          <rotationref ref="crystal19-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-19" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-3_pos_pos_top" />
+          <rotationref ref="crystal19-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="19" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-3_pos_neg_top" />
+          <rotationref ref="crystal19-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-19" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-3_pos_pos_bot" />
+          <rotationref ref="crystal20-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="20" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-3_pos_neg_bot" />
+          <rotationref ref="crystal20-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-20" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-3_pos_pos_top" />
+          <rotationref ref="crystal20-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="20" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-3_pos_neg_top" />
+          <rotationref ref="crystal20-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-20" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-3_pos_pos_bot" />
+          <rotationref ref="crystal21-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="21" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-3_pos_neg_bot" />
+          <rotationref ref="crystal21-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-21" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-3_pos_pos_top" />
+          <rotationref ref="crystal21-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="21" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-3_pos_neg_top" />
+          <rotationref ref="crystal21-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-21" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-3_pos_pos_bot" />
+          <rotationref ref="crystal22-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="22" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-3_pos_neg_bot" />
+          <rotationref ref="crystal22-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-22" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-3_pos_pos_top" />
+          <rotationref ref="crystal22-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="22" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-3_pos_neg_top" />
+          <rotationref ref="crystal22-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-22" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-3_pos_pos_bot" />
+          <rotationref ref="crystal23-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="23" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-3_pos_neg_bot" />
+          <rotationref ref="crystal23-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-23" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-3_pos_pos_top" />
+          <rotationref ref="crystal23-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="23" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-3_pos_neg_top" />
+          <rotationref ref="crystal23-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-23" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-4_pos_pos_bot" />
+          <rotationref ref="crystal1-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="1" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-4_pos_neg_bot" />
+          <rotationref ref="crystal1-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-1" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-4_pos_pos_top" />
+          <rotationref ref="crystal1-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="1" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-4_pos_neg_top" />
+          <rotationref ref="crystal1-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-1" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal2-4_pos_pos_bot" />
+          <rotationref ref="crystal2-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="2" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal2-4_pos_neg_bot" />
+          <rotationref ref="crystal2-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-2" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal2-4_pos_pos_top" />
+          <rotationref ref="crystal2-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="2" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal2-4_pos_neg_top" />
+          <rotationref ref="crystal2-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-2" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal3-4_pos_pos_bot" />
+          <rotationref ref="crystal3-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="3" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal3-4_pos_neg_bot" />
+          <rotationref ref="crystal3-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-3" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal3-4_pos_pos_top" />
+          <rotationref ref="crystal3-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="3" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal3-4_pos_neg_top" />
+          <rotationref ref="crystal3-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-3" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal4-4_pos_pos_bot" />
+          <rotationref ref="crystal4-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="4" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal4-4_pos_neg_bot" />
+          <rotationref ref="crystal4-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-4" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal4-4_pos_pos_top" />
+          <rotationref ref="crystal4-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="4" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal4-4_pos_neg_top" />
+          <rotationref ref="crystal4-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-4" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal5-4_pos_pos_bot" />
+          <rotationref ref="crystal5-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="5" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal5-4_pos_neg_bot" />
+          <rotationref ref="crystal5-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-5" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal5-4_pos_pos_top" />
+          <rotationref ref="crystal5-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="5" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal5-4_pos_neg_top" />
+          <rotationref ref="crystal5-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-5" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal6-4_pos_pos_bot" />
+          <rotationref ref="crystal6-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="6" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal6-4_pos_neg_bot" />
+          <rotationref ref="crystal6-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-6" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal6-4_pos_pos_top" />
+          <rotationref ref="crystal6-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="6" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal6-4_pos_neg_top" />
+          <rotationref ref="crystal6-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-6" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal7-4_pos_pos_bot" />
+          <rotationref ref="crystal7-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="7" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal7-4_pos_neg_bot" />
+          <rotationref ref="crystal7-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-7" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal7-4_pos_pos_top" />
+          <rotationref ref="crystal7-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="7" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal7-4_pos_neg_top" />
+          <rotationref ref="crystal7-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-7" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal8-4_pos_pos_bot" />
+          <rotationref ref="crystal8-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="8" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal8-4_pos_neg_bot" />
+          <rotationref ref="crystal8-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-8" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal8-4_pos_pos_top" />
+          <rotationref ref="crystal8-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="8" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal8-4_pos_neg_top" />
+          <rotationref ref="crystal8-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-8" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal9-4_pos_pos_bot" />
+          <rotationref ref="crystal9-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="9" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal9-4_pos_neg_bot" />
+          <rotationref ref="crystal9-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-9" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal9-4_pos_pos_top" />
+          <rotationref ref="crystal9-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="9" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal9-4_pos_neg_top" />
+          <rotationref ref="crystal9-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-9" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal10-4_pos_pos_bot" />
+          <rotationref ref="crystal10-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="10" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal10-4_pos_neg_bot" />
+          <rotationref ref="crystal10-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-10" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal10-4_pos_pos_top" />
+          <rotationref ref="crystal10-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="10" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal10-4_pos_neg_top" />
+          <rotationref ref="crystal10-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-10" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-4_pos_pos_bot" />
+          <rotationref ref="crystal11-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="11" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-4_pos_neg_bot" />
+          <rotationref ref="crystal11-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-11" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-4_pos_pos_top" />
+          <rotationref ref="crystal11-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="11" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-4_pos_neg_top" />
+          <rotationref ref="crystal11-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-11" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-4_pos_pos_bot" />
+          <rotationref ref="crystal12-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="12" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-4_pos_neg_bot" />
+          <rotationref ref="crystal12-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-12" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-4_pos_pos_top" />
+          <rotationref ref="crystal12-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="12" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-4_pos_neg_top" />
+          <rotationref ref="crystal12-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-12" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-4_pos_pos_bot" />
+          <rotationref ref="crystal13-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="13" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-4_pos_neg_bot" />
+          <rotationref ref="crystal13-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-13" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-4_pos_pos_top" />
+          <rotationref ref="crystal13-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="13" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-4_pos_neg_top" />
+          <rotationref ref="crystal13-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-13" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-4_pos_pos_bot" />
+          <rotationref ref="crystal14-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="14" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-4_pos_neg_bot" />
+          <rotationref ref="crystal14-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-14" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-4_pos_pos_top" />
+          <rotationref ref="crystal14-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="14" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-4_pos_neg_top" />
+          <rotationref ref="crystal14-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-14" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-4_pos_pos_bot" />
+          <rotationref ref="crystal15-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="15" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-4_pos_neg_bot" />
+          <rotationref ref="crystal15-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-15" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-4_pos_pos_top" />
+          <rotationref ref="crystal15-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="15" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-4_pos_neg_top" />
+          <rotationref ref="crystal15-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-15" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-4_pos_pos_bot" />
+          <rotationref ref="crystal16-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="16" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-4_pos_neg_bot" />
+          <rotationref ref="crystal16-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-16" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-4_pos_pos_top" />
+          <rotationref ref="crystal16-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="16" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-4_pos_neg_top" />
+          <rotationref ref="crystal16-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-16" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-4_pos_pos_bot" />
+          <rotationref ref="crystal17-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="17" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-4_pos_neg_bot" />
+          <rotationref ref="crystal17-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-17" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-4_pos_pos_top" />
+          <rotationref ref="crystal17-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="17" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-4_pos_neg_top" />
+          <rotationref ref="crystal17-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-17" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-4_pos_pos_bot" />
+          <rotationref ref="crystal18-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="18" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-4_pos_neg_bot" />
+          <rotationref ref="crystal18-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-18" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-4_pos_pos_top" />
+          <rotationref ref="crystal18-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="18" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-4_pos_neg_top" />
+          <rotationref ref="crystal18-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-18" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-4_pos_pos_bot" />
+          <rotationref ref="crystal19-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="19" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-4_pos_neg_bot" />
+          <rotationref ref="crystal19-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-19" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-4_pos_pos_top" />
+          <rotationref ref="crystal19-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="19" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-4_pos_neg_top" />
+          <rotationref ref="crystal19-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-19" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-4_pos_pos_bot" />
+          <rotationref ref="crystal20-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="20" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-4_pos_neg_bot" />
+          <rotationref ref="crystal20-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-20" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-4_pos_pos_top" />
+          <rotationref ref="crystal20-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="20" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-4_pos_neg_top" />
+          <rotationref ref="crystal20-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-20" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-4_pos_pos_bot" />
+          <rotationref ref="crystal21-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="21" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-4_pos_neg_bot" />
+          <rotationref ref="crystal21-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-21" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-4_pos_pos_top" />
+          <rotationref ref="crystal21-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="21" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-4_pos_neg_top" />
+          <rotationref ref="crystal21-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-21" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-4_pos_pos_bot" />
+          <rotationref ref="crystal22-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="22" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-4_pos_neg_bot" />
+          <rotationref ref="crystal22-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-22" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-4_pos_pos_top" />
+          <rotationref ref="crystal22-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="22" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-4_pos_neg_top" />
+          <rotationref ref="crystal22-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-22" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-4_pos_pos_bot" />
+          <rotationref ref="crystal23-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="23" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-4_pos_neg_bot" />
+          <rotationref ref="crystal23-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-23" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-4_pos_pos_top" />
+          <rotationref ref="crystal23-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="23" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-4_pos_neg_top" />
+          <rotationref ref="crystal23-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-23" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-5_pos_pos_bot" />
+          <rotationref ref="crystal1-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="1" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-5_pos_neg_bot" />
+          <rotationref ref="crystal1-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-1" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-5_pos_pos_top" />
+          <rotationref ref="crystal1-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="1" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-5_pos_neg_top" />
+          <rotationref ref="crystal1-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-1" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal2-5_pos_pos_bot" />
+          <rotationref ref="crystal2-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="2" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal2-5_pos_neg_bot" />
+          <rotationref ref="crystal2-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-2" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal2-5_pos_pos_top" />
+          <rotationref ref="crystal2-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="2" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal2-5_pos_neg_top" />
+          <rotationref ref="crystal2-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-2" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal3-5_pos_pos_bot" />
+          <rotationref ref="crystal3-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="3" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal3-5_pos_neg_bot" />
+          <rotationref ref="crystal3-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-3" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal3-5_pos_pos_top" />
+          <rotationref ref="crystal3-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="3" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal3-5_pos_neg_top" />
+          <rotationref ref="crystal3-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-3" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal4-5_pos_pos_bot" />
+          <rotationref ref="crystal4-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="4" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal4-5_pos_neg_bot" />
+          <rotationref ref="crystal4-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-4" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal4-5_pos_pos_top" />
+          <rotationref ref="crystal4-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="4" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal4-5_pos_neg_top" />
+          <rotationref ref="crystal4-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-4" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal5-5_pos_pos_bot" />
+          <rotationref ref="crystal5-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="5" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal5-5_pos_neg_bot" />
+          <rotationref ref="crystal5-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-5" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal5-5_pos_pos_top" />
+          <rotationref ref="crystal5-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="5" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal5-5_pos_neg_top" />
+          <rotationref ref="crystal5-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-5" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal6-5_pos_pos_bot" />
+          <rotationref ref="crystal6-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="6" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal6-5_pos_neg_bot" />
+          <rotationref ref="crystal6-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-6" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal6-5_pos_pos_top" />
+          <rotationref ref="crystal6-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="6" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal6-5_pos_neg_top" />
+          <rotationref ref="crystal6-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-6" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal7-5_pos_pos_bot" />
+          <rotationref ref="crystal7-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="7" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal7-5_pos_neg_bot" />
+          <rotationref ref="crystal7-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-7" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal7-5_pos_pos_top" />
+          <rotationref ref="crystal7-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="7" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal7-5_pos_neg_top" />
+          <rotationref ref="crystal7-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-7" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal8-5_pos_pos_bot" />
+          <rotationref ref="crystal8-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="8" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal8-5_pos_neg_bot" />
+          <rotationref ref="crystal8-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-8" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal8-5_pos_pos_top" />
+          <rotationref ref="crystal8-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="8" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal8-5_pos_neg_top" />
+          <rotationref ref="crystal8-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-8" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal9-5_pos_pos_bot" />
+          <rotationref ref="crystal9-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="9" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal9-5_pos_neg_bot" />
+          <rotationref ref="crystal9-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-9" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal9-5_pos_pos_top" />
+          <rotationref ref="crystal9-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="9" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal9-5_pos_neg_top" />
+          <rotationref ref="crystal9-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-9" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal10-5_pos_pos_bot" />
+          <rotationref ref="crystal10-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="10" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal10-5_pos_neg_bot" />
+          <rotationref ref="crystal10-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-10" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal10-5_pos_pos_top" />
+          <rotationref ref="crystal10-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="10" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal10-5_pos_neg_top" />
+          <rotationref ref="crystal10-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-10" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-5_pos_pos_bot" />
+          <rotationref ref="crystal11-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="11" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-5_pos_neg_bot" />
+          <rotationref ref="crystal11-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-11" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-5_pos_pos_top" />
+          <rotationref ref="crystal11-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="11" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-5_pos_neg_top" />
+          <rotationref ref="crystal11-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-11" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-5_pos_pos_bot" />
+          <rotationref ref="crystal12-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="12" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-5_pos_neg_bot" />
+          <rotationref ref="crystal12-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-12" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-5_pos_pos_top" />
+          <rotationref ref="crystal12-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="12" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-5_pos_neg_top" />
+          <rotationref ref="crystal12-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-12" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-5_pos_pos_bot" />
+          <rotationref ref="crystal13-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="13" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-5_pos_neg_bot" />
+          <rotationref ref="crystal13-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-13" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-5_pos_pos_top" />
+          <rotationref ref="crystal13-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="13" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-5_pos_neg_top" />
+          <rotationref ref="crystal13-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-13" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-5_pos_pos_bot" />
+          <rotationref ref="crystal14-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="14" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-5_pos_neg_bot" />
+          <rotationref ref="crystal14-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-14" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-5_pos_pos_top" />
+          <rotationref ref="crystal14-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="14" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-5_pos_neg_top" />
+          <rotationref ref="crystal14-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-14" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-5_pos_pos_bot" />
+          <rotationref ref="crystal15-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="15" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-5_pos_neg_bot" />
+          <rotationref ref="crystal15-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-15" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-5_pos_pos_top" />
+          <rotationref ref="crystal15-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="15" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-5_pos_neg_top" />
+          <rotationref ref="crystal15-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-15" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-5_pos_pos_bot" />
+          <rotationref ref="crystal16-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="16" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-5_pos_neg_bot" />
+          <rotationref ref="crystal16-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-16" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-5_pos_pos_top" />
+          <rotationref ref="crystal16-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="16" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-5_pos_neg_top" />
+          <rotationref ref="crystal16-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-16" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-5_pos_pos_bot" />
+          <rotationref ref="crystal17-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="17" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-5_pos_neg_bot" />
+          <rotationref ref="crystal17-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-17" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-5_pos_pos_top" />
+          <rotationref ref="crystal17-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="17" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-5_pos_neg_top" />
+          <rotationref ref="crystal17-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-17" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-5_pos_pos_bot" />
+          <rotationref ref="crystal18-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="18" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-5_pos_neg_bot" />
+          <rotationref ref="crystal18-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-18" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-5_pos_pos_top" />
+          <rotationref ref="crystal18-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="18" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-5_pos_neg_top" />
+          <rotationref ref="crystal18-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-18" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-5_pos_pos_bot" />
+          <rotationref ref="crystal19-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="19" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-5_pos_neg_bot" />
+          <rotationref ref="crystal19-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-19" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-5_pos_pos_top" />
+          <rotationref ref="crystal19-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="19" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-5_pos_neg_top" />
+          <rotationref ref="crystal19-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-19" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-5_pos_pos_bot" />
+          <rotationref ref="crystal20-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="20" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-5_pos_neg_bot" />
+          <rotationref ref="crystal20-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-20" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-5_pos_pos_top" />
+          <rotationref ref="crystal20-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="20" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-5_pos_neg_top" />
+          <rotationref ref="crystal20-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-20" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-5_pos_pos_bot" />
+          <rotationref ref="crystal21-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="21" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-5_pos_neg_bot" />
+          <rotationref ref="crystal21-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-21" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-5_pos_pos_top" />
+          <rotationref ref="crystal21-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="21" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-5_pos_neg_top" />
+          <rotationref ref="crystal21-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-21" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-5_pos_pos_bot" />
+          <rotationref ref="crystal22-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="22" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-5_pos_neg_bot" />
+          <rotationref ref="crystal22-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-22" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-5_pos_pos_top" />
+          <rotationref ref="crystal22-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="22" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-5_pos_neg_top" />
+          <rotationref ref="crystal22-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-22" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-5_pos_pos_bot" />
+          <rotationref ref="crystal23-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="23" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-5_pos_neg_bot" />
+          <rotationref ref="crystal23-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-23" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-5_pos_pos_top" />
+          <rotationref ref="crystal23-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="23" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-5_pos_neg_top" />
+          <rotationref ref="crystal23-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-23" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol name="front_flange_1">
+          <volumeref ref="front_flange" />
+          <positionref ref="front_flange_1inworld_volumepos" />
+        </physvol>
+        <physvol name="back_flange_1">
+          <volumeref ref="back_flange" />
+          <positionref ref="back_flange_1inworld_volumepos" />
+        </physvol>
+        <physvol name="ECAL_chamber_1">
+          <volumeref ref="ECAL_chamber" />
+          <positionref ref="ECAL_chamber_1inworld_volumepos" />
+        </physvol>
+        <physvol name="al_honeycomb_1">
+          <volumeref ref="al_honeycomb" />
+          <positionref ref="al_honeycomb_1inworld_volumepos" />
+        </physvol>
+        <physvol name="layer_1_top_1">
+          <volumeref ref="layer_1_top" />
+          <positionref ref="layer_1_top_1inworld_volumepos" />
+        </physvol>
+        <physvol name="layer_2_top_1">
+          <volumeref ref="layer_2_top" />
+          <positionref ref="layer_2_top_1inworld_volumepos" />
+        </physvol>
+        <physvol name="layer_3_top_1">
+          <volumeref ref="layer_3_top" />
+          <positionref ref="layer_3_top_1inworld_volumepos" />
+        </physvol>
+        <physvol name="layer_4_top_1">
+          <volumeref ref="layer_4_top" />
+          <positionref ref="layer_4_top_1inworld_volumepos" />
+        </physvol>
+        <physvol name="layer_1_bottom_1">
+          <volumeref ref="layer_1_bottom" />
+          <positionref ref="layer_1_bottom_1inworld_volumepos" />
+        </physvol>
+        <physvol name="layer_2_bottom_1">
+          <volumeref ref="layer_2_bottom" />
+          <positionref ref="layer_2_bottom_1inworld_volumepos" />
+        </physvol>
+        <physvol name="layer_3_bottom_1">
+          <volumeref ref="layer_3_bottom" />
+          <positionref ref="layer_3_bottom_1inworld_volumepos" />
+        </physvol>
+        <physvol name="layer_4_bottom_1">
+          <volumeref ref="layer_4_bottom" />
+          <positionref ref="layer_4_bottom_1inworld_volumepos" />
+        </physvol>
+        <physvol name="layer_5T_left_1">
+          <volumeref ref="layer_5T_left" />
+          <positionref ref="layer_5T_left_1inworld_volumepos" />
+        </physvol>
+        <physvol name="layer_5B_left_1">
+          <volumeref ref="layer_5B_left" />
+          <positionref ref="layer_5B_left_1inworld_volumepos" />
+        </physvol>
+        <physvol name="steel_bar_1">
+          <volumeref ref="steel_bar" />
+          <positionref ref="steel_bar_1inworld_volumepos" />
+        </physvol>
+        <physvol name="cu_Tpipe_inner_left_1">
+          <volumeref ref="cu_Tpipe_inner_left" />
+          <positionref ref="cu_Tpipe_inner_left_1inworld_volumepos" />
+          <rotationref ref="cu_Tpipe_inner_left_1inworld_volumerot" />
+        </physvol>
+        <physvol name="cu_Tpipe_inner_right_1">
+          <volumeref ref="cu_Tpipe_inner_right" />
+          <positionref ref="cu_Tpipe_inner_right_1inworld_volumepos" />
+          <rotationref ref="cu_Tpipe_inner_right_1inworld_volumerot" />
+        </physvol>
+        <physvol name="cu_Bpipe_inner_left_1">
+          <volumeref ref="cu_Bpipe_inner_left" />
+          <positionref ref="cu_Bpipe_inner_left_1inworld_volumepos" />
+          <rotationref ref="cu_Bpipe_inner_left_1inworld_volumerot" />
+        </physvol>
+        <physvol name="cu_Bpipe_inner_right_1">
+          <volumeref ref="cu_Bpipe_inner_right" />
+          <positionref ref="cu_Bpipe_inner_right_1inworld_volumepos" />
+          <rotationref ref="cu_Bpipe_inner_right_1inworld_volumerot" />
+        </physvol>
+        <physvol name="cu_Tpipe_outer_right1_1">
+          <volumeref ref="cu_Tpipe_outer_right1" />
+          <positionref ref="cu_Tpipe_outer_right1_1inworld_volumepos" />
+          <rotationref ref="cu_Tpipe_outer_right1_1inworld_volumerot" />
+        </physvol>
+        <physvol name="cu_Tpipe_outer_right2_1">
+          <volumeref ref="cu_Tpipe_outer_right2" />
+          <positionref ref="cu_Tpipe_outer_right2_1inworld_volumepos" />
+        </physvol>
+        <physvol name="cu_Tpipe_outer_right3_1">
+          <volumeref ref="cu_Tpipe_outer_right3" />
+          <positionref ref="cu_Tpipe_outer_right3_1inworld_volumepos" />
+          <rotationref ref="cu_Tpipe_outer_right3_1inworld_volumerot" />
+        </physvol>
+        <physvol name="cu_Bpipe_outer_right_1">
+          <volumeref ref="cu_Bpipe_outer_right" />
+          <positionref ref="cu_Bpipe_outer_right_1inworld_volumepos" />
+          <rotationref ref="cu_Bpipe_outer_right_1inworld_volumerot" />
+        </physvol>
+        <physvol name="cu_Bpipe_outer_right1_1">
+          <volumeref ref="cu_Bpipe_outer_right1" />
+          <positionref ref="cu_Bpipe_outer_right1_1inworld_volumepos" />
+          <rotationref ref="cu_Bpipe_outer_right1_1inworld_volumerot" />
+        </physvol>
+        <physvol name="cu_Bpipe_outer_right2_1">
+          <volumeref ref="cu_Bpipe_outer_right2" />
+          <positionref ref="cu_Bpipe_outer_right2_1inworld_volumepos" />
+        </physvol>
+        <physvol name="al_pipe_across_top1_1">
+          <volumeref ref="al_pipe_across_top1" />
+          <positionref ref="al_pipe_across_top1_1inworld_volumepos" />
+          <rotationref ref="al_pipe_across_top1_1inworld_volumerot" />
+        </physvol>
+        <physvol name="al_pipe_across_top2_1">
+          <volumeref ref="al_pipe_across_top2" />
+          <positionref ref="al_pipe_across_top2_1inworld_volumepos" />
+          <rotationref ref="al_pipe_across_top2_1inworld_volumerot" />
+        </physvol>
+        <physvol name="al_pipe_across_bottom1_1">
+          <volumeref ref="al_pipe_across_bottom1" />
+          <positionref ref="al_pipe_across_bottom1_1inworld_volumepos" />
+          <rotationref ref="al_pipe_across_bottom1_1inworld_volumerot" />
+        </physvol>
+        <physvol name="al_pipe_across_bottom2_1">
+          <volumeref ref="al_pipe_across_bottom2" />
+          <positionref ref="al_pipe_across_bottom2_1inworld_volumepos" />
+          <rotationref ref="al_pipe_across_bottom2_1inworld_volumerot" />
+        </physvol>
+        <physvol name="cu_plate_top_left_1">
+          <volumeref ref="cu_plate_top_left" />
+          <positionref ref="cu_plate_top_left_1inworld_volumepos" />
+        </physvol>
+        <physvol name="cu_plate_bottom_left_1">
+          <volumeref ref="cu_plate_bottom_left" />
+          <positionref ref="cu_plate_bottom_left_1inworld_volumepos" />
+        </physvol>
+        <physvol name="cu_plate_top_right_1">
+          <volumeref ref="cu_plate_top_right" />
+          <positionref ref="cu_plate_top_right_1inworld_volumepos" />
+        </physvol>
+        <physvol name="cu_plate_bottom_right_1">
+          <volumeref ref="cu_plate_bottom_right" />
+          <positionref ref="cu_plate_bottom_right_1inworld_volumepos" />
+        </physvol>
+        <physvol name="cu_plate_top_middle_1">
+          <volumeref ref="cu_plate_top_middle" />
+          <positionref ref="cu_plate_top_middle_1inworld_volumepos" />
+        </physvol>
+        <physvol name="cu_plate_bottom_middle_1">
+          <volumeref ref="cu_plate_bottom_middle" />
+          <positionref ref="cu_plate_bottom_middle_1inworld_volumepos" />
+        </physvol>
+        <visref ref="WorldVis" />
+      </volume>
+    </structure>
+    <setup name="Default" version="1.0">
+      <world ref="world_volume" />
+    </setup>
+  </gdml>
+  <fields>
+    <field_map_3d name="HPSDipoleFieldMap3D" lunit="mm" funit="tesla" filename="fieldmap/166acm2_4kg_corrected_unfolded_scaled_1.090896.dat" xoffset="21.17" yoffset="0.0" zoffset="457.2" />
+  </fields>
+</lcdd>
+

--- a/detector-data/detectors/HPS_Run2021Pass0_v1_1pt92GeV_fixed/SamplingFractions/Ecal.properties
+++ b/detector-data/detectors/HPS_Run2021Pass0_v1_1pt92GeV_fixed/SamplingFractions/Ecal.properties
@@ -1,0 +1,1 @@
+samplingFraction: 1.0

--- a/detector-data/detectors/HPS_Run2021Pass0_v1_1pt92GeV_fixed/SamplingFractions/Hodoscope.properties
+++ b/detector-data/detectors/HPS_Run2021Pass0_v1_1pt92GeV_fixed/SamplingFractions/Hodoscope.properties
@@ -1,0 +1,1 @@
+samplingFraction: 1.0

--- a/detector-data/detectors/HPS_Run2021Pass0_v1_1pt92GeV_fixed/compact.xml
+++ b/detector-data/detectors/HPS_Run2021Pass0_v1_1pt92GeV_fixed/compact.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <lccdd xmlns:compact="http://www.lcsim.org/schemas/compact/1.0" xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/compact/1.0/compact.xsd">
 
-<info name="HPS_Run2021Pass0_v1_1pt92GeV">
+<info name="HPS_Run2021Pass0_v1_1pt92GeV_fixed">
     <comment>HPS detector for 2021 run with fieldmap,
     Tracker at nominal opening angle, no SVT survey,
     this detector uses the corrected fieldmap scaled for 3.74 GeV beam.
@@ -534,14 +534,14 @@
         <millepede_constant name="22362" value="0.0" /> <!-- rw -->
 
         <!-- L3 Top/Bottom translations and angles -->
-        <millepede_constant name="11163" value="0.0 + 0.000678 - -0.059459 - 0.012216 - 0.006668 - 0.002504 + -0.7" /> <!-- u  -> global Y   -->
+        <millepede_constant name="11163" value="0.0 + 0.000678 - -0.059459 - 0.012216 - 0.006668 - 0.002504" /> <!-- u  -> global Y   -->
         <millepede_constant name="11263" value="0.0" /> <!-- v  -> X+svtAngle -->
         <millepede_constant name="11363" value="0.0" /> <!-- w  -> Z+svtAngle -->
         <millepede_constant name="12163" value="0.0" /> <!-- ru -->
         <millepede_constant name="12263" value="0.0" /> <!-- rv -->
         <millepede_constant name="12363" value="0.0" /> <!-- rw -->
 
-        <millepede_constant name="21163" value="0.0 + -0.046884 + -0.010228 - 0.075913 - 0.001767 - 0.023862 + -0.7" /> <!-- u -->
+        <millepede_constant name="21163" value="0.0 + -0.046884 + -0.010228 - 0.075913 - 0.001767 - 0.023862" /> <!-- u -->
         <millepede_constant name="21263" value="0.0" /> <!-- v -->
         <millepede_constant name="21363" value="0.0" /> <!-- w -->
         <millepede_constant name="22163" value="0.0" /> <!-- ru -->
@@ -549,14 +549,14 @@
         <millepede_constant name="22363" value="0.0" /> <!-- rw -->
 
         <!-- L4 Top/Bottom translations and angles -->
-        <millepede_constant name="11164" value="0.0 + -0.007361 - -0.033468 - -0.017968 - -0.013564 - 0.001690 + -0.7" /> <!-- u  -> global Y   -->
+        <millepede_constant name="11164" value="0.0 + -0.007361 - -0.033468 - -0.017968 - -0.013564 - 0.001690" /> <!-- u  -> global Y   -->
         <millepede_constant name="11264" value="0.0" /> <!-- v  -> X+svtAngle -->
         <millepede_constant name="11364" value="0.0" /> <!-- w  -> Z+svtAngle -->
         <millepede_constant name="12164" value="0.0" /> <!-- ru -->
         <millepede_constant name="12264" value="0.0" /> <!-- rv -->
         <millepede_constant name="12364" value="0.0" /> <!-- rw -->
 
-        <millepede_constant name="21164" value="0.0 + -0.033974 + -0.006749 - 0.051528 - -0.004088 - 0.021074 - 0.001095 + -0.7" /> <!-- u -->
+        <millepede_constant name="21164" value="0.0 + -0.033974 + -0.006749 - 0.051528 - -0.004088 - 0.021074 - 0.001095" /> <!-- u -->
         <millepede_constant name="21264" value="0.0" /> <!-- v -->
         <millepede_constant name="21364" value="0.0" /> <!-- w -->
         <millepede_constant name="22164" value="0.0" /> <!-- ru -->

--- a/detector-data/detectors/HPS_Run2021Pass0_v1_1pt92GeV_fixed/detector.properties
+++ b/detector-data/detectors/HPS_Run2021Pass0_v1_1pt92GeV_fixed/detector.properties
@@ -1,0 +1,1 @@
+name: HPS_Run2021Pass0_v1_1pt92GeV_fixed

--- a/detector-data/detectors/HPS_Run2021Pass0_v1_fixed/HPS_Run2021Pass0_v1_fixed.lcdd
+++ b/detector-data/detectors/HPS_Run2021Pass0_v1_fixed/HPS_Run2021Pass0_v1_fixed.lcdd
@@ -1,0 +1,10070 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lcdd xmlns:lcdd="http://www.lcsim.org/schemas/lcdd/1.0" xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/lcdd/1.0/lcdd.xsd">
+  <header>
+    <detector name="HPS_Run2021Pass0_v1_fixed" />
+    <generator name="lcsim" version="1.0" file="/sdf/group/hps/users/sgaiser/src/hps-java/detector-data/detectors/HPS_Run2021Pass0_v1/compact.xml" checksum="38842783" />
+    <author name="NONE" />
+    <comment>HPS detector for 2021 run with fieldmap, Tracker at nominal opening angle, no SVT survey, this detector uses the corrected fieldmap scaled for 3.74 GeV beam. Includes L0 and Hodoscope. ECAL with survey alignment for HPSEcal3 (global y/z translations). This detector has the full hierarchical alignment structure</comment>
+  </header>
+  <iddict>
+    <idspec name="HodoscopeForeHits" length="46">
+      <idfield signed="false" label="system" length="6" start="0" />
+      <idfield signed="false" label="barrel" length="3" start="6" />
+      <idfield signed="false" label="layer" length="4" start="9" />
+      <idfield signed="false" label="module" length="12" start="13" />
+      <idfield signed="false" label="sensor" length="1" start="25" />
+      <idfield signed="true" label="side" length="2" start="32" />
+      <idfield signed="false" label="strip" length="12" start="34" />
+    </idspec>
+    <idspec name="TrackerHitsFieldDef" length="46">
+      <idfield signed="false" label="system" length="6" start="0" />
+      <idfield signed="false" label="barrel" length="3" start="6" />
+      <idfield signed="false" label="layer" length="4" start="9" />
+      <idfield signed="false" label="module" length="12" start="13" />
+      <idfield signed="false" label="sensor" length="1" start="25" />
+      <idfield signed="true" label="side" length="2" start="32" />
+      <idfield signed="false" label="strip" length="12" start="34" />
+    </idspec>
+    <idspec name="TrackerHits" length="46">
+      <idfield signed="false" label="system" length="6" start="0" />
+      <idfield signed="false" label="barrel" length="3" start="6" />
+      <idfield signed="false" label="layer" length="4" start="9" />
+      <idfield signed="false" label="module" length="12" start="13" />
+      <idfield signed="false" label="sensor" length="1" start="25" />
+      <idfield signed="true" label="side" length="2" start="32" />
+      <idfield signed="false" label="strip" length="12" start="34" />
+    </idspec>
+    <idspec name="HodoscopeHits" length="23">
+      <idfield signed="false" label="system" length="6" start="0" />
+      <idfield signed="false" label="barrel" length="3" start="6" />
+      <idfield signed="false" label="layer" length="4" start="9" />
+      <idfield signed="false" label="ix" length="4" start="13" />
+      <idfield signed="true" label="iy" length="3" start="17" />
+      <idfield signed="true" label="hole" length="3" start="20" />
+    </idspec>
+    <idspec name="EcalHits" length="22">
+      <idfield signed="false" label="system" length="6" start="0" />
+      <idfield signed="false" label="layer" length="2" start="6" />
+      <idfield signed="true" label="ix" length="8" start="8" />
+      <idfield signed="true" label="iy" length="6" start="16" />
+    </idspec>
+    <idspec name="TrackerHitsECal" length="46">
+      <idfield signed="false" label="system" length="6" start="0" />
+      <idfield signed="false" label="barrel" length="3" start="6" />
+      <idfield signed="false" label="layer" length="4" start="9" />
+      <idfield signed="false" label="module" length="12" start="13" />
+      <idfield signed="false" label="sensor" length="1" start="25" />
+      <idfield signed="true" label="side" length="2" start="32" />
+      <idfield signed="false" label="strip" length="12" start="34" />
+    </idspec>
+  </iddict>
+  <sensitive_detectors>
+    <tracker name="Tracker" ecut="0.0" eunit="MeV" verbose="0" hits_collection="TrackerHits">
+      <idspecref ref="TrackerHits" />
+    </tracker>
+    <tracker name="ECalScoring" ecut="0.0" eunit="MeV" verbose="0" hits_collection="TrackerHitsECal">
+      <idspecref ref="TrackerHitsECal" />
+      <hit_processor type="ScoringTrackerHitProcessor" />
+    </tracker>
+    <calorimeter name="Ecal" ecut="0.0" eunit="MeV" verbose="0" hits_collection="EcalHits">
+      <idspecref ref="EcalHits" />
+      <grid_xyz grid_size_x="0.0" grid_size_y="0.0" grid_size_z="0.0" />
+    </calorimeter>
+    <tracker name="Hodoscope" ecut="0.0" eunit="MeV" verbose="0" hits_collection="HodoscopeHits">
+      <idspecref ref="HodoscopeHits" />
+    </tracker>
+  </sensitive_detectors>
+  <limits />
+  <regions>
+    <region name="TrackingRegion" store_secondaries="true" kill_tracks="false" cut="10.0" lunit="mm" threshold="1.0" eunit="MeV" />
+  </regions>
+  <display>
+    <vis name="InvisibleWithDaughters" line_style="unbroken" drawing_style="wireframe" show_daughters="true" visible="false">
+      <color R="0.0" G="0.0" B="0.0" alpha="0.0" />
+    </vis>
+    <vis name="SensorVis" line_style="unbroken" drawing_style="wireframe" show_daughters="true" visible="true">
+      <color R="1.0" G="0.0" B="0.0" alpha="1.0" />
+    </vis>
+    <vis name="SvtBoxVis" line_style="unbroken" drawing_style="wireframe" show_daughters="true" visible="true">
+      <color R="1.0" G="1.0" B="0.0" alpha="1.0" />
+    </vis>
+    <vis name="ComponentVis" line_style="unbroken" drawing_style="solid" show_daughters="false" visible="false">
+      <color R="0.0" G="0.2" B="0.4" alpha="0.0" />
+    </vis>
+    <vis name="HybridVis" line_style="unbroken" drawing_style="solid" show_daughters="true" visible="true">
+      <color R="0.0" G="1.0" B="0.0" alpha="1.0" />
+    </vis>
+    <vis name="ColdBlockVis" line_style="dashed" drawing_style="solid" show_daughters="true" visible="true">
+      <color R="0.75" G="0.73" B="0.75" alpha="1.0" />
+    </vis>
+    <vis name="ECALVis" line_style="unbroken" drawing_style="wireframe" show_daughters="true" visible="true">
+      <color R="0.8" G="0.5" B="0.1" alpha="1.0" />
+    </vis>
+    <vis name="HodoscopeVis" line_style="unbroken" drawing_style="solid" show_daughters="true" visible="true">
+      <color R="0.0" G="0.3372549" B="0.50980395" alpha="1.0" />
+    </vis>
+    <vis name="BasePlateVis" line_style="dashed" drawing_style="solid" show_daughters="true" visible="true">
+      <color R="0.35" G="0.35" B="0.35" alpha="1.0" />
+    </vis>
+    <vis name="BeamPlaneVis" line_style="unbroken" drawing_style="solid" show_daughters="false" visible="true">
+      <color R="1.0" G="1.0" B="1.0" alpha="1.0" />
+    </vis>
+    <vis name="HalfModuleVis" line_style="dashed" drawing_style="wireframe" show_daughters="true" visible="true">
+      <color R="1.0" G="1.0" B="1.0" alpha="1.0" />
+    </vis>
+    <vis name="CarbonFiberVis" line_style="unbroken" drawing_style="solid" show_daughters="true" visible="true">
+      <color R="0.88" G="0.88" B="0.88" alpha="1.0" />
+    </vis>
+    <vis name="ModuleVis" line_style="dotted" drawing_style="wireframe" show_daughters="true" visible="true">
+      <color R="1.0" G="1.0" B="1.0" alpha="1.0" />
+    </vis>
+    <vis name="SupportPlateVis" line_style="dashed" drawing_style="solid" show_daughters="true" visible="true">
+      <color R="0.45" G="0.45" B="0.45" alpha="1.0" />
+    </vis>
+    <vis name="LayerVis" line_style="unbroken" drawing_style="wireframe" show_daughters="true" visible="false">
+      <color R="0.0" G="0.0" B="1.0" alpha="0.0" />
+    </vis>
+    <vis name="ChamberVis" line_style="unbroken" drawing_style="wireframe" show_daughters="true" visible="true">
+      <color R="1.0" G="0.0" B="1.0" alpha="1.0" />
+    </vis>
+    <vis name="InvisibleNoDaughters" line_style="unbroken" drawing_style="wireframe" show_daughters="false" visible="false">
+      <color R="0.0" G="0.0" B="0.0" alpha="0.0" />
+    </vis>
+    <vis name="ActiveSensorVis" line_style="unbroken" drawing_style="solid" show_daughters="true" visible="true">
+      <color R="1.0" G="0.0" B="0.0" alpha="1.0" />
+    </vis>
+    <vis name="KaptonVis" line_style="unbroken" drawing_style="solid" show_daughters="true" visible="true">
+      <color R="0.91" G="0.77" B="0.06" alpha="1.0" />
+    </vis>
+    <vis name="SupportVolumeVis" line_style="dashed" drawing_style="wireframe" show_daughters="true" visible="true">
+      <color R="0.75" G="0.73" B="0.75" alpha="1.0" />
+    </vis>
+    <vis name="WorldVis" line_style="unbroken" drawing_style="wireframe" show_daughters="true" visible="false">
+      <color R="1.0" G="1.0" B="1.0" alpha="1.0" />
+    </vis>
+    <vis name="TrackingVis" line_style="unbroken" drawing_style="wireframe" show_daughters="true" visible="false">
+      <color R="1.0" G="1.0" B="1.0" alpha="1.0" />
+    </vis>
+  </display>
+  <gdml>
+    <define>
+      <rotation name="identity_rot" x="0.0" y="0.0" z="0.0" unit="radian" />
+      <rotation name="reflect_rot" x="3.141592653589793" y="0.0" z="0.0" unit="radian" />
+      <position name="identity_pos" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <constant name="bot_tr_x" value="-0.405" />
+      <constant name="x_rot_top" value="0.0" />
+      <constant name="hodoscopeXMin2" value="48.0" />
+      <constant name="hodoscopeXMin1" value="43.548" />
+      <constant name="scoringThickness" value="0.001" />
+      <constant name="ecal_back" value="8.0" />
+      <constant name="pivot" value="791.0" />
+      <constant name="bot_tr_y" value="-0.9125" />
+      <constant name="hodoscopeThickness" value="10.0" />
+      <constant name="bot_tr_z" value="2.6225" />
+      <constant name="bot_rot_beta" value="0.0" />
+      <constant name="dipoleMagnetWidth" value="1000.0" />
+      <constant name="top_rot_beta" value="0.0" />
+      <constant name="SA1" value="0.1" />
+      <constant name="x_rot_top_add" value="0.0" />
+      <constant name="SA2" value="0.05" />
+      <constant name="tracking_region_min" value="50.0" />
+      <constant name="y02t" value="21.419865625949214" />
+      <constant name="world_side" value="5000.0" />
+      <constant name="sensorLength" value="98.33" />
+      <constant name="sensorWidth" value="38.3399" />
+      <constant name="y02b" value="-21.419865625949214" />
+      <constant name="bot_rot_gamma" value="0.0013469727279283583" />
+      <constant name="x_rot_bot" value="0.0" />
+      <constant name="dipoleMagnetHeight" value="1000.0" />
+      <constant name="z02t" value="146.185" />
+      <constant name="top_rot_alpha" value="6.4964212772E-4" />
+      <constant name="y_rot" value="0.03052" />
+      <constant name="tracking_region_zmax" value="1368.0" />
+      <constant name="constBFieldY" value="-1.08" />
+      <constant name="top_tr_z" value="4.9375" />
+      <constant name="top_tr_y" value="2.725" />
+      <constant name="top_tr_x" value="-0.71" />
+      <constant name="dipoleMagnetLength" value="1080.0" />
+      <constant name="top_rot_gamma" value="-4.6882347412E-4" />
+      <constant name="y01t" value="21.419865625949214" />
+      <constant name="x_rot_bot_add" value="0.0" />
+      <constant name="zst" value="1.0" />
+      <constant name="bot_rot_alpha" value="5.150274940439E-4" />
+      <constant name="hodoscopePixelHeight" value="59.225" />
+      <constant name="beam_angle" value="0.03052" />
+      <constant name="z02b" value="161.185" />
+      <constant name="y01b" value="-21.419865625949214" />
+      <constant name="electronGapLeftEdge" value="382.492" />
+      <constant name="ecal_front" value="6.65" />
+      <constant name="z01t" value="138.815" />
+      <constant name="world_x" value="5000.0" />
+      <constant name="hodoscopeScoreDisplacement" value="1.0" />
+      <constant name="world_y" value="5000.0" />
+      <constant name="dipoleMagnetPositionX" value="21.17" />
+      <constant name="world_z" value="5000.0" />
+      <constant name="dipoleMagnetPositionZ" value="457.2" />
+      <constant name="tracking_region_radius" value="2000.0" />
+      <constant name="moduleWidth" value="40.34" />
+      <constant name="x_off" value="0.0" />
+      <constant name="electronGapRightEdge" value="474.962" />
+      <constant name="hodoscopeZ" value="1098.5" />
+      <constant name="moduleLength" value="100.0" />
+      <constant name="PI" value="3.14159265359" />
+      <constant name="ecal_dface" value="1448.0" />
+      <constant name="ecal_z" value="80.0" />
+      <constant name="z01b" value="153.815" />
+      <position name="tracking_region_pos" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <position name="base_position" x="21.336" y="0.0" z="349.9358" unit="mm" />
+      <rotation name="base_rotation" x="1.5707963267948963" y="-0.0" z="0.0" unit="radian" />
+      <position name="base_plate_position" x="0.0" y="0.0" z="-82.423" unit="mm" />
+      <rotation name="base_plate_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="support_plate_bottom_L14_position" x="-43.91306765955236" y="158.27805970493353" z="-64.29618504855034" unit="mm" />
+      <rotation name="support_plate_bottom_L14_rotation" x="0.0013959999999999999" y="3.3881317890172014E-21" z="3.111052254139705" unit="radian" />
+      <position name="support_plate_top_L14_position" x="-43.92289273297252" y="158.275538638572" z="63.9526433720102" unit="mm" />
+      <rotation name="support_plate_top_L14_rotation" x="-3.1412006535897934" y="4.235164736271502E-21" z="0.030433306424175563" unit="radian" />
+      <position name="support_plate_bottom_L46_position" x="0.14270823091617224" y="-354.5345474665431" z="-65.573" unit="mm" />
+      <rotation name="support_plate_bottom_L46_rotation" x="0.0" y="-0.0" z="3.1111093540316292" unit="radian" />
+      <position name="support_plate_top_L46_position" x="0.14255566889328364" y="-354.53517226223204" z="65.573" unit="mm" />
+      <rotation name="support_plate_top_L46_rotation" x="3.141592653589793" y="-0.0" z="0.030483299558163937" unit="radian" />
+      <position name="module_L1b_halfmodule_axial_position" x="-19.4763620296784" y="288.4308408110862" z="-7.8439612644705505" unit="mm" />
+      <rotation name="module_L1b_halfmodule_axial_rotation" x="-1.5694003267948962" y="-0.0305403994500879" z="1.5622113267948965" unit="radian" />
+      <position name="module_L1b_halfmodule_axial_sensor_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L1b_halfmodule_axial_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L1b_halfmodule_axial_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L1b_halfmodule_axial_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L1b_halfmodule_stereo_position" x="-18.951361692806728" y="296.04519371827337" z="-7.726768223078636" unit="mm" />
+      <rotation name="module_L1b_halfmodule_stereo_rotation" x="1.5721923267948965" y="0.030540399450088455" z="-1.4591623267948968" unit="radian" />
+      <position name="module_L1b_halfmodule_stereo_sensor_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L1b_halfmodule_stereo_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L1b_halfmodule_stereo_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L1b_halfmodule_stereo_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L1t_halfmodule_axial_position" x="-20.1794485390661" y="311.5550157182415" z="7.82498750613383" unit="mm" />
+      <rotation name="module_L1t_halfmodule_axial_rotation" x="1.5711883267948965" y="0.03043330642417559" z="1.5707963267948966" unit="radian" />
+      <position name="module_L1t_halfmodule_axial_sensor_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L1t_halfmodule_axial_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L1t_halfmodule_axial_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L1t_halfmodule_axial_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L1t_halfmodule_stereo_position" x="-19.16125214862157" y="303.98788379354727" z="7.800416579843663" unit="mm" />
+      <rotation name="module_L1t_halfmodule_stereo_rotation" x="-1.5704043267948966" y="-0.030433306424175424" z="-1.4707963267948967" unit="radian" />
+      <position name="module_L1t_halfmodule_stereo_sensor_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L1t_halfmodule_stereo_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L1t_halfmodule_stereo_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L1t_halfmodule_stereo_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L2b_halfmodule_axial_position" x="-18.19946284499224" y="238.4459152303712" z="-8.244426721240949" unit="mm" />
+      <rotation name="module_L2b_halfmodule_axial_rotation" x="-1.5694003267948966" y="-0.030540399450088455" z="1.5693003267948964" unit="radian" />
+      <position name="module_L2b_halfmodule_axial_sensor_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L2b_halfmodule_axial_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L2b_halfmodule_axial_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L2b_halfmodule_axial_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L2b_halfmodule_stereo_position" x="-17.669068629073763" y="246.06042408603088" z="-8.133561858869193" unit="mm" />
+      <rotation name="module_L2b_halfmodule_stereo_rotation" x="1.5721923267948965" y="0.0305403994500884" z="-1.4656833267948968" unit="radian" />
+      <position name="module_L2b_halfmodule_stereo_sensor_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L2b_halfmodule_stereo_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L2b_halfmodule_stereo_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L2b_halfmodule_stereo_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L2t_halfmodule_axial_position" x="-18.90790233353613" y="261.57064286534535" z="8.042521396503915" unit="mm" />
+      <rotation name="module_L2t_halfmodule_axial_rotation" x="1.5711883267948965" y="0.03043330642417559" z="1.5707963267948966" unit="radian" />
+      <position name="module_L2t_halfmodule_axial_sensor_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L2t_halfmodule_axial_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L2t_halfmodule_axial_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L2t_halfmodule_axial_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L2t_halfmodule_stereo_position" x="-17.891118829887205" y="254.00348918739766" z="8.072182218931573" unit="mm" />
+      <rotation name="module_L2t_halfmodule_stereo_rotation" x="-1.5704043267948966" y="-0.030433306424175424" z="-1.4707963267948967" unit="radian" />
+      <position name="module_L2t_halfmodule_stereo_sensor_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L2t_halfmodule_stereo_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L2t_halfmodule_stereo_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L2t_halfmodule_stereo_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3b_halfmodule_axial_position" x="-44.86653535485047" y="137.05267003736043" z="-25.672413778892928" unit="mm" />
+      <rotation name="module_L3b_halfmodule_axial_rotation" x="-1.5694003267948962" y="-0.030540399450088122" z="1.5707963267948963" unit="radian" />
+      <position name="module_L3b_halfmodule_axial_sensor_position" x="-3.414999999999999" y="30.0" z="-0.50725" unit="mm" />
+      <rotation name="module_L3b_halfmodule_axial_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3b_halfmodule_axial_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L3b_halfmodule_axial_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3b_halfmodule_axial_lamination_position" x="-3.414999999999999" y="30.0" z="-0.69225" unit="mm" />
+      <rotation name="module_L3b_halfmodule_axial_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3b_halfmodule_axial_cf_position" x="-3.414999999999999" y="30.0" z="-0.81875" unit="mm" />
+      <rotation name="module_L3b_halfmodule_axial_cf_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3b_halfmodule_axial_hybrid_position" x="-3.414999999999999" y="-55.0" z="0.12649999999999995" unit="mm" />
+      <rotation name="module_L3b_halfmodule_axial_hybrid_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3b_halfmodule_stereo_position" x="-45.31762685506874" y="145.4286365754165" z="-21.854831478310007" unit="mm" />
+      <rotation name="module_L3b_halfmodule_stereo_rotation" x="1.5721923267948963" y="0.03054039945008801" z="1.6707963267948964" unit="radian" />
+      <position name="module_L3b_halfmodule_stereo_sensor_position" x="-3.414999999999999" y="30.0" z="-0.50725" unit="mm" />
+      <rotation name="module_L3b_halfmodule_stereo_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3b_halfmodule_stereo_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L3b_halfmodule_stereo_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3b_halfmodule_stereo_lamination_position" x="-3.414999999999999" y="30.0" z="-0.69225" unit="mm" />
+      <rotation name="module_L3b_halfmodule_stereo_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3b_halfmodule_stereo_cf_position" x="-3.414999999999999" y="30.0" z="-0.81875" unit="mm" />
+      <rotation name="module_L3b_halfmodule_stereo_cf_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3b_halfmodule_stereo_hybrid_position" x="-3.414999999999999" y="-55.0" z="0.12649999999999995" unit="mm" />
+      <rotation name="module_L3b_halfmodule_stereo_hybrid_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3t_halfmodule_axial_position" x="-45.61670040744279" y="161.22559183511078" z="25.61125900534158" unit="mm" />
+      <rotation name="module_L3t_halfmodule_axial_rotation" x="1.5711883267948965" y="0.03043330642417559" z="1.5707963267948966" unit="radian" />
+      <position name="module_L3t_halfmodule_axial_sensor_position" x="-3.414999999999999" y="30.0" z="-0.50725" unit="mm" />
+      <rotation name="module_L3t_halfmodule_axial_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3t_halfmodule_axial_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L3t_halfmodule_axial_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3t_halfmodule_axial_lamination_position" x="-3.414999999999999" y="30.0" z="-0.69225" unit="mm" />
+      <rotation name="module_L3t_halfmodule_axial_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3t_halfmodule_axial_cf_position" x="-3.414999999999999" y="30.0" z="-0.81875" unit="mm" />
+      <rotation name="module_L3t_halfmodule_axial_cf_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3t_halfmodule_axial_hybrid_position" x="-3.414999999999999" y="-55.0" z="0.12649999999999995" unit="mm" />
+      <rotation name="module_L3t_halfmodule_axial_hybrid_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3t_halfmodule_stereo_position" x="-45.54676173869666" y="152.84185549481725" z="21.829706065586" unit="mm" />
+      <rotation name="module_L3t_halfmodule_stereo_rotation" x="-1.5704043267948962" y="-0.030433306424175535" z="1.6707963267948964" unit="radian" />
+      <position name="module_L3t_halfmodule_stereo_sensor_position" x="-3.414999999999999" y="30.0" z="-0.50725" unit="mm" />
+      <rotation name="module_L3t_halfmodule_stereo_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3t_halfmodule_stereo_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L3t_halfmodule_stereo_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3t_halfmodule_stereo_lamination_position" x="-3.414999999999999" y="30.0" z="-0.69225" unit="mm" />
+      <rotation name="module_L3t_halfmodule_stereo_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3t_halfmodule_stereo_cf_position" x="-3.414999999999999" y="30.0" z="-0.81875" unit="mm" />
+      <rotation name="module_L3t_halfmodule_stereo_cf_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3t_halfmodule_stereo_hybrid_position" x="-3.414999999999999" y="-55.0" z="0.12649999999999995" unit="mm" />
+      <rotation name="module_L3t_halfmodule_stereo_hybrid_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4b_halfmodule_axial_position" x="-41.81297014635422" y="37.09720378439058" z="-27.105817390045754" unit="mm" />
+      <rotation name="module_L4b_halfmodule_axial_rotation" x="-1.5694003267948962" y="-0.030540399450088122" z="1.5707963267948963" unit="radian" />
+      <position name="module_L4b_halfmodule_axial_sensor_position" x="-3.414999999999999" y="30.0" z="-0.50725" unit="mm" />
+      <rotation name="module_L4b_halfmodule_axial_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4b_halfmodule_axial_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L4b_halfmodule_axial_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4b_halfmodule_axial_lamination_position" x="-3.414999999999999" y="30.0" z="-0.69225" unit="mm" />
+      <rotation name="module_L4b_halfmodule_axial_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4b_halfmodule_axial_cf_position" x="-3.414999999999999" y="30.0" z="-0.81875" unit="mm" />
+      <rotation name="module_L4b_halfmodule_axial_cf_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4b_halfmodule_axial_hybrid_position" x="-3.414999999999999" y="-55.0" z="0.12649999999999995" unit="mm" />
+      <rotation name="module_L4b_halfmodule_axial_hybrid_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4b_halfmodule_stereo_position" x="-42.266005594434105" y="45.47317236141525" z="-23.244233373289834" unit="mm" />
+      <rotation name="module_L4b_halfmodule_stereo_rotation" x="1.5721923267948963" y="0.03054039945008801" z="1.6707963267948964" unit="radian" />
+      <position name="module_L4b_halfmodule_stereo_sensor_position" x="-3.414999999999999" y="30.0" z="-0.50725" unit="mm" />
+      <rotation name="module_L4b_halfmodule_stereo_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4b_halfmodule_stereo_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L4b_halfmodule_stereo_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4b_halfmodule_stereo_lamination_position" x="-3.414999999999999" y="30.0" z="-0.69225" unit="mm" />
+      <rotation name="module_L4b_halfmodule_stereo_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4b_halfmodule_stereo_cf_position" x="-3.414999999999999" y="30.0" z="-0.81875" unit="mm" />
+      <rotation name="module_L4b_halfmodule_stereo_cf_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4b_halfmodule_stereo_hybrid_position" x="-3.414999999999999" y="-55.0" z="0.12649999999999995" unit="mm" />
+      <rotation name="module_L4b_halfmodule_stereo_hybrid_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4t_halfmodule_axial_position" x="-42.57383952504715" y="61.27246976169503" z="27.090527741846074" unit="mm" />
+      <rotation name="module_L4t_halfmodule_axial_rotation" x="1.5711883267948965" y="0.03043330642417559" z="1.5707963267948966" unit="radian" />
+      <position name="module_L4t_halfmodule_axial_sensor_position" x="-3.414999999999999" y="30.0" z="-0.50725" unit="mm" />
+      <rotation name="module_L4t_halfmodule_axial_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4t_halfmodule_axial_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L4t_halfmodule_axial_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4t_halfmodule_axial_lamination_position" x="-3.414999999999999" y="30.0" z="-0.69225" unit="mm" />
+      <rotation name="module_L4t_halfmodule_axial_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4t_halfmodule_axial_cf_position" x="-3.414999999999999" y="30.0" z="-0.81875" unit="mm" />
+      <rotation name="module_L4t_halfmodule_axial_cf_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4t_halfmodule_axial_hybrid_position" x="-3.414999999999999" y="-55.0" z="0.12649999999999995" unit="mm" />
+      <rotation name="module_L4t_halfmodule_axial_hybrid_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4t_halfmodule_stereo_position" x="-42.51021339381717" y="52.88854680495761" z="23.323143912837278" unit="mm" />
+      <rotation name="module_L4t_halfmodule_stereo_rotation" x="-1.5704043267948962" y="-0.030433306424175535" z="1.6707963267948964" unit="radian" />
+      <position name="module_L4t_halfmodule_stereo_sensor_position" x="-3.414999999999999" y="30.0" z="-0.50725" unit="mm" />
+      <rotation name="module_L4t_halfmodule_stereo_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4t_halfmodule_stereo_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L4t_halfmodule_stereo_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4t_halfmodule_stereo_lamination_position" x="-3.414999999999999" y="30.0" z="-0.69225" unit="mm" />
+      <rotation name="module_L4t_halfmodule_stereo_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4t_halfmodule_stereo_cf_position" x="-3.414999999999999" y="30.0" z="-0.81875" unit="mm" />
+      <rotation name="module_L4t_halfmodule_stereo_cf_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4t_halfmodule_stereo_hybrid_position" x="-3.414999999999999" y="-55.0" z="0.12649999999999995" unit="mm" />
+      <rotation name="module_L4t_halfmodule_stereo_hybrid_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5b_halfmodule_axial_hole_position" x="-56.217250308986" y="-162.97132249781242" z="-26.654184000000008" unit="mm" />
+      <rotation name="module_L5b_halfmodule_axial_hole_rotation" x="-1.5707963267948966" y="-0.030483299558163958" z="1.5707963267948963" unit="radian" />
+      <position name="module_L5b_halfmodule_axial_hole_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L5b_halfmodule_axial_hole_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5b_halfmodule_axial_hole_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L5b_halfmodule_axial_hole_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5b_halfmodule_axial_hole_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L5b_halfmodule_axial_hole_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5b_halfmodule_axial_slot_position" x="44.72623159126889" y="-159.89327863637723" z="-26.792147000000007" unit="mm" />
+      <rotation name="module_L5b_halfmodule_axial_slot_rotation" x="-1.5707963267948963" y="-0.030483299558164013" z="-1.5718113267948963" unit="radian" />
+      <position name="module_L5b_halfmodule_axial_slot_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L5b_halfmodule_axial_slot_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5b_halfmodule_axial_slot_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L5b_halfmodule_axial_slot_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5b_halfmodule_axial_slot_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L5b_halfmodule_axial_slot_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5b_halfmodule_stereo_hole_position" x="-56.38945519192267" y="-155.65717305182127" z="-29.194184000000007" unit="mm" />
+      <rotation name="module_L5b_halfmodule_stereo_hole_rotation" x="1.5707963267948963" y="0.030483299558163958" z="1.6207963267948968" unit="radian" />
+      <position name="module_L5b_halfmodule_stereo_hole_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L5b_halfmodule_stereo_hole_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5b_halfmodule_stereo_hole_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L5b_halfmodule_stereo_hole_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5b_halfmodule_stereo_hole_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L5b_halfmodule_stereo_hole_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5b_halfmodule_stereo_slot_position" x="44.45375947605603" y="-152.58218661354013" z="-24.165285839201005" unit="mm" />
+      <rotation name="module_L5b_halfmodule_stereo_slot_rotation" x="1.5707963267948963" y="0.030483299558163958" z="-1.5200143267948967" unit="radian" />
+      <position name="module_L5b_halfmodule_stereo_slot_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L5b_halfmodule_stereo_slot_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5b_halfmodule_stereo_slot_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L5b_halfmodule_stereo_slot_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5b_halfmodule_stereo_slot_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L5b_halfmodule_stereo_slot_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5t_halfmodule_axial_hole_position" x="-56.924231591268885" y="-139.79172136362277" z="26.541470000000004" unit="mm" />
+      <rotation name="module_L5t_halfmodule_axial_hole_rotation" x="1.5707963267948966" y="0.030483299558164013" z="1.5707993267948968" unit="radian" />
+      <position name="module_L5t_halfmodule_axial_hole_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L5t_halfmodule_axial_hole_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5t_halfmodule_axial_hole_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L5t_halfmodule_axial_hole_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5t_halfmodule_axial_hole_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L5t_halfmodule_axial_hole_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5t_halfmodule_axial_slot_position" x="44.01925030898598" y="-136.71367750218758" z="26.432303000000005" unit="mm" />
+      <rotation name="module_L5t_halfmodule_axial_slot_rotation" x="1.5707963267948966" y="0.030483299558164013" z="-1.5733703267948964" unit="radian" />
+      <position name="module_L5t_halfmodule_axial_slot_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L5t_halfmodule_axial_slot_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5t_halfmodule_axial_slot_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L5t_halfmodule_axial_slot_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5t_halfmodule_axial_slot_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L5t_halfmodule_axial_slot_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5t_halfmodule_stereo_hole_position" x="-56.64679240590764" y="-147.10266192685603" z="29.177405900439815" unit="mm" />
+      <rotation name="module_L5t_halfmodule_stereo_hole_rotation" x="-1.5707963267948963" y="-0.030483299558164013" z="1.6201163267948966" unit="radian" />
+      <position name="module_L5t_halfmodule_stereo_hole_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L5t_halfmodule_stereo_hole_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5t_halfmodule_stereo_hole_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L5t_halfmodule_stereo_hole_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5t_halfmodule_stereo_hole_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L5t_halfmodule_stereo_hole_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5t_halfmodule_stereo_slot_position" x="44.19357232508188" y="-144.027762390977" z="24.091530036035536" unit="mm" />
+      <rotation name="module_L5t_halfmodule_stereo_slot_rotation" x="-1.5707963267948968" y="-0.030483299558163958" z="-1.5177933267948966" unit="radian" />
+      <position name="module_L5t_halfmodule_stereo_slot_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L5t_halfmodule_stereo_slot_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5t_halfmodule_stereo_slot_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L5t_halfmodule_stereo_slot_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5t_halfmodule_stereo_slot_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L5t_halfmodule_stereo_slot_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6b_halfmodule_axial_hole_position" x="-50.12153455494366" y="-362.8784065379883" z="-29.852538000000017" unit="mm" />
+      <rotation name="module_L6b_halfmodule_axial_hole_rotation" x="-1.5707963267948966" y="-0.030483299558163958" z="1.5724713267948967" unit="radian" />
+      <position name="module_L6b_halfmodule_axial_hole_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L6b_halfmodule_axial_hole_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6b_halfmodule_axial_hole_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L6b_halfmodule_axial_hole_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6b_halfmodule_axial_hole_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L6b_halfmodule_axial_hole_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6b_halfmodule_axial_slot_position" x="50.82194734531124" y="-359.8003626765531" z="-29.84663300000002" unit="mm" />
+      <rotation name="module_L6b_halfmodule_axial_slot_rotation" x="-1.5707963267948966" y="-0.030483299558163902" z="-1.5728073267948965" unit="radian" />
+      <position name="module_L6b_halfmodule_axial_slot_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L6b_halfmodule_axial_slot_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6b_halfmodule_axial_slot_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L6b_halfmodule_axial_slot_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6b_halfmodule_axial_slot_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L6b_halfmodule_axial_slot_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6b_halfmodule_stereo_hole_position" x="-50.28756533206903" y="-355.5640688265625" z="-32.29936354343249" unit="mm" />
+      <rotation name="module_L6b_halfmodule_stereo_hole_rotation" x="1.5707963267948968" y="0.030483299558163902" z="1.6204373267948966" unit="radian" />
+      <position name="module_L6b_halfmodule_stereo_hole_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L6b_halfmodule_stereo_hole_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6b_halfmodule_stereo_hole_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L6b_halfmodule_stereo_hole_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6b_halfmodule_stereo_hole_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L6b_halfmodule_stereo_hole_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6b_halfmodule_stereo_slot_position" x="50.55307230827514" y="-352.4891609689281" z="-27.21894385170075" unit="mm" />
+      <rotation name="module_L6b_halfmodule_stereo_slot_rotation" x="1.5707963267948963" y="0.03048329955816407" z="-1.5190973267948966" unit="radian" />
+      <position name="module_L6b_halfmodule_stereo_slot_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L6b_halfmodule_stereo_slot_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6b_halfmodule_stereo_slot_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L6b_halfmodule_stereo_slot_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6b_halfmodule_stereo_slot_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L6b_halfmodule_stereo_slot_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6t_halfmodule_axial_hole_position" x="-50.82851583722654" y="-339.6988054037986" z="29.535058000000006" unit="mm" />
+      <rotation name="module_L6t_halfmodule_axial_hole_rotation" x="1.5707963267948966" y="0.030483299558164013" z="1.5720093267948967" unit="radian" />
+      <position name="module_L6t_halfmodule_axial_hole_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L6t_halfmodule_axial_hole_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6t_halfmodule_axial_hole_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L6t_halfmodule_axial_hole_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6t_halfmodule_axial_hole_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L6t_halfmodule_axial_hole_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6t_halfmodule_axial_slot_position" x="50.11496606302833" y="-336.6207615423634" z="29.453632000000006" unit="mm" />
+      <rotation name="module_L6t_halfmodule_axial_slot_rotation" x="1.5707963267948966" y="0.030483299558163847" z="-1.5747723267948965" unit="radian" />
+      <position name="module_L6t_halfmodule_axial_slot_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L6t_halfmodule_axial_slot_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6t_halfmodule_axial_slot_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L6t_halfmodule_axial_slot_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6t_halfmodule_axial_slot_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L6t_halfmodule_axial_slot_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6t_halfmodule_stereo_hole_position" x="-50.54759087554505" y="-347.00963967614314" z="32.213967697359394" unit="mm" />
+      <rotation name="module_L6t_halfmodule_stereo_hole_rotation" x="-1.5707963267948963" y="-0.03048329955816379" z="1.6191823267948964" unit="radian" />
+      <position name="module_L6t_halfmodule_stereo_hole_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L6t_halfmodule_stereo_hole_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6t_halfmodule_stereo_hole_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L6t_halfmodule_stereo_hole_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6t_halfmodule_stereo_hole_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L6t_halfmodule_stereo_hole_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6t_halfmodule_stereo_slot_position" x="50.29296603598397" y="-343.9347342801519" z="27.13193402520686" unit="mm" />
+      <rotation name="module_L6t_halfmodule_stereo_slot_rotation" x="-1.5707963267948966" y="-0.030483299558163847" z="-1.517512326794897" unit="radian" />
+      <position name="module_L6t_halfmodule_stereo_slot_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L6t_halfmodule_stereo_slot_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6t_halfmodule_stereo_slot_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L6t_halfmodule_stereo_slot_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6t_halfmodule_stereo_slot_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L6t_halfmodule_stereo_slot_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7b_halfmodule_axial_hole_position" x="-44.02581880090134" y="-562.7854905781641" z="-33.05875100000001" unit="mm" />
+      <rotation name="module_L7b_halfmodule_axial_hole_rotation" x="-1.5707963267948966" y="-0.030483299558163902" z="1.5728003267948967" unit="radian" />
+      <position name="module_L7b_halfmodule_axial_hole_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L7b_halfmodule_axial_hole_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7b_halfmodule_axial_hole_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L7b_halfmodule_axial_hole_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7b_halfmodule_axial_hole_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L7b_halfmodule_axial_hole_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7b_halfmodule_axial_slot_position" x="56.917663099353554" y="-559.7074467167289" z="-33.00230400000001" unit="mm" />
+      <rotation name="module_L7b_halfmodule_axial_slot_rotation" x="-1.5707963267948968" y="-0.030483299558163736" z="-1.5736323267948966" unit="radian" />
+      <position name="module_L7b_halfmodule_axial_slot_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L7b_halfmodule_axial_slot_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7b_halfmodule_axial_slot_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L7b_halfmodule_axial_slot_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7b_halfmodule_axial_slot_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L7b_halfmodule_axial_slot_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7b_halfmodule_stereo_hole_position" x="-44.18806111860568" y="-555.4710373462109" z="-35.340047768179794" unit="mm" />
+      <rotation name="module_L7b_halfmodule_stereo_hole_rotation" x="1.5707963267948966" y="0.030483299558163958" z="1.6197933267948967" unit="radian" />
+      <position name="module_L7b_halfmodule_stereo_hole_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L7b_halfmodule_stereo_hole_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7b_halfmodule_stereo_hole_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L7b_halfmodule_stereo_hole_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7b_halfmodule_stereo_hole_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L7b_halfmodule_stereo_hole_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7b_halfmodule_stereo_slot_position" x="56.65264561081727" y="-552.3961273818608" z="-30.26100934805818" unit="mm" />
+      <rotation name="module_L7b_halfmodule_stereo_slot_rotation" x="1.5707963267948963" y="0.030483299558163958" z="-1.5181053267948965" unit="radian" />
+      <position name="module_L7b_halfmodule_stereo_slot_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L7b_halfmodule_stereo_slot_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7b_halfmodule_stereo_slot_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L7b_halfmodule_stereo_slot_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7b_halfmodule_stereo_slot_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L7b_halfmodule_stereo_slot_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7t_halfmodule_axial_hole_position" x="-44.732800083184195" y="-539.6058894439745" z="32.57358800000001" unit="mm" />
+      <rotation name="module_L7t_halfmodule_axial_hole_rotation" x="1.5707963267948966" y="0.030483299558163902" z="1.5725343267948966" unit="radian" />
+      <position name="module_L7t_halfmodule_axial_hole_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L7t_halfmodule_axial_hole_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7t_halfmodule_axial_hole_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L7t_halfmodule_axial_hole_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7t_halfmodule_axial_hole_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L7t_halfmodule_axial_hole_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7t_halfmodule_axial_slot_position" x="56.21068181707067" y="-536.5278455825394" z="32.48724600000001" unit="mm" />
+      <rotation name="module_L7t_halfmodule_axial_slot_rotation" x="1.5707963267948966" y="0.03048329955816407" z="-1.5754243267948964" unit="radian" />
+      <position name="module_L7t_halfmodule_axial_slot_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L7t_halfmodule_axial_slot_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7t_halfmodule_axial_slot_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L7t_halfmodule_axial_slot_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7t_halfmodule_axial_slot_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L7t_halfmodule_axial_slot_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7t_halfmodule_stereo_hole_position" x="-44.4520482188693" y="-546.916728994533" z="35.187660027707125" unit="mm" />
+      <rotation name="module_L7t_halfmodule_stereo_hole_rotation" x="-1.5707963267948966" y="-0.030483299558163958" z="1.6198633267948965" unit="radian" />
+      <position name="module_L7t_halfmodule_stereo_hole_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L7t_halfmodule_stereo_hole_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7t_halfmodule_stereo_hole_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L7t_halfmodule_stereo_hole_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7t_halfmodule_stereo_hole_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L7t_halfmodule_stereo_hole_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7t_halfmodule_stereo_slot_position" x="56.38605165921695" y="-543.8418985202362" z="30.056503822747324" unit="mm" />
+      <rotation name="module_L7t_halfmodule_stereo_slot_rotation" x="-1.5707963267948966" y="-0.030483299558163847" z="-1.5161223267948967" unit="radian" />
+      <position name="module_L7t_halfmodule_stereo_slot_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L7t_halfmodule_stereo_slot_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7t_halfmodule_stereo_slot_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L7t_halfmodule_stereo_slot_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7t_halfmodule_stereo_slot_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L7t_halfmodule_stereo_slot_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="BeamLeftVolume_component0_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="BeamLeftVolume_component0_rotation" x="0.0" y="0.0" z="0.0" unit="radian" />
+      <position name="BeamLeftVolume_component0Sensor0Position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="BeamLeftVolume_component0Sensor0Rotation" x="0.0" y="0.0" z="0.0" unit="radian" />
+      <position name="ElectronGapVolume_component0_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="ElectronGapVolume_component0_rotation" x="0.0" y="0.0" z="0.0" unit="radian" />
+      <position name="ElectronGapVolume_component0Sensor0Position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="ElectronGapVolume_component0Sensor0Rotation" x="0.0" y="0.0" z="0.0" unit="radian" />
+      <position name="BeamRightVolume_component0_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="BeamRightVolume_component0_rotation" x="0.0" y="0.0" z="0.0" unit="radian" />
+      <position name="BeamRightVolume_component0Sensor0Position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="BeamRightVolume_component0Sensor0Rotation" x="0.0" y="0.0" z="0.0" unit="radian" />
+      <position name="ECalScoring_BeamLeft_layer1_module0_position" x="214.099" y="122.8" z="1443.001" unit="mm" />
+      <rotation name="ECalScoring_BeamLeft_layer1_module0_rotation" x="0.0" y="0.0" z="-1.570796326795" unit="radian" />
+      <position name="ECalScoring_ElectronGap_layer1_module0_position" x="-23.38199999999999" y="130.465" z="1443.001" unit="mm" />
+      <rotation name="ECalScoring_ElectronGap_layer1_module0_rotation" x="0.0" y="0.0" z="-1.570796326795" unit="radian" />
+      <position name="ECalScoring_BeamRight_layer1_module0_position" x="-216.31099999999998" y="121.3" z="1443.001" unit="mm" />
+      <rotation name="ECalScoring_BeamRight_layer1_module0_rotation" x="0.0" y="0.0" z="-1.570796326795" unit="radian" />
+      <position name="ECalScoring_BeamLeft_layer2_module0_position" x="214.099" y="-122.8" z="1443.001" unit="mm" />
+      <rotation name="ECalScoring_BeamLeft_layer2_module0_rotation" x="0.0" y="0.0" z="-4.7123889803850005" unit="radian" />
+      <position name="ECalScoring_ElectronGap_layer2_module0_position" x="-23.38199999999999" y="-130.465" z="1443.001" unit="mm" />
+      <rotation name="ECalScoring_ElectronGap_layer2_module0_rotation" x="0.0" y="0.0" z="-4.7123889803850005" unit="radian" />
+      <position name="ECalScoring_BeamRight_layer2_module0_position" x="-216.31099999999998" y="-121.3" z="1443.001" unit="mm" />
+      <rotation name="ECalScoring_BeamRight_layer2_module0_rotation" x="0.0" y="0.0" z="-4.7123889803850005" unit="radian" />
+      <position name="crystal1-1_pos_pos_bot" x="50.20495188328156" y="-29.07473927539554" z="1528.1626281236922" unit="mm" />
+      <rotation name="crystal1-1_rot_pos_bot" x="-0.0084372997827221" y="-0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal1-1_pos_neg_bot" x="35.15547333249048" y="-29.07473927539554" z="1528.1626281236922" unit="mm" />
+      <rotation name="crystal1-1_rot_neg_bot" x="-0.0084372997827221" y="0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal1-1_pos_pos_top" x="50.20495188328156" y="29.974739275395542" z="1528.1626281236922" unit="mm" />
+      <rotation name="crystal1-1_rot_pos_top" x="0.0084372997827221" y="-0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal1-1_pos_neg_top" x="35.15547333249048" y="29.974739275395542" z="1528.1626281236922" unit="mm" />
+      <rotation name="crystal1-1_rot_neg_top" x="0.0084372997827221" y="0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal2-1_pos_pos_bot" x="65.05802548582456" y="-29.07473927539554" z="1528.2520480856124" unit="mm" />
+      <rotation name="crystal2-1_rot_pos_bot" x="-0.0084372997827221" y="-0.0253118993481663" z="0.0" unit="radian" />
+      <position name="crystal2-1_pos_pos_top" x="65.05802548582456" y="29.974739275395542" z="1528.2520480856124" unit="mm" />
+      <rotation name="crystal2-1_rot_pos_top" x="0.0084372997827221" y="-0.0253118993481663" z="0.0" unit="radian" />
+      <position name="crystal3-1_pos_pos_bot" x="79.9180994782841" y="-29.07473927539554" z="1528.3186477918262" unit="mm" />
+      <rotation name="crystal3-1_rot_pos_bot" x="-0.0084372997827221" y="-0.042186498913610496" z="0.0" unit="radian" />
+      <position name="crystal3-1_pos_pos_top" x="79.9180994782841" y="29.974739275395542" z="1528.3186477918262" unit="mm" />
+      <rotation name="crystal3-1_rot_pos_top" x="0.0084372997827221" y="-0.042186498913610496" z="0.0" unit="radian" />
+      <position name="crystal4-1_pos_pos_bot" x="94.78858692586502" y="-29.07473927539554" z="1528.3624082783765" unit="mm" />
+      <rotation name="crystal4-1_rot_pos_bot" x="-0.0084372997827221" y="-0.0590610984790547" z="0.0" unit="radian" />
+      <position name="crystal4-1_pos_pos_top" x="94.78858692586502" y="29.974739275395542" z="1528.3624082783765" unit="mm" />
+      <rotation name="crystal4-1_rot_pos_top" x="0.0084372997827221" y="-0.0590610984790547" z="0.0" unit="radian" />
+      <position name="crystal5-1_pos_pos_bot" x="109.67291416309662" y="-29.07473927539554" z="1528.3833170846683" unit="mm" />
+      <rotation name="crystal5-1_rot_pos_bot" x="-0.0084372997827221" y="-0.0759356980444989" z="0.0" unit="radian" />
+      <position name="crystal5-1_pos_pos_top" x="109.67291416309662" y="29.974739275395542" z="1528.3833170846683" unit="mm" />
+      <rotation name="crystal5-1_rot_pos_top" x="0.0084372997827221" y="-0.0759356980444989" z="0.0" unit="radian" />
+      <position name="crystal6-1_pos_pos_bot" x="124.57452638340096" y="-29.07473927539554" z="1528.381368257016" unit="mm" />
+      <rotation name="crystal6-1_rot_pos_bot" x="-0.0084372997827221" y="-0.0928102976099431" z="0.0" unit="radian" />
+      <position name="crystal6-1_pos_pos_top" x="124.57452638340096" y="29.974739275395542" z="1528.381368257016" unit="mm" />
+      <rotation name="crystal6-1_rot_pos_top" x="0.0084372997827221" y="-0.0928102976099431" z="0.0" unit="radian" />
+      <position name="crystal7-1_pos_pos_bot" x="139.4968932952259" y="-29.07473927539554" z="1528.3565623503396" unit="mm" />
+      <rotation name="crystal7-1_rot_pos_bot" x="-0.0084372997827221" y="-0.10968489717538729" z="0.0" unit="radian" />
+      <position name="crystal7-1_pos_pos_top" x="139.4968932952259" y="29.974739275395542" z="1528.3565623503396" unit="mm" />
+      <rotation name="crystal7-1_rot_pos_top" x="0.0084372997827221" y="-0.10968489717538729" z="0.0" unit="radian" />
+      <position name="crystal8-1_pos_pos_bot" x="154.44351486445828" y="-29.07473927539554" z="1528.3089064280052" unit="mm" />
+      <rotation name="crystal8-1_rot_pos_bot" x="-0.0084372997827221" y="-0.1265594967408315" z="0.0" unit="radian" />
+      <position name="crystal8-1_pos_pos_top" x="154.44351486445828" y="29.974739275395542" z="1528.3089064280052" unit="mm" />
+      <rotation name="crystal8-1_rot_pos_top" x="0.0084372997827221" y="-0.1265594967408315" z="0.0" unit="radian" />
+      <position name="crystal9-1_pos_pos_bot" x="169.41792716339802" y="-29.07473927539554" z="1528.2384140598156" unit="mm" />
+      <rotation name="crystal9-1_rot_pos_bot" x="-0.0084372997827221" y="-0.14343409630627568" z="0.0" unit="radian" />
+      <position name="crystal9-1_pos_pos_top" x="169.41792716339802" y="29.974739275395542" z="1528.2384140598156" unit="mm" />
+      <rotation name="crystal9-1_rot_pos_top" x="0.0084372997827221" y="-0.14343409630627568" z="0.0" unit="radian" />
+      <position name="crystal10-1_pos_pos_bot" x="184.42370834727978" y="-29.07473927539554" z="1528.1451053181452" unit="mm" />
+      <rotation name="crystal10-1_rot_pos_bot" x="-0.0084372997827221" y="-0.1603086958717199" z="0.0" unit="radian" />
+      <position name="crystal10-1_pos_pos_top" x="184.42370834727978" y="29.974739275395542" z="1528.1451053181452" unit="mm" />
+      <rotation name="crystal10-1_rot_pos_top" x="0.0084372997827221" y="-0.1603086958717199" z="0.0" unit="radian" />
+      <position name="crystal11-1_pos_pos_bot" x="199.46448478017476" y="-29.07473927539554" z="1528.0290067722244" unit="mm" />
+      <rotation name="crystal11-1_rot_pos_bot" x="-0.0084372997827221" y="-0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal11-1_pos_neg_bot" x="-114.1040595644027" y="-29.07473927539554" z="1528.0290067722244" unit="mm" />
+      <rotation name="crystal11-1_rot_neg_bot" x="-0.0084372997827221" y="0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal11-1_pos_pos_top" x="199.46448478017476" y="29.974739275395542" z="1528.0290067722244" unit="mm" />
+      <rotation name="crystal11-1_rot_pos_top" x="0.0084372997827221" y="-0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal11-1_pos_neg_top" x="-114.1040595644027" y="29.974739275395542" z="1528.0290067722244" unit="mm" />
+      <rotation name="crystal11-1_rot_neg_top" x="0.0084372997827221" y="0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal12-1_pos_pos_bot" x="214.5439373331128" y="-29.07473927539554" z="1527.8901514805746" unit="mm" />
+      <rotation name="crystal12-1_rot_pos_bot" x="-0.0084372997827221" y="-0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal12-1_pos_neg_bot" x="-129.1835121173408" y="-29.07473927539554" z="1527.8901514805746" unit="mm" />
+      <rotation name="crystal12-1_rot_neg_bot" x="-0.0084372997827221" y="0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal12-1_pos_pos_top" x="214.5439373331128" y="29.974739275395542" z="1527.8901514805746" unit="mm" />
+      <rotation name="crystal12-1_rot_pos_top" x="0.0084372997827221" y="-0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal12-1_pos_neg_top" x="-129.1835121173408" y="29.974739275395542" z="1527.8901514805746" unit="mm" />
+      <rotation name="crystal12-1_rot_neg_top" x="0.0084372997827221" y="0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal13-1_pos_pos_bot" x="229.66580787843168" y="-29.07473927539554" z="1527.7285789815953" unit="mm" />
+      <rotation name="crystal13-1_rot_pos_bot" x="-0.0084372997827221" y="-0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal13-1_pos_neg_bot" x="-144.30538266265967" y="-29.07473927539554" z="1527.7285789815953" unit="mm" />
+      <rotation name="crystal13-1_rot_neg_bot" x="-0.0084372997827221" y="0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal13-1_pos_pos_top" x="229.66580787843168" y="29.974739275395542" z="1527.7285789815953" unit="mm" />
+      <rotation name="crystal13-1_rot_pos_top" x="0.0084372997827221" y="-0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal13-1_pos_neg_top" x="-144.30538266265967" y="29.974739275395542" z="1527.7285789815953" unit="mm" />
+      <rotation name="crystal13-1_rot_neg_top" x="0.0084372997827221" y="0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal14-1_pos_pos_bot" x="244.83390600570817" y="-29.07473927539554" z="1527.5443352823047" unit="mm" />
+      <rotation name="crystal14-1_rot_pos_bot" x="-0.0084372997827221" y="-0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal14-1_pos_neg_bot" x="-159.47348078993616" y="-29.07473927539554" z="1527.5443352823047" unit="mm" />
+      <rotation name="crystal14-1_rot_neg_bot" x="-0.0084372997827221" y="0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal14-1_pos_pos_top" x="244.83390600570817" y="29.974739275395542" z="1527.5443352823047" unit="mm" />
+      <rotation name="crystal14-1_rot_pos_top" x="0.0084372997827221" y="-0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal14-1_pos_neg_top" x="-159.47348078993616" y="29.974739275395542" z="1527.5443352823047" unit="mm" />
+      <rotation name="crystal14-1_rot_neg_top" x="0.0084372997827221" y="0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal15-1_pos_pos_bot" x="260.0521159861688" y="-29.07473927539554" z="1527.3374728452397" unit="mm" />
+      <rotation name="crystal15-1_rot_pos_bot" x="-0.0084372997827221" y="-0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal15-1_pos_neg_bot" x="-174.6916907703968" y="-29.07473927539554" z="1527.3374728452397" unit="mm" />
+      <rotation name="crystal15-1_rot_neg_bot" x="-0.0084372997827221" y="0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal15-1_pos_pos_top" x="260.0521159861688" y="29.974739275395542" z="1527.3374728452397" unit="mm" />
+      <rotation name="crystal15-1_rot_pos_top" x="0.0084372997827221" y="-0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal15-1_pos_neg_top" x="-174.6916907703968" y="29.974739275395542" z="1527.3374728452397" unit="mm" />
+      <rotation name="crystal15-1_rot_neg_top" x="0.0084372997827221" y="0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal16-1_pos_pos_bot" x="275.32440401422616" y="-29.07473927539554" z="1527.108050573519" unit="mm" />
+      <rotation name="crystal16-1_rot_pos_bot" x="-0.0084372997827221" y="-0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal16-1_pos_neg_bot" x="-189.96397879845415" y="-29.07473927539554" z="1527.108050573519" unit="mm" />
+      <rotation name="crystal16-1_rot_neg_bot" x="-0.0084372997827221" y="0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal16-1_pos_pos_top" x="275.32440401422616" y="29.974739275395542" z="1527.108050573519" unit="mm" />
+      <rotation name="crystal16-1_rot_pos_top" x="0.0084372997827221" y="-0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal16-1_pos_neg_top" x="-189.96397879845415" y="29.974739275395542" z="1527.108050573519" unit="mm" />
+      <rotation name="crystal16-1_rot_neg_top" x="0.0084372997827221" y="0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal17-1_pos_pos_bot" x="290.6548257567732" y="-29.07473927539554" z="1526.8561337940675" unit="mm" />
+      <rotation name="crystal17-1_rot_pos_bot" x="-0.0084372997827221" y="-0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal17-1_pos_neg_bot" x="-205.2944005410012" y="-29.07473927539554" z="1526.8561337940675" unit="mm" />
+      <rotation name="crystal17-1_rot_neg_bot" x="-0.0084372997827221" y="0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal17-1_pos_pos_top" x="290.6548257567732" y="29.974739275395542" z="1526.8561337940675" unit="mm" />
+      <rotation name="crystal17-1_rot_pos_top" x="0.0084372997827221" y="-0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal17-1_pos_neg_top" x="-205.2944005410012" y="29.974739275395542" z="1526.8561337940675" unit="mm" />
+      <rotation name="crystal17-1_rot_neg_top" x="0.0084372997827221" y="0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal18-1_pos_pos_bot" x="306.0475342431027" y="-29.07473927539554" z="1526.581794239018" unit="mm" />
+      <rotation name="crystal18-1_rot_pos_bot" x="-0.0084372997827221" y="-0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal18-1_pos_neg_bot" x="-220.68710902733068" y="-29.07473927539554" z="1526.581794239018" unit="mm" />
+      <rotation name="crystal18-1_rot_neg_bot" x="-0.0084372997827221" y="0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal18-1_pos_pos_top" x="306.0475342431027" y="29.974739275395542" z="1526.581794239018" unit="mm" />
+      <rotation name="crystal18-1_rot_pos_top" x="0.0084372997827221" y="-0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal18-1_pos_neg_top" x="-220.68710902733068" y="29.974739275395542" z="1526.581794239018" unit="mm" />
+      <rotation name="crystal18-1_rot_neg_top" x="0.0084372997827221" y="0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal19-1_pos_pos_bot" x="321.5067881308382" y="-29.07473927539554" z="1526.2851100252847" unit="mm" />
+      <rotation name="crystal19-1_rot_pos_bot" x="-0.0084372997827221" y="-0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal19-1_pos_neg_bot" x="-236.14636291506616" y="-29.07473927539554" z="1526.2851100252847" unit="mm" />
+      <rotation name="crystal19-1_rot_neg_bot" x="-0.0084372997827221" y="0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal19-1_pos_pos_top" x="321.5067881308382" y="29.974739275395542" z="1526.2851100252847" unit="mm" />
+      <rotation name="crystal19-1_rot_pos_top" x="0.0084372997827221" y="-0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal19-1_pos_neg_top" x="-236.14636291506616" y="29.974739275395542" z="1526.2851100252847" unit="mm" />
+      <rotation name="crystal19-1_rot_neg_top" x="0.0084372997827221" y="0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal20-1_pos_pos_bot" x="337.03696038609246" y="-29.07473927539554" z="1525.9661656323178" unit="mm" />
+      <rotation name="crystal20-1_rot_pos_bot" x="-0.0084372997827221" y="-0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal20-1_pos_neg_bot" x="-251.67653517032045" y="-29.07473927539554" z="1525.9661656323178" unit="mm" />
+      <rotation name="crystal20-1_rot_neg_bot" x="-0.0084372997827221" y="0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal20-1_pos_pos_top" x="337.03696038609246" y="29.974739275395542" z="1525.9661656323178" unit="mm" />
+      <rotation name="crystal20-1_rot_pos_top" x="0.0084372997827221" y="-0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal20-1_pos_neg_top" x="-251.67653517032045" y="29.974739275395542" z="1525.9661656323178" unit="mm" />
+      <rotation name="crystal20-1_rot_neg_top" x="0.0084372997827221" y="0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal21-1_pos_pos_bot" x="352.64254741924634" y="-29.07473927539554" z="1525.625051878052" unit="mm" />
+      <rotation name="crystal21-1_rot_pos_bot" x="-0.0084372997827221" y="-0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal21-1_pos_neg_bot" x="-267.28212220347433" y="-29.07473927539554" z="1525.625051878052" unit="mm" />
+      <rotation name="crystal21-1_rot_neg_bot" x="-0.0084372997827221" y="0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal21-1_pos_pos_top" x="352.64254741924634" y="29.974739275395542" z="1525.625051878052" unit="mm" />
+      <rotation name="crystal21-1_rot_pos_top" x="0.0084372997827221" y="-0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal21-1_pos_neg_top" x="-267.28212220347433" y="29.974739275395542" z="1525.625051878052" unit="mm" />
+      <rotation name="crystal21-1_rot_neg_top" x="0.0084372997827221" y="0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal22-1_pos_pos_bot" x="368.32817872130425" y="-29.07473927539554" z="1525.2618658930442" unit="mm" />
+      <rotation name="crystal22-1_rot_pos_bot" x="-0.0084372997827221" y="-0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal22-1_pos_neg_bot" x="-282.96775350553224" y="-29.07473927539554" z="1525.2618658930442" unit="mm" />
+      <rotation name="crystal22-1_rot_neg_bot" x="-0.0084372997827221" y="0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal22-1_pos_pos_top" x="368.32817872130425" y="29.974739275395542" z="1525.2618658930442" unit="mm" />
+      <rotation name="crystal22-1_rot_pos_top" x="0.0084372997827221" y="-0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal22-1_pos_neg_top" x="-282.96775350553224" y="29.974739275395542" z="1525.2618658930442" unit="mm" />
+      <rotation name="crystal22-1_rot_neg_top" x="0.0084372997827221" y="0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal23-1_pos_pos_bot" x="384.09862704978" y="-29.07473927539554" z="1524.8767110928152" unit="mm" />
+      <rotation name="crystal23-1_rot_pos_bot" x="-0.0084372997827221" y="-0.3796784902224945" z="0.0" unit="radian" />
+      <position name="crystal23-1_pos_neg_bot" x="-298.738201834008" y="-29.07473927539554" z="1524.8767110928152" unit="mm" />
+      <rotation name="crystal23-1_rot_neg_bot" x="-0.0084372997827221" y="0.3796784902224945" z="0.0" unit="radian" />
+      <position name="crystal23-1_pos_pos_top" x="384.09862704978" y="29.974739275395542" z="1524.8767110928152" unit="mm" />
+      <rotation name="crystal23-1_rot_pos_top" x="0.0084372997827221" y="-0.3796784902224945" z="0.0" unit="radian" />
+      <position name="crystal23-1_pos_neg_top" x="-298.738201834008" y="29.974739275395542" z="1524.8767110928152" unit="mm" />
+      <rotation name="crystal23-1_rot_neg_top" x="0.0084372997827221" y="0.3796784902224945" z="0.0" unit="radian" />
+      <position name="crystal1-2_pos_pos_bot" x="50.20495188328156" y="-44.077812877938534" z="1528.2520480856124" unit="mm" />
+      <rotation name="crystal1-2_rot_pos_bot" x="-0.0253118993481663" y="-0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal1-2_pos_neg_bot" x="35.15547333249048" y="-44.077812877938534" z="1528.2520480856124" unit="mm" />
+      <rotation name="crystal1-2_rot_neg_bot" x="-0.0253118993481663" y="0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal1-2_pos_pos_top" x="50.20495188328156" y="44.97781287793853" z="1528.2520480856124" unit="mm" />
+      <rotation name="crystal1-2_rot_pos_top" x="0.0253118993481663" y="-0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal1-2_pos_neg_top" x="35.15547333249048" y="44.97781287793853" z="1528.2520480856124" unit="mm" />
+      <rotation name="crystal1-2_rot_neg_top" x="0.0253118993481663" y="0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal2-2_pos_pos_bot" x="65.05802548582456" y="-44.077812877938534" z="1528.3414680475323" unit="mm" />
+      <rotation name="crystal2-2_rot_pos_bot" x="-0.0253118993481663" y="-0.0253118993481663" z="0.0" unit="radian" />
+      <position name="crystal2-2_pos_neg_bot" x="20.302399729947485" y="-44.077812877938534" z="1528.3414680475323" unit="mm" />
+      <rotation name="crystal2-2_rot_neg_bot" x="-0.0253118993481663" y="0.0253118993481663" z="0.0" unit="radian" />
+      <position name="crystal2-2_pos_pos_top" x="65.05802548582456" y="44.97781287793853" z="1528.3414680475323" unit="mm" />
+      <rotation name="crystal2-2_rot_pos_top" x="0.0253118993481663" y="-0.0253118993481663" z="0.0" unit="radian" />
+      <position name="crystal2-2_pos_neg_top" x="20.302399729947485" y="44.97781287793853" z="1528.3414680475323" unit="mm" />
+      <rotation name="crystal2-2_rot_neg_top" x="0.0253118993481663" y="0.0253118993481663" z="0.0" unit="radian" />
+      <position name="crystal3-2_pos_pos_bot" x="79.9180994782841" y="-44.077812877938534" z="1528.4080677537463" unit="mm" />
+      <rotation name="crystal3-2_rot_pos_bot" x="-0.0253118993481663" y="-0.042186498913610496" z="0.0" unit="radian" />
+      <position name="crystal3-2_pos_neg_bot" x="5.442325737487934" y="-44.077812877938534" z="1528.4080677537463" unit="mm" />
+      <rotation name="crystal3-2_rot_neg_bot" x="-0.0253118993481663" y="0.042186498913610496" z="0.0" unit="radian" />
+      <position name="crystal3-2_pos_pos_top" x="79.9180994782841" y="44.97781287793853" z="1528.4080677537463" unit="mm" />
+      <rotation name="crystal3-2_rot_pos_top" x="0.0253118993481663" y="-0.042186498913610496" z="0.0" unit="radian" />
+      <position name="crystal3-2_pos_neg_top" x="5.442325737487934" y="44.97781287793853" z="1528.4080677537463" unit="mm" />
+      <rotation name="crystal3-2_rot_neg_top" x="0.0253118993481663" y="0.042186498913610496" z="0.0" unit="radian" />
+      <position name="crystal4-2_pos_pos_bot" x="94.78858692586502" y="-44.077812877938534" z="1528.4518282402964" unit="mm" />
+      <rotation name="crystal4-2_rot_pos_bot" x="-0.0253118993481663" y="-0.0590610984790547" z="0.0" unit="radian" />
+      <position name="crystal4-2_pos_neg_bot" x="-9.42816171009298" y="-44.077812877938534" z="1528.4518282402964" unit="mm" />
+      <rotation name="crystal4-2_rot_neg_bot" x="-0.0253118993481663" y="0.0590610984790547" z="0.0" unit="radian" />
+      <position name="crystal4-2_pos_pos_top" x="94.78858692586502" y="44.97781287793853" z="1528.4518282402964" unit="mm" />
+      <rotation name="crystal4-2_rot_pos_top" x="0.0253118993481663" y="-0.0590610984790547" z="0.0" unit="radian" />
+      <position name="crystal4-2_pos_neg_top" x="-9.42816171009298" y="44.97781287793853" z="1528.4518282402964" unit="mm" />
+      <rotation name="crystal4-2_rot_neg_top" x="0.0253118993481663" y="0.0590610984790547" z="0.0" unit="radian" />
+      <position name="crystal5-2_pos_pos_bot" x="109.67291416309662" y="-44.077812877938534" z="1528.4727370465882" unit="mm" />
+      <rotation name="crystal5-2_rot_pos_bot" x="-0.0253118993481663" y="-0.0759356980444989" z="0.0" unit="radian" />
+      <position name="crystal5-2_pos_neg_bot" x="-24.31248894732458" y="-44.077812877938534" z="1528.4727370465882" unit="mm" />
+      <rotation name="crystal5-2_rot_neg_bot" x="-0.0253118993481663" y="0.0759356980444989" z="0.0" unit="radian" />
+      <position name="crystal5-2_pos_pos_top" x="109.67291416309662" y="44.97781287793853" z="1528.4727370465882" unit="mm" />
+      <rotation name="crystal5-2_rot_pos_top" x="0.0253118993481663" y="-0.0759356980444989" z="0.0" unit="radian" />
+      <position name="crystal5-2_pos_neg_top" x="-24.31248894732458" y="44.97781287793853" z="1528.4727370465882" unit="mm" />
+      <rotation name="crystal5-2_rot_neg_top" x="0.0253118993481663" y="0.0759356980444989" z="0.0" unit="radian" />
+      <position name="crystal6-2_pos_pos_bot" x="124.57452638340096" y="-44.077812877938534" z="1528.4707882189361" unit="mm" />
+      <rotation name="crystal6-2_rot_pos_bot" x="-0.0253118993481663" y="-0.0928102976099431" z="0.0" unit="radian" />
+      <position name="crystal6-2_pos_neg_bot" x="-39.214101167628925" y="-44.077812877938534" z="1528.4707882189361" unit="mm" />
+      <rotation name="crystal6-2_rot_neg_bot" x="-0.0253118993481663" y="0.0928102976099431" z="0.0" unit="radian" />
+      <position name="crystal6-2_pos_pos_top" x="124.57452638340096" y="44.97781287793853" z="1528.4707882189361" unit="mm" />
+      <rotation name="crystal6-2_rot_pos_top" x="0.0253118993481663" y="-0.0928102976099431" z="0.0" unit="radian" />
+      <position name="crystal6-2_pos_neg_top" x="-39.214101167628925" y="44.97781287793853" z="1528.4707882189361" unit="mm" />
+      <rotation name="crystal6-2_rot_neg_top" x="0.0253118993481663" y="0.0928102976099431" z="0.0" unit="radian" />
+      <position name="crystal7-2_pos_pos_bot" x="139.4968932952259" y="-44.077812877938534" z="1528.4459823122595" unit="mm" />
+      <rotation name="crystal7-2_rot_pos_bot" x="-0.0253118993481663" y="-0.10968489717538729" z="0.0" unit="radian" />
+      <position name="crystal7-2_pos_neg_bot" x="-54.13646807945388" y="-44.077812877938534" z="1528.4459823122595" unit="mm" />
+      <rotation name="crystal7-2_rot_neg_bot" x="-0.0253118993481663" y="0.10968489717538729" z="0.0" unit="radian" />
+      <position name="crystal7-2_pos_pos_top" x="139.4968932952259" y="44.97781287793853" z="1528.4459823122595" unit="mm" />
+      <rotation name="crystal7-2_rot_pos_top" x="0.0253118993481663" y="-0.10968489717538729" z="0.0" unit="radian" />
+      <position name="crystal7-2_pos_neg_top" x="-54.13646807945388" y="44.97781287793853" z="1528.4459823122595" unit="mm" />
+      <rotation name="crystal7-2_rot_neg_top" x="0.0253118993481663" y="0.10968489717538729" z="0.0" unit="radian" />
+      <position name="crystal8-2_pos_pos_bot" x="154.44351486445828" y="-44.077812877938534" z="1528.3983263899254" unit="mm" />
+      <rotation name="crystal8-2_rot_pos_bot" x="-0.0253118993481663" y="-0.1265594967408315" z="0.0" unit="radian" />
+      <position name="crystal8-2_pos_neg_bot" x="-69.08308964868624" y="-44.077812877938534" z="1528.3983263899254" unit="mm" />
+      <rotation name="crystal8-2_rot_neg_bot" x="-0.0253118993481663" y="0.1265594967408315" z="0.0" unit="radian" />
+      <position name="crystal8-2_pos_pos_top" x="154.44351486445828" y="44.97781287793853" z="1528.3983263899254" unit="mm" />
+      <rotation name="crystal8-2_rot_pos_top" x="0.0253118993481663" y="-0.1265594967408315" z="0.0" unit="radian" />
+      <position name="crystal8-2_pos_neg_top" x="-69.08308964868624" y="44.97781287793853" z="1528.3983263899254" unit="mm" />
+      <rotation name="crystal8-2_rot_neg_top" x="0.0253118993481663" y="0.1265594967408315" z="0.0" unit="radian" />
+      <position name="crystal9-2_pos_pos_bot" x="169.41792716339802" y="-44.077812877938534" z="1528.3278340217357" unit="mm" />
+      <rotation name="crystal9-2_rot_pos_bot" x="-0.0253118993481663" y="-0.14343409630627568" z="0.0" unit="radian" />
+      <position name="crystal9-2_pos_neg_bot" x="-84.057501947626" y="-44.077812877938534" z="1528.3278340217357" unit="mm" />
+      <rotation name="crystal9-2_rot_neg_bot" x="-0.0253118993481663" y="0.14343409630627568" z="0.0" unit="radian" />
+      <position name="crystal9-2_pos_pos_top" x="169.41792716339802" y="44.97781287793853" z="1528.3278340217357" unit="mm" />
+      <rotation name="crystal9-2_rot_pos_top" x="0.0253118993481663" y="-0.14343409630627568" z="0.0" unit="radian" />
+      <position name="crystal9-2_pos_neg_top" x="-84.057501947626" y="44.97781287793853" z="1528.3278340217357" unit="mm" />
+      <rotation name="crystal9-2_rot_neg_top" x="0.0253118993481663" y="0.14343409630627568" z="0.0" unit="radian" />
+      <position name="crystal10-2_pos_pos_bot" x="184.42370834727978" y="-44.077812877938534" z="1528.2345252800653" unit="mm" />
+      <rotation name="crystal10-2_rot_pos_bot" x="-0.0253118993481663" y="-0.1603086958717199" z="0.0" unit="radian" />
+      <position name="crystal10-2_pos_neg_bot" x="-99.06328313150773" y="-44.077812877938534" z="1528.2345252800653" unit="mm" />
+      <rotation name="crystal10-2_rot_neg_bot" x="-0.0253118993481663" y="0.1603086958717199" z="0.0" unit="radian" />
+      <position name="crystal10-2_pos_pos_top" x="184.42370834727978" y="44.97781287793853" z="1528.2345252800653" unit="mm" />
+      <rotation name="crystal10-2_rot_pos_top" x="0.0253118993481663" y="-0.1603086958717199" z="0.0" unit="radian" />
+      <position name="crystal10-2_pos_neg_top" x="-99.06328313150773" y="44.97781287793853" z="1528.2345252800653" unit="mm" />
+      <rotation name="crystal10-2_rot_neg_top" x="0.0253118993481663" y="0.1603086958717199" z="0.0" unit="radian" />
+      <position name="crystal11-2_pos_pos_bot" x="199.46448478017476" y="-44.077812877938534" z="1528.1184267341444" unit="mm" />
+      <rotation name="crystal11-2_rot_pos_bot" x="-0.0253118993481663" y="-0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal11-2_pos_neg_bot" x="-114.1040595644027" y="-44.077812877938534" z="1528.1184267341444" unit="mm" />
+      <rotation name="crystal11-2_rot_neg_bot" x="-0.0253118993481663" y="0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal11-2_pos_pos_top" x="199.46448478017476" y="44.97781287793853" z="1528.1184267341444" unit="mm" />
+      <rotation name="crystal11-2_rot_pos_top" x="0.0253118993481663" y="-0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal11-2_pos_neg_top" x="-114.1040595644027" y="44.97781287793853" z="1528.1184267341444" unit="mm" />
+      <rotation name="crystal11-2_rot_neg_top" x="0.0253118993481663" y="0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal12-2_pos_pos_bot" x="214.5439373331128" y="-44.077812877938534" z="1527.9795714424947" unit="mm" />
+      <rotation name="crystal12-2_rot_pos_bot" x="-0.0253118993481663" y="-0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal12-2_pos_neg_bot" x="-129.1835121173408" y="-44.077812877938534" z="1527.9795714424947" unit="mm" />
+      <rotation name="crystal12-2_rot_neg_bot" x="-0.0253118993481663" y="0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal12-2_pos_pos_top" x="214.5439373331128" y="44.97781287793853" z="1527.9795714424947" unit="mm" />
+      <rotation name="crystal12-2_rot_pos_top" x="0.0253118993481663" y="-0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal12-2_pos_neg_top" x="-129.1835121173408" y="44.97781287793853" z="1527.9795714424947" unit="mm" />
+      <rotation name="crystal12-2_rot_neg_top" x="0.0253118993481663" y="0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal13-2_pos_pos_bot" x="229.66580787843168" y="-44.077812877938534" z="1527.8179989435152" unit="mm" />
+      <rotation name="crystal13-2_rot_pos_bot" x="-0.0253118993481663" y="-0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal13-2_pos_neg_bot" x="-144.30538266265967" y="-44.077812877938534" z="1527.8179989435152" unit="mm" />
+      <rotation name="crystal13-2_rot_neg_bot" x="-0.0253118993481663" y="0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal13-2_pos_pos_top" x="229.66580787843168" y="44.97781287793853" z="1527.8179989435152" unit="mm" />
+      <rotation name="crystal13-2_rot_pos_top" x="0.0253118993481663" y="-0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal13-2_pos_neg_top" x="-144.30538266265967" y="44.97781287793853" z="1527.8179989435152" unit="mm" />
+      <rotation name="crystal13-2_rot_neg_top" x="0.0253118993481663" y="0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal14-2_pos_pos_bot" x="244.83390600570817" y="-44.077812877938534" z="1527.6337552442246" unit="mm" />
+      <rotation name="crystal14-2_rot_pos_bot" x="-0.0253118993481663" y="-0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal14-2_pos_neg_bot" x="-159.47348078993616" y="-44.077812877938534" z="1527.6337552442246" unit="mm" />
+      <rotation name="crystal14-2_rot_neg_bot" x="-0.0253118993481663" y="0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal14-2_pos_pos_top" x="244.83390600570817" y="44.97781287793853" z="1527.6337552442246" unit="mm" />
+      <rotation name="crystal14-2_rot_pos_top" x="0.0253118993481663" y="-0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal14-2_pos_neg_top" x="-159.47348078993616" y="44.97781287793853" z="1527.6337552442246" unit="mm" />
+      <rotation name="crystal14-2_rot_neg_top" x="0.0253118993481663" y="0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal15-2_pos_pos_bot" x="260.0521159861688" y="-44.077812877938534" z="1527.42689280716" unit="mm" />
+      <rotation name="crystal15-2_rot_pos_bot" x="-0.0253118993481663" y="-0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal15-2_pos_neg_bot" x="-174.6916907703968" y="-44.077812877938534" z="1527.42689280716" unit="mm" />
+      <rotation name="crystal15-2_rot_neg_bot" x="-0.0253118993481663" y="0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal15-2_pos_pos_top" x="260.0521159861688" y="44.97781287793853" z="1527.42689280716" unit="mm" />
+      <rotation name="crystal15-2_rot_pos_top" x="0.0253118993481663" y="-0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal15-2_pos_neg_top" x="-174.6916907703968" y="44.97781287793853" z="1527.42689280716" unit="mm" />
+      <rotation name="crystal15-2_rot_neg_top" x="0.0253118993481663" y="0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal16-2_pos_pos_bot" x="275.32440401422616" y="-44.077812877938534" z="1527.1974705354392" unit="mm" />
+      <rotation name="crystal16-2_rot_pos_bot" x="-0.0253118993481663" y="-0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal16-2_pos_neg_bot" x="-189.96397879845415" y="-44.077812877938534" z="1527.1974705354392" unit="mm" />
+      <rotation name="crystal16-2_rot_neg_bot" x="-0.0253118993481663" y="0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal16-2_pos_pos_top" x="275.32440401422616" y="44.97781287793853" z="1527.1974705354392" unit="mm" />
+      <rotation name="crystal16-2_rot_pos_top" x="0.0253118993481663" y="-0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal16-2_pos_neg_top" x="-189.96397879845415" y="44.97781287793853" z="1527.1974705354392" unit="mm" />
+      <rotation name="crystal16-2_rot_neg_top" x="0.0253118993481663" y="0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal17-2_pos_pos_bot" x="290.6548257567732" y="-44.077812877938534" z="1526.9455537559877" unit="mm" />
+      <rotation name="crystal17-2_rot_pos_bot" x="-0.0253118993481663" y="-0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal17-2_pos_neg_bot" x="-205.2944005410012" y="-44.077812877938534" z="1526.9455537559877" unit="mm" />
+      <rotation name="crystal17-2_rot_neg_bot" x="-0.0253118993481663" y="0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal17-2_pos_pos_top" x="290.6548257567732" y="44.97781287793853" z="1526.9455537559877" unit="mm" />
+      <rotation name="crystal17-2_rot_pos_top" x="0.0253118993481663" y="-0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal17-2_pos_neg_top" x="-205.2944005410012" y="44.97781287793853" z="1526.9455537559877" unit="mm" />
+      <rotation name="crystal17-2_rot_neg_top" x="0.0253118993481663" y="0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal18-2_pos_pos_bot" x="306.0475342431027" y="-44.077812877938534" z="1526.6712142009383" unit="mm" />
+      <rotation name="crystal18-2_rot_pos_bot" x="-0.0253118993481663" y="-0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal18-2_pos_neg_bot" x="-220.68710902733068" y="-44.077812877938534" z="1526.6712142009383" unit="mm" />
+      <rotation name="crystal18-2_rot_neg_bot" x="-0.0253118993481663" y="0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal18-2_pos_pos_top" x="306.0475342431027" y="44.97781287793853" z="1526.6712142009383" unit="mm" />
+      <rotation name="crystal18-2_rot_pos_top" x="0.0253118993481663" y="-0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal18-2_pos_neg_top" x="-220.68710902733068" y="44.97781287793853" z="1526.6712142009383" unit="mm" />
+      <rotation name="crystal18-2_rot_neg_top" x="0.0253118993481663" y="0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal19-2_pos_pos_bot" x="321.5067881308382" y="-44.077812877938534" z="1526.3745299872046" unit="mm" />
+      <rotation name="crystal19-2_rot_pos_bot" x="-0.0253118993481663" y="-0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal19-2_pos_neg_bot" x="-236.14636291506616" y="-44.077812877938534" z="1526.3745299872046" unit="mm" />
+      <rotation name="crystal19-2_rot_neg_bot" x="-0.0253118993481663" y="0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal19-2_pos_pos_top" x="321.5067881308382" y="44.97781287793853" z="1526.3745299872046" unit="mm" />
+      <rotation name="crystal19-2_rot_pos_top" x="0.0253118993481663" y="-0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal19-2_pos_neg_top" x="-236.14636291506616" y="44.97781287793853" z="1526.3745299872046" unit="mm" />
+      <rotation name="crystal19-2_rot_neg_top" x="0.0253118993481663" y="0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal20-2_pos_pos_bot" x="337.03696038609246" y="-44.077812877938534" z="1526.055585594238" unit="mm" />
+      <rotation name="crystal20-2_rot_pos_bot" x="-0.0253118993481663" y="-0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal20-2_pos_neg_bot" x="-251.67653517032045" y="-44.077812877938534" z="1526.055585594238" unit="mm" />
+      <rotation name="crystal20-2_rot_neg_bot" x="-0.0253118993481663" y="0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal20-2_pos_pos_top" x="337.03696038609246" y="44.97781287793853" z="1526.055585594238" unit="mm" />
+      <rotation name="crystal20-2_rot_pos_top" x="0.0253118993481663" y="-0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal20-2_pos_neg_top" x="-251.67653517032045" y="44.97781287793853" z="1526.055585594238" unit="mm" />
+      <rotation name="crystal20-2_rot_neg_top" x="0.0253118993481663" y="0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal21-2_pos_pos_bot" x="352.64254741924634" y="-44.077812877938534" z="1525.7144718399722" unit="mm" />
+      <rotation name="crystal21-2_rot_pos_bot" x="-0.0253118993481663" y="-0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal21-2_pos_neg_bot" x="-267.28212220347433" y="-44.077812877938534" z="1525.7144718399722" unit="mm" />
+      <rotation name="crystal21-2_rot_neg_bot" x="-0.0253118993481663" y="0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal21-2_pos_pos_top" x="352.64254741924634" y="44.97781287793853" z="1525.7144718399722" unit="mm" />
+      <rotation name="crystal21-2_rot_pos_top" x="0.0253118993481663" y="-0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal21-2_pos_neg_top" x="-267.28212220347433" y="44.97781287793853" z="1525.7144718399722" unit="mm" />
+      <rotation name="crystal21-2_rot_neg_top" x="0.0253118993481663" y="0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal22-2_pos_pos_bot" x="368.32817872130425" y="-44.077812877938534" z="1525.351285854964" unit="mm" />
+      <rotation name="crystal22-2_rot_pos_bot" x="-0.0253118993481663" y="-0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal22-2_pos_neg_bot" x="-282.96775350553224" y="-44.077812877938534" z="1525.351285854964" unit="mm" />
+      <rotation name="crystal22-2_rot_neg_bot" x="-0.0253118993481663" y="0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal22-2_pos_pos_top" x="368.32817872130425" y="44.97781287793853" z="1525.351285854964" unit="mm" />
+      <rotation name="crystal22-2_rot_pos_top" x="0.0253118993481663" y="-0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal22-2_pos_neg_top" x="-282.96775350553224" y="44.97781287793853" z="1525.351285854964" unit="mm" />
+      <rotation name="crystal22-2_rot_neg_top" x="0.0253118993481663" y="0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal23-2_pos_pos_bot" x="384.09862704978" y="-44.077812877938534" z="1524.9661310547353" unit="mm" />
+      <rotation name="crystal23-2_rot_pos_bot" x="-0.0253118993481663" y="-0.3796784902224945" z="0.0" unit="radian" />
+      <position name="crystal23-2_pos_neg_bot" x="-298.738201834008" y="-44.077812877938534" z="1524.9661310547353" unit="mm" />
+      <rotation name="crystal23-2_rot_neg_bot" x="-0.0253118993481663" y="0.3796784902224945" z="0.0" unit="radian" />
+      <position name="crystal23-2_pos_pos_top" x="384.09862704978" y="44.97781287793853" z="1524.9661310547353" unit="mm" />
+      <rotation name="crystal23-2_rot_pos_top" x="0.0253118993481663" y="-0.3796784902224945" z="0.0" unit="radian" />
+      <position name="crystal23-2_pos_neg_top" x="-298.738201834008" y="44.97781287793853" z="1524.9661310547353" unit="mm" />
+      <rotation name="crystal23-2_rot_neg_top" x="0.0253118993481663" y="0.3796784902224945" z="0.0" unit="radian" />
+      <position name="crystal1-3_pos_pos_bot" x="50.20495188328156" y="-59.08788687039808" z="1528.3186477918262" unit="mm" />
+      <rotation name="crystal1-3_rot_pos_bot" x="-0.042186498913610496" y="-0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal1-3_pos_neg_bot" x="35.15547333249048" y="-59.08788687039808" z="1528.3186477918262" unit="mm" />
+      <rotation name="crystal1-3_rot_neg_bot" x="-0.042186498913610496" y="0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal1-3_pos_pos_top" x="50.20495188328156" y="59.987886870398086" z="1528.3186477918262" unit="mm" />
+      <rotation name="crystal1-3_rot_pos_top" x="0.042186498913610496" y="-0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal1-3_pos_neg_top" x="35.15547333249048" y="59.987886870398086" z="1528.3186477918262" unit="mm" />
+      <rotation name="crystal1-3_rot_neg_top" x="0.042186498913610496" y="0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal2-3_pos_pos_bot" x="65.05802548582456" y="-59.08788687039808" z="1528.4080677537463" unit="mm" />
+      <rotation name="crystal2-3_rot_pos_bot" x="-0.042186498913610496" y="-0.0253118993481663" z="0.0" unit="radian" />
+      <position name="crystal2-3_pos_neg_bot" x="20.302399729947485" y="-59.08788687039808" z="1528.4080677537463" unit="mm" />
+      <rotation name="crystal2-3_rot_neg_bot" x="-0.042186498913610496" y="0.0253118993481663" z="0.0" unit="radian" />
+      <position name="crystal2-3_pos_pos_top" x="65.05802548582456" y="59.987886870398086" z="1528.4080677537463" unit="mm" />
+      <rotation name="crystal2-3_rot_pos_top" x="0.042186498913610496" y="-0.0253118993481663" z="0.0" unit="radian" />
+      <position name="crystal2-3_pos_neg_top" x="20.302399729947485" y="59.987886870398086" z="1528.4080677537463" unit="mm" />
+      <rotation name="crystal2-3_rot_neg_top" x="0.042186498913610496" y="0.0253118993481663" z="0.0" unit="radian" />
+      <position name="crystal3-3_pos_pos_bot" x="79.9180994782841" y="-59.08788687039808" z="1528.47466745996" unit="mm" />
+      <rotation name="crystal3-3_rot_pos_bot" x="-0.042186498913610496" y="-0.042186498913610496" z="0.0" unit="radian" />
+      <position name="crystal3-3_pos_neg_bot" x="5.442325737487934" y="-59.08788687039808" z="1528.47466745996" unit="mm" />
+      <rotation name="crystal3-3_rot_neg_bot" x="-0.042186498913610496" y="0.042186498913610496" z="0.0" unit="radian" />
+      <position name="crystal3-3_pos_pos_top" x="79.9180994782841" y="59.987886870398086" z="1528.47466745996" unit="mm" />
+      <rotation name="crystal3-3_rot_pos_top" x="0.042186498913610496" y="-0.042186498913610496" z="0.0" unit="radian" />
+      <position name="crystal3-3_pos_neg_top" x="5.442325737487934" y="59.987886870398086" z="1528.47466745996" unit="mm" />
+      <rotation name="crystal3-3_rot_neg_top" x="0.042186498913610496" y="0.042186498913610496" z="0.0" unit="radian" />
+      <position name="crystal4-3_pos_pos_bot" x="94.78858692586502" y="-59.08788687039808" z="1528.5184279465104" unit="mm" />
+      <rotation name="crystal4-3_rot_pos_bot" x="-0.042186498913610496" y="-0.0590610984790547" z="0.0" unit="radian" />
+      <position name="crystal4-3_pos_neg_bot" x="-9.42816171009298" y="-59.08788687039808" z="1528.5184279465104" unit="mm" />
+      <rotation name="crystal4-3_rot_neg_bot" x="-0.042186498913610496" y="0.0590610984790547" z="0.0" unit="radian" />
+      <position name="crystal4-3_pos_pos_top" x="94.78858692586502" y="59.987886870398086" z="1528.5184279465104" unit="mm" />
+      <rotation name="crystal4-3_rot_pos_top" x="0.042186498913610496" y="-0.0590610984790547" z="0.0" unit="radian" />
+      <position name="crystal4-3_pos_neg_top" x="-9.42816171009298" y="59.987886870398086" z="1528.5184279465104" unit="mm" />
+      <rotation name="crystal4-3_rot_neg_top" x="0.042186498913610496" y="0.0590610984790547" z="0.0" unit="radian" />
+      <position name="crystal5-3_pos_pos_bot" x="109.67291416309662" y="-59.08788687039808" z="1528.5393367528022" unit="mm" />
+      <rotation name="crystal5-3_rot_pos_bot" x="-0.042186498913610496" y="-0.0759356980444989" z="0.0" unit="radian" />
+      <position name="crystal5-3_pos_neg_bot" x="-24.31248894732458" y="-59.08788687039808" z="1528.5393367528022" unit="mm" />
+      <rotation name="crystal5-3_rot_neg_bot" x="-0.042186498913610496" y="0.0759356980444989" z="0.0" unit="radian" />
+      <position name="crystal5-3_pos_pos_top" x="109.67291416309662" y="59.987886870398086" z="1528.5393367528022" unit="mm" />
+      <rotation name="crystal5-3_rot_pos_top" x="0.042186498913610496" y="-0.0759356980444989" z="0.0" unit="radian" />
+      <position name="crystal5-3_pos_neg_top" x="-24.31248894732458" y="59.987886870398086" z="1528.5393367528022" unit="mm" />
+      <rotation name="crystal5-3_rot_neg_top" x="0.042186498913610496" y="0.0759356980444989" z="0.0" unit="radian" />
+      <position name="crystal6-3_pos_pos_bot" x="124.57452638340096" y="-59.08788687039808" z="1528.53738792515" unit="mm" />
+      <rotation name="crystal6-3_rot_pos_bot" x="-0.042186498913610496" y="-0.0928102976099431" z="0.0" unit="radian" />
+      <position name="crystal6-3_pos_neg_bot" x="-39.214101167628925" y="-59.08788687039808" z="1528.53738792515" unit="mm" />
+      <rotation name="crystal6-3_rot_neg_bot" x="-0.042186498913610496" y="0.0928102976099431" z="0.0" unit="radian" />
+      <position name="crystal6-3_pos_pos_top" x="124.57452638340096" y="59.987886870398086" z="1528.53738792515" unit="mm" />
+      <rotation name="crystal6-3_rot_pos_top" x="0.042186498913610496" y="-0.0928102976099431" z="0.0" unit="radian" />
+      <position name="crystal6-3_pos_neg_top" x="-39.214101167628925" y="59.987886870398086" z="1528.53738792515" unit="mm" />
+      <rotation name="crystal6-3_rot_neg_top" x="0.042186498913610496" y="0.0928102976099431" z="0.0" unit="radian" />
+      <position name="crystal7-3_pos_pos_bot" x="139.4968932952259" y="-59.08788687039808" z="1528.5125820184735" unit="mm" />
+      <rotation name="crystal7-3_rot_pos_bot" x="-0.042186498913610496" y="-0.10968489717538729" z="0.0" unit="radian" />
+      <position name="crystal7-3_pos_neg_bot" x="-54.13646807945388" y="-59.08788687039808" z="1528.5125820184735" unit="mm" />
+      <rotation name="crystal7-3_rot_neg_bot" x="-0.042186498913610496" y="0.10968489717538729" z="0.0" unit="radian" />
+      <position name="crystal7-3_pos_pos_top" x="139.4968932952259" y="59.987886870398086" z="1528.5125820184735" unit="mm" />
+      <rotation name="crystal7-3_rot_pos_top" x="0.042186498913610496" y="-0.10968489717538729" z="0.0" unit="radian" />
+      <position name="crystal7-3_pos_neg_top" x="-54.13646807945388" y="59.987886870398086" z="1528.5125820184735" unit="mm" />
+      <rotation name="crystal7-3_rot_neg_top" x="0.042186498913610496" y="0.10968489717538729" z="0.0" unit="radian" />
+      <position name="crystal8-3_pos_pos_bot" x="154.44351486445828" y="-59.08788687039808" z="1528.4649260961392" unit="mm" />
+      <rotation name="crystal8-3_rot_pos_bot" x="-0.042186498913610496" y="-0.1265594967408315" z="0.0" unit="radian" />
+      <position name="crystal8-3_pos_neg_bot" x="-69.08308964868624" y="-59.08788687039808" z="1528.4649260961392" unit="mm" />
+      <rotation name="crystal8-3_rot_neg_bot" x="-0.042186498913610496" y="0.1265594967408315" z="0.0" unit="radian" />
+      <position name="crystal8-3_pos_pos_top" x="154.44351486445828" y="59.987886870398086" z="1528.4649260961392" unit="mm" />
+      <rotation name="crystal8-3_rot_pos_top" x="0.042186498913610496" y="-0.1265594967408315" z="0.0" unit="radian" />
+      <position name="crystal8-3_pos_neg_top" x="-69.08308964868624" y="59.987886870398086" z="1528.4649260961392" unit="mm" />
+      <rotation name="crystal8-3_rot_neg_top" x="0.042186498913610496" y="0.1265594967408315" z="0.0" unit="radian" />
+      <position name="crystal9-3_pos_pos_bot" x="169.41792716339802" y="-59.08788687039808" z="1528.3944337279495" unit="mm" />
+      <rotation name="crystal9-3_rot_pos_bot" x="-0.042186498913610496" y="-0.14343409630627568" z="0.0" unit="radian" />
+      <position name="crystal9-3_pos_neg_bot" x="-84.057501947626" y="-59.08788687039808" z="1528.3944337279495" unit="mm" />
+      <rotation name="crystal9-3_rot_neg_bot" x="-0.042186498913610496" y="0.14343409630627568" z="0.0" unit="radian" />
+      <position name="crystal9-3_pos_pos_top" x="169.41792716339802" y="59.987886870398086" z="1528.3944337279495" unit="mm" />
+      <rotation name="crystal9-3_rot_pos_top" x="0.042186498913610496" y="-0.14343409630627568" z="0.0" unit="radian" />
+      <position name="crystal9-3_pos_neg_top" x="-84.057501947626" y="59.987886870398086" z="1528.3944337279495" unit="mm" />
+      <rotation name="crystal9-3_rot_neg_top" x="0.042186498913610496" y="0.14343409630627568" z="0.0" unit="radian" />
+      <position name="crystal10-3_pos_pos_bot" x="184.42370834727978" y="-59.08788687039808" z="1528.301124986279" unit="mm" />
+      <rotation name="crystal10-3_rot_pos_bot" x="-0.042186498913610496" y="-0.1603086958717199" z="0.0" unit="radian" />
+      <position name="crystal10-3_pos_neg_bot" x="-99.06328313150773" y="-59.08788687039808" z="1528.301124986279" unit="mm" />
+      <rotation name="crystal10-3_rot_neg_bot" x="-0.042186498913610496" y="0.1603086958717199" z="0.0" unit="radian" />
+      <position name="crystal10-3_pos_pos_top" x="184.42370834727978" y="59.987886870398086" z="1528.301124986279" unit="mm" />
+      <rotation name="crystal10-3_rot_pos_top" x="0.042186498913610496" y="-0.1603086958717199" z="0.0" unit="radian" />
+      <position name="crystal10-3_pos_neg_top" x="-99.06328313150773" y="59.987886870398086" z="1528.301124986279" unit="mm" />
+      <rotation name="crystal10-3_rot_neg_top" x="0.042186498913610496" y="0.1603086958717199" z="0.0" unit="radian" />
+      <position name="crystal11-3_pos_pos_bot" x="199.46448478017476" y="-59.08788687039808" z="1528.1850264403583" unit="mm" />
+      <rotation name="crystal11-3_rot_pos_bot" x="-0.042186498913610496" y="-0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal11-3_pos_neg_bot" x="-114.1040595644027" y="-59.08788687039808" z="1528.1850264403583" unit="mm" />
+      <rotation name="crystal11-3_rot_neg_bot" x="-0.042186498913610496" y="0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal11-3_pos_pos_top" x="199.46448478017476" y="59.987886870398086" z="1528.1850264403583" unit="mm" />
+      <rotation name="crystal11-3_rot_pos_top" x="0.042186498913610496" y="-0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal11-3_pos_neg_top" x="-114.1040595644027" y="59.987886870398086" z="1528.1850264403583" unit="mm" />
+      <rotation name="crystal11-3_rot_neg_top" x="0.042186498913610496" y="0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal12-3_pos_pos_bot" x="214.5439373331128" y="-59.08788687039808" z="1528.0461711487085" unit="mm" />
+      <rotation name="crystal12-3_rot_pos_bot" x="-0.042186498913610496" y="-0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal12-3_pos_neg_bot" x="-129.1835121173408" y="-59.08788687039808" z="1528.0461711487085" unit="mm" />
+      <rotation name="crystal12-3_rot_neg_bot" x="-0.042186498913610496" y="0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal12-3_pos_pos_top" x="214.5439373331128" y="59.987886870398086" z="1528.0461711487085" unit="mm" />
+      <rotation name="crystal12-3_rot_pos_top" x="0.042186498913610496" y="-0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal12-3_pos_neg_top" x="-129.1835121173408" y="59.987886870398086" z="1528.0461711487085" unit="mm" />
+      <rotation name="crystal12-3_rot_neg_top" x="0.042186498913610496" y="0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal13-3_pos_pos_bot" x="229.66580787843168" y="-59.08788687039808" z="1527.8845986497292" unit="mm" />
+      <rotation name="crystal13-3_rot_pos_bot" x="-0.042186498913610496" y="-0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal13-3_pos_neg_bot" x="-144.30538266265967" y="-59.08788687039808" z="1527.8845986497292" unit="mm" />
+      <rotation name="crystal13-3_rot_neg_bot" x="-0.042186498913610496" y="0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal13-3_pos_pos_top" x="229.66580787843168" y="59.987886870398086" z="1527.8845986497292" unit="mm" />
+      <rotation name="crystal13-3_rot_pos_top" x="0.042186498913610496" y="-0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal13-3_pos_neg_top" x="-144.30538266265967" y="59.987886870398086" z="1527.8845986497292" unit="mm" />
+      <rotation name="crystal13-3_rot_neg_top" x="0.042186498913610496" y="0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal14-3_pos_pos_bot" x="244.83390600570817" y="-59.08788687039808" z="1527.7003549504386" unit="mm" />
+      <rotation name="crystal14-3_rot_pos_bot" x="-0.042186498913610496" y="-0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal14-3_pos_neg_bot" x="-159.47348078993616" y="-59.08788687039808" z="1527.7003549504386" unit="mm" />
+      <rotation name="crystal14-3_rot_neg_bot" x="-0.042186498913610496" y="0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal14-3_pos_pos_top" x="244.83390600570817" y="59.987886870398086" z="1527.7003549504386" unit="mm" />
+      <rotation name="crystal14-3_rot_pos_top" x="0.042186498913610496" y="-0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal14-3_pos_neg_top" x="-159.47348078993616" y="59.987886870398086" z="1527.7003549504386" unit="mm" />
+      <rotation name="crystal14-3_rot_neg_top" x="0.042186498913610496" y="0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal15-3_pos_pos_bot" x="260.0521159861688" y="-59.08788687039808" z="1527.4934925133737" unit="mm" />
+      <rotation name="crystal15-3_rot_pos_bot" x="-0.042186498913610496" y="-0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal15-3_pos_neg_bot" x="-174.6916907703968" y="-59.08788687039808" z="1527.4934925133737" unit="mm" />
+      <rotation name="crystal15-3_rot_neg_bot" x="-0.042186498913610496" y="0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal15-3_pos_pos_top" x="260.0521159861688" y="59.987886870398086" z="1527.4934925133737" unit="mm" />
+      <rotation name="crystal15-3_rot_pos_top" x="0.042186498913610496" y="-0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal15-3_pos_neg_top" x="-174.6916907703968" y="59.987886870398086" z="1527.4934925133737" unit="mm" />
+      <rotation name="crystal15-3_rot_neg_top" x="0.042186498913610496" y="0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal16-3_pos_pos_bot" x="275.32440401422616" y="-59.08788687039808" z="1527.264070241653" unit="mm" />
+      <rotation name="crystal16-3_rot_pos_bot" x="-0.042186498913610496" y="-0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal16-3_pos_neg_bot" x="-189.96397879845415" y="-59.08788687039808" z="1527.264070241653" unit="mm" />
+      <rotation name="crystal16-3_rot_neg_bot" x="-0.042186498913610496" y="0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal16-3_pos_pos_top" x="275.32440401422616" y="59.987886870398086" z="1527.264070241653" unit="mm" />
+      <rotation name="crystal16-3_rot_pos_top" x="0.042186498913610496" y="-0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal16-3_pos_neg_top" x="-189.96397879845415" y="59.987886870398086" z="1527.264070241653" unit="mm" />
+      <rotation name="crystal16-3_rot_neg_top" x="0.042186498913610496" y="0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal17-3_pos_pos_bot" x="290.6548257567732" y="-59.08788687039808" z="1527.0121534622015" unit="mm" />
+      <rotation name="crystal17-3_rot_pos_bot" x="-0.042186498913610496" y="-0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal17-3_pos_neg_bot" x="-205.2944005410012" y="-59.08788687039808" z="1527.0121534622015" unit="mm" />
+      <rotation name="crystal17-3_rot_neg_bot" x="-0.042186498913610496" y="0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal17-3_pos_pos_top" x="290.6548257567732" y="59.987886870398086" z="1527.0121534622015" unit="mm" />
+      <rotation name="crystal17-3_rot_pos_top" x="0.042186498913610496" y="-0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal17-3_pos_neg_top" x="-205.2944005410012" y="59.987886870398086" z="1527.0121534622015" unit="mm" />
+      <rotation name="crystal17-3_rot_neg_top" x="0.042186498913610496" y="0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal18-3_pos_pos_bot" x="306.0475342431027" y="-59.08788687039808" z="1526.737813907152" unit="mm" />
+      <rotation name="crystal18-3_rot_pos_bot" x="-0.042186498913610496" y="-0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal18-3_pos_neg_bot" x="-220.68710902733068" y="-59.08788687039808" z="1526.737813907152" unit="mm" />
+      <rotation name="crystal18-3_rot_neg_bot" x="-0.042186498913610496" y="0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal18-3_pos_pos_top" x="306.0475342431027" y="59.987886870398086" z="1526.737813907152" unit="mm" />
+      <rotation name="crystal18-3_rot_pos_top" x="0.042186498913610496" y="-0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal18-3_pos_neg_top" x="-220.68710902733068" y="59.987886870398086" z="1526.737813907152" unit="mm" />
+      <rotation name="crystal18-3_rot_neg_top" x="0.042186498913610496" y="0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal19-3_pos_pos_bot" x="321.5067881308382" y="-59.08788687039808" z="1526.4411296934186" unit="mm" />
+      <rotation name="crystal19-3_rot_pos_bot" x="-0.042186498913610496" y="-0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal19-3_pos_neg_bot" x="-236.14636291506616" y="-59.08788687039808" z="1526.4411296934186" unit="mm" />
+      <rotation name="crystal19-3_rot_neg_bot" x="-0.042186498913610496" y="0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal19-3_pos_pos_top" x="321.5067881308382" y="59.987886870398086" z="1526.4411296934186" unit="mm" />
+      <rotation name="crystal19-3_rot_pos_top" x="0.042186498913610496" y="-0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal19-3_pos_neg_top" x="-236.14636291506616" y="59.987886870398086" z="1526.4411296934186" unit="mm" />
+      <rotation name="crystal19-3_rot_neg_top" x="0.042186498913610496" y="0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal20-3_pos_pos_bot" x="337.03696038609246" y="-59.08788687039808" z="1526.1221853004517" unit="mm" />
+      <rotation name="crystal20-3_rot_pos_bot" x="-0.042186498913610496" y="-0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal20-3_pos_neg_bot" x="-251.67653517032045" y="-59.08788687039808" z="1526.1221853004517" unit="mm" />
+      <rotation name="crystal20-3_rot_neg_bot" x="-0.042186498913610496" y="0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal20-3_pos_pos_top" x="337.03696038609246" y="59.987886870398086" z="1526.1221853004517" unit="mm" />
+      <rotation name="crystal20-3_rot_pos_top" x="0.042186498913610496" y="-0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal20-3_pos_neg_top" x="-251.67653517032045" y="59.987886870398086" z="1526.1221853004517" unit="mm" />
+      <rotation name="crystal20-3_rot_neg_top" x="0.042186498913610496" y="0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal21-3_pos_pos_bot" x="352.64254741924634" y="-59.08788687039808" z="1525.781071546186" unit="mm" />
+      <rotation name="crystal21-3_rot_pos_bot" x="-0.042186498913610496" y="-0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal21-3_pos_neg_bot" x="-267.28212220347433" y="-59.08788687039808" z="1525.781071546186" unit="mm" />
+      <rotation name="crystal21-3_rot_neg_bot" x="-0.042186498913610496" y="0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal21-3_pos_pos_top" x="352.64254741924634" y="59.987886870398086" z="1525.781071546186" unit="mm" />
+      <rotation name="crystal21-3_rot_pos_top" x="0.042186498913610496" y="-0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal21-3_pos_neg_top" x="-267.28212220347433" y="59.987886870398086" z="1525.781071546186" unit="mm" />
+      <rotation name="crystal21-3_rot_neg_top" x="0.042186498913610496" y="0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal22-3_pos_pos_bot" x="368.32817872130425" y="-59.08788687039808" z="1525.417885561178" unit="mm" />
+      <rotation name="crystal22-3_rot_pos_bot" x="-0.042186498913610496" y="-0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal22-3_pos_neg_bot" x="-282.96775350553224" y="-59.08788687039808" z="1525.417885561178" unit="mm" />
+      <rotation name="crystal22-3_rot_neg_bot" x="-0.042186498913610496" y="0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal22-3_pos_pos_top" x="368.32817872130425" y="59.987886870398086" z="1525.417885561178" unit="mm" />
+      <rotation name="crystal22-3_rot_pos_top" x="0.042186498913610496" y="-0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal22-3_pos_neg_top" x="-282.96775350553224" y="59.987886870398086" z="1525.417885561178" unit="mm" />
+      <rotation name="crystal22-3_rot_neg_top" x="0.042186498913610496" y="0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal23-3_pos_pos_bot" x="384.09862704978" y="-59.08788687039808" z="1525.032730760949" unit="mm" />
+      <rotation name="crystal23-3_rot_pos_bot" x="-0.042186498913610496" y="-0.3796784902224945" z="0.0" unit="radian" />
+      <position name="crystal23-3_pos_neg_bot" x="-298.738201834008" y="-59.08788687039808" z="1525.032730760949" unit="mm" />
+      <rotation name="crystal23-3_rot_neg_bot" x="-0.042186498913610496" y="0.3796784902224945" z="0.0" unit="radian" />
+      <position name="crystal23-3_pos_pos_top" x="384.09862704978" y="59.987886870398086" z="1525.032730760949" unit="mm" />
+      <rotation name="crystal23-3_rot_pos_top" x="0.042186498913610496" y="-0.3796784902224945" z="0.0" unit="radian" />
+      <position name="crystal23-3_pos_neg_top" x="-298.738201834008" y="59.987886870398086" z="1525.032730760949" unit="mm" />
+      <rotation name="crystal23-3_rot_neg_top" x="0.042186498913610496" y="0.3796784902224945" z="0.0" unit="radian" />
+      <position name="crystal1-4_pos_pos_bot" x="50.20495188328156" y="-74.108374317979" z="1528.3624082783765" unit="mm" />
+      <rotation name="crystal1-4_rot_pos_bot" x="-0.0590610984790547" y="-0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal1-4_pos_neg_bot" x="35.15547333249048" y="-74.108374317979" z="1528.3624082783765" unit="mm" />
+      <rotation name="crystal1-4_rot_neg_bot" x="-0.0590610984790547" y="0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal1-4_pos_pos_top" x="50.20495188328156" y="75.008374317979" z="1528.3624082783765" unit="mm" />
+      <rotation name="crystal1-4_rot_pos_top" x="0.0590610984790547" y="-0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal1-4_pos_neg_top" x="35.15547333249048" y="75.008374317979" z="1528.3624082783765" unit="mm" />
+      <rotation name="crystal1-4_rot_neg_top" x="0.0590610984790547" y="0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal2-4_pos_pos_bot" x="65.05802548582456" y="-74.108374317979" z="1528.4518282402964" unit="mm" />
+      <rotation name="crystal2-4_rot_pos_bot" x="-0.0590610984790547" y="-0.0253118993481663" z="0.0" unit="radian" />
+      <position name="crystal2-4_pos_neg_bot" x="20.302399729947485" y="-74.108374317979" z="1528.4518282402964" unit="mm" />
+      <rotation name="crystal2-4_rot_neg_bot" x="-0.0590610984790547" y="0.0253118993481663" z="0.0" unit="radian" />
+      <position name="crystal2-4_pos_pos_top" x="65.05802548582456" y="75.008374317979" z="1528.4518282402964" unit="mm" />
+      <rotation name="crystal2-4_rot_pos_top" x="0.0590610984790547" y="-0.0253118993481663" z="0.0" unit="radian" />
+      <position name="crystal2-4_pos_neg_top" x="20.302399729947485" y="75.008374317979" z="1528.4518282402964" unit="mm" />
+      <rotation name="crystal2-4_rot_neg_top" x="0.0590610984790547" y="0.0253118993481663" z="0.0" unit="radian" />
+      <position name="crystal3-4_pos_pos_bot" x="79.9180994782841" y="-74.108374317979" z="1528.5184279465104" unit="mm" />
+      <rotation name="crystal3-4_rot_pos_bot" x="-0.0590610984790547" y="-0.042186498913610496" z="0.0" unit="radian" />
+      <position name="crystal3-4_pos_neg_bot" x="5.442325737487934" y="-74.108374317979" z="1528.5184279465104" unit="mm" />
+      <rotation name="crystal3-4_rot_neg_bot" x="-0.0590610984790547" y="0.042186498913610496" z="0.0" unit="radian" />
+      <position name="crystal3-4_pos_pos_top" x="79.9180994782841" y="75.008374317979" z="1528.5184279465104" unit="mm" />
+      <rotation name="crystal3-4_rot_pos_top" x="0.0590610984790547" y="-0.042186498913610496" z="0.0" unit="radian" />
+      <position name="crystal3-4_pos_neg_top" x="5.442325737487934" y="75.008374317979" z="1528.5184279465104" unit="mm" />
+      <rotation name="crystal3-4_rot_neg_top" x="0.0590610984790547" y="0.042186498913610496" z="0.0" unit="radian" />
+      <position name="crystal4-4_pos_pos_bot" x="94.78858692586502" y="-74.108374317979" z="1528.5621884330608" unit="mm" />
+      <rotation name="crystal4-4_rot_pos_bot" x="-0.0590610984790547" y="-0.0590610984790547" z="0.0" unit="radian" />
+      <position name="crystal4-4_pos_neg_bot" x="-9.42816171009298" y="-74.108374317979" z="1528.5621884330608" unit="mm" />
+      <rotation name="crystal4-4_rot_neg_bot" x="-0.0590610984790547" y="0.0590610984790547" z="0.0" unit="radian" />
+      <position name="crystal4-4_pos_pos_top" x="94.78858692586502" y="75.008374317979" z="1528.5621884330608" unit="mm" />
+      <rotation name="crystal4-4_rot_pos_top" x="0.0590610984790547" y="-0.0590610984790547" z="0.0" unit="radian" />
+      <position name="crystal4-4_pos_neg_top" x="-9.42816171009298" y="75.008374317979" z="1528.5621884330608" unit="mm" />
+      <rotation name="crystal4-4_rot_neg_top" x="0.0590610984790547" y="0.0590610984790547" z="0.0" unit="radian" />
+      <position name="crystal5-4_pos_pos_bot" x="109.67291416309662" y="-74.108374317979" z="1528.5830972393524" unit="mm" />
+      <rotation name="crystal5-4_rot_pos_bot" x="-0.0590610984790547" y="-0.0759356980444989" z="0.0" unit="radian" />
+      <position name="crystal5-4_pos_neg_bot" x="-24.31248894732458" y="-74.108374317979" z="1528.5830972393524" unit="mm" />
+      <rotation name="crystal5-4_rot_neg_bot" x="-0.0590610984790547" y="0.0759356980444989" z="0.0" unit="radian" />
+      <position name="crystal5-4_pos_pos_top" x="109.67291416309662" y="75.008374317979" z="1528.5830972393524" unit="mm" />
+      <rotation name="crystal5-4_rot_pos_top" x="0.0590610984790547" y="-0.0759356980444989" z="0.0" unit="radian" />
+      <position name="crystal5-4_pos_neg_top" x="-24.31248894732458" y="75.008374317979" z="1528.5830972393524" unit="mm" />
+      <rotation name="crystal5-4_rot_neg_top" x="0.0590610984790547" y="0.0759356980444989" z="0.0" unit="radian" />
+      <position name="crystal6-4_pos_pos_bot" x="124.57452638340096" y="-74.108374317979" z="1528.5811484117003" unit="mm" />
+      <rotation name="crystal6-4_rot_pos_bot" x="-0.0590610984790547" y="-0.0928102976099431" z="0.0" unit="radian" />
+      <position name="crystal6-4_pos_neg_bot" x="-39.214101167628925" y="-74.108374317979" z="1528.5811484117003" unit="mm" />
+      <rotation name="crystal6-4_rot_neg_bot" x="-0.0590610984790547" y="0.0928102976099431" z="0.0" unit="radian" />
+      <position name="crystal6-4_pos_pos_top" x="124.57452638340096" y="75.008374317979" z="1528.5811484117003" unit="mm" />
+      <rotation name="crystal6-4_rot_pos_top" x="0.0590610984790547" y="-0.0928102976099431" z="0.0" unit="radian" />
+      <position name="crystal6-4_pos_neg_top" x="-39.214101167628925" y="75.008374317979" z="1528.5811484117003" unit="mm" />
+      <rotation name="crystal6-4_rot_neg_top" x="0.0590610984790547" y="0.0928102976099431" z="0.0" unit="radian" />
+      <position name="crystal7-4_pos_pos_bot" x="139.4968932952259" y="-74.108374317979" z="1528.5563425050236" unit="mm" />
+      <rotation name="crystal7-4_rot_pos_bot" x="-0.0590610984790547" y="-0.10968489717538729" z="0.0" unit="radian" />
+      <position name="crystal7-4_pos_neg_bot" x="-54.13646807945388" y="-74.108374317979" z="1528.5563425050236" unit="mm" />
+      <rotation name="crystal7-4_rot_neg_bot" x="-0.0590610984790547" y="0.10968489717538729" z="0.0" unit="radian" />
+      <position name="crystal7-4_pos_pos_top" x="139.4968932952259" y="75.008374317979" z="1528.5563425050236" unit="mm" />
+      <rotation name="crystal7-4_rot_pos_top" x="0.0590610984790547" y="-0.10968489717538729" z="0.0" unit="radian" />
+      <position name="crystal7-4_pos_neg_top" x="-54.13646807945388" y="75.008374317979" z="1528.5563425050236" unit="mm" />
+      <rotation name="crystal7-4_rot_neg_top" x="0.0590610984790547" y="0.10968489717538729" z="0.0" unit="radian" />
+      <position name="crystal8-4_pos_pos_bot" x="154.44351486445828" y="-74.108374317979" z="1528.5086865826895" unit="mm" />
+      <rotation name="crystal8-4_rot_pos_bot" x="-0.0590610984790547" y="-0.1265594967408315" z="0.0" unit="radian" />
+      <position name="crystal8-4_pos_neg_bot" x="-69.08308964868624" y="-74.108374317979" z="1528.5086865826895" unit="mm" />
+      <rotation name="crystal8-4_rot_neg_bot" x="-0.0590610984790547" y="0.1265594967408315" z="0.0" unit="radian" />
+      <position name="crystal8-4_pos_pos_top" x="154.44351486445828" y="75.008374317979" z="1528.5086865826895" unit="mm" />
+      <rotation name="crystal8-4_rot_pos_top" x="0.0590610984790547" y="-0.1265594967408315" z="0.0" unit="radian" />
+      <position name="crystal8-4_pos_neg_top" x="-69.08308964868624" y="75.008374317979" z="1528.5086865826895" unit="mm" />
+      <rotation name="crystal8-4_rot_neg_top" x="0.0590610984790547" y="0.1265594967408315" z="0.0" unit="radian" />
+      <position name="crystal9-4_pos_pos_bot" x="169.41792716339802" y="-74.108374317979" z="1528.4381942144998" unit="mm" />
+      <rotation name="crystal9-4_rot_pos_bot" x="-0.0590610984790547" y="-0.14343409630627568" z="0.0" unit="radian" />
+      <position name="crystal9-4_pos_neg_bot" x="-84.057501947626" y="-74.108374317979" z="1528.4381942144998" unit="mm" />
+      <rotation name="crystal9-4_rot_neg_bot" x="-0.0590610984790547" y="0.14343409630627568" z="0.0" unit="radian" />
+      <position name="crystal9-4_pos_pos_top" x="169.41792716339802" y="75.008374317979" z="1528.4381942144998" unit="mm" />
+      <rotation name="crystal9-4_rot_pos_top" x="0.0590610984790547" y="-0.14343409630627568" z="0.0" unit="radian" />
+      <position name="crystal9-4_pos_neg_top" x="-84.057501947626" y="75.008374317979" z="1528.4381942144998" unit="mm" />
+      <rotation name="crystal9-4_rot_neg_top" x="0.0590610984790547" y="0.14343409630627568" z="0.0" unit="radian" />
+      <position name="crystal10-4_pos_pos_bot" x="184.42370834727978" y="-74.108374317979" z="1528.3448854728294" unit="mm" />
+      <rotation name="crystal10-4_rot_pos_bot" x="-0.0590610984790547" y="-0.1603086958717199" z="0.0" unit="radian" />
+      <position name="crystal10-4_pos_neg_bot" x="-99.06328313150773" y="-74.108374317979" z="1528.3448854728294" unit="mm" />
+      <rotation name="crystal10-4_rot_neg_bot" x="-0.0590610984790547" y="0.1603086958717199" z="0.0" unit="radian" />
+      <position name="crystal10-4_pos_pos_top" x="184.42370834727978" y="75.008374317979" z="1528.3448854728294" unit="mm" />
+      <rotation name="crystal10-4_rot_pos_top" x="0.0590610984790547" y="-0.1603086958717199" z="0.0" unit="radian" />
+      <position name="crystal10-4_pos_neg_top" x="-99.06328313150773" y="75.008374317979" z="1528.3448854728294" unit="mm" />
+      <rotation name="crystal10-4_rot_neg_top" x="0.0590610984790547" y="0.1603086958717199" z="0.0" unit="radian" />
+      <position name="crystal11-4_pos_pos_bot" x="199.46448478017476" y="-74.108374317979" z="1528.2287869269085" unit="mm" />
+      <rotation name="crystal11-4_rot_pos_bot" x="-0.0590610984790547" y="-0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal11-4_pos_neg_bot" x="-114.1040595644027" y="-74.108374317979" z="1528.2287869269085" unit="mm" />
+      <rotation name="crystal11-4_rot_neg_bot" x="-0.0590610984790547" y="0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal11-4_pos_pos_top" x="199.46448478017476" y="75.008374317979" z="1528.2287869269085" unit="mm" />
+      <rotation name="crystal11-4_rot_pos_top" x="0.0590610984790547" y="-0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal11-4_pos_neg_top" x="-114.1040595644027" y="75.008374317979" z="1528.2287869269085" unit="mm" />
+      <rotation name="crystal11-4_rot_neg_top" x="0.0590610984790547" y="0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal12-4_pos_pos_bot" x="214.5439373331128" y="-74.108374317979" z="1528.0899316352588" unit="mm" />
+      <rotation name="crystal12-4_rot_pos_bot" x="-0.0590610984790547" y="-0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal12-4_pos_neg_bot" x="-129.1835121173408" y="-74.108374317979" z="1528.0899316352588" unit="mm" />
+      <rotation name="crystal12-4_rot_neg_bot" x="-0.0590610984790547" y="0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal12-4_pos_pos_top" x="214.5439373331128" y="75.008374317979" z="1528.0899316352588" unit="mm" />
+      <rotation name="crystal12-4_rot_pos_top" x="0.0590610984790547" y="-0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal12-4_pos_neg_top" x="-129.1835121173408" y="75.008374317979" z="1528.0899316352588" unit="mm" />
+      <rotation name="crystal12-4_rot_neg_top" x="0.0590610984790547" y="0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal13-4_pos_pos_bot" x="229.66580787843168" y="-74.108374317979" z="1527.9283591362796" unit="mm" />
+      <rotation name="crystal13-4_rot_pos_bot" x="-0.0590610984790547" y="-0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal13-4_pos_neg_bot" x="-144.30538266265967" y="-74.108374317979" z="1527.9283591362796" unit="mm" />
+      <rotation name="crystal13-4_rot_neg_bot" x="-0.0590610984790547" y="0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal13-4_pos_pos_top" x="229.66580787843168" y="75.008374317979" z="1527.9283591362796" unit="mm" />
+      <rotation name="crystal13-4_rot_pos_top" x="0.0590610984790547" y="-0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal13-4_pos_neg_top" x="-144.30538266265967" y="75.008374317979" z="1527.9283591362796" unit="mm" />
+      <rotation name="crystal13-4_rot_neg_top" x="0.0590610984790547" y="0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal14-4_pos_pos_bot" x="244.83390600570817" y="-74.108374317979" z="1527.744115436989" unit="mm" />
+      <rotation name="crystal14-4_rot_pos_bot" x="-0.0590610984790547" y="-0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal14-4_pos_neg_bot" x="-159.47348078993616" y="-74.108374317979" z="1527.744115436989" unit="mm" />
+      <rotation name="crystal14-4_rot_neg_bot" x="-0.0590610984790547" y="0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal14-4_pos_pos_top" x="244.83390600570817" y="75.008374317979" z="1527.744115436989" unit="mm" />
+      <rotation name="crystal14-4_rot_pos_top" x="0.0590610984790547" y="-0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal14-4_pos_neg_top" x="-159.47348078993616" y="75.008374317979" z="1527.744115436989" unit="mm" />
+      <rotation name="crystal14-4_rot_neg_top" x="0.0590610984790547" y="0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal15-4_pos_pos_bot" x="260.0521159861688" y="-74.108374317979" z="1527.537252999924" unit="mm" />
+      <rotation name="crystal15-4_rot_pos_bot" x="-0.0590610984790547" y="-0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal15-4_pos_neg_bot" x="-174.6916907703968" y="-74.108374317979" z="1527.537252999924" unit="mm" />
+      <rotation name="crystal15-4_rot_neg_bot" x="-0.0590610984790547" y="0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal15-4_pos_pos_top" x="260.0521159861688" y="75.008374317979" z="1527.537252999924" unit="mm" />
+      <rotation name="crystal15-4_rot_pos_top" x="0.0590610984790547" y="-0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal15-4_pos_neg_top" x="-174.6916907703968" y="75.008374317979" z="1527.537252999924" unit="mm" />
+      <rotation name="crystal15-4_rot_neg_top" x="0.0590610984790547" y="0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal16-4_pos_pos_bot" x="275.32440401422616" y="-74.108374317979" z="1527.3078307282033" unit="mm" />
+      <rotation name="crystal16-4_rot_pos_bot" x="-0.0590610984790547" y="-0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal16-4_pos_neg_bot" x="-189.96397879845415" y="-74.108374317979" z="1527.3078307282033" unit="mm" />
+      <rotation name="crystal16-4_rot_neg_bot" x="-0.0590610984790547" y="0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal16-4_pos_pos_top" x="275.32440401422616" y="75.008374317979" z="1527.3078307282033" unit="mm" />
+      <rotation name="crystal16-4_rot_pos_top" x="0.0590610984790547" y="-0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal16-4_pos_neg_top" x="-189.96397879845415" y="75.008374317979" z="1527.3078307282033" unit="mm" />
+      <rotation name="crystal16-4_rot_neg_top" x="0.0590610984790547" y="0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal17-4_pos_pos_bot" x="290.6548257567732" y="-74.108374317979" z="1527.0559139487518" unit="mm" />
+      <rotation name="crystal17-4_rot_pos_bot" x="-0.0590610984790547" y="-0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal17-4_pos_neg_bot" x="-205.2944005410012" y="-74.108374317979" z="1527.0559139487518" unit="mm" />
+      <rotation name="crystal17-4_rot_neg_bot" x="-0.0590610984790547" y="0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal17-4_pos_pos_top" x="290.6548257567732" y="75.008374317979" z="1527.0559139487518" unit="mm" />
+      <rotation name="crystal17-4_rot_pos_top" x="0.0590610984790547" y="-0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal17-4_pos_neg_top" x="-205.2944005410012" y="75.008374317979" z="1527.0559139487518" unit="mm" />
+      <rotation name="crystal17-4_rot_neg_top" x="0.0590610984790547" y="0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal18-4_pos_pos_bot" x="306.0475342431027" y="-74.108374317979" z="1526.7815743937024" unit="mm" />
+      <rotation name="crystal18-4_rot_pos_bot" x="-0.0590610984790547" y="-0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal18-4_pos_neg_bot" x="-220.68710902733068" y="-74.108374317979" z="1526.7815743937024" unit="mm" />
+      <rotation name="crystal18-4_rot_neg_bot" x="-0.0590610984790547" y="0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal18-4_pos_pos_top" x="306.0475342431027" y="75.008374317979" z="1526.7815743937024" unit="mm" />
+      <rotation name="crystal18-4_rot_pos_top" x="0.0590610984790547" y="-0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal18-4_pos_neg_top" x="-220.68710902733068" y="75.008374317979" z="1526.7815743937024" unit="mm" />
+      <rotation name="crystal18-4_rot_neg_top" x="0.0590610984790547" y="0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal19-4_pos_pos_bot" x="321.5067881308382" y="-74.108374317979" z="1526.4848901799687" unit="mm" />
+      <rotation name="crystal19-4_rot_pos_bot" x="-0.0590610984790547" y="-0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal19-4_pos_neg_bot" x="-236.14636291506616" y="-74.108374317979" z="1526.4848901799687" unit="mm" />
+      <rotation name="crystal19-4_rot_neg_bot" x="-0.0590610984790547" y="0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal19-4_pos_pos_top" x="321.5067881308382" y="75.008374317979" z="1526.4848901799687" unit="mm" />
+      <rotation name="crystal19-4_rot_pos_top" x="0.0590610984790547" y="-0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal19-4_pos_neg_top" x="-236.14636291506616" y="75.008374317979" z="1526.4848901799687" unit="mm" />
+      <rotation name="crystal19-4_rot_neg_top" x="0.0590610984790547" y="0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal20-4_pos_pos_bot" x="337.03696038609246" y="-74.108374317979" z="1526.165945787002" unit="mm" />
+      <rotation name="crystal20-4_rot_pos_bot" x="-0.0590610984790547" y="-0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal20-4_pos_neg_bot" x="-251.67653517032045" y="-74.108374317979" z="1526.165945787002" unit="mm" />
+      <rotation name="crystal20-4_rot_neg_bot" x="-0.0590610984790547" y="0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal20-4_pos_pos_top" x="337.03696038609246" y="75.008374317979" z="1526.165945787002" unit="mm" />
+      <rotation name="crystal20-4_rot_pos_top" x="0.0590610984790547" y="-0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal20-4_pos_neg_top" x="-251.67653517032045" y="75.008374317979" z="1526.165945787002" unit="mm" />
+      <rotation name="crystal20-4_rot_neg_top" x="0.0590610984790547" y="0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal21-4_pos_pos_bot" x="352.64254741924634" y="-74.108374317979" z="1525.8248320327364" unit="mm" />
+      <rotation name="crystal21-4_rot_pos_bot" x="-0.0590610984790547" y="-0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal21-4_pos_neg_bot" x="-267.28212220347433" y="-74.108374317979" z="1525.8248320327364" unit="mm" />
+      <rotation name="crystal21-4_rot_neg_bot" x="-0.0590610984790547" y="0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal21-4_pos_pos_top" x="352.64254741924634" y="75.008374317979" z="1525.8248320327364" unit="mm" />
+      <rotation name="crystal21-4_rot_pos_top" x="0.0590610984790547" y="-0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal21-4_pos_neg_top" x="-267.28212220347433" y="75.008374317979" z="1525.8248320327364" unit="mm" />
+      <rotation name="crystal21-4_rot_neg_top" x="0.0590610984790547" y="0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal22-4_pos_pos_bot" x="368.32817872130425" y="-74.108374317979" z="1525.4616460477282" unit="mm" />
+      <rotation name="crystal22-4_rot_pos_bot" x="-0.0590610984790547" y="-0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal22-4_pos_neg_bot" x="-282.96775350553224" y="-74.108374317979" z="1525.4616460477282" unit="mm" />
+      <rotation name="crystal22-4_rot_neg_bot" x="-0.0590610984790547" y="0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal22-4_pos_pos_top" x="368.32817872130425" y="75.008374317979" z="1525.4616460477282" unit="mm" />
+      <rotation name="crystal22-4_rot_pos_top" x="0.0590610984790547" y="-0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal22-4_pos_neg_top" x="-282.96775350553224" y="75.008374317979" z="1525.4616460477282" unit="mm" />
+      <rotation name="crystal22-4_rot_neg_top" x="0.0590610984790547" y="0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal23-4_pos_pos_bot" x="384.09862704978" y="-74.108374317979" z="1525.0764912474995" unit="mm" />
+      <rotation name="crystal23-4_rot_pos_bot" x="-0.0590610984790547" y="-0.3796784902224945" z="0.0" unit="radian" />
+      <position name="crystal23-4_pos_neg_bot" x="-298.738201834008" y="-74.108374317979" z="1525.0764912474995" unit="mm" />
+      <rotation name="crystal23-4_rot_neg_bot" x="-0.0590610984790547" y="0.3796784902224945" z="0.0" unit="radian" />
+      <position name="crystal23-4_pos_pos_top" x="384.09862704978" y="75.008374317979" z="1525.0764912474995" unit="mm" />
+      <rotation name="crystal23-4_rot_pos_top" x="0.0590610984790547" y="-0.3796784902224945" z="0.0" unit="radian" />
+      <position name="crystal23-4_pos_neg_top" x="-298.738201834008" y="75.008374317979" z="1525.0764912474995" unit="mm" />
+      <rotation name="crystal23-4_rot_neg_top" x="0.0590610984790547" y="0.3796784902224945" z="0.0" unit="radian" />
+      <position name="crystal1-5_pos_pos_bot" x="50.20495188328156" y="-89.1427015552106" z="1528.3833170846683" unit="mm" />
+      <rotation name="crystal1-5_rot_pos_bot" x="-0.0759356980444989" y="-0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal1-5_pos_neg_bot" x="35.15547333249048" y="-89.1427015552106" z="1528.3833170846683" unit="mm" />
+      <rotation name="crystal1-5_rot_neg_bot" x="-0.0759356980444989" y="0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal1-5_pos_pos_top" x="50.20495188328156" y="90.0427015552106" z="1528.3833170846683" unit="mm" />
+      <rotation name="crystal1-5_rot_pos_top" x="0.0759356980444989" y="-0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal1-5_pos_neg_top" x="35.15547333249048" y="90.0427015552106" z="1528.3833170846683" unit="mm" />
+      <rotation name="crystal1-5_rot_neg_top" x="0.0759356980444989" y="0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal2-5_pos_pos_bot" x="65.05802548582456" y="-89.1427015552106" z="1528.4727370465882" unit="mm" />
+      <rotation name="crystal2-5_rot_pos_bot" x="-0.0759356980444989" y="-0.0253118993481663" z="0.0" unit="radian" />
+      <position name="crystal2-5_pos_neg_bot" x="20.302399729947485" y="-89.1427015552106" z="1528.4727370465882" unit="mm" />
+      <rotation name="crystal2-5_rot_neg_bot" x="-0.0759356980444989" y="0.0253118993481663" z="0.0" unit="radian" />
+      <position name="crystal2-5_pos_pos_top" x="65.05802548582456" y="90.0427015552106" z="1528.4727370465882" unit="mm" />
+      <rotation name="crystal2-5_rot_pos_top" x="0.0759356980444989" y="-0.0253118993481663" z="0.0" unit="radian" />
+      <position name="crystal2-5_pos_neg_top" x="20.302399729947485" y="90.0427015552106" z="1528.4727370465882" unit="mm" />
+      <rotation name="crystal2-5_rot_neg_top" x="0.0759356980444989" y="0.0253118993481663" z="0.0" unit="radian" />
+      <position name="crystal3-5_pos_pos_bot" x="79.9180994782841" y="-89.1427015552106" z="1528.5393367528022" unit="mm" />
+      <rotation name="crystal3-5_rot_pos_bot" x="-0.0759356980444989" y="-0.042186498913610496" z="0.0" unit="radian" />
+      <position name="crystal3-5_pos_neg_bot" x="5.442325737487934" y="-89.1427015552106" z="1528.5393367528022" unit="mm" />
+      <rotation name="crystal3-5_rot_neg_bot" x="-0.0759356980444989" y="0.042186498913610496" z="0.0" unit="radian" />
+      <position name="crystal3-5_pos_pos_top" x="79.9180994782841" y="90.0427015552106" z="1528.5393367528022" unit="mm" />
+      <rotation name="crystal3-5_rot_pos_top" x="0.0759356980444989" y="-0.042186498913610496" z="0.0" unit="radian" />
+      <position name="crystal3-5_pos_neg_top" x="5.442325737487934" y="90.0427015552106" z="1528.5393367528022" unit="mm" />
+      <rotation name="crystal3-5_rot_neg_top" x="0.0759356980444989" y="0.042186498913610496" z="0.0" unit="radian" />
+      <position name="crystal4-5_pos_pos_bot" x="94.78858692586502" y="-89.1427015552106" z="1528.5830972393524" unit="mm" />
+      <rotation name="crystal4-5_rot_pos_bot" x="-0.0759356980444989" y="-0.0590610984790547" z="0.0" unit="radian" />
+      <position name="crystal4-5_pos_neg_bot" x="-9.42816171009298" y="-89.1427015552106" z="1528.5830972393524" unit="mm" />
+      <rotation name="crystal4-5_rot_neg_bot" x="-0.0759356980444989" y="0.0590610984790547" z="0.0" unit="radian" />
+      <position name="crystal4-5_pos_pos_top" x="94.78858692586502" y="90.0427015552106" z="1528.5830972393524" unit="mm" />
+      <rotation name="crystal4-5_rot_pos_top" x="0.0759356980444989" y="-0.0590610984790547" z="0.0" unit="radian" />
+      <position name="crystal4-5_pos_neg_top" x="-9.42816171009298" y="90.0427015552106" z="1528.5830972393524" unit="mm" />
+      <rotation name="crystal4-5_rot_neg_top" x="0.0759356980444989" y="0.0590610984790547" z="0.0" unit="radian" />
+      <position name="crystal5-5_pos_pos_bot" x="109.67291416309662" y="-89.1427015552106" z="1528.6040060456442" unit="mm" />
+      <rotation name="crystal5-5_rot_pos_bot" x="-0.0759356980444989" y="-0.0759356980444989" z="0.0" unit="radian" />
+      <position name="crystal5-5_pos_neg_bot" x="-24.31248894732458" y="-89.1427015552106" z="1528.6040060456442" unit="mm" />
+      <rotation name="crystal5-5_rot_neg_bot" x="-0.0759356980444989" y="0.0759356980444989" z="0.0" unit="radian" />
+      <position name="crystal5-5_pos_pos_top" x="109.67291416309662" y="90.0427015552106" z="1528.6040060456442" unit="mm" />
+      <rotation name="crystal5-5_rot_pos_top" x="0.0759356980444989" y="-0.0759356980444989" z="0.0" unit="radian" />
+      <position name="crystal5-5_pos_neg_top" x="-24.31248894732458" y="90.0427015552106" z="1528.6040060456442" unit="mm" />
+      <rotation name="crystal5-5_rot_neg_top" x="0.0759356980444989" y="0.0759356980444989" z="0.0" unit="radian" />
+      <position name="crystal6-5_pos_pos_bot" x="124.57452638340096" y="-89.1427015552106" z="1528.602057217992" unit="mm" />
+      <rotation name="crystal6-5_rot_pos_bot" x="-0.0759356980444989" y="-0.0928102976099431" z="0.0" unit="radian" />
+      <position name="crystal6-5_pos_neg_bot" x="-39.214101167628925" y="-89.1427015552106" z="1528.602057217992" unit="mm" />
+      <rotation name="crystal6-5_rot_neg_bot" x="-0.0759356980444989" y="0.0928102976099431" z="0.0" unit="radian" />
+      <position name="crystal6-5_pos_pos_top" x="124.57452638340096" y="90.0427015552106" z="1528.602057217992" unit="mm" />
+      <rotation name="crystal6-5_rot_pos_top" x="0.0759356980444989" y="-0.0928102976099431" z="0.0" unit="radian" />
+      <position name="crystal6-5_pos_neg_top" x="-39.214101167628925" y="90.0427015552106" z="1528.602057217992" unit="mm" />
+      <rotation name="crystal6-5_rot_neg_top" x="0.0759356980444989" y="0.0928102976099431" z="0.0" unit="radian" />
+      <position name="crystal7-5_pos_pos_bot" x="139.4968932952259" y="-89.1427015552106" z="1528.5772513113154" unit="mm" />
+      <rotation name="crystal7-5_rot_pos_bot" x="-0.0759356980444989" y="-0.10968489717538729" z="0.0" unit="radian" />
+      <position name="crystal7-5_pos_neg_bot" x="-54.13646807945388" y="-89.1427015552106" z="1528.5772513113154" unit="mm" />
+      <rotation name="crystal7-5_rot_neg_bot" x="-0.0759356980444989" y="0.10968489717538729" z="0.0" unit="radian" />
+      <position name="crystal7-5_pos_pos_top" x="139.4968932952259" y="90.0427015552106" z="1528.5772513113154" unit="mm" />
+      <rotation name="crystal7-5_rot_pos_top" x="0.0759356980444989" y="-0.10968489717538729" z="0.0" unit="radian" />
+      <position name="crystal7-5_pos_neg_top" x="-54.13646807945388" y="90.0427015552106" z="1528.5772513113154" unit="mm" />
+      <rotation name="crystal7-5_rot_neg_top" x="0.0759356980444989" y="0.10968489717538729" z="0.0" unit="radian" />
+      <position name="crystal8-5_pos_pos_bot" x="154.44351486445828" y="-89.1427015552106" z="1528.5295953889813" unit="mm" />
+      <rotation name="crystal8-5_rot_pos_bot" x="-0.0759356980444989" y="-0.1265594967408315" z="0.0" unit="radian" />
+      <position name="crystal8-5_pos_neg_bot" x="-69.08308964868624" y="-89.1427015552106" z="1528.5295953889813" unit="mm" />
+      <rotation name="crystal8-5_rot_neg_bot" x="-0.0759356980444989" y="0.1265594967408315" z="0.0" unit="radian" />
+      <position name="crystal8-5_pos_pos_top" x="154.44351486445828" y="90.0427015552106" z="1528.5295953889813" unit="mm" />
+      <rotation name="crystal8-5_rot_pos_top" x="0.0759356980444989" y="-0.1265594967408315" z="0.0" unit="radian" />
+      <position name="crystal8-5_pos_neg_top" x="-69.08308964868624" y="90.0427015552106" z="1528.5295953889813" unit="mm" />
+      <rotation name="crystal8-5_rot_neg_top" x="0.0759356980444989" y="0.1265594967408315" z="0.0" unit="radian" />
+      <position name="crystal9-5_pos_pos_bot" x="169.41792716339802" y="-89.1427015552106" z="1528.4591030207916" unit="mm" />
+      <rotation name="crystal9-5_rot_pos_bot" x="-0.0759356980444989" y="-0.14343409630627568" z="0.0" unit="radian" />
+      <position name="crystal9-5_pos_neg_bot" x="-84.057501947626" y="-89.1427015552106" z="1528.4591030207916" unit="mm" />
+      <rotation name="crystal9-5_rot_neg_bot" x="-0.0759356980444989" y="0.14343409630627568" z="0.0" unit="radian" />
+      <position name="crystal9-5_pos_pos_top" x="169.41792716339802" y="90.0427015552106" z="1528.4591030207916" unit="mm" />
+      <rotation name="crystal9-5_rot_pos_top" x="0.0759356980444989" y="-0.14343409630627568" z="0.0" unit="radian" />
+      <position name="crystal9-5_pos_neg_top" x="-84.057501947626" y="90.0427015552106" z="1528.4591030207916" unit="mm" />
+      <rotation name="crystal9-5_rot_neg_top" x="0.0759356980444989" y="0.14343409630627568" z="0.0" unit="radian" />
+      <position name="crystal10-5_pos_pos_bot" x="184.42370834727978" y="-89.1427015552106" z="1528.3657942791212" unit="mm" />
+      <rotation name="crystal10-5_rot_pos_bot" x="-0.0759356980444989" y="-0.1603086958717199" z="0.0" unit="radian" />
+      <position name="crystal10-5_pos_neg_bot" x="-99.06328313150773" y="-89.1427015552106" z="1528.3657942791212" unit="mm" />
+      <rotation name="crystal10-5_rot_neg_bot" x="-0.0759356980444989" y="0.1603086958717199" z="0.0" unit="radian" />
+      <position name="crystal10-5_pos_pos_top" x="184.42370834727978" y="90.0427015552106" z="1528.3657942791212" unit="mm" />
+      <rotation name="crystal10-5_rot_pos_top" x="0.0759356980444989" y="-0.1603086958717199" z="0.0" unit="radian" />
+      <position name="crystal10-5_pos_neg_top" x="-99.06328313150773" y="90.0427015552106" z="1528.3657942791212" unit="mm" />
+      <rotation name="crystal10-5_rot_neg_top" x="0.0759356980444989" y="0.1603086958717199" z="0.0" unit="radian" />
+      <position name="crystal11-5_pos_pos_bot" x="199.46448478017476" y="-89.1427015552106" z="1528.2496957332003" unit="mm" />
+      <rotation name="crystal11-5_rot_pos_bot" x="-0.0759356980444989" y="-0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal11-5_pos_neg_bot" x="-114.1040595644027" y="-89.1427015552106" z="1528.2496957332003" unit="mm" />
+      <rotation name="crystal11-5_rot_neg_bot" x="-0.0759356980444989" y="0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal11-5_pos_pos_top" x="199.46448478017476" y="90.0427015552106" z="1528.2496957332003" unit="mm" />
+      <rotation name="crystal11-5_rot_pos_top" x="0.0759356980444989" y="-0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal11-5_pos_neg_top" x="-114.1040595644027" y="90.0427015552106" z="1528.2496957332003" unit="mm" />
+      <rotation name="crystal11-5_rot_neg_top" x="0.0759356980444989" y="0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal12-5_pos_pos_bot" x="214.5439373331128" y="-89.1427015552106" z="1528.1108404415506" unit="mm" />
+      <rotation name="crystal12-5_rot_pos_bot" x="-0.0759356980444989" y="-0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal12-5_pos_neg_bot" x="-129.1835121173408" y="-89.1427015552106" z="1528.1108404415506" unit="mm" />
+      <rotation name="crystal12-5_rot_neg_bot" x="-0.0759356980444989" y="0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal12-5_pos_pos_top" x="214.5439373331128" y="90.0427015552106" z="1528.1108404415506" unit="mm" />
+      <rotation name="crystal12-5_rot_pos_top" x="0.0759356980444989" y="-0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal12-5_pos_neg_top" x="-129.1835121173408" y="90.0427015552106" z="1528.1108404415506" unit="mm" />
+      <rotation name="crystal12-5_rot_neg_top" x="0.0759356980444989" y="0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal13-5_pos_pos_bot" x="229.66580787843168" y="-89.1427015552106" z="1527.9492679425712" unit="mm" />
+      <rotation name="crystal13-5_rot_pos_bot" x="-0.0759356980444989" y="-0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal13-5_pos_neg_bot" x="-144.30538266265967" y="-89.1427015552106" z="1527.9492679425712" unit="mm" />
+      <rotation name="crystal13-5_rot_neg_bot" x="-0.0759356980444989" y="0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal13-5_pos_pos_top" x="229.66580787843168" y="90.0427015552106" z="1527.9492679425712" unit="mm" />
+      <rotation name="crystal13-5_rot_pos_top" x="0.0759356980444989" y="-0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal13-5_pos_neg_top" x="-144.30538266265967" y="90.0427015552106" z="1527.9492679425712" unit="mm" />
+      <rotation name="crystal13-5_rot_neg_top" x="0.0759356980444989" y="0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal14-5_pos_pos_bot" x="244.83390600570817" y="-89.1427015552106" z="1527.7650242432805" unit="mm" />
+      <rotation name="crystal14-5_rot_pos_bot" x="-0.0759356980444989" y="-0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal14-5_pos_neg_bot" x="-159.47348078993616" y="-89.1427015552106" z="1527.7650242432805" unit="mm" />
+      <rotation name="crystal14-5_rot_neg_bot" x="-0.0759356980444989" y="0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal14-5_pos_pos_top" x="244.83390600570817" y="90.0427015552106" z="1527.7650242432805" unit="mm" />
+      <rotation name="crystal14-5_rot_pos_top" x="0.0759356980444989" y="-0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal14-5_pos_neg_top" x="-159.47348078993616" y="90.0427015552106" z="1527.7650242432805" unit="mm" />
+      <rotation name="crystal14-5_rot_neg_top" x="0.0759356980444989" y="0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal15-5_pos_pos_bot" x="260.0521159861688" y="-89.1427015552106" z="1527.5581618062158" unit="mm" />
+      <rotation name="crystal15-5_rot_pos_bot" x="-0.0759356980444989" y="-0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal15-5_pos_neg_bot" x="-174.6916907703968" y="-89.1427015552106" z="1527.5581618062158" unit="mm" />
+      <rotation name="crystal15-5_rot_neg_bot" x="-0.0759356980444989" y="0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal15-5_pos_pos_top" x="260.0521159861688" y="90.0427015552106" z="1527.5581618062158" unit="mm" />
+      <rotation name="crystal15-5_rot_pos_top" x="0.0759356980444989" y="-0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal15-5_pos_neg_top" x="-174.6916907703968" y="90.0427015552106" z="1527.5581618062158" unit="mm" />
+      <rotation name="crystal15-5_rot_neg_top" x="0.0759356980444989" y="0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal16-5_pos_pos_bot" x="275.32440401422616" y="-89.1427015552106" z="1527.328739534495" unit="mm" />
+      <rotation name="crystal16-5_rot_pos_bot" x="-0.0759356980444989" y="-0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal16-5_pos_neg_bot" x="-189.96397879845415" y="-89.1427015552106" z="1527.328739534495" unit="mm" />
+      <rotation name="crystal16-5_rot_neg_bot" x="-0.0759356980444989" y="0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal16-5_pos_pos_top" x="275.32440401422616" y="90.0427015552106" z="1527.328739534495" unit="mm" />
+      <rotation name="crystal16-5_rot_pos_top" x="0.0759356980444989" y="-0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal16-5_pos_neg_top" x="-189.96397879845415" y="90.0427015552106" z="1527.328739534495" unit="mm" />
+      <rotation name="crystal16-5_rot_neg_top" x="0.0759356980444989" y="0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal17-5_pos_pos_bot" x="290.6548257567732" y="-89.1427015552106" z="1527.0768227550436" unit="mm" />
+      <rotation name="crystal17-5_rot_pos_bot" x="-0.0759356980444989" y="-0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal17-5_pos_neg_bot" x="-205.2944005410012" y="-89.1427015552106" z="1527.0768227550436" unit="mm" />
+      <rotation name="crystal17-5_rot_neg_bot" x="-0.0759356980444989" y="0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal17-5_pos_pos_top" x="290.6548257567732" y="90.0427015552106" z="1527.0768227550436" unit="mm" />
+      <rotation name="crystal17-5_rot_pos_top" x="0.0759356980444989" y="-0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal17-5_pos_neg_top" x="-205.2944005410012" y="90.0427015552106" z="1527.0768227550436" unit="mm" />
+      <rotation name="crystal17-5_rot_neg_top" x="0.0759356980444989" y="0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal18-5_pos_pos_bot" x="306.0475342431027" y="-89.1427015552106" z="1526.8024831999942" unit="mm" />
+      <rotation name="crystal18-5_rot_pos_bot" x="-0.0759356980444989" y="-0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal18-5_pos_neg_bot" x="-220.68710902733068" y="-89.1427015552106" z="1526.8024831999942" unit="mm" />
+      <rotation name="crystal18-5_rot_neg_bot" x="-0.0759356980444989" y="0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal18-5_pos_pos_top" x="306.0475342431027" y="90.0427015552106" z="1526.8024831999942" unit="mm" />
+      <rotation name="crystal18-5_rot_pos_top" x="0.0759356980444989" y="-0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal18-5_pos_neg_top" x="-220.68710902733068" y="90.0427015552106" z="1526.8024831999942" unit="mm" />
+      <rotation name="crystal18-5_rot_neg_top" x="0.0759356980444989" y="0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal19-5_pos_pos_bot" x="321.5067881308382" y="-89.1427015552106" z="1526.5057989862605" unit="mm" />
+      <rotation name="crystal19-5_rot_pos_bot" x="-0.0759356980444989" y="-0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal19-5_pos_neg_bot" x="-236.14636291506616" y="-89.1427015552106" z="1526.5057989862605" unit="mm" />
+      <rotation name="crystal19-5_rot_neg_bot" x="-0.0759356980444989" y="0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal19-5_pos_pos_top" x="321.5067881308382" y="90.0427015552106" z="1526.5057989862605" unit="mm" />
+      <rotation name="crystal19-5_rot_pos_top" x="0.0759356980444989" y="-0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal19-5_pos_neg_top" x="-236.14636291506616" y="90.0427015552106" z="1526.5057989862605" unit="mm" />
+      <rotation name="crystal19-5_rot_neg_top" x="0.0759356980444989" y="0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal20-5_pos_pos_bot" x="337.03696038609246" y="-89.1427015552106" z="1526.186854593294" unit="mm" />
+      <rotation name="crystal20-5_rot_pos_bot" x="-0.0759356980444989" y="-0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal20-5_pos_neg_bot" x="-251.67653517032045" y="-89.1427015552106" z="1526.186854593294" unit="mm" />
+      <rotation name="crystal20-5_rot_neg_bot" x="-0.0759356980444989" y="0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal20-5_pos_pos_top" x="337.03696038609246" y="90.0427015552106" z="1526.186854593294" unit="mm" />
+      <rotation name="crystal20-5_rot_pos_top" x="0.0759356980444989" y="-0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal20-5_pos_neg_top" x="-251.67653517032045" y="90.0427015552106" z="1526.186854593294" unit="mm" />
+      <rotation name="crystal20-5_rot_neg_top" x="0.0759356980444989" y="0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal21-5_pos_pos_bot" x="352.64254741924634" y="-89.1427015552106" z="1525.8457408390282" unit="mm" />
+      <rotation name="crystal21-5_rot_pos_bot" x="-0.0759356980444989" y="-0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal21-5_pos_neg_bot" x="-267.28212220347433" y="-89.1427015552106" z="1525.8457408390282" unit="mm" />
+      <rotation name="crystal21-5_rot_neg_bot" x="-0.0759356980444989" y="0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal21-5_pos_pos_top" x="352.64254741924634" y="90.0427015552106" z="1525.8457408390282" unit="mm" />
+      <rotation name="crystal21-5_rot_pos_top" x="0.0759356980444989" y="-0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal21-5_pos_neg_top" x="-267.28212220347433" y="90.0427015552106" z="1525.8457408390282" unit="mm" />
+      <rotation name="crystal21-5_rot_neg_top" x="0.0759356980444989" y="0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal22-5_pos_pos_bot" x="368.32817872130425" y="-89.1427015552106" z="1525.48255485402" unit="mm" />
+      <rotation name="crystal22-5_rot_pos_bot" x="-0.0759356980444989" y="-0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal22-5_pos_neg_bot" x="-282.96775350553224" y="-89.1427015552106" z="1525.48255485402" unit="mm" />
+      <rotation name="crystal22-5_rot_neg_bot" x="-0.0759356980444989" y="0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal22-5_pos_pos_top" x="368.32817872130425" y="90.0427015552106" z="1525.48255485402" unit="mm" />
+      <rotation name="crystal22-5_rot_pos_top" x="0.0759356980444989" y="-0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal22-5_pos_neg_top" x="-282.96775350553224" y="90.0427015552106" z="1525.48255485402" unit="mm" />
+      <rotation name="crystal22-5_rot_neg_top" x="0.0759356980444989" y="0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal23-5_pos_pos_bot" x="384.09862704978" y="-89.1427015552106" z="1525.0974000537913" unit="mm" />
+      <rotation name="crystal23-5_rot_pos_bot" x="-0.0759356980444989" y="-0.3796784902224945" z="0.0" unit="radian" />
+      <position name="crystal23-5_pos_neg_bot" x="-298.738201834008" y="-89.1427015552106" z="1525.0974000537913" unit="mm" />
+      <rotation name="crystal23-5_rot_neg_bot" x="-0.0759356980444989" y="0.3796784902224945" z="0.0" unit="radian" />
+      <position name="crystal23-5_pos_pos_top" x="384.09862704978" y="90.0427015552106" z="1525.0974000537913" unit="mm" />
+      <rotation name="crystal23-5_rot_pos_top" x="0.0759356980444989" y="-0.3796784902224945" z="0.0" unit="radian" />
+      <position name="crystal23-5_pos_neg_top" x="-298.738201834008" y="90.0427015552106" z="1525.0974000537913" unit="mm" />
+      <rotation name="crystal23-5_rot_neg_top" x="0.0759356980444989" y="0.3796784902224945" z="0.0" unit="radian" />
+      <rotation name="hodo_rot" x="0.0" y="0.0" z="0.0" unit="radian" />
+      <position name="hodo_pos_L1TP0" x="73.63" y="44.2" z="1103.5" unit="mm" />
+      <position name="hodo_forecover_pos_L1TP0" x="73.63" y="44.2" z="1098.625" unit="mm" />
+      <position name="hodo_postcover_pos_L1TP0" x="73.63" y="44.2" z="1108.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L1TP0" x="65.75500000000001" y="44.2" z="1103.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L1TP0" x="81.50500000000001" y="44.2" z="1103.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L1TP0" x="73.63" y="74.17500000000001" z="1103.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L1TP0" x="73.63" y="14.225000000000003" z="1103.5" unit="mm" />
+      <position name="hodo_pos_L1BP0" x="73.63" y="-44.2" z="1103.5" unit="mm" />
+      <position name="hodo_forecover_pos_L1BP0" x="73.63" y="-44.2" z="1098.625" unit="mm" />
+      <position name="hodo_postcover_pos_L1BP0" x="73.63" y="-44.2" z="1108.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L1BP0" x="65.75500000000001" y="-44.2" z="1103.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L1BP0" x="81.50500000000001" y="-44.2" z="1103.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L1BP0" x="73.63" y="-14.225000000000003" z="1103.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L1BP0" x="73.63" y="-74.17500000000001" z="1103.5" unit="mm" />
+      <position name="hodo_pos_L1TP1" x="98.63" y="44.2" z="1103.5" unit="mm" />
+      <position name="hodo_forecover_pos_L1TP1" x="98.63" y="44.2" z="1098.625" unit="mm" />
+      <position name="hodo_postcover_pos_L1TP1" x="98.63" y="44.2" z="1108.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L1TP1" x="81.555" y="44.2" z="1103.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L1TP1" x="115.70500000000001" y="44.2" z="1103.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L1TP1" x="98.63" y="74.17500000000001" z="1103.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L1TP1" x="98.63" y="14.225000000000003" z="1103.5" unit="mm" />
+      <position name="hodo_pos_L1BP1" x="98.63" y="-44.2" z="1103.5" unit="mm" />
+      <position name="hodo_forecover_pos_L1BP1" x="98.63" y="-44.2" z="1098.625" unit="mm" />
+      <position name="hodo_postcover_pos_L1BP1" x="98.63" y="-44.2" z="1108.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L1BP1" x="81.555" y="-44.2" z="1103.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L1BP1" x="115.70500000000001" y="-44.2" z="1103.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L1BP1" x="98.63" y="-14.225000000000003" z="1103.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L1BP1" x="98.63" y="-74.17500000000001" z="1103.5" unit="mm" />
+      <position name="hodo_pos_L1TP2" x="137.78" y="44.2" z="1103.5" unit="mm" />
+      <position name="hodo_forecover_pos_L1TP2" x="137.78" y="44.2" z="1098.625" unit="mm" />
+      <position name="hodo_postcover_pos_L1TP2" x="137.78" y="44.2" z="1108.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L1TP2" x="115.75500000000001" y="44.2" z="1103.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L1TP2" x="159.805" y="44.2" z="1103.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L1TP2" x="137.78" y="74.17500000000001" z="1103.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L1TP2" x="137.78" y="14.225000000000003" z="1103.5" unit="mm" />
+      <position name="hodo_pos_L1BP2" x="137.78" y="-44.2" z="1103.5" unit="mm" />
+      <position name="hodo_forecover_pos_L1BP2" x="137.78" y="-44.2" z="1098.625" unit="mm" />
+      <position name="hodo_postcover_pos_L1BP2" x="137.78" y="-44.2" z="1108.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L1BP2" x="115.75500000000001" y="-44.2" z="1103.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L1BP2" x="159.805" y="-44.2" z="1103.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L1BP2" x="137.78" y="-14.225000000000003" z="1103.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L1BP2" x="137.78" y="-74.17500000000001" z="1103.5" unit="mm" />
+      <position name="hodo_pos_L1TP3" x="181.88" y="44.2" z="1103.5" unit="mm" />
+      <position name="hodo_forecover_pos_L1TP3" x="181.88" y="44.2" z="1098.625" unit="mm" />
+      <position name="hodo_postcover_pos_L1TP3" x="181.88" y="44.2" z="1108.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L1TP3" x="159.855" y="44.2" z="1103.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L1TP3" x="203.905" y="44.2" z="1103.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L1TP3" x="181.88" y="74.17500000000001" z="1103.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L1TP3" x="181.88" y="14.225000000000003" z="1103.5" unit="mm" />
+      <position name="hodo_pos_L1BP3" x="181.88" y="-44.2" z="1103.5" unit="mm" />
+      <position name="hodo_forecover_pos_L1BP3" x="181.88" y="-44.2" z="1098.625" unit="mm" />
+      <position name="hodo_postcover_pos_L1BP3" x="181.88" y="-44.2" z="1108.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L1BP3" x="159.855" y="-44.2" z="1103.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L1BP3" x="203.905" y="-44.2" z="1103.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L1BP3" x="181.88" y="-14.225000000000003" z="1103.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L1BP3" x="181.88" y="-74.17500000000001" z="1103.5" unit="mm" />
+      <position name="hodo_pos_L1TP4" x="225.98000000000002" y="44.2" z="1103.5" unit="mm" />
+      <position name="hodo_forecover_pos_L1TP4" x="225.98000000000002" y="44.2" z="1098.625" unit="mm" />
+      <position name="hodo_postcover_pos_L1TP4" x="225.98000000000002" y="44.2" z="1108.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L1TP4" x="203.955" y="44.2" z="1103.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L1TP4" x="248.00500000000002" y="44.2" z="1103.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L1TP4" x="225.98000000000002" y="74.17500000000001" z="1103.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L1TP4" x="225.98000000000002" y="14.225000000000003" z="1103.5" unit="mm" />
+      <position name="hodo_pos_L1BP4" x="225.98000000000002" y="-44.2" z="1103.5" unit="mm" />
+      <position name="hodo_forecover_pos_L1BP4" x="225.98000000000002" y="-44.2" z="1098.625" unit="mm" />
+      <position name="hodo_postcover_pos_L1BP4" x="225.98000000000002" y="-44.2" z="1108.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L1BP4" x="203.955" y="-44.2" z="1103.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L1BP4" x="248.00500000000002" y="-44.2" z="1103.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L1BP4" x="225.98000000000002" y="-14.225000000000003" z="1103.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L1BP4" x="225.98000000000002" y="-74.17500000000001" z="1103.5" unit="mm" />
+      <position name="hodo_pos_L2TP0" x="78.61999999999999" y="44.2" z="1115.5" unit="mm" />
+      <position name="hodo_forecover_pos_L2TP0" x="78.61999999999999" y="44.2" z="1110.625" unit="mm" />
+      <position name="hodo_postcover_pos_L2TP0" x="78.61999999999999" y="44.2" z="1120.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L2TP0" x="69.095" y="44.2" z="1115.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L2TP0" x="88.145" y="44.2" z="1115.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L2TP0" x="78.61999999999999" y="74.17500000000001" z="1115.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L2TP0" x="78.61999999999999" y="14.225000000000003" z="1115.5" unit="mm" />
+      <position name="hodo_pos_L2BP0" x="78.61999999999999" y="-44.2" z="1115.5" unit="mm" />
+      <position name="hodo_forecover_pos_L2BP0" x="78.61999999999999" y="-44.2" z="1110.625" unit="mm" />
+      <position name="hodo_postcover_pos_L2BP0" x="78.61999999999999" y="-44.2" z="1120.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L2BP0" x="69.095" y="-44.2" z="1115.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L2BP0" x="88.145" y="-44.2" z="1115.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L2BP0" x="78.61999999999999" y="-14.225000000000003" z="1115.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L2BP0" x="78.61999999999999" y="-74.17500000000001" z="1115.5" unit="mm" />
+      <position name="hodo_pos_L2TP1" x="110.22" y="44.2" z="1115.5" unit="mm" />
+      <position name="hodo_forecover_pos_L2TP1" x="110.22" y="44.2" z="1110.625" unit="mm" />
+      <position name="hodo_postcover_pos_L2TP1" x="110.22" y="44.2" z="1120.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L2TP1" x="88.19500000000001" y="44.2" z="1115.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L2TP1" x="132.245" y="44.2" z="1115.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L2TP1" x="110.22" y="74.17500000000001" z="1115.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L2TP1" x="110.22" y="14.225000000000003" z="1115.5" unit="mm" />
+      <position name="hodo_pos_L2BP1" x="110.22" y="-44.2" z="1115.5" unit="mm" />
+      <position name="hodo_forecover_pos_L2BP1" x="110.22" y="-44.2" z="1110.625" unit="mm" />
+      <position name="hodo_postcover_pos_L2BP1" x="110.22" y="-44.2" z="1120.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L2BP1" x="88.19500000000001" y="-44.2" z="1115.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L2BP1" x="132.245" y="-44.2" z="1115.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L2BP1" x="110.22" y="-14.225000000000003" z="1115.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L2BP1" x="110.22" y="-74.17500000000001" z="1115.5" unit="mm" />
+      <position name="hodo_pos_L2TP2" x="154.32000000000002" y="44.2" z="1115.5" unit="mm" />
+      <position name="hodo_forecover_pos_L2TP2" x="154.32000000000002" y="44.2" z="1110.625" unit="mm" />
+      <position name="hodo_postcover_pos_L2TP2" x="154.32000000000002" y="44.2" z="1120.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L2TP2" x="132.29500000000002" y="44.2" z="1115.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L2TP2" x="176.34500000000003" y="44.2" z="1115.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L2TP2" x="154.32000000000002" y="74.17500000000001" z="1115.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L2TP2" x="154.32000000000002" y="14.225000000000003" z="1115.5" unit="mm" />
+      <position name="hodo_pos_L2BP2" x="154.32000000000002" y="-44.2" z="1115.5" unit="mm" />
+      <position name="hodo_forecover_pos_L2BP2" x="154.32000000000002" y="-44.2" z="1110.625" unit="mm" />
+      <position name="hodo_postcover_pos_L2BP2" x="154.32000000000002" y="-44.2" z="1120.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L2BP2" x="132.29500000000002" y="-44.2" z="1115.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L2BP2" x="176.34500000000003" y="-44.2" z="1115.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L2BP2" x="154.32000000000002" y="-14.225000000000003" z="1115.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L2BP2" x="154.32000000000002" y="-74.17500000000001" z="1115.5" unit="mm" />
+      <position name="hodo_pos_L2TP3" x="198.42000000000004" y="44.2" z="1115.5" unit="mm" />
+      <position name="hodo_forecover_pos_L2TP3" x="198.42000000000004" y="44.2" z="1110.625" unit="mm" />
+      <position name="hodo_postcover_pos_L2TP3" x="198.42000000000004" y="44.2" z="1120.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L2TP3" x="176.39500000000004" y="44.2" z="1115.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L2TP3" x="220.44500000000005" y="44.2" z="1115.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L2TP3" x="198.42000000000004" y="74.17500000000001" z="1115.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L2TP3" x="198.42000000000004" y="14.225000000000003" z="1115.5" unit="mm" />
+      <position name="hodo_pos_L2BP3" x="198.42000000000004" y="-44.2" z="1115.5" unit="mm" />
+      <position name="hodo_forecover_pos_L2BP3" x="198.42000000000004" y="-44.2" z="1110.625" unit="mm" />
+      <position name="hodo_postcover_pos_L2BP3" x="198.42000000000004" y="-44.2" z="1120.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L2BP3" x="176.39500000000004" y="-44.2" z="1115.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L2BP3" x="220.44500000000005" y="-44.2" z="1115.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L2BP3" x="198.42000000000004" y="-14.225000000000003" z="1115.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L2BP3" x="198.42000000000004" y="-74.17500000000001" z="1115.5" unit="mm" />
+      <position name="hodo_pos_L2TP4" x="235.92000000000002" y="44.2" z="1115.5" unit="mm" />
+      <position name="hodo_forecover_pos_L2TP4" x="235.92000000000002" y="44.2" z="1110.625" unit="mm" />
+      <position name="hodo_postcover_pos_L2TP4" x="235.92000000000002" y="44.2" z="1120.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L2TP4" x="220.495" y="44.2" z="1115.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L2TP4" x="251.34500000000003" y="44.2" z="1115.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L2TP4" x="235.92000000000002" y="74.17500000000001" z="1115.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L2TP4" x="235.92000000000002" y="14.225000000000003" z="1115.5" unit="mm" />
+      <position name="hodo_pos_L2BP4" x="235.92000000000002" y="-44.2" z="1115.5" unit="mm" />
+      <position name="hodo_forecover_pos_L2BP4" x="235.92000000000002" y="-44.2" z="1110.625" unit="mm" />
+      <position name="hodo_postcover_pos_L2BP4" x="235.92000000000002" y="-44.2" z="1120.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L2BP4" x="220.495" y="-44.2" z="1115.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L2BP4" x="251.34500000000003" y="-44.2" z="1115.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L2BP4" x="235.92000000000002" y="-14.225000000000003" z="1115.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L2BP4" x="235.92000000000002" y="-74.17500000000001" z="1115.5" unit="mm" />
+      <position name="hodo_bufferT_pos" x="153.99" y="54.2" z="1109.5" unit="mm" />
+      <position name="hodo_bufferB_pos" x="153.99" y="-54.2" z="1109.5" unit="mm" />
+      <position name="front_flange_1inworld_volumepos" x="2.1420000000000003" y="0" z="137.80000000000001" unit="cm" />
+      <position name="back_flange_1inworld_volumepos" x="-12.608499999999999" y="0" z="180.80000000000001" unit="cm" />
+      <position name="ECAL_chamber_1inworld_volumepos" x="-11.940800000000001" y="0" z="159.30000000000001" unit="cm" />
+      <position name="al_honeycomb_1inworld_volumepos" x="-18.858000000000001" y="0" z="155.80000000000001" unit="cm" />
+      <position name="layer_1_top_1inworld_volumepos" x="4.1920000000000002" y="8.0999999999999996" z="152.80000000000001" unit="cm" />
+      <position name="layer_2_top_1inworld_volumepos" x="4.1920000000000002" y="6.6899999999999995" z="152.80000000000001" unit="cm" />
+      <position name="layer_3_top_1inworld_volumepos" x="4.1920000000000002" y="5.2799999999999994" z="152.80000000000001" unit="cm" />
+      <position name="layer_4_top_1inworld_volumepos" x="4.1920000000000002" y="3.8699999999999992" z="152.80000000000001" unit="cm" />
+      <position name="layer_1_bottom_1inworld_volumepos" x="4.1920000000000002" y="-4.0999999999999996" z="152.80000000000001" unit="cm" />
+      <position name="layer_2_bottom_1inworld_volumepos" x="4.1920000000000002" y="-5.5099999999999998" z="152.80000000000001" unit="cm" />
+      <position name="layer_3_bottom_1inworld_volumepos" x="4.1920000000000002" y="-6.9199999999999999" z="152.80000000000001" unit="cm" />
+      <position name="layer_4_bottom_1inworld_volumepos" x="4.1920000000000002" y="-8.3300000000000001" z="152.80000000000001" unit="cm" />
+      <position name="layer_5T_left_1inworld_volumepos" x="4.1920000000000002" y="2.46" z="152.80000000000001" unit="cm" />
+      <position name="layer_5B_left_1inworld_volumepos" x="4.1920000000000002" y="-2.6899999999999995" z="152.80000000000001" unit="cm" />
+      <position name="steel_bar_1inworld_volumepos" x="-35.357999999999997" y="0.90000000000000002" z="152.80000000000001" unit="cm" />
+      <position name="cu_Tpipe_inner_left_1inworld_volumepos" x="1.6420000000000003" y="2.7000000000000002" z="152.80000000000001" unit="cm" />
+      <rotation name="cu_Tpipe_inner_left_1inworld_volumerot" x="0" y="-0.95599999999999996" z="0" unit="deg" />
+      <position name="cu_Tpipe_inner_right_1inworld_volumepos" x="-9.1580000000000013" y="2.7000000000000002" z="152.80000000000001" unit="cm" />
+      <rotation name="cu_Tpipe_inner_right_1inworld_volumerot" x="0" y="9.6799999999999997" z="0" unit="deg" />
+      <position name="cu_Bpipe_inner_left_1inworld_volumepos" x="1.6420000000000003" y="-2.7000000000000002" z="152.80000000000001" unit="cm" />
+      <rotation name="cu_Bpipe_inner_left_1inworld_volumerot" x="0" y="-0.95599999999999996" z="0" unit="deg" />
+      <position name="cu_Bpipe_inner_right_1inworld_volumepos" x="-9.1580000000000013" y="-2.7000000000000002" z="152.80000000000001" unit="cm" />
+      <rotation name="cu_Bpipe_inner_right_1inworld_volumerot" x="0" y="9.6799999999999997" z="0" unit="deg" />
+      <position name="cu_Tpipe_outer_right1_1inworld_volumepos" x="-10.858000000000001" y="1.3999999999999999" z="154.30000000000001" unit="cm" />
+      <rotation name="cu_Tpipe_outer_right1_1inworld_volumerot" x="0" y="10" z="0" unit="deg" />
+      <position name="cu_Tpipe_outer_right2_1inworld_volumepos" x="-27.858000000000001" y="1.3999999999999999" z="154.30000000000001" unit="cm" />
+      <position name="cu_Tpipe_outer_right3_1inworld_volumepos" x="-34.857999999999997" y="1.5" z="142.10000000000002" unit="cm" />
+      <rotation name="cu_Tpipe_outer_right3_1inworld_volumerot" x="-0" y="90" z="0" unit="deg" />
+      <position name="cu_Bpipe_outer_right_1inworld_volumepos" x="-34.857999999999997" y="-1.5" z="142.10000000000002" unit="cm" />
+      <rotation name="cu_Bpipe_outer_right_1inworld_volumerot" x="-0" y="90" z="0" unit="deg" />
+      <position name="cu_Bpipe_outer_right1_1inworld_volumepos" x="-10.858000000000001" y="-1.3999999999999999" z="154.30000000000001" unit="cm" />
+      <rotation name="cu_Bpipe_outer_right1_1inworld_volumerot" x="0" y="10" z="0" unit="deg" />
+      <position name="cu_Bpipe_outer_right2_1inworld_volumepos" x="-27.858000000000001" y="-1.3999999999999999" z="154.30000000000001" unit="cm" />
+      <position name="al_pipe_across_top1_1inworld_volumepos" x="2.1420000000000003" y="9" z="142.10000000000002" unit="cm" />
+      <rotation name="al_pipe_across_top1_1inworld_volumerot" x="-90" y="86.999999999999957" z="180" unit="deg" />
+      <position name="al_pipe_across_top2_1inworld_volumepos" x="2.1420000000000003" y="4" z="142.10000000000002" unit="cm" />
+      <rotation name="al_pipe_across_top2_1inworld_volumerot" x="-90" y="89.000000000000099" z="180" unit="deg" />
+      <position name="al_pipe_across_bottom1_1inworld_volumepos" x="2.1420000000000003" y="-9" z="142.10000000000002" unit="cm" />
+      <rotation name="al_pipe_across_bottom1_1inworld_volumerot" x="90" y="86.999999999999957" z="0" unit="deg" />
+      <position name="al_pipe_across_bottom2_1inworld_volumepos" x="2.1420000000000003" y="-4" z="142.10000000000002" unit="cm" />
+      <rotation name="al_pipe_across_bottom2_1inworld_volumerot" x="90" y="89.000000000000099" z="0" unit="deg" />
+      <position name="cu_plate_top_left_1inworld_volumepos" x="22.141999999999999" y="1.6000000000000001" z="152.80000000000001" unit="cm" />
+      <position name="cu_plate_bottom_left_1inworld_volumepos" x="22.141999999999999" y="-1.6000000000000001" z="152.80000000000001" unit="cm" />
+      <position name="cu_plate_top_right_1inworld_volumepos" x="-20.858000000000001" y="1.6000000000000001" z="152.80000000000001" unit="cm" />
+      <position name="cu_plate_bottom_right_1inworld_volumepos" x="-20.858000000000001" y="-1.6000000000000001" z="152.80000000000001" unit="cm" />
+      <position name="cu_plate_top_middle_1inworld_volumepos" x="-3.3579999999999997" y="3.1000000000000001" z="152.80000000000001" unit="cm" />
+      <position name="cu_plate_bottom_middle_1inworld_volumepos" x="-3.3579999999999997" y="-3.1000000000000001" z="152.80000000000001" unit="cm" />
+      <position name="hodo_flange_1intracking_volumepos" x="2.1170000000000004" y="0" z="134.30000000000001" unit="cm" />
+      <position name="arms1_block1_1intracking_volumepos" x="21.517000000000003" y="14.938225000000001" z="132.70000000000002" unit="cm" />
+      <position name="arms1_block2_1intracking_volumepos" x="9.5170000000000012" y="14.938225000000001" z="132.70000000000002" unit="cm" />
+      <position name="arms1_block3_1intracking_volumepos" x="21.517000000000003" y="-14.938225000000001" z="132.70000000000002" unit="cm" />
+      <position name="arms1_block4_1intracking_volumepos" x="9.5170000000000012" y="-14.938225000000001" z="132.70000000000002" unit="cm" />
+      <position name="cross_bar_top_1intracking_volumepos" x="15.517000000000003" y="16.34" z="132.70000000000002" unit="cm" />
+      <position name="cross_bar_bottom_1intracking_volumepos" x="15.517000000000003" y="-16.34" z="132.70000000000002" unit="cm" />
+      <position name="support_arm_bottom_left_plus_block_1intracking_volumepos" x="21.517000000000003" y="-12.771562277258594" z="121.10000000000001" unit="cm" />
+      <position name="support_arm_bottom_right_1intracking_volumepos" x="9.5170000000000012" y="-12.771562277258594" z="121.10000000000001" unit="cm" />
+      <position name="support_arm_top_left_1intracking_volumepos" x="21.517000000000003" y="12.771562277258594" z="121.10000000000001" unit="cm" />
+      <rotation name="support_arm_top_left_1intracking_volumerot" x="0" y="-0" z="180" unit="deg" />
+      <position name="support_arm_top_right_1intracking_volumepos" x="9.5170000000000012" y="12.771562277258594" z="121.10000000000001" unit="cm" />
+      <rotation name="support_arm_top_right_1intracking_volumerot" x="0" y="-0" z="180" unit="deg" />
+      <position name="u_support_bar_bottom_1intracking_volumepos" x="15.517000000000003" y="-9.8400000000000034" z="110.899" unit="cm" />
+      <position name="u_support_bar_upper1_1intracking_volumepos" x="15.517000000000003" y="-8.5400000000000027" z="110.65000000000001" unit="cm" />
+      <position name="u_support_bar_upper2_1intracking_volumepos" x="15.517000000000003" y="-8.5400000000000027" z="111.2" unit="cm" />
+      <position name="u_support_bar_top_1intracking_volumepos" x="15.517000000000003" y="9.8400000000000034" z="110.899" unit="cm" />
+      <position name="u_support_bar_upper3_1intracking_volumepos" x="15.517000000000003" y="8.5400000000000027" z="110.65000000000001" unit="cm" />
+      <position name="u_support_bar_upper4_1intracking_volumepos" x="15.517000000000003" y="8.5400000000000027" z="111.2" unit="cm" />
+      <constant name="svt_chamber_box_z" value="609.6" />
+      <constant name="svt_chamber_flare1_z" value="1285.621" />
+      <constant name="svt_chamber_flare2_z" value="1478.407" />
+      <constant name="svt_chamber_flange_z" value="1614.297" />
+      <constant name="svt_chamber_x" value="21.17" />
+      <constant name="svt_chamber_z" value="1318-1623.822" />
+    </define>
+    <materials>
+      <element Z="1" formula="H" name="H">
+        <atom type="A" unit="g/mol" value="1.00794" />
+      </element>
+      <element Z="82" formula="Pb" name="Pb">
+        <atom type="A" unit="g/mol" value="207.217" />
+      </element>
+      <element Z="74" formula="W" name="W">
+        <atom type="A" unit="g/mol" value="183.842" />
+      </element>
+      <element Z="8" formula="O" name="O">
+        <atom type="A" unit="g/mol" value="15.9994" />
+      </element>
+      <element Z="6" formula="C" name="C">
+        <atom type="A" unit="g/mol" value="12.0107" />
+      </element>
+      <element Z="22" formula="Ti" name="Ti">
+        <atom type="A" unit="g/mol" value="47.8667" />
+      </element>
+      <material name="Vacuum">
+        <D type="density" unit="g/cm3" value="0.00000001" />
+        <fraction n="1" ref="H" />
+      </material>
+      <material name="WorldMaterial">
+        <D type="density" unit="g/cm3" value="0.0000000000000001" />
+        <fraction n="1.0" ref="Vacuum" />
+      </material>
+      <material name="TrackingMaterial">
+        <D type="density" unit="g/cm3" value="0.0000000000000001" />
+        <fraction n="1.0" ref="Vacuum" />
+      </material>
+      <material name="LeadTungstate">
+        <D value="8.28" unit="g/cm3" type="density" />
+        <composite n="1" ref="Pb" />
+        <composite n="1" ref="W" />
+        <composite n="4" ref="O" />
+      </material>
+      <material name="EJ204_PlasticScintillator">
+        <D value="1.032" unit="g/cm3" type="density" />
+        <fraction n="0.523618" ref="H" />
+        <fraction n="0.476382" ref="C" />
+      </material>
+      <material name="TitaniumDioxide">
+        <D value="4.23" unit="g/cm3" type="density" />
+        <composite n="1" ref="Ti" />
+        <composite n="2" ref="O" />
+      </material>
+      <material name="Mylar">
+        <D value="1.4" unit="g/cm3" type="density" />
+        <fraction n="0.041958" ref="H" />
+        <fraction n="0.625017" ref="C" />
+        <fraction n="0.333025" ref="O" />
+      </material>
+      <material name="GenericFoam">
+        <D value="0.052" unit="g/cm3" type="density" />
+        <fraction n="0.5" ref="H" />
+        <fraction n="0.5" ref="C" />
+      </material>
+      <element name="Al" formula="Al" Z="13">
+        <atom type="A" unit="g/mol" value="26.9815" />
+      </element>
+      <material name="Aluminum">
+        <RL type="X0" unit="cm" value="8.89632" />
+        <NIL type="lambda" unit="cm" value="38.8766" />
+        <D type="density" unit="g/cm3" value="2.699" />
+        <composite n="1" ref="Al" />
+      </material>
+      <element name="Si" formula="Si" Z="14">
+        <atom type="A" unit="g/mol" value="28.0854" />
+      </element>
+      <material name="Silicon">
+        <RL type="X0" unit="cm" value="9.36607" />
+        <NIL type="lambda" unit="cm" value="45.7531" />
+        <D type="density" unit="g/cm3" value="2.33" />
+        <composite n="1" ref="Si" />
+      </material>
+      <element name="N" formula="N" Z="7">
+        <atom type="A" unit="g/mol" value="14.0068" />
+      </element>
+      <material name="Kapton">
+        <D value="1.43" unit="g/cm3" />
+        <composite n="22" ref="C" />
+        <composite n="10" ref="H" />
+        <composite n="2" ref="N" />
+        <composite n="5" ref="O" />
+      </material>
+      <material name="Epoxy">
+        <D type="density" value="1.3" unit="g/cm3" />
+        <composite n="44" ref="H" />
+        <composite n="15" ref="C" />
+        <composite n="7" ref="O" />
+      </material>
+      <material name="CarbonFiber">
+        <D type="density" value="1.5" unit="g/cm3" />
+        <fraction n="0.65" ref="C" />
+        <fraction n="0.35" ref="Epoxy" />
+      </material>
+      <element name="Cl" formula="Cl" Z="17">
+        <atom type="A" unit="g/mol" value="35.4526" />
+      </element>
+      <material name="Quartz">
+        <D type="density" value="2.2" unit="g/cm3" />
+        <composite n="1" ref="Si" />
+        <composite n="2" ref="O" />
+      </material>
+      <material name="G10">
+        <D type="density" value="1.7" unit="g/cm3" />
+        <fraction n="0.08" ref="Cl" />
+        <fraction n="0.773" ref="Quartz" />
+        <fraction n="0.147" ref="Epoxy" />
+      </material>
+      <material name="Polystyrene">
+        <D value="1.032" unit="g/cm3" />
+        <composite n="19" ref="C" />
+        <composite n="21" ref="H" />
+      </material>
+      <material name="Carbon">
+        <RL type="X0" unit="cm" value="21.3485" />
+        <NIL type="lambda" unit="cm" value="40.1008" />
+        <D type="density" unit="g/cm3" value="2" />
+        <composite n="1" ref="C" />
+      </material>
+      <material name="G4_Al" Z="13">
+        <D unit="g/cm3" value="2.6989999999999998" />
+        <atom unit="g/mole" value="26.981538" />
+      </material>
+      <material name="AlHoneycomb" Z="13">
+        <D unit="g/cm3" value="0.13" />
+        <atom unit="g/mole" value="26.981538" />
+      </material>
+      <element name="MANGANESE_elm" formula="MN" Z="25">
+        <atom unit="g/mole" value="54.938048999999999" />
+      </element>
+      <element name="SILICON_elm" formula="SI" Z="14">
+        <atom unit="g/mole" value="28.0855" />
+      </element>
+      <element name="CHROMIUM_elm" formula="CR" Z="24">
+        <atom unit="g/mole" value="51.996099999999998" />
+      </element>
+      <element name="NICKEL_elm" formula="NI" Z="28">
+        <atom unit="g/mole" value="58.693399999999997" />
+      </element>
+      <element name="IRON_elm" formula="FE" Z="26">
+        <atom unit="g/mole" value="55.844999999999999" />
+      </element>
+      <material name="StainlessSteel">
+        <D unit="g/cm3" value="8.0199999999999996" />
+        <fraction n="0.18999999761581421" ref="CHROMIUM_elm" />
+        <fraction n="0.68000000715255737" ref="IRON_elm" />
+        <fraction n="0.019999999552965164" ref="MANGANESE_elm" />
+        <fraction n="0.10000000149011612" ref="NICKEL_elm" />
+        <fraction n="0.0099999997764825821" ref="SILICON_elm" />
+      </material>
+      <material name="G4_Cu" Z="29">
+        <D unit="g/cm3" value="8.9600000000000009" />
+        <atom unit="g/mole" value="63.545645059999998" />
+      </material>
+      <element name="OXYGEN_elm" formula="O" Z="8">
+        <atom unit="g/mole" value="15.9994" />
+      </element>
+      <element name="CARBON_elm" formula="C" Z="6">
+        <atom unit="g/mole" value="12.0107" />
+      </element>
+      <element name="HYDROGEN_elm" formula="H" Z="1">
+        <atom unit="g/mole" value="1.0079400000000001" />
+      </element>
+      <material name="G10_FR4">
+        <D unit="g/cm3" value="1.8500000000000001" />
+        <fraction n="0.40416482090950012" ref="CARBON_elm" />
+        <fraction n="0.067835167050361633" ref="HYDROGEN_elm" />
+        <fraction n="0.28119435906410217" ref="OXYGEN_elm" />
+        <fraction n="0.24680563807487488" ref="SILICON_elm" />
+      </material>
+      <material name="SiO2">
+        <D unit="g/cm3" value="2.2000000000000002" />
+        <fraction n="0.53256505727767944" ref="OXYGEN_elm" />
+        <fraction n="0.46743491291999817" ref="SILICON_elm" />
+      </material>
+      <element Z="26" formula="Fe" name="Iron">
+        <atom value="55.845" />
+      </element>
+      <element Z="24" formula="Cr" name="Chromium">
+        <atom value="51.9961" />
+      </element>
+      <element Z="28" formula="Ni" name="Nickel">
+        <atom value="58.6934" />
+      </element>
+      <material formula=" " name="Stainless_304">
+        <D value="8.00" />
+        <fraction n="0.733078" ref="Iron" />
+        <fraction n="0.191516" ref="Chromium" />
+        <fraction n="0.075406" ref="Nickel" />
+      </material>
+      <material Z="1" name="G4_Galactic" state="gas">
+        <T unit="K" value="2.73" />
+        <P unit="pascal" value="3e-18" />
+        <!-- <MEE unit="eV" value="21.8"/> -->
+        <D unit="g/cm3" value="2e-25" />
+        <atom unit="g/mole" value="1.01" />
+      </material>
+    </materials>
+    <solids>
+      <box name="world_box" x="world_x" y="world_y" z="world_z" />
+      <tube name="tracking_cylinder" deltaphi="6.283185307179586" rmin="0.0" rmax="tracking_region_radius" z="2*tracking_region_zmax" />
+      <box name="baseBox" x="406.4" y="1282.6999999999998" z="171.196" />
+      <box name="base_plateBox" x="406.4" y="1282.6999999999998" z="6.35" />
+      <box name="support_plate_bottom_L14Box" x="234.95" y="456.4" z="9.524999999999999" />
+      <box name="support_plate_top_L14Box" x="234.95" y="456.4" z="9.524999999999999" />
+      <box name="support_plate_bottom_L46Box" x="342.9" y="533.4" z="12.7" />
+      <box name="support_plate_top_L46Box" x="342.9" y="533.4" z="12.7" />
+      <box name="module_L1b_halfmodule_axialBox" x="14.525" y="30.0" z="0.2" />
+      <box name="module_L1b_halfmodule_axial_sensorBox" x="14.525" y="30.0" z="0.2" />
+      <box name="module_L1b_halfmodule_axial_sensor_activeBox" x="14.025" y="30.0" z="0.2" />
+      <box name="module_L1b_halfmodule_stereoBox" x="14.525" y="30.0" z="0.2" />
+      <box name="module_L1b_halfmodule_stereo_sensorBox" x="14.525" y="30.0" z="0.2" />
+      <box name="module_L1b_halfmodule_stereo_sensor_activeBox" x="14.025" y="30.0" z="0.2" />
+      <box name="module_L1t_halfmodule_axialBox" x="14.525" y="30.0" z="0.2" />
+      <box name="module_L1t_halfmodule_axial_sensorBox" x="14.525" y="30.0" z="0.2" />
+      <box name="module_L1t_halfmodule_axial_sensor_activeBox" x="14.025" y="30.0" z="0.2" />
+      <box name="module_L1t_halfmodule_stereoBox" x="14.525" y="30.0" z="0.2" />
+      <box name="module_L1t_halfmodule_stereo_sensorBox" x="14.525" y="30.0" z="0.2" />
+      <box name="module_L1t_halfmodule_stereo_sensor_activeBox" x="14.025" y="30.0" z="0.2" />
+      <box name="module_L2b_halfmodule_axialBox" x="14.525" y="30.0" z="0.2" />
+      <box name="module_L2b_halfmodule_axial_sensorBox" x="14.525" y="30.0" z="0.2" />
+      <box name="module_L2b_halfmodule_axial_sensor_activeBox" x="14.025" y="30.0" z="0.2" />
+      <box name="module_L2b_halfmodule_stereoBox" x="14.525" y="30.0" z="0.2" />
+      <box name="module_L2b_halfmodule_stereo_sensorBox" x="14.525" y="30.0" z="0.2" />
+      <box name="module_L2b_halfmodule_stereo_sensor_activeBox" x="14.025" y="30.0" z="0.2" />
+      <box name="module_L2t_halfmodule_axialBox" x="14.525" y="30.0" z="0.2" />
+      <box name="module_L2t_halfmodule_axial_sensorBox" x="14.525" y="30.0" z="0.2" />
+      <box name="module_L2t_halfmodule_axial_sensor_activeBox" x="14.025" y="30.0" z="0.2" />
+      <box name="module_L2t_halfmodule_stereoBox" x="14.525" y="30.0" z="0.2" />
+      <box name="module_L2t_halfmodule_stereo_sensorBox" x="14.525" y="30.0" z="0.2" />
+      <box name="module_L2t_halfmodule_stereo_sensor_activeBox" x="14.025" y="30.0" z="0.2" />
+      <box name="module_L3b_halfmodule_axialBox" x="47.17" y="200.0" z="1.8405" />
+      <box name="module_L3b_halfmodule_axial_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L3b_halfmodule_axial_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L3b_halfmodule_axial_laminationBox" x="38.0" y="100.0" z="0.05" />
+      <box name="module_L3b_halfmodule_axial_cfBox" x="36.02" y="100.0" z="0.203" />
+      <box name="module_L3b_halfmodule_axial_hybridBox" x="40.34" y="70.0" z="1.5875" />
+      <box name="module_L3b_halfmodule_stereoBox" x="47.17" y="200.0" z="1.8405" />
+      <box name="module_L3b_halfmodule_stereo_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L3b_halfmodule_stereo_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L3b_halfmodule_stereo_laminationBox" x="38.0" y="100.0" z="0.05" />
+      <box name="module_L3b_halfmodule_stereo_cfBox" x="36.02" y="100.0" z="0.203" />
+      <box name="module_L3b_halfmodule_stereo_hybridBox" x="40.34" y="70.0" z="1.5875" />
+      <box name="module_L3t_halfmodule_axialBox" x="47.17" y="200.0" z="1.8405" />
+      <box name="module_L3t_halfmodule_axial_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L3t_halfmodule_axial_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L3t_halfmodule_axial_laminationBox" x="38.0" y="100.0" z="0.05" />
+      <box name="module_L3t_halfmodule_axial_cfBox" x="36.02" y="100.0" z="0.203" />
+      <box name="module_L3t_halfmodule_axial_hybridBox" x="40.34" y="70.0" z="1.5875" />
+      <box name="module_L3t_halfmodule_stereoBox" x="47.17" y="200.0" z="1.8405" />
+      <box name="module_L3t_halfmodule_stereo_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L3t_halfmodule_stereo_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L3t_halfmodule_stereo_laminationBox" x="38.0" y="100.0" z="0.05" />
+      <box name="module_L3t_halfmodule_stereo_cfBox" x="36.02" y="100.0" z="0.203" />
+      <box name="module_L3t_halfmodule_stereo_hybridBox" x="40.34" y="70.0" z="1.5875" />
+      <box name="module_L4b_halfmodule_axialBox" x="47.17" y="200.0" z="1.8405" />
+      <box name="module_L4b_halfmodule_axial_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L4b_halfmodule_axial_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L4b_halfmodule_axial_laminationBox" x="38.0" y="100.0" z="0.05" />
+      <box name="module_L4b_halfmodule_axial_cfBox" x="36.02" y="100.0" z="0.203" />
+      <box name="module_L4b_halfmodule_axial_hybridBox" x="40.34" y="70.0" z="1.5875" />
+      <box name="module_L4b_halfmodule_stereoBox" x="47.17" y="200.0" z="1.8405" />
+      <box name="module_L4b_halfmodule_stereo_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L4b_halfmodule_stereo_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L4b_halfmodule_stereo_laminationBox" x="38.0" y="100.0" z="0.05" />
+      <box name="module_L4b_halfmodule_stereo_cfBox" x="36.02" y="100.0" z="0.203" />
+      <box name="module_L4b_halfmodule_stereo_hybridBox" x="40.34" y="70.0" z="1.5875" />
+      <box name="module_L4t_halfmodule_axialBox" x="47.17" y="200.0" z="1.8405" />
+      <box name="module_L4t_halfmodule_axial_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L4t_halfmodule_axial_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L4t_halfmodule_axial_laminationBox" x="38.0" y="100.0" z="0.05" />
+      <box name="module_L4t_halfmodule_axial_cfBox" x="36.02" y="100.0" z="0.203" />
+      <box name="module_L4t_halfmodule_axial_hybridBox" x="40.34" y="70.0" z="1.5875" />
+      <box name="module_L4t_halfmodule_stereoBox" x="47.17" y="200.0" z="1.8405" />
+      <box name="module_L4t_halfmodule_stereo_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L4t_halfmodule_stereo_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L4t_halfmodule_stereo_laminationBox" x="38.0" y="100.0" z="0.05" />
+      <box name="module_L4t_halfmodule_stereo_cfBox" x="36.02" y="100.0" z="0.203" />
+      <box name="module_L4t_halfmodule_stereo_hybridBox" x="40.34" y="70.0" z="1.5875" />
+      <box name="module_L5b_halfmodule_axial_holeBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L5b_halfmodule_axial_hole_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L5b_halfmodule_axial_hole_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L5b_halfmodule_axial_hole_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L5b_halfmodule_axial_slotBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L5b_halfmodule_axial_slot_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L5b_halfmodule_axial_slot_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L5b_halfmodule_axial_slot_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L5b_halfmodule_stereo_holeBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L5b_halfmodule_stereo_hole_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L5b_halfmodule_stereo_hole_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L5b_halfmodule_stereo_hole_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L5b_halfmodule_stereo_slotBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L5b_halfmodule_stereo_slot_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L5b_halfmodule_stereo_slot_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L5b_halfmodule_stereo_slot_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L5t_halfmodule_axial_holeBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L5t_halfmodule_axial_hole_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L5t_halfmodule_axial_hole_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L5t_halfmodule_axial_hole_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L5t_halfmodule_axial_slotBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L5t_halfmodule_axial_slot_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L5t_halfmodule_axial_slot_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L5t_halfmodule_axial_slot_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L5t_halfmodule_stereo_holeBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L5t_halfmodule_stereo_hole_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L5t_halfmodule_stereo_hole_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L5t_halfmodule_stereo_hole_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L5t_halfmodule_stereo_slotBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L5t_halfmodule_stereo_slot_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L5t_halfmodule_stereo_slot_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L5t_halfmodule_stereo_slot_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L6b_halfmodule_axial_holeBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L6b_halfmodule_axial_hole_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L6b_halfmodule_axial_hole_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L6b_halfmodule_axial_hole_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L6b_halfmodule_axial_slotBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L6b_halfmodule_axial_slot_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L6b_halfmodule_axial_slot_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L6b_halfmodule_axial_slot_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L6b_halfmodule_stereo_holeBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L6b_halfmodule_stereo_hole_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L6b_halfmodule_stereo_hole_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L6b_halfmodule_stereo_hole_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L6b_halfmodule_stereo_slotBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L6b_halfmodule_stereo_slot_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L6b_halfmodule_stereo_slot_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L6b_halfmodule_stereo_slot_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L6t_halfmodule_axial_holeBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L6t_halfmodule_axial_hole_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L6t_halfmodule_axial_hole_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L6t_halfmodule_axial_hole_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L6t_halfmodule_axial_slotBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L6t_halfmodule_axial_slot_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L6t_halfmodule_axial_slot_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L6t_halfmodule_axial_slot_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L6t_halfmodule_stereo_holeBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L6t_halfmodule_stereo_hole_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L6t_halfmodule_stereo_hole_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L6t_halfmodule_stereo_hole_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L6t_halfmodule_stereo_slotBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L6t_halfmodule_stereo_slot_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L6t_halfmodule_stereo_slot_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L6t_halfmodule_stereo_slot_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L7b_halfmodule_axial_holeBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L7b_halfmodule_axial_hole_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L7b_halfmodule_axial_hole_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L7b_halfmodule_axial_hole_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L7b_halfmodule_axial_slotBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L7b_halfmodule_axial_slot_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L7b_halfmodule_axial_slot_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L7b_halfmodule_axial_slot_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L7b_halfmodule_stereo_holeBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L7b_halfmodule_stereo_hole_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L7b_halfmodule_stereo_hole_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L7b_halfmodule_stereo_hole_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L7b_halfmodule_stereo_slotBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L7b_halfmodule_stereo_slot_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L7b_halfmodule_stereo_slot_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L7b_halfmodule_stereo_slot_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L7t_halfmodule_axial_holeBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L7t_halfmodule_axial_hole_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L7t_halfmodule_axial_hole_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L7t_halfmodule_axial_hole_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L7t_halfmodule_axial_slotBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L7t_halfmodule_axial_slot_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L7t_halfmodule_axial_slot_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L7t_halfmodule_axial_slot_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L7t_halfmodule_stereo_holeBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L7t_halfmodule_stereo_hole_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L7t_halfmodule_stereo_hole_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L7t_halfmodule_stereo_hole_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L7t_halfmodule_stereo_slotBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L7t_halfmodule_stereo_slot_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L7t_halfmodule_stereo_slot_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L7t_halfmodule_stereo_slot_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="BeamLeftBox" x="211.6" y="382.492" z="0.001" />
+      <box name="BeamLeftVolume_component0Box" x="211.6" y="382.492" z="0.001" />
+      <box name="BeamLeftVolume_component0Sensor0Box" x="211.6" y="382.492" z="0.001" />
+      <box name="ElectronGapBox" x="196.26999999999998" y="92.46999999999997" z="0.001" />
+      <box name="ElectronGapVolume_component0Box" x="196.26999999999998" y="92.46999999999997" z="0.001" />
+      <box name="ElectronGapVolume_component0Sensor0Box" x="196.26999999999998" y="92.46999999999997" z="0.001" />
+      <box name="BeamRightBox" x="214.6" y="293.38800000000003" z="0.001" />
+      <box name="BeamRightVolume_component0Box" x="214.6" y="293.38800000000003" z="0.001" />
+      <box name="BeamRightVolume_component0Sensor0Box" x="214.6" y="293.38800000000003" z="0.001" />
+      <trd name="crystal_trap" x1="13.3" x2="16.0" y1="13.3" y2="16.0" z="160.0" />
+      <box name="hodo_pixel_L1TP0" x="15.7" y="59.9" z="9.5" />
+      <box name="hodo_cover_L1TP0" x="15.7" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L1TP0" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L1TP0" x="15.799999999999999" y="0.05" z="10.0" />
+      <box name="hodo_pixel_L1BP0" x="15.7" y="59.9" z="9.5" />
+      <box name="hodo_cover_L1BP0" x="15.7" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L1BP0" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L1BP0" x="15.799999999999999" y="0.05" z="10.0" />
+      <box name="hodo_pixel_L1TP1" x="34.1" y="59.9" z="9.5" />
+      <box name="hodo_cover_L1TP1" x="34.1" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L1TP1" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L1TP1" x="34.2" y="0.05" z="10.0" />
+      <box name="hodo_pixel_L1BP1" x="34.1" y="59.9" z="9.5" />
+      <box name="hodo_cover_L1BP1" x="34.1" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L1BP1" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L1BP1" x="34.2" y="0.05" z="10.0" />
+      <box name="hodo_pixel_L1TP2" x="44.0" y="59.9" z="9.5" />
+      <box name="hodo_cover_L1TP2" x="44.0" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L1TP2" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L1TP2" x="44.1" y="0.05" z="10.0" />
+      <box name="hodo_pixel_L1BP2" x="44.0" y="59.9" z="9.5" />
+      <box name="hodo_cover_L1BP2" x="44.0" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L1BP2" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L1BP2" x="44.1" y="0.05" z="10.0" />
+      <box name="hodo_pixel_L1TP3" x="44.0" y="59.9" z="9.5" />
+      <box name="hodo_cover_L1TP3" x="44.0" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L1TP3" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L1TP3" x="44.1" y="0.05" z="10.0" />
+      <box name="hodo_pixel_L1BP3" x="44.0" y="59.9" z="9.5" />
+      <box name="hodo_cover_L1BP3" x="44.0" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L1BP3" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L1BP3" x="44.1" y="0.05" z="10.0" />
+      <box name="hodo_pixel_L1TP4" x="44.0" y="59.9" z="9.5" />
+      <box name="hodo_cover_L1TP4" x="44.0" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L1TP4" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L1TP4" x="44.1" y="0.05" z="10.0" />
+      <box name="hodo_pixel_L1BP4" x="44.0" y="59.9" z="9.5" />
+      <box name="hodo_cover_L1BP4" x="44.0" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L1BP4" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L1BP4" x="44.1" y="0.05" z="10.0" />
+      <box name="hodo_pixel_L2TP0" x="19.0" y="59.9" z="9.5" />
+      <box name="hodo_cover_L2TP0" x="19.0" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L2TP0" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L2TP0" x="19.1" y="0.05" z="10.0" />
+      <box name="hodo_pixel_L2BP0" x="19.0" y="59.9" z="9.5" />
+      <box name="hodo_cover_L2BP0" x="19.0" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L2BP0" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L2BP0" x="19.1" y="0.05" z="10.0" />
+      <box name="hodo_pixel_L2TP1" x="44.0" y="59.9" z="9.5" />
+      <box name="hodo_cover_L2TP1" x="44.0" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L2TP1" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L2TP1" x="44.1" y="0.05" z="10.0" />
+      <box name="hodo_pixel_L2BP1" x="44.0" y="59.9" z="9.5" />
+      <box name="hodo_cover_L2BP1" x="44.0" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L2BP1" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L2BP1" x="44.1" y="0.05" z="10.0" />
+      <box name="hodo_pixel_L2TP2" x="44.0" y="59.9" z="9.5" />
+      <box name="hodo_cover_L2TP2" x="44.0" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L2TP2" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L2TP2" x="44.1" y="0.05" z="10.0" />
+      <box name="hodo_pixel_L2BP2" x="44.0" y="59.9" z="9.5" />
+      <box name="hodo_cover_L2BP2" x="44.0" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L2BP2" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L2BP2" x="44.1" y="0.05" z="10.0" />
+      <box name="hodo_pixel_L2TP3" x="44.0" y="59.9" z="9.5" />
+      <box name="hodo_cover_L2TP3" x="44.0" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L2TP3" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L2TP3" x="44.1" y="0.05" z="10.0" />
+      <box name="hodo_pixel_L2BP3" x="44.0" y="59.9" z="9.5" />
+      <box name="hodo_cover_L2BP3" x="44.0" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L2BP3" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L2BP3" x="44.1" y="0.05" z="10.0" />
+      <box name="hodo_pixel_L2TP4" x="30.8" y="59.9" z="9.5" />
+      <box name="hodo_cover_L2TP4" x="30.8" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L2TP4" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L2TP4" x="30.900000000000002" y="0.05" z="10.0" />
+      <box name="hodo_pixel_L2BP4" x="30.8" y="59.9" z="9.5" />
+      <box name="hodo_cover_L2BP4" x="30.8" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L2BP4" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L2BP4" x="30.900000000000002" y="0.05" z="10.0" />
+      <box name="hodo_buffer" x="187.64" y="80.0" z="2.0" />
+      <box name="world_volume_solid" x="2000" y="2000" z="2000" lunit="cm" />
+      <box name="front_flange_box_shape" x="76.835000000000008" y="45.719999999999999" z="2" lunit="cm" />
+      <trap name="front_chamber_trap_shape" z="3" theta="-0.98799999999999999" phi="0" x1="33.119799999999998" x2="33.119799999999998" x3="33.406400000000005" x4="33.406400000000005" y1="1.6000000000000001" y2="1.6000000000000001" alpha1="0" alpha2="0" aunit="deg" lunit="cm" />
+      <subtraction name="front_minus_chamber_shape">
+        <first ref="front_flange_box_shape" />
+        <second ref="front_chamber_trap_shape" />
+        <position name="front_minus_chamber_shapefront_chamber_trap_shapepos" x="-14.6309" y="0" z="0" unit="cm" />
+      </subtraction>
+      <eltube name="flange_photontube_inside_shape" dx="1.1000000000000001" dy="1.1000000000000001" dz="3" lunit="cm" />
+      <subtraction name="front_minus_photontube_shape">
+        <first ref="front_minus_chamber_shape" />
+        <second ref="flange_photontube_inside_shape" />
+        <position name="front_minus_photontube_shapeflange_photontube_inside_shapepos" x="2.0007000000000001" y="0" z="0" unit="cm" />
+        <rotation name="front_minus_photontube_shapeflange_photontube_inside_shaperot" x="0" y="1.7480000000000002" z="0" unit="deg" />
+      </subtraction>
+      <trap name="front_egap_trap_shape" z="3" theta="-4.7960000000000003" phi="0" x1="2.5683000000000002" x2="2.5683000000000002" x3="2.9716000000000005" x4="2.9716000000000005" y1="5.266" y2="5.266" alpha1="0" alpha2="0" aunit="deg" lunit="cm" />
+      <subtraction name="front_minus_egap_shape">
+        <first ref="front_minus_photontube_shape" />
+        <second ref="front_egap_trap_shape" />
+        <position name="front_minus_egap_shapefront_egap_trap_shapepos" x="-4.4683000000000002" y="0" z="0" unit="cm" />
+      </subtraction>
+      <eltube name="flange_egap_inside_tube_shape" dx="2.633" dy="2.633" dz="3" lunit="cm" />
+      <subtraction name="front_minus_egapleft_shape">
+        <first ref="front_minus_egap_shape" />
+        <second ref="flange_egap_inside_tube_shape" />
+        <position name="front_minus_egapleft_shapeflange_egap_inside_tube_shapepos" x="-3.0832999999999999" y="0" z="0" unit="cm" />
+        <rotation name="front_minus_egapleft_shapeflange_egap_inside_tube_shaperot" x="0" y="-0.95599999999999996" z="0" unit="deg" />
+      </subtraction>
+      <eltube name="flange_egap_inside_tube2_shape" dx="2.633" dy="2.633" dz="3" lunit="cm" />
+      <subtraction name="front_flange_shape">
+        <first ref="front_minus_egapleft_shape" />
+        <second ref="flange_egap_inside_tube2_shape" />
+        <position name="front_flange_shapeflange_egap_inside_tube2_shapepos" x="-5.8532000000000002" y="0" z="0" unit="cm" />
+        <rotation name="front_flange_shapeflange_egap_inside_tube2_shaperot" x="0" y="-8.5939999999999994" z="0" unit="deg" />
+      </subtraction>
+      <box name="back_flange_box_shape" x="50.5" y="16" z="2" lunit="cm" />
+      <trap name="back_chamber_trap_shape" z="3" theta="-0.98799999999999999" phi="0" x1="37.227899999999998" x2="37.227899999999998" x3="37.514499999999998" x4="37.514499999999998" y1="1.6000000000000001" y2="1.6000000000000001" alpha1="0" alpha2="0" aunit="deg" lunit="cm" />
+      <subtraction name="back_minus_chamber_shape">
+        <first ref="back_flange_box_shape" />
+        <second ref="back_chamber_trap_shape" />
+        <position name="back_minus_chamber_shapeback_chamber_trap_shapepos" x="-0.62210000000000043" y="0" z="0" unit="cm" />
+      </subtraction>
+      <eltube name="flange_photontube_inside2_shape" dx="1.1000000000000001" dy="1.1000000000000001" dz="3" lunit="cm" />
+      <subtraction name="back_minus_photontube_shape">
+        <first ref="back_minus_chamber_shape" />
+        <second ref="flange_photontube_inside2_shape" />
+        <position name="back_minus_photontube_shapeflange_photontube_inside2_shapepos" x="18.063500000000001" y="0" z="0" unit="cm" />
+        <rotation name="back_minus_photontube_shapeflange_photontube_inside2_shaperot" x="0" y="1.7480000000000002" z="0" unit="deg" />
+      </subtraction>
+      <trap name="back_egap_trap_shape" z="3" theta="-4.7960000000000003" phi="0" x1="8.3492999999999995" x2="8.3492999999999995" x3="8.7525999999999993" x4="8.7525999999999993" y1="5.266" y2="5.266" alpha1="0" alpha2="0" aunit="deg" lunit="cm" />
+      <subtraction name="back_minus_egap_shape">
+        <first ref="back_minus_photontube_shape" />
+        <second ref="back_egap_trap_shape" />
+        <position name="back_minus_egap_shapeback_egap_trap_shapepos" x="6.674199999999999" y="0" z="0" unit="cm" />
+      </subtraction>
+      <eltube name="flange_egap_inside_tube3_shape" dx="2.633" dy="2.633" dz="3" lunit="cm" />
+      <subtraction name="back_minus_egapleft_shape">
+        <first ref="back_minus_egap_shape" />
+        <second ref="flange_egap_inside_tube3_shape" />
+        <position name="back_minus_egapleft_shapeflange_egap_inside_tube3_shapepos" x="10.9497" y="0" z="0" unit="cm" />
+        <rotation name="back_minus_egapleft_shapeflange_egap_inside_tube3_shaperot" x="0" y="-0.95599999999999996" z="0" unit="deg" />
+      </subtraction>
+      <eltube name="flange_egap_inside_tube4_shape" dx="2.633" dy="2.633" dz="3" lunit="cm" />
+      <subtraction name="back_flange_shape">
+        <first ref="back_minus_egapleft_shape" />
+        <second ref="flange_egap_inside_tube4_shape" />
+        <position name="back_flange_shapeflange_egap_inside_tube4_shapepos" x="2.3986999999999994" y="0" z="0" unit="cm" />
+        <rotation name="back_flange_shapeflange_egap_inside_tube4_shaperot" x="0" y="-8.5939999999999994" z="0" unit="deg" />
+      </subtraction>
+      <trap name="chamber_trap_shape" z="45" theta="-1.8640000000000001" phi="0" x1="37.700000000000003" x2="37.700000000000003" x3="40.629000000000005" x4="40.629000000000005" y1="2.8000000000000003" y2="2.8000000000000003" alpha1="0" alpha2="0" aunit="deg" lunit="cm" />
+      <box name="chamber_cutaway_box_shape" x="50" y="1" z="30" lunit="cm" />
+      <subtraction name="chamber_trim1_shape">
+        <first ref="chamber_trap_shape" />
+        <second ref="chamber_cutaway_box_shape" />
+        <position name="chamber_trim1_shapechamber_cutaway_box_shapepos" x="0" y="1.6000000000000001" z="-9" unit="cm" />
+      </subtraction>
+      <box name="chamber_cutaway_box2_shape" x="50" y="1" z="30" lunit="cm" />
+      <subtraction name="chamber_trim2_shape">
+        <first ref="chamber_trim1_shape" />
+        <second ref="chamber_cutaway_box2_shape" />
+        <position name="chamber_trim2_shapechamber_cutaway_box2_shapepos" x="0" y="-1.6000000000000001" z="-9" unit="cm" />
+      </subtraction>
+      <eltube name="photontube_outside_shape" dx="1.3" dy="1.3" dz="23.5" lunit="cm" />
+      <union name="chamber_with_photontube_shape">
+        <first ref="chamber_trim2_shape" />
+        <second ref="photontube_outside_shape" />
+        <position name="chamber_with_photontube_shapephotontube_outside_shapepos" x="16.739699999999999" y="0" z="0" unit="cm" />
+        <rotation name="chamber_with_photontube_shapephotontube_outside_shaperot" x="0" y="1.7480000000000002" z="0" unit="deg" />
+      </union>
+      <trap name="egap_outside_trap_upper_shape" z="45" theta="-4.7960000000000003" phi="0" x1="10.691200000000002" x2="5.2344000000000008" x3="16.741099999999999" x4="11.284300000000002" y1="3.2330000000000001" y2="3.2330000000000001" alpha1="0.26900000000000002" alpha2="0.26900000000000002" aunit="deg" lunit="cm" />
+      <union name="chamber_with_egap_upper_shape">
+        <first ref="chamber_with_photontube_shape" />
+        <second ref="egap_outside_trap_upper_shape" />
+        <position name="chamber_with_egap_upper_shapeegap_outside_trap_upper_shapepos" x="7.7018000000000004" y="1.6165" z="0" unit="cm" />
+      </union>
+      <trap name="egap_outside_trap_lower_shape" z="45" theta="-4.7960000000000003" phi="0" x1="5.2344000000000008" x2="10.691200000000002" x3="11.284300000000002" x4="16.741099999999999" y1="3.2330000000000001" y2="3.2330000000000001" alpha1="-0.26900000000000002" alpha2="-0.26900000000000002" aunit="deg" lunit="cm" />
+      <union name="chamber_with_egap_lower_shape">
+        <first ref="chamber_with_egap_upper_shape" />
+        <second ref="egap_outside_trap_lower_shape" />
+        <position name="chamber_with_egap_lower_shapeegap_outside_trap_lower_shapepos" x="7.7018000000000004" y="-1.6165" z="0" unit="cm" />
+      </union>
+      <box name="chamber_cutaway_box3_shape" x="50" y="1" z="30" lunit="cm" />
+      <subtraction name="chamber_with_egap_trimtop_shape">
+        <first ref="chamber_with_egap_lower_shape" />
+        <second ref="chamber_cutaway_box3_shape" />
+        <position name="chamber_with_egap_trimtop_shapechamber_cutaway_box3_shapepos" x="0" y="3.4329999999999998" z="-9" unit="cm" />
+      </subtraction>
+      <box name="chamber_cutaway_box4_shape" x="50" y="1" z="30" lunit="cm" />
+      <subtraction name="chamber_with_egap_trimbot_shape">
+        <first ref="chamber_with_egap_trimtop_shape" />
+        <second ref="chamber_cutaway_box4_shape" />
+        <position name="chamber_with_egap_trimbot_shapechamber_cutaway_box4_shapepos" x="0" y="-3.4329999999999998" z="-9" unit="cm" />
+      </subtraction>
+      <box name="back_end_box_shape" x="76.835000000000008" y="45.719999999999999" z="5" lunit="cm" />
+      <subtraction name="chamber_outside_trim1_shape">
+        <first ref="chamber_with_egap_trimbot_shape" />
+        <second ref="back_end_box_shape" />
+        <position name="chamber_outside_trim1_shapeback_end_box_shapepos" x="0" y="0" z="-23" unit="cm" />
+      </subtraction>
+      <box name="back_end_box2_shape" x="76.835000000000008" y="45.719999999999999" z="5" lunit="cm" />
+      <subtraction name="chamber_outside_trim2_shape">
+        <first ref="chamber_outside_trim1_shape" />
+        <second ref="back_end_box2_shape" />
+        <position name="chamber_outside_trim2_shapeback_end_box2_shapepos" x="0" y="0" z="23" unit="cm" />
+      </subtraction>
+      <eltube name="photontube_inside_shape" dx="1.1000000000000001" dy="1.1000000000000001" dz="23.5" lunit="cm" />
+      <subtraction name="chamber_minus_photontube_shape">
+        <first ref="chamber_outside_trim2_shape" />
+        <second ref="photontube_inside_shape" />
+        <position name="chamber_minus_photontube_shapephotontube_inside_shapepos" x="16.739699999999999" y="0" z="0" unit="cm" />
+        <rotation name="chamber_minus_photontube_shapephotontube_inside_shaperot" x="0" y="1.7480000000000002" z="0" unit="deg" />
+      </subtraction>
+      <trap name="chamber_inside_trap_shape" z="45.000100000000003" theta="-0.98799999999999999" phi="0" x1="33.1676" x2="33.1676" x3="37.466699999999996" x4="37.466699999999996" y1="1.6000000000000001" y2="1.6000000000000001" alpha1="0" alpha2="0" aunit="deg" lunit="cm" />
+      <subtraction name="chamber_minus_inside_shape">
+        <first ref="chamber_minus_photontube_shape" />
+        <second ref="chamber_inside_trap_shape" />
+        <position name="chamber_minus_inside_shapechamber_inside_trap_shapepos" x="-0.91889999999999938" y="0" z="0" unit="cm" />
+      </subtraction>
+      <trap name="egap_inside_trap_shape" z="45.000100000000003" theta="-4.7960000000000003" phi="0" x1="2.6355000000000004" x2="2.6355000000000004" x3="8.6853999999999996" x4="8.6853999999999996" y1="5.266" y2="5.266" alpha1="0" alpha2="0" aunit="deg" lunit="cm" />
+      <subtraction name="chamber_minus_egapinside_shape">
+        <first ref="chamber_minus_inside_shape" />
+        <second ref="egap_inside_trap_shape" />
+        <position name="chamber_minus_egapinside_shapeegap_inside_trap_shapepos" x="7.8105000000000011" y="0" z="0" unit="cm" />
+      </subtraction>
+      <eltube name="egap_inside_tube_shape" dx="2.633" dy="2.633" dz="24" lunit="cm" />
+      <subtraction name="chamber_minus_egap_left_shape">
+        <first ref="chamber_minus_egapinside_shape" />
+        <second ref="egap_inside_tube_shape" />
+        <position name="chamber_minus_egap_left_shapeegap_inside_tube_shapepos" x="10.640750000000001" y="0" z="0" unit="cm" />
+        <rotation name="chamber_minus_egap_left_shapeegap_inside_tube_shaperot" x="0" y="-0.95599999999999996" z="0" unit="deg" />
+      </subtraction>
+      <tube name="egap_inside_tube2_shape" rmin="0" rmax="2.633" z="48" startphi="0" deltaphi="360" aunit="deg" lunit="cm" />
+      <subtraction name="ECAL_chamber_shape">
+        <first ref="chamber_minus_egap_left_shape" />
+        <second ref="egap_inside_tube2_shape" />
+        <position name="ECAL_chamber_shapeegap_inside_tube2_shapepos" x="4.9802999999999997" y="0" z="0" unit="cm" />
+        <rotation name="ECAL_chamber_shapeegap_inside_tube2_shaperot" x="0" y="-8.5939999999999994" z="0" unit="deg" />
+      </subtraction>
+      <box name="al_honeycomb_shape" x="6" y="1.6000000000000001" z="6" lunit="cm" />
+      <box name="ecal_box_outer1_shape" x="80" y="1.3999999999999999" z="20.100000000000001" lunit="cm" />
+      <box name="ecal_box_inner1_shape" x="78" y="2" z="21" lunit="cm" />
+      <subtraction name="ecal_box_minus_inner1_shape">
+        <first ref="ecal_box_outer1_shape" />
+        <second ref="ecal_box_inner1_shape" />
+        <position name="ecal_box_minus_inner1_shapeecal_box_inner1_shapepos" x="0" y="0.16" z="1.8500000000000001" unit="cm" />
+      </subtraction>
+      <box name="ecal_box_inner2_shape" x="68" y="1.2" z="7.4199999999999999" lunit="cm" />
+      <subtraction name="ecal_box_minus_inner2_shape">
+        <first ref="ecal_box_minus_inner1_shape" />
+        <second ref="ecal_box_inner2_shape" />
+        <position name="ecal_box_minus_inner2_shapeecal_box_inner2_shapepos" x="0" y="0.16" z="-10.050000000000001" unit="cm" />
+      </subtraction>
+      <para name="ppd_0_shape" x="0.59999999999999998" y="1.3999999999999999" z="1.5" alpha="0" theta="0" phi="0" aunit="deg" lunit="cm" />
+      <union name="box_with_ppd_shape">
+        <first ref="ecal_box_minus_inner2_shape" />
+        <second ref="ppd_0_shape" />
+        <position name="box_with_ppd_shapeppd_0_shapepos" x="0" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <para name="ppd_1_shape" x="0.59999999999999998" y="1.3999999999999999" z="1.5" alpha="0" theta="-3.8700000000000001" phi="0" aunit="deg" lunit="cm" />
+      <union name="box_with_ppd1_shape">
+        <first ref="box_with_ppd_shape" />
+        <second ref="ppd_1_shape" />
+        <position name="box_with_ppd1_shapeppd_1_shapepos" x="-5.2400000000000002" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <para name="ppd_2_shape" x="0.59999999999999998" y="1.3999999999999999" z="1.5" alpha="0" theta="-7.7400000000000002" phi="0" aunit="deg" lunit="cm" />
+      <union name="box_with_ppd2_shape">
+        <first ref="box_with_ppd1_shape" />
+        <second ref="ppd_2_shape" />
+        <position name="box_with_ppd2_shapeppd_2_shapepos" x="-10.5" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <para name="ppd_3_shape" x="0.59999999999999998" y="1.3999999999999999" z="1.5" alpha="0" theta="-11.619999999999999" phi="0" aunit="deg" lunit="cm" />
+      <union name="box_with_ppd3_shape">
+        <first ref="box_with_ppd2_shape" />
+        <second ref="ppd_3_shape" />
+        <position name="box_with_ppd3_shapeppd_3_shapepos" x="-15.800000000000001" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <para name="ppd_4_shape" x="0.59999999999999998" y="1.3999999999999999" z="1.5" alpha="0" theta="-15.49" phi="0" aunit="deg" lunit="cm" />
+      <union name="box_with_ppd4_shape">
+        <first ref="box_with_ppd3_shape" />
+        <second ref="ppd_4_shape" />
+        <position name="box_with_ppd4_shapeppd_4_shapepos" x="-21.170000000000002" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <para name="ppd_5_shape" x="0.59999999999999998" y="1.3999999999999999" z="1.5" alpha="0" theta="-19.359999999999999" phi="0" aunit="deg" lunit="cm" />
+      <union name="box_with_ppd5_shape">
+        <first ref="box_with_ppd4_shape" />
+        <second ref="ppd_5_shape" />
+        <position name="box_with_ppd5_shapeppd_5_shapepos" x="-26.640000000000001" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <para name="ppd_6_shape" x="0.59999999999999998" y="1.3999999999999999" z="1.5" alpha="0" theta="3.8700000000000001" phi="0" aunit="deg" lunit="cm" />
+      <union name="box_with_ppd6_shape">
+        <first ref="box_with_ppd5_shape" />
+        <second ref="ppd_6_shape" />
+        <position name="box_with_ppd6_shapeppd_6_shapepos" x="5.2400000000000002" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <para name="ppd_7_shape" x="0.59999999999999998" y="1.3999999999999999" z="1.5" alpha="0" theta="7.7400000000000002" phi="0" aunit="deg" lunit="cm" />
+      <union name="box_with_ppd7_shape">
+        <first ref="box_with_ppd6_shape" />
+        <second ref="ppd_7_shape" />
+        <position name="box_with_ppd7_shapeppd_7_shapepos" x="10.5" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <para name="ppd_8_shape" x="0.59999999999999998" y="1.3999999999999999" z="1.5" alpha="0" theta="11.619999999999999" phi="0" aunit="deg" lunit="cm" />
+      <union name="box_with_ppd8_shape">
+        <first ref="box_with_ppd7_shape" />
+        <second ref="ppd_8_shape" />
+        <position name="box_with_ppd8_shapeppd_8_shapepos" x="15.800000000000001" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <para name="ppd_9_shape" x="0.59999999999999998" y="1.3999999999999999" z="1.5" alpha="0" theta="15.49" phi="0" aunit="deg" lunit="cm" />
+      <union name="box_with_ppd9_shape">
+        <first ref="box_with_ppd8_shape" />
+        <second ref="ppd_9_shape" />
+        <position name="box_with_ppd9_shapeppd_9_shapepos" x="21.170000000000002" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <para name="ppd_10_shape" x="0.59999999999999998" y="1.3999999999999999" z="1.5" alpha="0" theta="19.359999999999999" phi="0" aunit="deg" lunit="cm" />
+      <union name="layer_1_top_shape">
+        <first ref="box_with_ppd9_shape" />
+        <second ref="ppd_10_shape" />
+        <position name="layer_1_top_shapeppd_10_shapepos" x="26.640000000000001" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <union name="layer_2_top_shape">
+        <first ref="box_with_ppd9_shape" />
+        <second ref="ppd_10_shape" />
+        <position name="layer_2_top_shapeppd_10_shapepos" x="26.640000000000001" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <union name="layer_3_top_shape">
+        <first ref="box_with_ppd9_shape" />
+        <second ref="ppd_10_shape" />
+        <position name="layer_3_top_shapeppd_10_shapepos" x="26.640000000000001" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <union name="layer_4_top_shape">
+        <first ref="box_with_ppd9_shape" />
+        <second ref="ppd_10_shape" />
+        <position name="layer_4_top_shapeppd_10_shapepos" x="26.640000000000001" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <union name="layer_1_bottom_shape">
+        <first ref="box_with_ppd9_shape" />
+        <second ref="ppd_10_shape" />
+        <position name="layer_1_bottom_shapeppd_10_shapepos" x="26.640000000000001" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <union name="layer_2_bottom_shape">
+        <first ref="box_with_ppd9_shape" />
+        <second ref="ppd_10_shape" />
+        <position name="layer_2_bottom_shapeppd_10_shapepos" x="26.640000000000001" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <union name="layer_3_bottom_shape">
+        <first ref="box_with_ppd9_shape" />
+        <second ref="ppd_10_shape" />
+        <position name="layer_3_bottom_shapeppd_10_shapepos" x="26.640000000000001" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <union name="layer_4_bottom_shape">
+        <first ref="box_with_ppd9_shape" />
+        <second ref="ppd_10_shape" />
+        <position name="layer_4_bottom_shapeppd_10_shapepos" x="26.640000000000001" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <para name="ppd_left2_shape" x="0.40000000000000002" y="1.3999999999999999" z="20.100000000000001" alpha="0" theta="0.96999999999999997" phi="0" aunit="deg" lunit="cm" />
+      <union name="layer_5a1_1_shape">
+        <first ref="ecal_box_minus_inner2_shape" />
+        <second ref="ppd_left2_shape" />
+        <position name="layer_5a1_1_shapeppd_left2_shapepos" x="-1.903" y="0" z="0" unit="cm" />
+      </union>
+      <para name="ppd_left1_shape" x="0.502" y="1.3999999999999999" z="1.5" alpha="0" theta="0.96999999999999997" phi="0" aunit="deg" lunit="cm" />
+      <union name="layer_5a1_shape">
+        <first ref="layer_5a1_1_shape" />
+        <second ref="ppd_left1_shape" />
+        <position name="layer_5a1_shapeppd_left1_shapepos" x="-1.6499999999999999" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <trd name="electron_hole_left_shape" x1="38.177" x2="38.856999999999999" y1="4" y2="4" z="20.199999999999999" lunit="cm" />
+      <subtraction name="layer_5a2_shape">
+        <first ref="layer_5a1_shape" />
+        <second ref="electron_hole_left_shape" />
+        <position name="layer_5a2_shapeelectron_hole_left_shapepos" x="-21.361499999999999" y="0" z="0" unit="cm" />
+      </subtraction>
+      <union name="layer_5a3_shape">
+        <first ref="layer_5a2_shape" />
+        <second ref="ppd_6_shape" />
+        <position name="layer_5a3_shapeppd_6_shapepos" x="5.2400000000000002" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <union name="layer_5a4_shape">
+        <first ref="layer_5a3_shape" />
+        <second ref="ppd_7_shape" />
+        <position name="layer_5a4_shapeppd_7_shapepos" x="10.5" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <union name="layer_5a5_shape">
+        <first ref="layer_5a4_shape" />
+        <second ref="ppd_8_shape" />
+        <position name="layer_5a5_shapeppd_8_shapepos" x="15.800000000000001" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <union name="layer_5a6_shape">
+        <first ref="layer_5a5_shape" />
+        <second ref="ppd_9_shape" />
+        <position name="layer_5a6_shapeppd_9_shapepos" x="21.170000000000002" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <union name="layer_5a7_shape">
+        <first ref="layer_5a6_shape" />
+        <second ref="ppd_10_shape" />
+        <position name="layer_5a7_shapeppd_10_shapepos" x="26.640000000000001" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <union name="layer_5T_left_shape">
+        <first ref="layer_5a7_shape" />
+        <second ref="ppd_0_shape" />
+        <position name="layer_5T_left_shapeppd_0_shapepos" x="0" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <union name="layer_5B_left_shape">
+        <first ref="layer_5a7_shape" />
+        <second ref="ppd_0_shape" />
+        <position name="layer_5B_left_shapeppd_0_shapepos" x="0" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <box name="steel_bar_shape" x="3" y="1.5" z="20" lunit="cm" />
+      <tube name="cu_Tpipe_inner_left_shape" rmin="0.29999999999999999" rmax="0.40000000000000002" z="20.100000000000001" startphi="0" deltaphi="360" aunit="deg" lunit="cm" />
+      <tube name="cu_Tpipe_inner_right_shape" rmin="0.29999999999999999" rmax="0.40000000000000002" z="20.100000000000001" startphi="0" deltaphi="360" aunit="deg" lunit="cm" />
+      <tube name="cu_Bpipe_inner_left_shape" rmin="0.29999999999999999" rmax="0.40000000000000002" z="20.100000000000001" startphi="0" deltaphi="360" aunit="deg" lunit="cm" />
+      <tube name="cu_Bpipe_inner_right_shape" rmin="0.29999999999999999" rmax="0.40000000000000002" z="20.100000000000001" startphi="0" deltaphi="360" aunit="deg" lunit="cm" />
+      <eltube name="cu_Tpipe_outer_right1_shape" dx="0.5" dy="0.10000000000000001" dz="10" lunit="cm" />
+      <eltube name="cu_Tpipe_outer_right2_shape" dx="0.5" dy="0.10000000000000001" dz="10" lunit="cm" />
+      <tube name="cu_Tpipe_outer_right3_shape" rmin="0.29999999999999999" rmax="0.40000000000000002" z="8" startphi="0" deltaphi="360" aunit="deg" lunit="cm" />
+      <tube name="cu_Bpipe_outer_right_shape" rmin="0.29999999999999999" rmax="0.40000000000000002" z="8" startphi="0" deltaphi="360" aunit="deg" lunit="cm" />
+      <eltube name="cu_Bpipe_outer_right1_shape" dx="0.5" dy="0.10000000000000001" dz="10" lunit="cm" />
+      <eltube name="cu_Bpipe_outer_right2_shape" dx="0.5" dy="0.10000000000000001" dz="10" lunit="cm" />
+      <tube name="al_pipe_across_top1_shape" rmin="0.29999999999999999" rmax="0.40000000000000002" z="66" startphi="0" deltaphi="360" aunit="deg" lunit="cm" />
+      <tube name="al_pipe_across_top2_shape" rmin="0.29999999999999999" rmax="0.40000000000000002" z="74" startphi="0" deltaphi="360" aunit="deg" lunit="cm" />
+      <tube name="al_pipe_across_bottom1_shape" rmin="0.29999999999999999" rmax="0.40000000000000002" z="70" startphi="0" deltaphi="360" aunit="deg" lunit="cm" />
+      <tube name="al_pipe_across_bottom2_shape" rmin="0.29999999999999999" rmax="0.40000000000000002" z="78" startphi="0" deltaphi="360" aunit="deg" lunit="cm" />
+      <para name="cu_plate_top_left_shape" x="40" y="0.10000000000000001" z="20" alpha="0" theta="0.96999999999999997" phi="0" aunit="deg" lunit="cm" />
+      <para name="cu_plate_bottom_left_shape" x="40" y="0.10000000000000001" z="20" alpha="0" theta="0.96999999999999997" phi="0" aunit="deg" lunit="cm" />
+      <para name="cu_plate_top_right_shape" x="22" y="0.10000000000000001" z="20" alpha="0" theta="9.6799999999999997" phi="180" aunit="deg" lunit="cm" />
+      <para name="cu_plate_bottom_right_shape" x="22" y="0.10000000000000001" z="20" alpha="0" theta="-9.6799999999999997" phi="0" aunit="deg" lunit="cm" />
+      <trd name="cu_plate_top_middle_shape" x1="7" x2="9.8000000000000007" y1="0.10000000000000001" y2="0.10000000000000001" z="20" lunit="cm" />
+      <trd name="cu_plate_bottom_middle_shape" x1="7" x2="9.8000000000000007" y1="0.10000000000000001" y2="0.10000000000000001" z="20" lunit="cm" />
+      <box name="tracking_volume_solid" x="2000" y="2000" z="2000" lunit="cm" />
+      <box name="hodo_flange_outer_shape" x="76.835000000000008" y="45.719999999999999" z="5" lunit="cm" />
+      <box name="hodo_flange_inner_shape" x="65.035000000000011" y="33.480000000000004" z="5.0010000000000003" lunit="cm" />
+      <subtraction name="hodo_flange_only_shape">
+        <first ref="hodo_flange_outer_shape" />
+        <second ref="hodo_flange_inner_shape" />
+      </subtraction>
+      <box name="Flange_extrusion_1_shape" x="2.5" y="3.5" z="1.5" lunit="cm" />
+      <union name="hodo_flange_ex1_shape">
+        <first ref="hodo_flange_only_shape" />
+        <second ref="Flange_extrusion_1_shape" />
+        <position name="hodo_flange_ex1_shapeFlange_extrusion_1_shapepos" x="19.400000000000002" y="14.990000000000002" z="-0.10000000000000001" unit="cm" />
+      </union>
+      <box name="Flange_extrusion_2_shape" x="2.5" y="3.5" z="1.5" lunit="cm" />
+      <union name="hodo_flange_ex2_shape">
+        <first ref="hodo_flange_ex1_shape" />
+        <second ref="Flange_extrusion_2_shape" />
+        <position name="hodo_flange_ex2_shapeFlange_extrusion_2_shapepos" x="19.400000000000002" y="-14.990000000000002" z="-0.10000000000000001" unit="cm" />
+      </union>
+      <box name="Flange_extrusion_3_shape" x="2.5" y="3.5" z="1.5" lunit="cm" />
+      <union name="hodo_flange_ex3_shape">
+        <first ref="hodo_flange_ex2_shape" />
+        <second ref="Flange_extrusion_3_shape" />
+        <position name="hodo_flange_ex3_shapeFlange_extrusion_3_shapepos" x="7.4000000000000004" y="14.990000000000002" z="-0.10000000000000001" unit="cm" />
+      </union>
+      <box name="Flange_extrusion_4_shape" x="2.5" y="3.5" z="1.5" lunit="cm" />
+      <union name="hodo_flange_shape">
+        <first ref="hodo_flange_ex3_shape" />
+        <second ref="Flange_extrusion_4_shape" />
+        <position name="hodo_flange_shapeFlange_extrusion_4_shapepos" x="7.4000000000000004" y="-14.990000000000002" z="-0.10000000000000001" unit="cm" />
+      </union>
+      <trap name="arms1_block1_shape" z="1.5" theta="3.9490533936242498" phi="90" x1="2.5" x2="2.5" x3="2.5" x4="2.5" y1="3.7071000000000001" y2="3.5" alpha1="0" alpha2="0" aunit="deg" lunit="cm" />
+      <trap name="arms1_block2_shape" z="1.5" theta="3.9490533936242498" phi="90" x1="2.5" x2="2.5" x3="2.5" x4="2.5" y1="3.7071000000000001" y2="3.5" alpha1="0" alpha2="0" aunit="deg" lunit="cm" />
+      <trap name="arms1_block3_shape" z="1.5" theta="-3.9490533936242498" phi="90" x1="2.5" x2="2.5" x3="2.5" x4="2.5" y1="3.7071000000000001" y2="3.5" alpha1="0" alpha2="0" aunit="deg" lunit="cm" />
+      <trap name="arms1_block4_shape" z="1.5" theta="-3.9490533936242498" phi="90" x1="2.5" x2="2.5" x3="2.5" x4="2.5" y1="3.7071000000000001" y2="3.5" alpha1="0" alpha2="0" aunit="deg" lunit="cm" />
+      <box name="cross_bar_top_shape" x="9.5" y="0.80000000000000004" z="1.5" lunit="cm" />
+      <box name="cross_bar_bottom_shape" x="9.5" y="0.80000000000000004" z="1.5" lunit="cm" />
+      <trap name="support_arm_bottom_left_arm_shape" z="21.700000000000003" theta="-9.8039344658558196" phi="90" x1="0.60000000000000009" x2="0.60000000000000009" x3="0.60000000000000009" x4="0.60000000000000009" y1="2.2938300486668619" y2="3.2271000000000001" alpha1="0" alpha2="0" aunit="deg" lunit="cm" />
+      <box name="support_arm_bottom_left_notch_shape" x="2" y="1.7800000000000002" z="1.401" lunit="cm" />
+      <box name="end_block_bottom_left_block_shape" x="2" y="0.78000000000000003" z="1.4000000000000001" lunit="cm" />
+      <box name="end_block_bottom_left_subs_shape" x="2.0010000000000003" y="1" z="1.401" lunit="cm" />
+      <subtraction name="support_arm_bottom_left_with_notch_shape">
+        <first ref="support_arm_bottom_left_arm_shape" />
+        <second ref="support_arm_bottom_left_notch_shape" />
+        <position name="support_arm_bottom_left_with_notch_shapesupport_arm_bottom_left_notch_shapepos" x="0" y="2.9215622772585932" z="-10.151000000000002" unit="cm" />
+      </subtraction>
+      <subtraction name="end_block_bottom_left_shape">
+        <first ref="end_block_bottom_left_block_shape" />
+        <second ref="end_block_bottom_left_subs_shape" />
+        <position name="end_block_bottom_left_shapeend_block_bottom_left_subs_shapepos" x="0" y="0.60999999999999999" z="-0.30099999999999999" unit="cm" />
+      </subtraction>
+      <union name="support_arm_bottom_left_plus_block_shape">
+        <first ref="support_arm_bottom_left_with_notch_shape" />
+        <second ref="end_block_bottom_left_shape" />
+        <position name="support_arm_bottom_left_plus_block_shapeend_block_bottom_left_shapepos" x="0" y="2.4215622772585932" z="-10.15" unit="cm" />
+      </union>
+      <union name="support_arm_bottom_right_shape">
+        <first ref="support_arm_bottom_left_with_notch_shape" />
+        <second ref="end_block_bottom_left_shape" />
+        <position name="support_arm_bottom_right_shapeend_block_bottom_left_shapepos" x="0" y="2.4215622772585932" z="-10.15" unit="cm" />
+      </union>
+      <union name="support_arm_top_left_shape">
+        <first ref="support_arm_bottom_left_with_notch_shape" />
+        <second ref="end_block_bottom_left_shape" />
+        <position name="support_arm_top_left_shapeend_block_bottom_left_shapepos" x="0" y="2.4215622772585932" z="-10.15" unit="cm" />
+      </union>
+      <union name="support_arm_top_right_shape">
+        <first ref="support_arm_bottom_left_with_notch_shape" />
+        <second ref="end_block_bottom_left_shape" />
+        <position name="support_arm_top_right_shapeend_block_bottom_left_shapepos" x="0" y="2.4215622772585932" z="-10.15" unit="cm" />
+      </union>
+      <box name="u_support_bar_bottom_shape" x="16" y="0.80000000000000004" z="0.90000000000000002" lunit="cm" />
+      <box name="u_support_bar_upper1_shape" x="16" y="1.8" z="0.40000000000000002" lunit="cm" />
+      <box name="u_support_bar_upper2_shape" x="16" y="1.8" z="0.30000000000000004" lunit="cm" />
+      <box name="u_support_bar_top_shape" x="16" y="0.80000000000000004" z="0.90000000000000002" lunit="cm" />
+      <box name="u_support_bar_upper3_shape" x="16" y="1.8" z="0.40000000000000002" lunit="cm" />
+      <box name="u_support_bar_upper4_shape" x="16" y="1.8" z="0.30000000000000004" lunit="cm" />
+      <box lunit="mm" name="svt_chamber_outer_box" x="454.152" y="203.2" z="1219.2" />
+      <box lunit="mm" name="svt_chamber_inner_box" x="416.052" y="177.8" z="1221.2" />
+      <subtraction name="svt_chamber_box">
+        <first ref="svt_chamber_outer_box" />
+        <second ref="svt_chamber_inner_box" />
+      </subtraction>
+      <trd lunit="mm" name="svt_chamber_outer_flare1" x1="454.152" x2="454.152" y1="203.2" y2="254.832" z="132.842" />
+      <trd lunit="mm" name="svt_chamber_inner_flare1" x1="416.052" x2="416.052" y1="172.864" y2="234.368" z="158.242" />
+      <subtraction name="svt_chamber_flare1">
+        <first ref="svt_chamber_outer_flare1" />
+        <second ref="svt_chamber_inner_flare1" />
+      </subtraction>
+      <trd lunit="mm" name="svt_chamber_outer_flare2" x1="454.152" x2="679.704" y1="254.832" y2="353.06" z="252.73" />
+      <trd lunit="mm" name="svt_chamber_inner_flare2" x1="404.718" x2="652.938" y1="224.496" y2="332.596" z="278.13" />
+      <subtraction name="svt_chamber_flare2">
+        <first ref="svt_chamber_outer_flare2" />
+        <second ref="svt_chamber_inner_flare2" />
+      </subtraction>
+      <box lunit="mm" name="svt_chamber_outer_flange" x="768.35" y="457.2" z="19.05" />
+      <box lunit="mm" name="svt_chamber_inner_flange" x="654.05" y="342.9" z="25.4" />
+      <subtraction name="svt_chamber_flange">
+        <first ref="svt_chamber_outer_flange" />
+        <second ref="svt_chamber_inner_flange" />
+      </subtraction>
+      <box lunit="mm" name="WorldBox" x="80000" y="80000" z="80000" />
+    </solids>
+    <structure>
+      <volume name="base_plate_volume">
+        <materialref ref="Aluminum" />
+        <solidref ref="base_plateBox" />
+        <visref ref="BasePlateVis" />
+      </volume>
+      <volume name="support_plate_bottom_L14_volume">
+        <materialref ref="Aluminum" />
+        <solidref ref="support_plate_bottom_L14Box" />
+        <visref ref="SupportPlateVis" />
+      </volume>
+      <volume name="support_plate_top_L14_volume">
+        <materialref ref="Aluminum" />
+        <solidref ref="support_plate_top_L14Box" />
+        <visref ref="SupportPlateVis" />
+      </volume>
+      <volume name="support_plate_bottom_L46_volume">
+        <materialref ref="Aluminum" />
+        <solidref ref="support_plate_bottom_L46Box" />
+        <visref ref="SupportPlateVis" />
+      </volume>
+      <volume name="support_plate_top_L46_volume">
+        <materialref ref="Aluminum" />
+        <solidref ref="support_plate_top_L46Box" />
+        <visref ref="SupportPlateVis" />
+      </volume>
+      <volume name="module_L1b_halfmodule_axial_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L1b_halfmodule_axial_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L1b_halfmodule_axial_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L1b_halfmodule_axial_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L1b_halfmodule_axial_sensor_active_volume" />
+          <positionref ref="module_L1b_halfmodule_axial_sensor_active_position" />
+          <rotationref ref="module_L1b_halfmodule_axial_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L1b_halfmodule_axial_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L1b_halfmodule_axialBox" />
+        <physvol>
+          <volumeref ref="module_L1b_halfmodule_axial_sensor_volume" />
+          <positionref ref="module_L1b_halfmodule_axial_sensor_position" />
+          <rotationref ref="module_L1b_halfmodule_axial_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <visref ref="HalfModuleVis" />
+      </volume>
+      <volume name="module_L1b_halfmodule_stereo_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L1b_halfmodule_stereo_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L1b_halfmodule_stereo_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L1b_halfmodule_stereo_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L1b_halfmodule_stereo_sensor_active_volume" />
+          <positionref ref="module_L1b_halfmodule_stereo_sensor_active_position" />
+          <rotationref ref="module_L1b_halfmodule_stereo_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L1b_halfmodule_stereo_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L1b_halfmodule_stereoBox" />
+        <physvol>
+          <volumeref ref="module_L1b_halfmodule_stereo_sensor_volume" />
+          <positionref ref="module_L1b_halfmodule_stereo_sensor_position" />
+          <rotationref ref="module_L1b_halfmodule_stereo_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <visref ref="HalfModuleVis" />
+      </volume>
+      <volume name="module_L1t_halfmodule_axial_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L1t_halfmodule_axial_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L1t_halfmodule_axial_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L1t_halfmodule_axial_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L1t_halfmodule_axial_sensor_active_volume" />
+          <positionref ref="module_L1t_halfmodule_axial_sensor_active_position" />
+          <rotationref ref="module_L1t_halfmodule_axial_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L1t_halfmodule_axial_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L1t_halfmodule_axialBox" />
+        <physvol>
+          <volumeref ref="module_L1t_halfmodule_axial_sensor_volume" />
+          <positionref ref="module_L1t_halfmodule_axial_sensor_position" />
+          <rotationref ref="module_L1t_halfmodule_axial_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <visref ref="HalfModuleVis" />
+      </volume>
+      <volume name="module_L1t_halfmodule_stereo_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L1t_halfmodule_stereo_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L1t_halfmodule_stereo_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L1t_halfmodule_stereo_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L1t_halfmodule_stereo_sensor_active_volume" />
+          <positionref ref="module_L1t_halfmodule_stereo_sensor_active_position" />
+          <rotationref ref="module_L1t_halfmodule_stereo_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L1t_halfmodule_stereo_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L1t_halfmodule_stereoBox" />
+        <physvol>
+          <volumeref ref="module_L1t_halfmodule_stereo_sensor_volume" />
+          <positionref ref="module_L1t_halfmodule_stereo_sensor_position" />
+          <rotationref ref="module_L1t_halfmodule_stereo_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <visref ref="HalfModuleVis" />
+      </volume>
+      <volume name="module_L2b_halfmodule_axial_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L2b_halfmodule_axial_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L2b_halfmodule_axial_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L2b_halfmodule_axial_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L2b_halfmodule_axial_sensor_active_volume" />
+          <positionref ref="module_L2b_halfmodule_axial_sensor_active_position" />
+          <rotationref ref="module_L2b_halfmodule_axial_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L2b_halfmodule_axial_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L2b_halfmodule_axialBox" />
+        <physvol>
+          <volumeref ref="module_L2b_halfmodule_axial_sensor_volume" />
+          <positionref ref="module_L2b_halfmodule_axial_sensor_position" />
+          <rotationref ref="module_L2b_halfmodule_axial_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <visref ref="HalfModuleVis" />
+      </volume>
+      <volume name="module_L2b_halfmodule_stereo_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L2b_halfmodule_stereo_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L2b_halfmodule_stereo_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L2b_halfmodule_stereo_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L2b_halfmodule_stereo_sensor_active_volume" />
+          <positionref ref="module_L2b_halfmodule_stereo_sensor_active_position" />
+          <rotationref ref="module_L2b_halfmodule_stereo_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L2b_halfmodule_stereo_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L2b_halfmodule_stereoBox" />
+        <physvol>
+          <volumeref ref="module_L2b_halfmodule_stereo_sensor_volume" />
+          <positionref ref="module_L2b_halfmodule_stereo_sensor_position" />
+          <rotationref ref="module_L2b_halfmodule_stereo_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <visref ref="HalfModuleVis" />
+      </volume>
+      <volume name="module_L2t_halfmodule_axial_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L2t_halfmodule_axial_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L2t_halfmodule_axial_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L2t_halfmodule_axial_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L2t_halfmodule_axial_sensor_active_volume" />
+          <positionref ref="module_L2t_halfmodule_axial_sensor_active_position" />
+          <rotationref ref="module_L2t_halfmodule_axial_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L2t_halfmodule_axial_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L2t_halfmodule_axialBox" />
+        <physvol>
+          <volumeref ref="module_L2t_halfmodule_axial_sensor_volume" />
+          <positionref ref="module_L2t_halfmodule_axial_sensor_position" />
+          <rotationref ref="module_L2t_halfmodule_axial_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <visref ref="HalfModuleVis" />
+      </volume>
+      <volume name="module_L2t_halfmodule_stereo_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L2t_halfmodule_stereo_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L2t_halfmodule_stereo_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L2t_halfmodule_stereo_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L2t_halfmodule_stereo_sensor_active_volume" />
+          <positionref ref="module_L2t_halfmodule_stereo_sensor_active_position" />
+          <rotationref ref="module_L2t_halfmodule_stereo_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L2t_halfmodule_stereo_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L2t_halfmodule_stereoBox" />
+        <physvol>
+          <volumeref ref="module_L2t_halfmodule_stereo_sensor_volume" />
+          <positionref ref="module_L2t_halfmodule_stereo_sensor_position" />
+          <rotationref ref="module_L2t_halfmodule_stereo_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <visref ref="HalfModuleVis" />
+      </volume>
+      <volume name="module_L3b_halfmodule_axial_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L3b_halfmodule_axial_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L3b_halfmodule_axial_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L3b_halfmodule_axial_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L3b_halfmodule_axial_sensor_active_volume" />
+          <positionref ref="module_L3b_halfmodule_axial_sensor_active_position" />
+          <rotationref ref="module_L3b_halfmodule_axial_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L3b_halfmodule_axial_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L3b_halfmodule_axial_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L3b_halfmodule_axial_cf_volume">
+        <materialref ref="CarbonFiber" />
+        <solidref ref="module_L3b_halfmodule_axial_cfBox" />
+        <visref ref="CarbonFiberVis" />
+      </volume>
+      <volume name="module_L3b_halfmodule_axial_hybrid_volume">
+        <materialref ref="G10" />
+        <solidref ref="module_L3b_halfmodule_axial_hybridBox" />
+        <visref ref="HybridVis" />
+      </volume>
+      <volume name="module_L3b_halfmodule_axial_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L3b_halfmodule_axialBox" />
+        <physvol>
+          <volumeref ref="module_L3b_halfmodule_axial_sensor_volume" />
+          <positionref ref="module_L3b_halfmodule_axial_sensor_position" />
+          <rotationref ref="module_L3b_halfmodule_axial_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L3b_halfmodule_axial_lamination_volume" />
+          <positionref ref="module_L3b_halfmodule_axial_lamination_position" />
+          <rotationref ref="module_L3b_halfmodule_axial_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L3b_halfmodule_axial_cf_volume" />
+          <positionref ref="module_L3b_halfmodule_axial_cf_position" />
+          <rotationref ref="module_L3b_halfmodule_axial_cf_rotation" />
+          <physvolid field_name="component" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L3b_halfmodule_axial_hybrid_volume" />
+          <positionref ref="module_L3b_halfmodule_axial_hybrid_position" />
+          <rotationref ref="module_L3b_halfmodule_axial_hybrid_rotation" />
+          <physvolid field_name="component" value="3" />
+        </physvol>
+        <visref ref="HalfModuleVis" />
+      </volume>
+      <volume name="module_L3b_halfmodule_stereo_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L3b_halfmodule_stereo_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L3b_halfmodule_stereo_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L3b_halfmodule_stereo_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L3b_halfmodule_stereo_sensor_active_volume" />
+          <positionref ref="module_L3b_halfmodule_stereo_sensor_active_position" />
+          <rotationref ref="module_L3b_halfmodule_stereo_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L3b_halfmodule_stereo_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L3b_halfmodule_stereo_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L3b_halfmodule_stereo_cf_volume">
+        <materialref ref="CarbonFiber" />
+        <solidref ref="module_L3b_halfmodule_stereo_cfBox" />
+        <visref ref="CarbonFiberVis" />
+      </volume>
+      <volume name="module_L3b_halfmodule_stereo_hybrid_volume">
+        <materialref ref="G10" />
+        <solidref ref="module_L3b_halfmodule_stereo_hybridBox" />
+        <visref ref="HybridVis" />
+      </volume>
+      <volume name="module_L3b_halfmodule_stereo_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L3b_halfmodule_stereoBox" />
+        <physvol>
+          <volumeref ref="module_L3b_halfmodule_stereo_sensor_volume" />
+          <positionref ref="module_L3b_halfmodule_stereo_sensor_position" />
+          <rotationref ref="module_L3b_halfmodule_stereo_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L3b_halfmodule_stereo_lamination_volume" />
+          <positionref ref="module_L3b_halfmodule_stereo_lamination_position" />
+          <rotationref ref="module_L3b_halfmodule_stereo_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L3b_halfmodule_stereo_cf_volume" />
+          <positionref ref="module_L3b_halfmodule_stereo_cf_position" />
+          <rotationref ref="module_L3b_halfmodule_stereo_cf_rotation" />
+          <physvolid field_name="component" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L3b_halfmodule_stereo_hybrid_volume" />
+          <positionref ref="module_L3b_halfmodule_stereo_hybrid_position" />
+          <rotationref ref="module_L3b_halfmodule_stereo_hybrid_rotation" />
+          <physvolid field_name="component" value="3" />
+        </physvol>
+        <visref ref="HalfModuleVis" />
+      </volume>
+      <volume name="module_L3t_halfmodule_axial_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L3t_halfmodule_axial_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L3t_halfmodule_axial_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L3t_halfmodule_axial_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L3t_halfmodule_axial_sensor_active_volume" />
+          <positionref ref="module_L3t_halfmodule_axial_sensor_active_position" />
+          <rotationref ref="module_L3t_halfmodule_axial_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L3t_halfmodule_axial_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L3t_halfmodule_axial_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L3t_halfmodule_axial_cf_volume">
+        <materialref ref="CarbonFiber" />
+        <solidref ref="module_L3t_halfmodule_axial_cfBox" />
+        <visref ref="CarbonFiberVis" />
+      </volume>
+      <volume name="module_L3t_halfmodule_axial_hybrid_volume">
+        <materialref ref="G10" />
+        <solidref ref="module_L3t_halfmodule_axial_hybridBox" />
+        <visref ref="HybridVis" />
+      </volume>
+      <volume name="module_L3t_halfmodule_axial_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L3t_halfmodule_axialBox" />
+        <physvol>
+          <volumeref ref="module_L3t_halfmodule_axial_sensor_volume" />
+          <positionref ref="module_L3t_halfmodule_axial_sensor_position" />
+          <rotationref ref="module_L3t_halfmodule_axial_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L3t_halfmodule_axial_lamination_volume" />
+          <positionref ref="module_L3t_halfmodule_axial_lamination_position" />
+          <rotationref ref="module_L3t_halfmodule_axial_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L3t_halfmodule_axial_cf_volume" />
+          <positionref ref="module_L3t_halfmodule_axial_cf_position" />
+          <rotationref ref="module_L3t_halfmodule_axial_cf_rotation" />
+          <physvolid field_name="component" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L3t_halfmodule_axial_hybrid_volume" />
+          <positionref ref="module_L3t_halfmodule_axial_hybrid_position" />
+          <rotationref ref="module_L3t_halfmodule_axial_hybrid_rotation" />
+          <physvolid field_name="component" value="3" />
+        </physvol>
+        <visref ref="HalfModuleVis" />
+      </volume>
+      <volume name="module_L3t_halfmodule_stereo_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L3t_halfmodule_stereo_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L3t_halfmodule_stereo_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L3t_halfmodule_stereo_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L3t_halfmodule_stereo_sensor_active_volume" />
+          <positionref ref="module_L3t_halfmodule_stereo_sensor_active_position" />
+          <rotationref ref="module_L3t_halfmodule_stereo_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L3t_halfmodule_stereo_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L3t_halfmodule_stereo_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L3t_halfmodule_stereo_cf_volume">
+        <materialref ref="CarbonFiber" />
+        <solidref ref="module_L3t_halfmodule_stereo_cfBox" />
+        <visref ref="CarbonFiberVis" />
+      </volume>
+      <volume name="module_L3t_halfmodule_stereo_hybrid_volume">
+        <materialref ref="G10" />
+        <solidref ref="module_L3t_halfmodule_stereo_hybridBox" />
+        <visref ref="HybridVis" />
+      </volume>
+      <volume name="module_L3t_halfmodule_stereo_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L3t_halfmodule_stereoBox" />
+        <physvol>
+          <volumeref ref="module_L3t_halfmodule_stereo_sensor_volume" />
+          <positionref ref="module_L3t_halfmodule_stereo_sensor_position" />
+          <rotationref ref="module_L3t_halfmodule_stereo_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L3t_halfmodule_stereo_lamination_volume" />
+          <positionref ref="module_L3t_halfmodule_stereo_lamination_position" />
+          <rotationref ref="module_L3t_halfmodule_stereo_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L3t_halfmodule_stereo_cf_volume" />
+          <positionref ref="module_L3t_halfmodule_stereo_cf_position" />
+          <rotationref ref="module_L3t_halfmodule_stereo_cf_rotation" />
+          <physvolid field_name="component" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L3t_halfmodule_stereo_hybrid_volume" />
+          <positionref ref="module_L3t_halfmodule_stereo_hybrid_position" />
+          <rotationref ref="module_L3t_halfmodule_stereo_hybrid_rotation" />
+          <physvolid field_name="component" value="3" />
+        </physvol>
+        <visref ref="HalfModuleVis" />
+      </volume>
+      <volume name="module_L4b_halfmodule_axial_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L4b_halfmodule_axial_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L4b_halfmodule_axial_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L4b_halfmodule_axial_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L4b_halfmodule_axial_sensor_active_volume" />
+          <positionref ref="module_L4b_halfmodule_axial_sensor_active_position" />
+          <rotationref ref="module_L4b_halfmodule_axial_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L4b_halfmodule_axial_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L4b_halfmodule_axial_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L4b_halfmodule_axial_cf_volume">
+        <materialref ref="CarbonFiber" />
+        <solidref ref="module_L4b_halfmodule_axial_cfBox" />
+        <visref ref="CarbonFiberVis" />
+      </volume>
+      <volume name="module_L4b_halfmodule_axial_hybrid_volume">
+        <materialref ref="G10" />
+        <solidref ref="module_L4b_halfmodule_axial_hybridBox" />
+        <visref ref="HybridVis" />
+      </volume>
+      <volume name="module_L4b_halfmodule_axial_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L4b_halfmodule_axialBox" />
+        <physvol>
+          <volumeref ref="module_L4b_halfmodule_axial_sensor_volume" />
+          <positionref ref="module_L4b_halfmodule_axial_sensor_position" />
+          <rotationref ref="module_L4b_halfmodule_axial_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L4b_halfmodule_axial_lamination_volume" />
+          <positionref ref="module_L4b_halfmodule_axial_lamination_position" />
+          <rotationref ref="module_L4b_halfmodule_axial_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L4b_halfmodule_axial_cf_volume" />
+          <positionref ref="module_L4b_halfmodule_axial_cf_position" />
+          <rotationref ref="module_L4b_halfmodule_axial_cf_rotation" />
+          <physvolid field_name="component" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L4b_halfmodule_axial_hybrid_volume" />
+          <positionref ref="module_L4b_halfmodule_axial_hybrid_position" />
+          <rotationref ref="module_L4b_halfmodule_axial_hybrid_rotation" />
+          <physvolid field_name="component" value="3" />
+        </physvol>
+        <visref ref="HalfModuleVis" />
+      </volume>
+      <volume name="module_L4b_halfmodule_stereo_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L4b_halfmodule_stereo_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L4b_halfmodule_stereo_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L4b_halfmodule_stereo_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L4b_halfmodule_stereo_sensor_active_volume" />
+          <positionref ref="module_L4b_halfmodule_stereo_sensor_active_position" />
+          <rotationref ref="module_L4b_halfmodule_stereo_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L4b_halfmodule_stereo_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L4b_halfmodule_stereo_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L4b_halfmodule_stereo_cf_volume">
+        <materialref ref="CarbonFiber" />
+        <solidref ref="module_L4b_halfmodule_stereo_cfBox" />
+        <visref ref="CarbonFiberVis" />
+      </volume>
+      <volume name="module_L4b_halfmodule_stereo_hybrid_volume">
+        <materialref ref="G10" />
+        <solidref ref="module_L4b_halfmodule_stereo_hybridBox" />
+        <visref ref="HybridVis" />
+      </volume>
+      <volume name="module_L4b_halfmodule_stereo_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L4b_halfmodule_stereoBox" />
+        <physvol>
+          <volumeref ref="module_L4b_halfmodule_stereo_sensor_volume" />
+          <positionref ref="module_L4b_halfmodule_stereo_sensor_position" />
+          <rotationref ref="module_L4b_halfmodule_stereo_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L4b_halfmodule_stereo_lamination_volume" />
+          <positionref ref="module_L4b_halfmodule_stereo_lamination_position" />
+          <rotationref ref="module_L4b_halfmodule_stereo_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L4b_halfmodule_stereo_cf_volume" />
+          <positionref ref="module_L4b_halfmodule_stereo_cf_position" />
+          <rotationref ref="module_L4b_halfmodule_stereo_cf_rotation" />
+          <physvolid field_name="component" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L4b_halfmodule_stereo_hybrid_volume" />
+          <positionref ref="module_L4b_halfmodule_stereo_hybrid_position" />
+          <rotationref ref="module_L4b_halfmodule_stereo_hybrid_rotation" />
+          <physvolid field_name="component" value="3" />
+        </physvol>
+        <visref ref="HalfModuleVis" />
+      </volume>
+      <volume name="module_L4t_halfmodule_axial_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L4t_halfmodule_axial_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L4t_halfmodule_axial_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L4t_halfmodule_axial_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L4t_halfmodule_axial_sensor_active_volume" />
+          <positionref ref="module_L4t_halfmodule_axial_sensor_active_position" />
+          <rotationref ref="module_L4t_halfmodule_axial_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L4t_halfmodule_axial_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L4t_halfmodule_axial_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L4t_halfmodule_axial_cf_volume">
+        <materialref ref="CarbonFiber" />
+        <solidref ref="module_L4t_halfmodule_axial_cfBox" />
+        <visref ref="CarbonFiberVis" />
+      </volume>
+      <volume name="module_L4t_halfmodule_axial_hybrid_volume">
+        <materialref ref="G10" />
+        <solidref ref="module_L4t_halfmodule_axial_hybridBox" />
+        <visref ref="HybridVis" />
+      </volume>
+      <volume name="module_L4t_halfmodule_axial_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L4t_halfmodule_axialBox" />
+        <physvol>
+          <volumeref ref="module_L4t_halfmodule_axial_sensor_volume" />
+          <positionref ref="module_L4t_halfmodule_axial_sensor_position" />
+          <rotationref ref="module_L4t_halfmodule_axial_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L4t_halfmodule_axial_lamination_volume" />
+          <positionref ref="module_L4t_halfmodule_axial_lamination_position" />
+          <rotationref ref="module_L4t_halfmodule_axial_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L4t_halfmodule_axial_cf_volume" />
+          <positionref ref="module_L4t_halfmodule_axial_cf_position" />
+          <rotationref ref="module_L4t_halfmodule_axial_cf_rotation" />
+          <physvolid field_name="component" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L4t_halfmodule_axial_hybrid_volume" />
+          <positionref ref="module_L4t_halfmodule_axial_hybrid_position" />
+          <rotationref ref="module_L4t_halfmodule_axial_hybrid_rotation" />
+          <physvolid field_name="component" value="3" />
+        </physvol>
+        <visref ref="HalfModuleVis" />
+      </volume>
+      <volume name="module_L4t_halfmodule_stereo_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L4t_halfmodule_stereo_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L4t_halfmodule_stereo_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L4t_halfmodule_stereo_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L4t_halfmodule_stereo_sensor_active_volume" />
+          <positionref ref="module_L4t_halfmodule_stereo_sensor_active_position" />
+          <rotationref ref="module_L4t_halfmodule_stereo_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L4t_halfmodule_stereo_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L4t_halfmodule_stereo_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L4t_halfmodule_stereo_cf_volume">
+        <materialref ref="CarbonFiber" />
+        <solidref ref="module_L4t_halfmodule_stereo_cfBox" />
+        <visref ref="CarbonFiberVis" />
+      </volume>
+      <volume name="module_L4t_halfmodule_stereo_hybrid_volume">
+        <materialref ref="G10" />
+        <solidref ref="module_L4t_halfmodule_stereo_hybridBox" />
+        <visref ref="HybridVis" />
+      </volume>
+      <volume name="module_L4t_halfmodule_stereo_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L4t_halfmodule_stereoBox" />
+        <physvol>
+          <volumeref ref="module_L4t_halfmodule_stereo_sensor_volume" />
+          <positionref ref="module_L4t_halfmodule_stereo_sensor_position" />
+          <rotationref ref="module_L4t_halfmodule_stereo_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L4t_halfmodule_stereo_lamination_volume" />
+          <positionref ref="module_L4t_halfmodule_stereo_lamination_position" />
+          <rotationref ref="module_L4t_halfmodule_stereo_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L4t_halfmodule_stereo_cf_volume" />
+          <positionref ref="module_L4t_halfmodule_stereo_cf_position" />
+          <rotationref ref="module_L4t_halfmodule_stereo_cf_rotation" />
+          <physvolid field_name="component" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L4t_halfmodule_stereo_hybrid_volume" />
+          <positionref ref="module_L4t_halfmodule_stereo_hybrid_position" />
+          <rotationref ref="module_L4t_halfmodule_stereo_hybrid_rotation" />
+          <physvolid field_name="component" value="3" />
+        </physvol>
+        <visref ref="HalfModuleVis" />
+      </volume>
+      <volume name="module_L5b_halfmodule_axial_hole_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L5b_halfmodule_axial_hole_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L5b_halfmodule_axial_hole_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L5b_halfmodule_axial_hole_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L5b_halfmodule_axial_hole_sensor_active_volume" />
+          <positionref ref="module_L5b_halfmodule_axial_hole_sensor_active_position" />
+          <rotationref ref="module_L5b_halfmodule_axial_hole_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L5b_halfmodule_axial_hole_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L5b_halfmodule_axial_hole_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L5b_halfmodule_axial_hole_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L5b_halfmodule_axial_holeBox" />
+        <physvol>
+          <volumeref ref="module_L5b_halfmodule_axial_hole_sensor_volume" />
+          <positionref ref="module_L5b_halfmodule_axial_hole_sensor_position" />
+          <rotationref ref="module_L5b_halfmodule_axial_hole_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L5b_halfmodule_axial_hole_lamination_volume" />
+          <positionref ref="module_L5b_halfmodule_axial_hole_lamination_position" />
+          <rotationref ref="module_L5b_halfmodule_axial_hole_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L5b_halfmodule_axial_slot_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L5b_halfmodule_axial_slot_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L5b_halfmodule_axial_slot_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L5b_halfmodule_axial_slot_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L5b_halfmodule_axial_slot_sensor_active_volume" />
+          <positionref ref="module_L5b_halfmodule_axial_slot_sensor_active_position" />
+          <rotationref ref="module_L5b_halfmodule_axial_slot_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L5b_halfmodule_axial_slot_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L5b_halfmodule_axial_slot_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L5b_halfmodule_axial_slot_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L5b_halfmodule_axial_slotBox" />
+        <physvol>
+          <volumeref ref="module_L5b_halfmodule_axial_slot_sensor_volume" />
+          <positionref ref="module_L5b_halfmodule_axial_slot_sensor_position" />
+          <rotationref ref="module_L5b_halfmodule_axial_slot_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L5b_halfmodule_axial_slot_lamination_volume" />
+          <positionref ref="module_L5b_halfmodule_axial_slot_lamination_position" />
+          <rotationref ref="module_L5b_halfmodule_axial_slot_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L5b_halfmodule_stereo_hole_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L5b_halfmodule_stereo_hole_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L5b_halfmodule_stereo_hole_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L5b_halfmodule_stereo_hole_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L5b_halfmodule_stereo_hole_sensor_active_volume" />
+          <positionref ref="module_L5b_halfmodule_stereo_hole_sensor_active_position" />
+          <rotationref ref="module_L5b_halfmodule_stereo_hole_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L5b_halfmodule_stereo_hole_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L5b_halfmodule_stereo_hole_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L5b_halfmodule_stereo_hole_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L5b_halfmodule_stereo_holeBox" />
+        <physvol>
+          <volumeref ref="module_L5b_halfmodule_stereo_hole_sensor_volume" />
+          <positionref ref="module_L5b_halfmodule_stereo_hole_sensor_position" />
+          <rotationref ref="module_L5b_halfmodule_stereo_hole_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L5b_halfmodule_stereo_hole_lamination_volume" />
+          <positionref ref="module_L5b_halfmodule_stereo_hole_lamination_position" />
+          <rotationref ref="module_L5b_halfmodule_stereo_hole_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L5b_halfmodule_stereo_slot_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L5b_halfmodule_stereo_slot_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L5b_halfmodule_stereo_slot_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L5b_halfmodule_stereo_slot_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L5b_halfmodule_stereo_slot_sensor_active_volume" />
+          <positionref ref="module_L5b_halfmodule_stereo_slot_sensor_active_position" />
+          <rotationref ref="module_L5b_halfmodule_stereo_slot_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L5b_halfmodule_stereo_slot_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L5b_halfmodule_stereo_slot_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L5b_halfmodule_stereo_slot_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L5b_halfmodule_stereo_slotBox" />
+        <physvol>
+          <volumeref ref="module_L5b_halfmodule_stereo_slot_sensor_volume" />
+          <positionref ref="module_L5b_halfmodule_stereo_slot_sensor_position" />
+          <rotationref ref="module_L5b_halfmodule_stereo_slot_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L5b_halfmodule_stereo_slot_lamination_volume" />
+          <positionref ref="module_L5b_halfmodule_stereo_slot_lamination_position" />
+          <rotationref ref="module_L5b_halfmodule_stereo_slot_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L5t_halfmodule_axial_hole_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L5t_halfmodule_axial_hole_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L5t_halfmodule_axial_hole_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L5t_halfmodule_axial_hole_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L5t_halfmodule_axial_hole_sensor_active_volume" />
+          <positionref ref="module_L5t_halfmodule_axial_hole_sensor_active_position" />
+          <rotationref ref="module_L5t_halfmodule_axial_hole_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L5t_halfmodule_axial_hole_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L5t_halfmodule_axial_hole_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L5t_halfmodule_axial_hole_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L5t_halfmodule_axial_holeBox" />
+        <physvol>
+          <volumeref ref="module_L5t_halfmodule_axial_hole_sensor_volume" />
+          <positionref ref="module_L5t_halfmodule_axial_hole_sensor_position" />
+          <rotationref ref="module_L5t_halfmodule_axial_hole_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L5t_halfmodule_axial_hole_lamination_volume" />
+          <positionref ref="module_L5t_halfmodule_axial_hole_lamination_position" />
+          <rotationref ref="module_L5t_halfmodule_axial_hole_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L5t_halfmodule_axial_slot_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L5t_halfmodule_axial_slot_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L5t_halfmodule_axial_slot_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L5t_halfmodule_axial_slot_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L5t_halfmodule_axial_slot_sensor_active_volume" />
+          <positionref ref="module_L5t_halfmodule_axial_slot_sensor_active_position" />
+          <rotationref ref="module_L5t_halfmodule_axial_slot_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L5t_halfmodule_axial_slot_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L5t_halfmodule_axial_slot_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L5t_halfmodule_axial_slot_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L5t_halfmodule_axial_slotBox" />
+        <physvol>
+          <volumeref ref="module_L5t_halfmodule_axial_slot_sensor_volume" />
+          <positionref ref="module_L5t_halfmodule_axial_slot_sensor_position" />
+          <rotationref ref="module_L5t_halfmodule_axial_slot_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L5t_halfmodule_axial_slot_lamination_volume" />
+          <positionref ref="module_L5t_halfmodule_axial_slot_lamination_position" />
+          <rotationref ref="module_L5t_halfmodule_axial_slot_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L5t_halfmodule_stereo_hole_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L5t_halfmodule_stereo_hole_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L5t_halfmodule_stereo_hole_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L5t_halfmodule_stereo_hole_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L5t_halfmodule_stereo_hole_sensor_active_volume" />
+          <positionref ref="module_L5t_halfmodule_stereo_hole_sensor_active_position" />
+          <rotationref ref="module_L5t_halfmodule_stereo_hole_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L5t_halfmodule_stereo_hole_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L5t_halfmodule_stereo_hole_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L5t_halfmodule_stereo_hole_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L5t_halfmodule_stereo_holeBox" />
+        <physvol>
+          <volumeref ref="module_L5t_halfmodule_stereo_hole_sensor_volume" />
+          <positionref ref="module_L5t_halfmodule_stereo_hole_sensor_position" />
+          <rotationref ref="module_L5t_halfmodule_stereo_hole_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L5t_halfmodule_stereo_hole_lamination_volume" />
+          <positionref ref="module_L5t_halfmodule_stereo_hole_lamination_position" />
+          <rotationref ref="module_L5t_halfmodule_stereo_hole_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L5t_halfmodule_stereo_slot_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L5t_halfmodule_stereo_slot_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L5t_halfmodule_stereo_slot_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L5t_halfmodule_stereo_slot_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L5t_halfmodule_stereo_slot_sensor_active_volume" />
+          <positionref ref="module_L5t_halfmodule_stereo_slot_sensor_active_position" />
+          <rotationref ref="module_L5t_halfmodule_stereo_slot_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L5t_halfmodule_stereo_slot_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L5t_halfmodule_stereo_slot_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L5t_halfmodule_stereo_slot_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L5t_halfmodule_stereo_slotBox" />
+        <physvol>
+          <volumeref ref="module_L5t_halfmodule_stereo_slot_sensor_volume" />
+          <positionref ref="module_L5t_halfmodule_stereo_slot_sensor_position" />
+          <rotationref ref="module_L5t_halfmodule_stereo_slot_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L5t_halfmodule_stereo_slot_lamination_volume" />
+          <positionref ref="module_L5t_halfmodule_stereo_slot_lamination_position" />
+          <rotationref ref="module_L5t_halfmodule_stereo_slot_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L6b_halfmodule_axial_hole_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L6b_halfmodule_axial_hole_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L6b_halfmodule_axial_hole_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L6b_halfmodule_axial_hole_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L6b_halfmodule_axial_hole_sensor_active_volume" />
+          <positionref ref="module_L6b_halfmodule_axial_hole_sensor_active_position" />
+          <rotationref ref="module_L6b_halfmodule_axial_hole_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L6b_halfmodule_axial_hole_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L6b_halfmodule_axial_hole_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L6b_halfmodule_axial_hole_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L6b_halfmodule_axial_holeBox" />
+        <physvol>
+          <volumeref ref="module_L6b_halfmodule_axial_hole_sensor_volume" />
+          <positionref ref="module_L6b_halfmodule_axial_hole_sensor_position" />
+          <rotationref ref="module_L6b_halfmodule_axial_hole_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L6b_halfmodule_axial_hole_lamination_volume" />
+          <positionref ref="module_L6b_halfmodule_axial_hole_lamination_position" />
+          <rotationref ref="module_L6b_halfmodule_axial_hole_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L6b_halfmodule_axial_slot_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L6b_halfmodule_axial_slot_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L6b_halfmodule_axial_slot_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L6b_halfmodule_axial_slot_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L6b_halfmodule_axial_slot_sensor_active_volume" />
+          <positionref ref="module_L6b_halfmodule_axial_slot_sensor_active_position" />
+          <rotationref ref="module_L6b_halfmodule_axial_slot_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L6b_halfmodule_axial_slot_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L6b_halfmodule_axial_slot_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L6b_halfmodule_axial_slot_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L6b_halfmodule_axial_slotBox" />
+        <physvol>
+          <volumeref ref="module_L6b_halfmodule_axial_slot_sensor_volume" />
+          <positionref ref="module_L6b_halfmodule_axial_slot_sensor_position" />
+          <rotationref ref="module_L6b_halfmodule_axial_slot_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L6b_halfmodule_axial_slot_lamination_volume" />
+          <positionref ref="module_L6b_halfmodule_axial_slot_lamination_position" />
+          <rotationref ref="module_L6b_halfmodule_axial_slot_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L6b_halfmodule_stereo_hole_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L6b_halfmodule_stereo_hole_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L6b_halfmodule_stereo_hole_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L6b_halfmodule_stereo_hole_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L6b_halfmodule_stereo_hole_sensor_active_volume" />
+          <positionref ref="module_L6b_halfmodule_stereo_hole_sensor_active_position" />
+          <rotationref ref="module_L6b_halfmodule_stereo_hole_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L6b_halfmodule_stereo_hole_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L6b_halfmodule_stereo_hole_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L6b_halfmodule_stereo_hole_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L6b_halfmodule_stereo_holeBox" />
+        <physvol>
+          <volumeref ref="module_L6b_halfmodule_stereo_hole_sensor_volume" />
+          <positionref ref="module_L6b_halfmodule_stereo_hole_sensor_position" />
+          <rotationref ref="module_L6b_halfmodule_stereo_hole_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L6b_halfmodule_stereo_hole_lamination_volume" />
+          <positionref ref="module_L6b_halfmodule_stereo_hole_lamination_position" />
+          <rotationref ref="module_L6b_halfmodule_stereo_hole_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L6b_halfmodule_stereo_slot_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L6b_halfmodule_stereo_slot_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L6b_halfmodule_stereo_slot_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L6b_halfmodule_stereo_slot_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L6b_halfmodule_stereo_slot_sensor_active_volume" />
+          <positionref ref="module_L6b_halfmodule_stereo_slot_sensor_active_position" />
+          <rotationref ref="module_L6b_halfmodule_stereo_slot_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L6b_halfmodule_stereo_slot_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L6b_halfmodule_stereo_slot_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L6b_halfmodule_stereo_slot_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L6b_halfmodule_stereo_slotBox" />
+        <physvol>
+          <volumeref ref="module_L6b_halfmodule_stereo_slot_sensor_volume" />
+          <positionref ref="module_L6b_halfmodule_stereo_slot_sensor_position" />
+          <rotationref ref="module_L6b_halfmodule_stereo_slot_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L6b_halfmodule_stereo_slot_lamination_volume" />
+          <positionref ref="module_L6b_halfmodule_stereo_slot_lamination_position" />
+          <rotationref ref="module_L6b_halfmodule_stereo_slot_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L6t_halfmodule_axial_hole_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L6t_halfmodule_axial_hole_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L6t_halfmodule_axial_hole_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L6t_halfmodule_axial_hole_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L6t_halfmodule_axial_hole_sensor_active_volume" />
+          <positionref ref="module_L6t_halfmodule_axial_hole_sensor_active_position" />
+          <rotationref ref="module_L6t_halfmodule_axial_hole_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L6t_halfmodule_axial_hole_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L6t_halfmodule_axial_hole_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L6t_halfmodule_axial_hole_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L6t_halfmodule_axial_holeBox" />
+        <physvol>
+          <volumeref ref="module_L6t_halfmodule_axial_hole_sensor_volume" />
+          <positionref ref="module_L6t_halfmodule_axial_hole_sensor_position" />
+          <rotationref ref="module_L6t_halfmodule_axial_hole_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L6t_halfmodule_axial_hole_lamination_volume" />
+          <positionref ref="module_L6t_halfmodule_axial_hole_lamination_position" />
+          <rotationref ref="module_L6t_halfmodule_axial_hole_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L6t_halfmodule_axial_slot_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L6t_halfmodule_axial_slot_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L6t_halfmodule_axial_slot_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L6t_halfmodule_axial_slot_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L6t_halfmodule_axial_slot_sensor_active_volume" />
+          <positionref ref="module_L6t_halfmodule_axial_slot_sensor_active_position" />
+          <rotationref ref="module_L6t_halfmodule_axial_slot_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L6t_halfmodule_axial_slot_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L6t_halfmodule_axial_slot_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L6t_halfmodule_axial_slot_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L6t_halfmodule_axial_slotBox" />
+        <physvol>
+          <volumeref ref="module_L6t_halfmodule_axial_slot_sensor_volume" />
+          <positionref ref="module_L6t_halfmodule_axial_slot_sensor_position" />
+          <rotationref ref="module_L6t_halfmodule_axial_slot_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L6t_halfmodule_axial_slot_lamination_volume" />
+          <positionref ref="module_L6t_halfmodule_axial_slot_lamination_position" />
+          <rotationref ref="module_L6t_halfmodule_axial_slot_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L6t_halfmodule_stereo_hole_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L6t_halfmodule_stereo_hole_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L6t_halfmodule_stereo_hole_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L6t_halfmodule_stereo_hole_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L6t_halfmodule_stereo_hole_sensor_active_volume" />
+          <positionref ref="module_L6t_halfmodule_stereo_hole_sensor_active_position" />
+          <rotationref ref="module_L6t_halfmodule_stereo_hole_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L6t_halfmodule_stereo_hole_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L6t_halfmodule_stereo_hole_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L6t_halfmodule_stereo_hole_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L6t_halfmodule_stereo_holeBox" />
+        <physvol>
+          <volumeref ref="module_L6t_halfmodule_stereo_hole_sensor_volume" />
+          <positionref ref="module_L6t_halfmodule_stereo_hole_sensor_position" />
+          <rotationref ref="module_L6t_halfmodule_stereo_hole_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L6t_halfmodule_stereo_hole_lamination_volume" />
+          <positionref ref="module_L6t_halfmodule_stereo_hole_lamination_position" />
+          <rotationref ref="module_L6t_halfmodule_stereo_hole_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L6t_halfmodule_stereo_slot_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L6t_halfmodule_stereo_slot_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L6t_halfmodule_stereo_slot_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L6t_halfmodule_stereo_slot_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L6t_halfmodule_stereo_slot_sensor_active_volume" />
+          <positionref ref="module_L6t_halfmodule_stereo_slot_sensor_active_position" />
+          <rotationref ref="module_L6t_halfmodule_stereo_slot_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L6t_halfmodule_stereo_slot_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L6t_halfmodule_stereo_slot_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L6t_halfmodule_stereo_slot_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L6t_halfmodule_stereo_slotBox" />
+        <physvol>
+          <volumeref ref="module_L6t_halfmodule_stereo_slot_sensor_volume" />
+          <positionref ref="module_L6t_halfmodule_stereo_slot_sensor_position" />
+          <rotationref ref="module_L6t_halfmodule_stereo_slot_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L6t_halfmodule_stereo_slot_lamination_volume" />
+          <positionref ref="module_L6t_halfmodule_stereo_slot_lamination_position" />
+          <rotationref ref="module_L6t_halfmodule_stereo_slot_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L7b_halfmodule_axial_hole_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L7b_halfmodule_axial_hole_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L7b_halfmodule_axial_hole_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L7b_halfmodule_axial_hole_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L7b_halfmodule_axial_hole_sensor_active_volume" />
+          <positionref ref="module_L7b_halfmodule_axial_hole_sensor_active_position" />
+          <rotationref ref="module_L7b_halfmodule_axial_hole_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L7b_halfmodule_axial_hole_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L7b_halfmodule_axial_hole_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L7b_halfmodule_axial_hole_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L7b_halfmodule_axial_holeBox" />
+        <physvol>
+          <volumeref ref="module_L7b_halfmodule_axial_hole_sensor_volume" />
+          <positionref ref="module_L7b_halfmodule_axial_hole_sensor_position" />
+          <rotationref ref="module_L7b_halfmodule_axial_hole_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L7b_halfmodule_axial_hole_lamination_volume" />
+          <positionref ref="module_L7b_halfmodule_axial_hole_lamination_position" />
+          <rotationref ref="module_L7b_halfmodule_axial_hole_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L7b_halfmodule_axial_slot_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L7b_halfmodule_axial_slot_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L7b_halfmodule_axial_slot_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L7b_halfmodule_axial_slot_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L7b_halfmodule_axial_slot_sensor_active_volume" />
+          <positionref ref="module_L7b_halfmodule_axial_slot_sensor_active_position" />
+          <rotationref ref="module_L7b_halfmodule_axial_slot_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L7b_halfmodule_axial_slot_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L7b_halfmodule_axial_slot_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L7b_halfmodule_axial_slot_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L7b_halfmodule_axial_slotBox" />
+        <physvol>
+          <volumeref ref="module_L7b_halfmodule_axial_slot_sensor_volume" />
+          <positionref ref="module_L7b_halfmodule_axial_slot_sensor_position" />
+          <rotationref ref="module_L7b_halfmodule_axial_slot_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L7b_halfmodule_axial_slot_lamination_volume" />
+          <positionref ref="module_L7b_halfmodule_axial_slot_lamination_position" />
+          <rotationref ref="module_L7b_halfmodule_axial_slot_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L7b_halfmodule_stereo_hole_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L7b_halfmodule_stereo_hole_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L7b_halfmodule_stereo_hole_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L7b_halfmodule_stereo_hole_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L7b_halfmodule_stereo_hole_sensor_active_volume" />
+          <positionref ref="module_L7b_halfmodule_stereo_hole_sensor_active_position" />
+          <rotationref ref="module_L7b_halfmodule_stereo_hole_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L7b_halfmodule_stereo_hole_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L7b_halfmodule_stereo_hole_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L7b_halfmodule_stereo_hole_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L7b_halfmodule_stereo_holeBox" />
+        <physvol>
+          <volumeref ref="module_L7b_halfmodule_stereo_hole_sensor_volume" />
+          <positionref ref="module_L7b_halfmodule_stereo_hole_sensor_position" />
+          <rotationref ref="module_L7b_halfmodule_stereo_hole_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L7b_halfmodule_stereo_hole_lamination_volume" />
+          <positionref ref="module_L7b_halfmodule_stereo_hole_lamination_position" />
+          <rotationref ref="module_L7b_halfmodule_stereo_hole_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L7b_halfmodule_stereo_slot_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L7b_halfmodule_stereo_slot_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L7b_halfmodule_stereo_slot_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L7b_halfmodule_stereo_slot_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L7b_halfmodule_stereo_slot_sensor_active_volume" />
+          <positionref ref="module_L7b_halfmodule_stereo_slot_sensor_active_position" />
+          <rotationref ref="module_L7b_halfmodule_stereo_slot_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L7b_halfmodule_stereo_slot_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L7b_halfmodule_stereo_slot_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L7b_halfmodule_stereo_slot_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L7b_halfmodule_stereo_slotBox" />
+        <physvol>
+          <volumeref ref="module_L7b_halfmodule_stereo_slot_sensor_volume" />
+          <positionref ref="module_L7b_halfmodule_stereo_slot_sensor_position" />
+          <rotationref ref="module_L7b_halfmodule_stereo_slot_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L7b_halfmodule_stereo_slot_lamination_volume" />
+          <positionref ref="module_L7b_halfmodule_stereo_slot_lamination_position" />
+          <rotationref ref="module_L7b_halfmodule_stereo_slot_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L7t_halfmodule_axial_hole_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L7t_halfmodule_axial_hole_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L7t_halfmodule_axial_hole_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L7t_halfmodule_axial_hole_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L7t_halfmodule_axial_hole_sensor_active_volume" />
+          <positionref ref="module_L7t_halfmodule_axial_hole_sensor_active_position" />
+          <rotationref ref="module_L7t_halfmodule_axial_hole_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L7t_halfmodule_axial_hole_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L7t_halfmodule_axial_hole_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L7t_halfmodule_axial_hole_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L7t_halfmodule_axial_holeBox" />
+        <physvol>
+          <volumeref ref="module_L7t_halfmodule_axial_hole_sensor_volume" />
+          <positionref ref="module_L7t_halfmodule_axial_hole_sensor_position" />
+          <rotationref ref="module_L7t_halfmodule_axial_hole_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L7t_halfmodule_axial_hole_lamination_volume" />
+          <positionref ref="module_L7t_halfmodule_axial_hole_lamination_position" />
+          <rotationref ref="module_L7t_halfmodule_axial_hole_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L7t_halfmodule_axial_slot_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L7t_halfmodule_axial_slot_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L7t_halfmodule_axial_slot_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L7t_halfmodule_axial_slot_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L7t_halfmodule_axial_slot_sensor_active_volume" />
+          <positionref ref="module_L7t_halfmodule_axial_slot_sensor_active_position" />
+          <rotationref ref="module_L7t_halfmodule_axial_slot_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L7t_halfmodule_axial_slot_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L7t_halfmodule_axial_slot_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L7t_halfmodule_axial_slot_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L7t_halfmodule_axial_slotBox" />
+        <physvol>
+          <volumeref ref="module_L7t_halfmodule_axial_slot_sensor_volume" />
+          <positionref ref="module_L7t_halfmodule_axial_slot_sensor_position" />
+          <rotationref ref="module_L7t_halfmodule_axial_slot_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L7t_halfmodule_axial_slot_lamination_volume" />
+          <positionref ref="module_L7t_halfmodule_axial_slot_lamination_position" />
+          <rotationref ref="module_L7t_halfmodule_axial_slot_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L7t_halfmodule_stereo_hole_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L7t_halfmodule_stereo_hole_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L7t_halfmodule_stereo_hole_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L7t_halfmodule_stereo_hole_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L7t_halfmodule_stereo_hole_sensor_active_volume" />
+          <positionref ref="module_L7t_halfmodule_stereo_hole_sensor_active_position" />
+          <rotationref ref="module_L7t_halfmodule_stereo_hole_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L7t_halfmodule_stereo_hole_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L7t_halfmodule_stereo_hole_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L7t_halfmodule_stereo_hole_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L7t_halfmodule_stereo_holeBox" />
+        <physvol>
+          <volumeref ref="module_L7t_halfmodule_stereo_hole_sensor_volume" />
+          <positionref ref="module_L7t_halfmodule_stereo_hole_sensor_position" />
+          <rotationref ref="module_L7t_halfmodule_stereo_hole_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L7t_halfmodule_stereo_hole_lamination_volume" />
+          <positionref ref="module_L7t_halfmodule_stereo_hole_lamination_position" />
+          <rotationref ref="module_L7t_halfmodule_stereo_hole_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L7t_halfmodule_stereo_slot_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L7t_halfmodule_stereo_slot_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L7t_halfmodule_stereo_slot_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L7t_halfmodule_stereo_slot_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L7t_halfmodule_stereo_slot_sensor_active_volume" />
+          <positionref ref="module_L7t_halfmodule_stereo_slot_sensor_active_position" />
+          <rotationref ref="module_L7t_halfmodule_stereo_slot_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L7t_halfmodule_stereo_slot_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L7t_halfmodule_stereo_slot_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L7t_halfmodule_stereo_slot_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L7t_halfmodule_stereo_slotBox" />
+        <physvol>
+          <volumeref ref="module_L7t_halfmodule_stereo_slot_sensor_volume" />
+          <positionref ref="module_L7t_halfmodule_stereo_slot_sensor_position" />
+          <rotationref ref="module_L7t_halfmodule_stereo_slot_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L7t_halfmodule_stereo_slot_lamination_volume" />
+          <positionref ref="module_L7t_halfmodule_stereo_slot_lamination_position" />
+          <rotationref ref="module_L7t_halfmodule_stereo_slot_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="base_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="baseBox" />
+        <physvol>
+          <volumeref ref="base_plate_volume" />
+          <positionref ref="base_plate_position" />
+          <rotationref ref="base_plate_rotation" />
+        </physvol>
+        <physvol>
+          <volumeref ref="support_plate_bottom_L14_volume" />
+          <positionref ref="support_plate_bottom_L14_position" />
+          <rotationref ref="support_plate_bottom_L14_rotation" />
+        </physvol>
+        <physvol>
+          <volumeref ref="support_plate_top_L14_volume" />
+          <positionref ref="support_plate_top_L14_position" />
+          <rotationref ref="support_plate_top_L14_rotation" />
+        </physvol>
+        <physvol>
+          <volumeref ref="support_plate_bottom_L46_volume" />
+          <positionref ref="support_plate_bottom_L46_position" />
+          <rotationref ref="support_plate_bottom_L46_rotation" />
+        </physvol>
+        <physvol>
+          <volumeref ref="support_plate_top_L46_volume" />
+          <positionref ref="support_plate_top_L46_position" />
+          <rotationref ref="support_plate_top_L46_rotation" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L1b_halfmodule_axial_volume" />
+          <positionref ref="module_L1b_halfmodule_axial_position" />
+          <rotationref ref="module_L1b_halfmodule_axial_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="2" />
+          <physvolid field_name="module" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L1b_halfmodule_stereo_volume" />
+          <positionref ref="module_L1b_halfmodule_stereo_position" />
+          <rotationref ref="module_L1b_halfmodule_stereo_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="1" />
+          <physvolid field_name="module" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L1t_halfmodule_axial_volume" />
+          <positionref ref="module_L1t_halfmodule_axial_position" />
+          <rotationref ref="module_L1t_halfmodule_axial_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="1" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L1t_halfmodule_stereo_volume" />
+          <positionref ref="module_L1t_halfmodule_stereo_position" />
+          <rotationref ref="module_L1t_halfmodule_stereo_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="2" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L2b_halfmodule_axial_volume" />
+          <positionref ref="module_L2b_halfmodule_axial_position" />
+          <rotationref ref="module_L2b_halfmodule_axial_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="4" />
+          <physvolid field_name="module" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L2b_halfmodule_stereo_volume" />
+          <positionref ref="module_L2b_halfmodule_stereo_position" />
+          <rotationref ref="module_L2b_halfmodule_stereo_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="3" />
+          <physvolid field_name="module" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L2t_halfmodule_axial_volume" />
+          <positionref ref="module_L2t_halfmodule_axial_position" />
+          <rotationref ref="module_L2t_halfmodule_axial_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="3" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L2t_halfmodule_stereo_volume" />
+          <positionref ref="module_L2t_halfmodule_stereo_position" />
+          <rotationref ref="module_L2t_halfmodule_stereo_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="4" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L3b_halfmodule_axial_volume" />
+          <positionref ref="module_L3b_halfmodule_axial_position" />
+          <rotationref ref="module_L3b_halfmodule_axial_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="6" />
+          <physvolid field_name="module" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L3b_halfmodule_stereo_volume" />
+          <positionref ref="module_L3b_halfmodule_stereo_position" />
+          <rotationref ref="module_L3b_halfmodule_stereo_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="5" />
+          <physvolid field_name="module" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L3t_halfmodule_axial_volume" />
+          <positionref ref="module_L3t_halfmodule_axial_position" />
+          <rotationref ref="module_L3t_halfmodule_axial_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="5" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L3t_halfmodule_stereo_volume" />
+          <positionref ref="module_L3t_halfmodule_stereo_position" />
+          <rotationref ref="module_L3t_halfmodule_stereo_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="6" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L4b_halfmodule_axial_volume" />
+          <positionref ref="module_L4b_halfmodule_axial_position" />
+          <rotationref ref="module_L4b_halfmodule_axial_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="8" />
+          <physvolid field_name="module" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L4b_halfmodule_stereo_volume" />
+          <positionref ref="module_L4b_halfmodule_stereo_position" />
+          <rotationref ref="module_L4b_halfmodule_stereo_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="7" />
+          <physvolid field_name="module" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L4t_halfmodule_axial_volume" />
+          <positionref ref="module_L4t_halfmodule_axial_position" />
+          <rotationref ref="module_L4t_halfmodule_axial_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="7" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L4t_halfmodule_stereo_volume" />
+          <positionref ref="module_L4t_halfmodule_stereo_position" />
+          <rotationref ref="module_L4t_halfmodule_stereo_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="8" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L5b_halfmodule_axial_hole_volume" />
+          <positionref ref="module_L5b_halfmodule_axial_hole_position" />
+          <rotationref ref="module_L5b_halfmodule_axial_hole_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="10" />
+          <physvolid field_name="module" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L5b_halfmodule_axial_slot_volume" />
+          <positionref ref="module_L5b_halfmodule_axial_slot_position" />
+          <rotationref ref="module_L5b_halfmodule_axial_slot_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="10" />
+          <physvolid field_name="module" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L5b_halfmodule_stereo_hole_volume" />
+          <positionref ref="module_L5b_halfmodule_stereo_hole_position" />
+          <rotationref ref="module_L5b_halfmodule_stereo_hole_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="9" />
+          <physvolid field_name="module" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L5b_halfmodule_stereo_slot_volume" />
+          <positionref ref="module_L5b_halfmodule_stereo_slot_position" />
+          <rotationref ref="module_L5b_halfmodule_stereo_slot_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="9" />
+          <physvolid field_name="module" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L5t_halfmodule_axial_hole_volume" />
+          <positionref ref="module_L5t_halfmodule_axial_hole_position" />
+          <rotationref ref="module_L5t_halfmodule_axial_hole_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="9" />
+          <physvolid field_name="module" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L5t_halfmodule_axial_slot_volume" />
+          <positionref ref="module_L5t_halfmodule_axial_slot_position" />
+          <rotationref ref="module_L5t_halfmodule_axial_slot_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="9" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L5t_halfmodule_stereo_hole_volume" />
+          <positionref ref="module_L5t_halfmodule_stereo_hole_position" />
+          <rotationref ref="module_L5t_halfmodule_stereo_hole_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="10" />
+          <physvolid field_name="module" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L5t_halfmodule_stereo_slot_volume" />
+          <positionref ref="module_L5t_halfmodule_stereo_slot_position" />
+          <rotationref ref="module_L5t_halfmodule_stereo_slot_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="10" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L6b_halfmodule_axial_hole_volume" />
+          <positionref ref="module_L6b_halfmodule_axial_hole_position" />
+          <rotationref ref="module_L6b_halfmodule_axial_hole_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="12" />
+          <physvolid field_name="module" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L6b_halfmodule_axial_slot_volume" />
+          <positionref ref="module_L6b_halfmodule_axial_slot_position" />
+          <rotationref ref="module_L6b_halfmodule_axial_slot_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="12" />
+          <physvolid field_name="module" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L6b_halfmodule_stereo_hole_volume" />
+          <positionref ref="module_L6b_halfmodule_stereo_hole_position" />
+          <rotationref ref="module_L6b_halfmodule_stereo_hole_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="11" />
+          <physvolid field_name="module" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L6b_halfmodule_stereo_slot_volume" />
+          <positionref ref="module_L6b_halfmodule_stereo_slot_position" />
+          <rotationref ref="module_L6b_halfmodule_stereo_slot_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="11" />
+          <physvolid field_name="module" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L6t_halfmodule_axial_hole_volume" />
+          <positionref ref="module_L6t_halfmodule_axial_hole_position" />
+          <rotationref ref="module_L6t_halfmodule_axial_hole_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="11" />
+          <physvolid field_name="module" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L6t_halfmodule_axial_slot_volume" />
+          <positionref ref="module_L6t_halfmodule_axial_slot_position" />
+          <rotationref ref="module_L6t_halfmodule_axial_slot_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="11" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L6t_halfmodule_stereo_hole_volume" />
+          <positionref ref="module_L6t_halfmodule_stereo_hole_position" />
+          <rotationref ref="module_L6t_halfmodule_stereo_hole_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="12" />
+          <physvolid field_name="module" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L6t_halfmodule_stereo_slot_volume" />
+          <positionref ref="module_L6t_halfmodule_stereo_slot_position" />
+          <rotationref ref="module_L6t_halfmodule_stereo_slot_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="12" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L7b_halfmodule_axial_hole_volume" />
+          <positionref ref="module_L7b_halfmodule_axial_hole_position" />
+          <rotationref ref="module_L7b_halfmodule_axial_hole_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="14" />
+          <physvolid field_name="module" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L7b_halfmodule_axial_slot_volume" />
+          <positionref ref="module_L7b_halfmodule_axial_slot_position" />
+          <rotationref ref="module_L7b_halfmodule_axial_slot_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="14" />
+          <physvolid field_name="module" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L7b_halfmodule_stereo_hole_volume" />
+          <positionref ref="module_L7b_halfmodule_stereo_hole_position" />
+          <rotationref ref="module_L7b_halfmodule_stereo_hole_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="13" />
+          <physvolid field_name="module" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L7b_halfmodule_stereo_slot_volume" />
+          <positionref ref="module_L7b_halfmodule_stereo_slot_position" />
+          <rotationref ref="module_L7b_halfmodule_stereo_slot_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="13" />
+          <physvolid field_name="module" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L7t_halfmodule_axial_hole_volume" />
+          <positionref ref="module_L7t_halfmodule_axial_hole_position" />
+          <rotationref ref="module_L7t_halfmodule_axial_hole_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="13" />
+          <physvolid field_name="module" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L7t_halfmodule_axial_slot_volume" />
+          <positionref ref="module_L7t_halfmodule_axial_slot_position" />
+          <rotationref ref="module_L7t_halfmodule_axial_slot_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="13" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L7t_halfmodule_stereo_hole_volume" />
+          <positionref ref="module_L7t_halfmodule_stereo_hole_position" />
+          <rotationref ref="module_L7t_halfmodule_stereo_hole_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="14" />
+          <physvolid field_name="module" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L7t_halfmodule_stereo_slot_volume" />
+          <positionref ref="module_L7t_halfmodule_stereo_slot_position" />
+          <rotationref ref="module_L7t_halfmodule_stereo_slot_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="14" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <visref ref="SvtBoxVis" />
+      </volume>
+      <volume name="BeamLeftVolume_component0Sensor0">
+        <materialref ref="Vacuum" />
+        <solidref ref="BeamLeftVolume_component0Sensor0Box" />
+        <sdref ref="ECalScoring" />
+      </volume>
+      <volume name="BeamLeftVolume_component0">
+        <materialref ref="Vacuum" />
+        <solidref ref="BeamLeftVolume_component0Box" />
+        <physvol>
+          <volumeref ref="BeamLeftVolume_component0Sensor0" />
+          <positionref ref="BeamLeftVolume_component0Sensor0Position" />
+          <rotationref ref="BeamLeftVolume_component0Sensor0Rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+      </volume>
+      <volume name="BeamLeftVolume">
+        <materialref ref="Vacuum" />
+        <solidref ref="BeamLeftBox" />
+        <physvol>
+          <volumeref ref="BeamLeftVolume_component0" />
+          <positionref ref="BeamLeftVolume_component0_position" />
+          <rotationref ref="BeamLeftVolume_component0_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+      </volume>
+      <volume name="ElectronGapVolume_component0Sensor0">
+        <materialref ref="Vacuum" />
+        <solidref ref="ElectronGapVolume_component0Sensor0Box" />
+        <sdref ref="ECalScoring" />
+      </volume>
+      <volume name="ElectronGapVolume_component0">
+        <materialref ref="Vacuum" />
+        <solidref ref="ElectronGapVolume_component0Box" />
+        <physvol>
+          <volumeref ref="ElectronGapVolume_component0Sensor0" />
+          <positionref ref="ElectronGapVolume_component0Sensor0Position" />
+          <rotationref ref="ElectronGapVolume_component0Sensor0Rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+      </volume>
+      <volume name="ElectronGapVolume">
+        <materialref ref="Vacuum" />
+        <solidref ref="ElectronGapBox" />
+        <physvol>
+          <volumeref ref="ElectronGapVolume_component0" />
+          <positionref ref="ElectronGapVolume_component0_position" />
+          <rotationref ref="ElectronGapVolume_component0_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+      </volume>
+      <volume name="BeamRightVolume_component0Sensor0">
+        <materialref ref="Vacuum" />
+        <solidref ref="BeamRightVolume_component0Sensor0Box" />
+        <sdref ref="ECalScoring" />
+      </volume>
+      <volume name="BeamRightVolume_component0">
+        <materialref ref="Vacuum" />
+        <solidref ref="BeamRightVolume_component0Box" />
+        <physvol>
+          <volumeref ref="BeamRightVolume_component0Sensor0" />
+          <positionref ref="BeamRightVolume_component0Sensor0Position" />
+          <rotationref ref="BeamRightVolume_component0Sensor0Rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+      </volume>
+      <volume name="BeamRightVolume">
+        <materialref ref="Vacuum" />
+        <solidref ref="BeamRightBox" />
+        <physvol>
+          <volumeref ref="BeamRightVolume_component0" />
+          <positionref ref="BeamRightVolume_component0_position" />
+          <rotationref ref="BeamRightVolume_component0_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+      </volume>
+      <volume name="crystal_volume">
+        <materialref ref="LeadTungstate" />
+        <solidref ref="crystal_trap" />
+        <sdref ref="Ecal" />
+        <visref ref="ECALVis" />
+      </volume>
+      <volume name="hodo_vol_L1TP0">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L1TP0" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L1TP0">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L1TP0" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L1TP0">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L1TP0" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L1TP0">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L1TP0" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_vol_L1BP0">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L1BP0" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L1BP0">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L1BP0" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L1BP0">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L1BP0" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L1BP0">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L1BP0" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_vol_L1TP1">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L1TP1" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L1TP1">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L1TP1" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L1TP1">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L1TP1" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L1TP1">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L1TP1" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_vol_L1BP1">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L1BP1" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L1BP1">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L1BP1" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L1BP1">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L1BP1" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L1BP1">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L1BP1" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_vol_L1TP2">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L1TP2" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L1TP2">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L1TP2" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L1TP2">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L1TP2" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L1TP2">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L1TP2" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_vol_L1BP2">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L1BP2" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L1BP2">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L1BP2" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L1BP2">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L1BP2" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L1BP2">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L1BP2" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_vol_L1TP3">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L1TP3" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L1TP3">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L1TP3" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L1TP3">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L1TP3" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L1TP3">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L1TP3" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_vol_L1BP3">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L1BP3" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L1BP3">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L1BP3" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L1BP3">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L1BP3" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L1BP3">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L1BP3" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_vol_L1TP4">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L1TP4" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L1TP4">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L1TP4" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L1TP4">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L1TP4" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L1TP4">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L1TP4" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_vol_L1BP4">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L1BP4" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L1BP4">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L1BP4" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L1BP4">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L1BP4" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L1BP4">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L1BP4" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_vol_L2TP0">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L2TP0" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L2TP0">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L2TP0" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L2TP0">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L2TP0" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L2TP0">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L2TP0" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_vol_L2BP0">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L2BP0" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L2BP0">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L2BP0" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L2BP0">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L2BP0" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L2BP0">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L2BP0" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_vol_L2TP1">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L2TP1" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L2TP1">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L2TP1" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L2TP1">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L2TP1" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L2TP1">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L2TP1" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_vol_L2BP1">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L2BP1" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L2BP1">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L2BP1" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L2BP1">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L2BP1" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L2BP1">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L2BP1" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_vol_L2TP2">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L2TP2" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L2TP2">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L2TP2" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L2TP2">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L2TP2" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L2TP2">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L2TP2" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_vol_L2BP2">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L2BP2" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L2BP2">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L2BP2" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L2BP2">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L2BP2" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L2BP2">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L2BP2" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_vol_L2TP3">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L2TP3" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L2TP3">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L2TP3" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L2TP3">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L2TP3" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L2TP3">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L2TP3" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_vol_L2BP3">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L2BP3" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L2BP3">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L2BP3" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L2BP3">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L2BP3" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L2BP3">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L2BP3" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_vol_L2TP4">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L2TP4" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L2TP4">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L2TP4" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L2TP4">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L2TP4" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L2TP4">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L2TP4" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_vol_L2BP4">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L2BP4" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L2BP4">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L2BP4" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L2BP4">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L2BP4" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L2BP4">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L2BP4" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_buffer_vol">
+        <materialref ref="Carbon" />
+        <solidref ref="hodo_buffer" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="front_flange">
+        <materialref ref="G4_Al" />
+        <solidref ref="front_flange_shape" />
+      </volume>
+      <volume name="back_flange">
+        <materialref ref="G4_Al" />
+        <solidref ref="back_flange_shape" />
+      </volume>
+      <volume name="ECAL_chamber">
+        <materialref ref="G4_Al" />
+        <solidref ref="ECAL_chamber_shape" />
+      </volume>
+      <volume name="al_honeycomb">
+        <materialref ref="AlHoneycomb" />
+        <solidref ref="al_honeycomb_shape" />
+      </volume>
+      <volume name="layer_1_top">
+        <materialref ref="G4_Al" />
+        <solidref ref="layer_1_top_shape" />
+      </volume>
+      <volume name="layer_2_top">
+        <materialref ref="G4_Al" />
+        <solidref ref="layer_2_top_shape" />
+      </volume>
+      <volume name="layer_3_top">
+        <materialref ref="G4_Al" />
+        <solidref ref="layer_3_top_shape" />
+      </volume>
+      <volume name="layer_4_top">
+        <materialref ref="G4_Al" />
+        <solidref ref="layer_4_top_shape" />
+      </volume>
+      <volume name="layer_1_bottom">
+        <materialref ref="G4_Al" />
+        <solidref ref="layer_1_bottom_shape" />
+      </volume>
+      <volume name="layer_2_bottom">
+        <materialref ref="G4_Al" />
+        <solidref ref="layer_2_bottom_shape" />
+      </volume>
+      <volume name="layer_3_bottom">
+        <materialref ref="G4_Al" />
+        <solidref ref="layer_3_bottom_shape" />
+      </volume>
+      <volume name="layer_4_bottom">
+        <materialref ref="G4_Al" />
+        <solidref ref="layer_4_bottom_shape" />
+      </volume>
+      <volume name="layer_5T_left">
+        <materialref ref="G4_Al" />
+        <solidref ref="layer_5T_left_shape" />
+      </volume>
+      <volume name="layer_5B_left">
+        <materialref ref="G4_Al" />
+        <solidref ref="layer_5B_left_shape" />
+      </volume>
+      <volume name="steel_bar">
+        <materialref ref="StainlessSteel" />
+        <solidref ref="steel_bar_shape" />
+      </volume>
+      <volume name="cu_Tpipe_inner_left">
+        <materialref ref="G4_Cu" />
+        <solidref ref="cu_Tpipe_inner_left_shape" />
+      </volume>
+      <volume name="cu_Tpipe_inner_right">
+        <materialref ref="G4_Cu" />
+        <solidref ref="cu_Tpipe_inner_right_shape" />
+      </volume>
+      <volume name="cu_Bpipe_inner_left">
+        <materialref ref="G4_Cu" />
+        <solidref ref="cu_Bpipe_inner_left_shape" />
+      </volume>
+      <volume name="cu_Bpipe_inner_right">
+        <materialref ref="G4_Cu" />
+        <solidref ref="cu_Bpipe_inner_right_shape" />
+      </volume>
+      <volume name="cu_Tpipe_outer_right1">
+        <materialref ref="G4_Cu" />
+        <solidref ref="cu_Tpipe_outer_right1_shape" />
+      </volume>
+      <volume name="cu_Tpipe_outer_right2">
+        <materialref ref="G4_Cu" />
+        <solidref ref="cu_Tpipe_outer_right2_shape" />
+      </volume>
+      <volume name="cu_Tpipe_outer_right3">
+        <materialref ref="G4_Cu" />
+        <solidref ref="cu_Tpipe_outer_right3_shape" />
+      </volume>
+      <volume name="cu_Bpipe_outer_right">
+        <materialref ref="G4_Cu" />
+        <solidref ref="cu_Bpipe_outer_right_shape" />
+      </volume>
+      <volume name="cu_Bpipe_outer_right1">
+        <materialref ref="G4_Cu" />
+        <solidref ref="cu_Bpipe_outer_right1_shape" />
+      </volume>
+      <volume name="cu_Bpipe_outer_right2">
+        <materialref ref="G4_Cu" />
+        <solidref ref="cu_Bpipe_outer_right2_shape" />
+      </volume>
+      <volume name="al_pipe_across_top1">
+        <materialref ref="G4_Al" />
+        <solidref ref="al_pipe_across_top1_shape" />
+      </volume>
+      <volume name="al_pipe_across_top2">
+        <materialref ref="G4_Al" />
+        <solidref ref="al_pipe_across_top2_shape" />
+      </volume>
+      <volume name="al_pipe_across_bottom1">
+        <materialref ref="G4_Al" />
+        <solidref ref="al_pipe_across_bottom1_shape" />
+      </volume>
+      <volume name="al_pipe_across_bottom2">
+        <materialref ref="G4_Al" />
+        <solidref ref="al_pipe_across_bottom2_shape" />
+      </volume>
+      <volume name="cu_plate_top_left">
+        <materialref ref="G4_Cu" />
+        <solidref ref="cu_plate_top_left_shape" />
+      </volume>
+      <volume name="cu_plate_bottom_left">
+        <materialref ref="G4_Cu" />
+        <solidref ref="cu_plate_bottom_left_shape" />
+      </volume>
+      <volume name="cu_plate_top_right">
+        <materialref ref="G4_Cu" />
+        <solidref ref="cu_plate_top_right_shape" />
+      </volume>
+      <volume name="cu_plate_bottom_right">
+        <materialref ref="G4_Cu" />
+        <solidref ref="cu_plate_bottom_right_shape" />
+      </volume>
+      <volume name="cu_plate_top_middle">
+        <materialref ref="G4_Cu" />
+        <solidref ref="cu_plate_top_middle_shape" />
+      </volume>
+      <volume name="cu_plate_bottom_middle">
+        <materialref ref="G4_Cu" />
+        <solidref ref="cu_plate_bottom_middle_shape" />
+      </volume>
+      <volume name="hodo_flange">
+        <materialref ref="Aluminum" />
+        <solidref ref="hodo_flange_shape" />
+      </volume>
+      <volume name="arms1_block1">
+        <materialref ref="G10_FR4" />
+        <solidref ref="arms1_block1_shape" />
+      </volume>
+      <volume name="arms1_block2">
+        <materialref ref="G10_FR4" />
+        <solidref ref="arms1_block2_shape" />
+      </volume>
+      <volume name="arms1_block3">
+        <materialref ref="G10_FR4" />
+        <solidref ref="arms1_block3_shape" />
+      </volume>
+      <volume name="arms1_block4">
+        <materialref ref="G10_FR4" />
+        <solidref ref="arms1_block4_shape" />
+      </volume>
+      <volume name="cross_bar_top">
+        <materialref ref="G10_FR4" />
+        <solidref ref="cross_bar_top_shape" />
+      </volume>
+      <volume name="cross_bar_bottom">
+        <materialref ref="G10_FR4" />
+        <solidref ref="cross_bar_bottom_shape" />
+      </volume>
+      <volume name="support_arm_bottom_left_plus_block">
+        <materialref ref="G10_FR4" />
+        <solidref ref="support_arm_bottom_left_plus_block_shape" />
+      </volume>
+      <volume name="support_arm_bottom_right">
+        <materialref ref="G10_FR4" />
+        <solidref ref="support_arm_bottom_right_shape" />
+      </volume>
+      <volume name="support_arm_top_left">
+        <materialref ref="G10_FR4" />
+        <solidref ref="support_arm_top_left_shape" />
+      </volume>
+      <volume name="support_arm_top_right">
+        <materialref ref="G10_FR4" />
+        <solidref ref="support_arm_top_right_shape" />
+      </volume>
+      <volume name="u_support_bar_bottom">
+        <materialref ref="G10_FR4" />
+        <solidref ref="u_support_bar_bottom_shape" />
+      </volume>
+      <volume name="u_support_bar_upper1">
+        <materialref ref="G10_FR4" />
+        <solidref ref="u_support_bar_upper1_shape" />
+      </volume>
+      <volume name="u_support_bar_upper2">
+        <materialref ref="G10_FR4" />
+        <solidref ref="u_support_bar_upper2_shape" />
+      </volume>
+      <volume name="u_support_bar_top">
+        <materialref ref="G10_FR4" />
+        <solidref ref="u_support_bar_top_shape" />
+      </volume>
+      <volume name="u_support_bar_upper3">
+        <materialref ref="G10_FR4" />
+        <solidref ref="u_support_bar_upper3_shape" />
+      </volume>
+      <volume name="u_support_bar_upper4">
+        <materialref ref="G10_FR4" />
+        <solidref ref="u_support_bar_upper4_shape" />
+      </volume>
+      <volume name="svt_chamber_box_vol">
+        <materialref ref="Stainless_304" />
+        <solidref ref="svt_chamber_box" />
+      </volume>
+      <volume name="svt_chamber_flare1_vol">
+        <materialref ref="Stainless_304" />
+        <solidref ref="svt_chamber_flare1" />
+      </volume>
+      <volume name="svt_chamber_flare2_vol">
+        <materialref ref="Stainless_304" />
+        <solidref ref="svt_chamber_flare2" />
+      </volume>
+      <volume name="svt_chamber_flange_vol">
+        <materialref ref="Stainless_304" />
+        <solidref ref="svt_chamber_flange" />
+      </volume>
+      <volume name="tracking_volume">
+        <materialref ref="TrackingMaterial" />
+        <solidref ref="tracking_cylinder" />
+        <physvol>
+          <volumeref ref="base_volume" />
+          <positionref ref="base_position" />
+          <rotationref ref="base_rotation" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L1TP0" />
+          <positionref ref="hodo_pos_L1TP0" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="0" />
+          <physvolid field_name="ix" value="0" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1TP0" />
+          <positionref ref="hodo_forecover_pos_L1TP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1TP0" />
+          <positionref ref="hodo_postcover_pos_L1TP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1TP0" />
+          <positionref ref="hodo_sidereflR_pos_L1TP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1TP0" />
+          <positionref ref="hodo_siderefl2L_pos_L1TP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1TP0" />
+          <positionref ref="hodo_topreflT_pos_L1TP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1TP0" />
+          <positionref ref="hodo_toprefl2B_pos_L1TP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L1BP0" />
+          <positionref ref="hodo_pos_L1BP0" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="0" />
+          <physvolid field_name="ix" value="0" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1BP0" />
+          <positionref ref="hodo_forecover_pos_L1BP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1BP0" />
+          <positionref ref="hodo_postcover_pos_L1BP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1BP0" />
+          <positionref ref="hodo_sidereflR_pos_L1BP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1BP0" />
+          <positionref ref="hodo_siderefl2L_pos_L1BP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1BP0" />
+          <positionref ref="hodo_topreflT_pos_L1BP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1BP0" />
+          <positionref ref="hodo_toprefl2B_pos_L1BP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L1TP1" />
+          <positionref ref="hodo_pos_L1TP1" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="0" />
+          <physvolid field_name="ix" value="1" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1TP1" />
+          <positionref ref="hodo_forecover_pos_L1TP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1TP1" />
+          <positionref ref="hodo_postcover_pos_L1TP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1TP1" />
+          <positionref ref="hodo_sidereflR_pos_L1TP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1TP1" />
+          <positionref ref="hodo_siderefl2L_pos_L1TP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1TP1" />
+          <positionref ref="hodo_topreflT_pos_L1TP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1TP1" />
+          <positionref ref="hodo_toprefl2B_pos_L1TP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L1BP1" />
+          <positionref ref="hodo_pos_L1BP1" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="0" />
+          <physvolid field_name="ix" value="1" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1BP1" />
+          <positionref ref="hodo_forecover_pos_L1BP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1BP1" />
+          <positionref ref="hodo_postcover_pos_L1BP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1BP1" />
+          <positionref ref="hodo_sidereflR_pos_L1BP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1BP1" />
+          <positionref ref="hodo_siderefl2L_pos_L1BP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1BP1" />
+          <positionref ref="hodo_topreflT_pos_L1BP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1BP1" />
+          <positionref ref="hodo_toprefl2B_pos_L1BP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L1TP2" />
+          <positionref ref="hodo_pos_L1TP2" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="0" />
+          <physvolid field_name="ix" value="2" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1TP2" />
+          <positionref ref="hodo_forecover_pos_L1TP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1TP2" />
+          <positionref ref="hodo_postcover_pos_L1TP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1TP2" />
+          <positionref ref="hodo_sidereflR_pos_L1TP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1TP2" />
+          <positionref ref="hodo_siderefl2L_pos_L1TP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1TP2" />
+          <positionref ref="hodo_topreflT_pos_L1TP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1TP2" />
+          <positionref ref="hodo_toprefl2B_pos_L1TP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L1BP2" />
+          <positionref ref="hodo_pos_L1BP2" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="0" />
+          <physvolid field_name="ix" value="2" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1BP2" />
+          <positionref ref="hodo_forecover_pos_L1BP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1BP2" />
+          <positionref ref="hodo_postcover_pos_L1BP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1BP2" />
+          <positionref ref="hodo_sidereflR_pos_L1BP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1BP2" />
+          <positionref ref="hodo_siderefl2L_pos_L1BP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1BP2" />
+          <positionref ref="hodo_topreflT_pos_L1BP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1BP2" />
+          <positionref ref="hodo_toprefl2B_pos_L1BP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L1TP3" />
+          <positionref ref="hodo_pos_L1TP3" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="0" />
+          <physvolid field_name="ix" value="3" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1TP3" />
+          <positionref ref="hodo_forecover_pos_L1TP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1TP3" />
+          <positionref ref="hodo_postcover_pos_L1TP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1TP3" />
+          <positionref ref="hodo_sidereflR_pos_L1TP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1TP3" />
+          <positionref ref="hodo_siderefl2L_pos_L1TP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1TP3" />
+          <positionref ref="hodo_topreflT_pos_L1TP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1TP3" />
+          <positionref ref="hodo_toprefl2B_pos_L1TP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L1BP3" />
+          <positionref ref="hodo_pos_L1BP3" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="0" />
+          <physvolid field_name="ix" value="3" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1BP3" />
+          <positionref ref="hodo_forecover_pos_L1BP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1BP3" />
+          <positionref ref="hodo_postcover_pos_L1BP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1BP3" />
+          <positionref ref="hodo_sidereflR_pos_L1BP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1BP3" />
+          <positionref ref="hodo_siderefl2L_pos_L1BP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1BP3" />
+          <positionref ref="hodo_topreflT_pos_L1BP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1BP3" />
+          <positionref ref="hodo_toprefl2B_pos_L1BP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L1TP4" />
+          <positionref ref="hodo_pos_L1TP4" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="0" />
+          <physvolid field_name="ix" value="4" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1TP4" />
+          <positionref ref="hodo_forecover_pos_L1TP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1TP4" />
+          <positionref ref="hodo_postcover_pos_L1TP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1TP4" />
+          <positionref ref="hodo_sidereflR_pos_L1TP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1TP4" />
+          <positionref ref="hodo_siderefl2L_pos_L1TP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1TP4" />
+          <positionref ref="hodo_topreflT_pos_L1TP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1TP4" />
+          <positionref ref="hodo_toprefl2B_pos_L1TP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L1BP4" />
+          <positionref ref="hodo_pos_L1BP4" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="0" />
+          <physvolid field_name="ix" value="4" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1BP4" />
+          <positionref ref="hodo_forecover_pos_L1BP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1BP4" />
+          <positionref ref="hodo_postcover_pos_L1BP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1BP4" />
+          <positionref ref="hodo_sidereflR_pos_L1BP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1BP4" />
+          <positionref ref="hodo_siderefl2L_pos_L1BP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1BP4" />
+          <positionref ref="hodo_topreflT_pos_L1BP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1BP4" />
+          <positionref ref="hodo_toprefl2B_pos_L1BP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L2TP0" />
+          <positionref ref="hodo_pos_L2TP0" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="1" />
+          <physvolid field_name="ix" value="0" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2TP0" />
+          <positionref ref="hodo_forecover_pos_L2TP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2TP0" />
+          <positionref ref="hodo_postcover_pos_L2TP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2TP0" />
+          <positionref ref="hodo_sidereflR_pos_L2TP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2TP0" />
+          <positionref ref="hodo_siderefl2L_pos_L2TP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2TP0" />
+          <positionref ref="hodo_topreflT_pos_L2TP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2TP0" />
+          <positionref ref="hodo_toprefl2B_pos_L2TP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L2BP0" />
+          <positionref ref="hodo_pos_L2BP0" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="1" />
+          <physvolid field_name="ix" value="0" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2BP0" />
+          <positionref ref="hodo_forecover_pos_L2BP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2BP0" />
+          <positionref ref="hodo_postcover_pos_L2BP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2BP0" />
+          <positionref ref="hodo_sidereflR_pos_L2BP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2BP0" />
+          <positionref ref="hodo_siderefl2L_pos_L2BP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2BP0" />
+          <positionref ref="hodo_topreflT_pos_L2BP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2BP0" />
+          <positionref ref="hodo_toprefl2B_pos_L2BP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L2TP1" />
+          <positionref ref="hodo_pos_L2TP1" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="1" />
+          <physvolid field_name="ix" value="1" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2TP1" />
+          <positionref ref="hodo_forecover_pos_L2TP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2TP1" />
+          <positionref ref="hodo_postcover_pos_L2TP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2TP1" />
+          <positionref ref="hodo_sidereflR_pos_L2TP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2TP1" />
+          <positionref ref="hodo_siderefl2L_pos_L2TP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2TP1" />
+          <positionref ref="hodo_topreflT_pos_L2TP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2TP1" />
+          <positionref ref="hodo_toprefl2B_pos_L2TP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L2BP1" />
+          <positionref ref="hodo_pos_L2BP1" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="1" />
+          <physvolid field_name="ix" value="1" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2BP1" />
+          <positionref ref="hodo_forecover_pos_L2BP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2BP1" />
+          <positionref ref="hodo_postcover_pos_L2BP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2BP1" />
+          <positionref ref="hodo_sidereflR_pos_L2BP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2BP1" />
+          <positionref ref="hodo_siderefl2L_pos_L2BP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2BP1" />
+          <positionref ref="hodo_topreflT_pos_L2BP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2BP1" />
+          <positionref ref="hodo_toprefl2B_pos_L2BP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L2TP2" />
+          <positionref ref="hodo_pos_L2TP2" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="1" />
+          <physvolid field_name="ix" value="2" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2TP2" />
+          <positionref ref="hodo_forecover_pos_L2TP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2TP2" />
+          <positionref ref="hodo_postcover_pos_L2TP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2TP2" />
+          <positionref ref="hodo_sidereflR_pos_L2TP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2TP2" />
+          <positionref ref="hodo_siderefl2L_pos_L2TP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2TP2" />
+          <positionref ref="hodo_topreflT_pos_L2TP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2TP2" />
+          <positionref ref="hodo_toprefl2B_pos_L2TP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L2BP2" />
+          <positionref ref="hodo_pos_L2BP2" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="1" />
+          <physvolid field_name="ix" value="2" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2BP2" />
+          <positionref ref="hodo_forecover_pos_L2BP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2BP2" />
+          <positionref ref="hodo_postcover_pos_L2BP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2BP2" />
+          <positionref ref="hodo_sidereflR_pos_L2BP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2BP2" />
+          <positionref ref="hodo_siderefl2L_pos_L2BP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2BP2" />
+          <positionref ref="hodo_topreflT_pos_L2BP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2BP2" />
+          <positionref ref="hodo_toprefl2B_pos_L2BP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L2TP3" />
+          <positionref ref="hodo_pos_L2TP3" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="1" />
+          <physvolid field_name="ix" value="3" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2TP3" />
+          <positionref ref="hodo_forecover_pos_L2TP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2TP3" />
+          <positionref ref="hodo_postcover_pos_L2TP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2TP3" />
+          <positionref ref="hodo_sidereflR_pos_L2TP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2TP3" />
+          <positionref ref="hodo_siderefl2L_pos_L2TP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2TP3" />
+          <positionref ref="hodo_topreflT_pos_L2TP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2TP3" />
+          <positionref ref="hodo_toprefl2B_pos_L2TP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L2BP3" />
+          <positionref ref="hodo_pos_L2BP3" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="1" />
+          <physvolid field_name="ix" value="3" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2BP3" />
+          <positionref ref="hodo_forecover_pos_L2BP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2BP3" />
+          <positionref ref="hodo_postcover_pos_L2BP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2BP3" />
+          <positionref ref="hodo_sidereflR_pos_L2BP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2BP3" />
+          <positionref ref="hodo_siderefl2L_pos_L2BP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2BP3" />
+          <positionref ref="hodo_topreflT_pos_L2BP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2BP3" />
+          <positionref ref="hodo_toprefl2B_pos_L2BP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L2TP4" />
+          <positionref ref="hodo_pos_L2TP4" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="1" />
+          <physvolid field_name="ix" value="4" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2TP4" />
+          <positionref ref="hodo_forecover_pos_L2TP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2TP4" />
+          <positionref ref="hodo_postcover_pos_L2TP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2TP4" />
+          <positionref ref="hodo_sidereflR_pos_L2TP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2TP4" />
+          <positionref ref="hodo_siderefl2L_pos_L2TP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2TP4" />
+          <positionref ref="hodo_topreflT_pos_L2TP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2TP4" />
+          <positionref ref="hodo_toprefl2B_pos_L2TP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L2BP4" />
+          <positionref ref="hodo_pos_L2BP4" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="1" />
+          <physvolid field_name="ix" value="4" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2BP4" />
+          <positionref ref="hodo_forecover_pos_L2BP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2BP4" />
+          <positionref ref="hodo_postcover_pos_L2BP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2BP4" />
+          <positionref ref="hodo_sidereflR_pos_L2BP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2BP4" />
+          <positionref ref="hodo_siderefl2L_pos_L2BP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2BP4" />
+          <positionref ref="hodo_topreflT_pos_L2BP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2BP4" />
+          <positionref ref="hodo_toprefl2B_pos_L2BP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_buffer_vol" />
+          <positionref ref="hodo_bufferT_pos" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_buffer_vol" />
+          <positionref ref="hodo_bufferB_pos" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol name="hodo_flange_1">
+          <volumeref ref="hodo_flange" />
+          <positionref ref="hodo_flange_1intracking_volumepos" />
+        </physvol>
+        <physvol name="arms1_block1_1">
+          <volumeref ref="arms1_block1" />
+          <positionref ref="arms1_block1_1intracking_volumepos" />
+        </physvol>
+        <physvol name="arms1_block2_1">
+          <volumeref ref="arms1_block2" />
+          <positionref ref="arms1_block2_1intracking_volumepos" />
+        </physvol>
+        <physvol name="arms1_block3_1">
+          <volumeref ref="arms1_block3" />
+          <positionref ref="arms1_block3_1intracking_volumepos" />
+        </physvol>
+        <physvol name="arms1_block4_1">
+          <volumeref ref="arms1_block4" />
+          <positionref ref="arms1_block4_1intracking_volumepos" />
+        </physvol>
+        <physvol name="cross_bar_top_1">
+          <volumeref ref="cross_bar_top" />
+          <positionref ref="cross_bar_top_1intracking_volumepos" />
+        </physvol>
+        <physvol name="cross_bar_bottom_1">
+          <volumeref ref="cross_bar_bottom" />
+          <positionref ref="cross_bar_bottom_1intracking_volumepos" />
+        </physvol>
+        <physvol name="support_arm_bottom_left_plus_block_1">
+          <volumeref ref="support_arm_bottom_left_plus_block" />
+          <positionref ref="support_arm_bottom_left_plus_block_1intracking_volumepos" />
+        </physvol>
+        <physvol name="support_arm_bottom_right_1">
+          <volumeref ref="support_arm_bottom_right" />
+          <positionref ref="support_arm_bottom_right_1intracking_volumepos" />
+        </physvol>
+        <physvol name="support_arm_top_left_1">
+          <volumeref ref="support_arm_top_left" />
+          <positionref ref="support_arm_top_left_1intracking_volumepos" />
+          <rotationref ref="support_arm_top_left_1intracking_volumerot" />
+        </physvol>
+        <physvol name="support_arm_top_right_1">
+          <volumeref ref="support_arm_top_right" />
+          <positionref ref="support_arm_top_right_1intracking_volumepos" />
+          <rotationref ref="support_arm_top_right_1intracking_volumerot" />
+        </physvol>
+        <physvol name="u_support_bar_bottom_1">
+          <volumeref ref="u_support_bar_bottom" />
+          <positionref ref="u_support_bar_bottom_1intracking_volumepos" />
+        </physvol>
+        <physvol name="u_support_bar_upper1_1">
+          <volumeref ref="u_support_bar_upper1" />
+          <positionref ref="u_support_bar_upper1_1intracking_volumepos" />
+        </physvol>
+        <physvol name="u_support_bar_upper2_1">
+          <volumeref ref="u_support_bar_upper2" />
+          <positionref ref="u_support_bar_upper2_1intracking_volumepos" />
+        </physvol>
+        <physvol name="u_support_bar_top_1">
+          <volumeref ref="u_support_bar_top" />
+          <positionref ref="u_support_bar_top_1intracking_volumepos" />
+        </physvol>
+        <physvol name="u_support_bar_upper3_1">
+          <volumeref ref="u_support_bar_upper3" />
+          <positionref ref="u_support_bar_upper3_1intracking_volumepos" />
+        </physvol>
+        <physvol name="u_support_bar_upper4_1">
+          <volumeref ref="u_support_bar_upper4" />
+          <positionref ref="u_support_bar_upper4_1intracking_volumepos" />
+        </physvol>
+        <physvol>
+          <volumeref ref="svt_chamber_box_vol" />
+          <position name="svt_chamber_box_position" x="svt_chamber_x" y="0" z="svt_chamber_z+svt_chamber_box_z" />
+        </physvol>
+        <physvol>
+          <volumeref ref="svt_chamber_flare1_vol" />
+          <position name="svt_chamber_flare1_position" x="svt_chamber_x" y="0" z="svt_chamber_z+svt_chamber_flare1_z" />
+        </physvol>
+        <physvol>
+          <volumeref ref="svt_chamber_flare2_vol" />
+          <position name="svt_chamber_flare2_position" x="svt_chamber_x" y="0" z="svt_chamber_z+svt_chamber_flare2_z" />
+        </physvol>
+        <physvol>
+          <volumeref ref="svt_chamber_flange_vol" />
+          <position name="svt_chamber_flange_position" x="svt_chamber_x" y="0" z="svt_chamber_z+svt_chamber_flange_z" />
+        </physvol>
+        <regionref ref="TrackingRegion" />
+        <visref ref="TrackingVis" />
+      </volume>
+      <volume name="world_volume">
+        <materialref ref="WorldMaterial" />
+        <solidref ref="world_box" />
+        <physvol>
+          <volumeref ref="tracking_volume" />
+          <positionref ref="tracking_region_pos" />
+          <rotationref ref="identity_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="BeamLeftVolume" />
+          <positionref ref="ECalScoring_BeamLeft_layer1_module0_position" />
+          <rotationref ref="ECalScoring_BeamLeft_layer1_module0_rotation" />
+          <physvolid field_name="system" value="29" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="1" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="ElectronGapVolume" />
+          <positionref ref="ECalScoring_ElectronGap_layer1_module0_position" />
+          <rotationref ref="ECalScoring_ElectronGap_layer1_module0_rotation" />
+          <physvolid field_name="system" value="29" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="1" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="BeamRightVolume" />
+          <positionref ref="ECalScoring_BeamRight_layer1_module0_position" />
+          <rotationref ref="ECalScoring_BeamRight_layer1_module0_rotation" />
+          <physvolid field_name="system" value="29" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="1" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="BeamLeftVolume" />
+          <positionref ref="ECalScoring_BeamLeft_layer2_module0_position" />
+          <rotationref ref="ECalScoring_BeamLeft_layer2_module0_rotation" />
+          <physvolid field_name="system" value="29" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="2" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="ElectronGapVolume" />
+          <positionref ref="ECalScoring_ElectronGap_layer2_module0_position" />
+          <rotationref ref="ECalScoring_ElectronGap_layer2_module0_rotation" />
+          <physvolid field_name="system" value="29" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="2" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="BeamRightVolume" />
+          <positionref ref="ECalScoring_BeamRight_layer2_module0_position" />
+          <rotationref ref="ECalScoring_BeamRight_layer2_module0_rotation" />
+          <physvolid field_name="system" value="29" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="2" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-1_pos_pos_bot" />
+          <rotationref ref="crystal1-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="1" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-1_pos_neg_bot" />
+          <rotationref ref="crystal1-1_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-1" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-1_pos_pos_top" />
+          <rotationref ref="crystal1-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="1" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-1_pos_neg_top" />
+          <rotationref ref="crystal1-1_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-1" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal2-1_pos_pos_bot" />
+          <rotationref ref="crystal2-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="2" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal2-1_pos_pos_top" />
+          <rotationref ref="crystal2-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="2" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal3-1_pos_pos_bot" />
+          <rotationref ref="crystal3-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="3" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal3-1_pos_pos_top" />
+          <rotationref ref="crystal3-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="3" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal4-1_pos_pos_bot" />
+          <rotationref ref="crystal4-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="4" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal4-1_pos_pos_top" />
+          <rotationref ref="crystal4-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="4" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal5-1_pos_pos_bot" />
+          <rotationref ref="crystal5-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="5" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal5-1_pos_pos_top" />
+          <rotationref ref="crystal5-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="5" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal6-1_pos_pos_bot" />
+          <rotationref ref="crystal6-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="6" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal6-1_pos_pos_top" />
+          <rotationref ref="crystal6-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="6" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal7-1_pos_pos_bot" />
+          <rotationref ref="crystal7-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="7" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal7-1_pos_pos_top" />
+          <rotationref ref="crystal7-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="7" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal8-1_pos_pos_bot" />
+          <rotationref ref="crystal8-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="8" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal8-1_pos_pos_top" />
+          <rotationref ref="crystal8-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="8" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal9-1_pos_pos_bot" />
+          <rotationref ref="crystal9-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="9" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal9-1_pos_pos_top" />
+          <rotationref ref="crystal9-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="9" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal10-1_pos_pos_bot" />
+          <rotationref ref="crystal10-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="10" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal10-1_pos_pos_top" />
+          <rotationref ref="crystal10-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="10" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-1_pos_pos_bot" />
+          <rotationref ref="crystal11-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="11" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-1_pos_neg_bot" />
+          <rotationref ref="crystal11-1_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-11" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-1_pos_pos_top" />
+          <rotationref ref="crystal11-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="11" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-1_pos_neg_top" />
+          <rotationref ref="crystal11-1_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-11" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-1_pos_pos_bot" />
+          <rotationref ref="crystal12-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="12" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-1_pos_neg_bot" />
+          <rotationref ref="crystal12-1_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-12" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-1_pos_pos_top" />
+          <rotationref ref="crystal12-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="12" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-1_pos_neg_top" />
+          <rotationref ref="crystal12-1_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-12" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-1_pos_pos_bot" />
+          <rotationref ref="crystal13-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="13" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-1_pos_neg_bot" />
+          <rotationref ref="crystal13-1_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-13" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-1_pos_pos_top" />
+          <rotationref ref="crystal13-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="13" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-1_pos_neg_top" />
+          <rotationref ref="crystal13-1_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-13" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-1_pos_pos_bot" />
+          <rotationref ref="crystal14-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="14" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-1_pos_neg_bot" />
+          <rotationref ref="crystal14-1_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-14" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-1_pos_pos_top" />
+          <rotationref ref="crystal14-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="14" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-1_pos_neg_top" />
+          <rotationref ref="crystal14-1_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-14" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-1_pos_pos_bot" />
+          <rotationref ref="crystal15-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="15" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-1_pos_neg_bot" />
+          <rotationref ref="crystal15-1_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-15" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-1_pos_pos_top" />
+          <rotationref ref="crystal15-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="15" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-1_pos_neg_top" />
+          <rotationref ref="crystal15-1_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-15" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-1_pos_pos_bot" />
+          <rotationref ref="crystal16-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="16" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-1_pos_neg_bot" />
+          <rotationref ref="crystal16-1_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-16" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-1_pos_pos_top" />
+          <rotationref ref="crystal16-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="16" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-1_pos_neg_top" />
+          <rotationref ref="crystal16-1_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-16" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-1_pos_pos_bot" />
+          <rotationref ref="crystal17-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="17" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-1_pos_neg_bot" />
+          <rotationref ref="crystal17-1_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-17" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-1_pos_pos_top" />
+          <rotationref ref="crystal17-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="17" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-1_pos_neg_top" />
+          <rotationref ref="crystal17-1_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-17" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-1_pos_pos_bot" />
+          <rotationref ref="crystal18-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="18" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-1_pos_neg_bot" />
+          <rotationref ref="crystal18-1_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-18" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-1_pos_pos_top" />
+          <rotationref ref="crystal18-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="18" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-1_pos_neg_top" />
+          <rotationref ref="crystal18-1_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-18" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-1_pos_pos_bot" />
+          <rotationref ref="crystal19-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="19" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-1_pos_neg_bot" />
+          <rotationref ref="crystal19-1_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-19" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-1_pos_pos_top" />
+          <rotationref ref="crystal19-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="19" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-1_pos_neg_top" />
+          <rotationref ref="crystal19-1_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-19" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-1_pos_pos_bot" />
+          <rotationref ref="crystal20-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="20" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-1_pos_neg_bot" />
+          <rotationref ref="crystal20-1_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-20" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-1_pos_pos_top" />
+          <rotationref ref="crystal20-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="20" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-1_pos_neg_top" />
+          <rotationref ref="crystal20-1_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-20" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-1_pos_pos_bot" />
+          <rotationref ref="crystal21-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="21" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-1_pos_neg_bot" />
+          <rotationref ref="crystal21-1_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-21" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-1_pos_pos_top" />
+          <rotationref ref="crystal21-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="21" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-1_pos_neg_top" />
+          <rotationref ref="crystal21-1_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-21" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-1_pos_pos_bot" />
+          <rotationref ref="crystal22-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="22" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-1_pos_neg_bot" />
+          <rotationref ref="crystal22-1_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-22" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-1_pos_pos_top" />
+          <rotationref ref="crystal22-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="22" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-1_pos_neg_top" />
+          <rotationref ref="crystal22-1_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-22" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-1_pos_pos_bot" />
+          <rotationref ref="crystal23-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="23" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-1_pos_neg_bot" />
+          <rotationref ref="crystal23-1_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-23" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-1_pos_pos_top" />
+          <rotationref ref="crystal23-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="23" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-1_pos_neg_top" />
+          <rotationref ref="crystal23-1_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-23" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-2_pos_pos_bot" />
+          <rotationref ref="crystal1-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="1" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-2_pos_neg_bot" />
+          <rotationref ref="crystal1-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-1" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-2_pos_pos_top" />
+          <rotationref ref="crystal1-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="1" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-2_pos_neg_top" />
+          <rotationref ref="crystal1-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-1" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal2-2_pos_pos_bot" />
+          <rotationref ref="crystal2-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="2" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal2-2_pos_neg_bot" />
+          <rotationref ref="crystal2-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-2" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal2-2_pos_pos_top" />
+          <rotationref ref="crystal2-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="2" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal2-2_pos_neg_top" />
+          <rotationref ref="crystal2-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-2" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal3-2_pos_pos_bot" />
+          <rotationref ref="crystal3-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="3" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal3-2_pos_neg_bot" />
+          <rotationref ref="crystal3-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-3" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal3-2_pos_pos_top" />
+          <rotationref ref="crystal3-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="3" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal3-2_pos_neg_top" />
+          <rotationref ref="crystal3-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-3" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal4-2_pos_pos_bot" />
+          <rotationref ref="crystal4-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="4" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal4-2_pos_neg_bot" />
+          <rotationref ref="crystal4-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-4" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal4-2_pos_pos_top" />
+          <rotationref ref="crystal4-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="4" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal4-2_pos_neg_top" />
+          <rotationref ref="crystal4-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-4" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal5-2_pos_pos_bot" />
+          <rotationref ref="crystal5-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="5" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal5-2_pos_neg_bot" />
+          <rotationref ref="crystal5-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-5" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal5-2_pos_pos_top" />
+          <rotationref ref="crystal5-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="5" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal5-2_pos_neg_top" />
+          <rotationref ref="crystal5-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-5" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal6-2_pos_pos_bot" />
+          <rotationref ref="crystal6-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="6" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal6-2_pos_neg_bot" />
+          <rotationref ref="crystal6-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-6" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal6-2_pos_pos_top" />
+          <rotationref ref="crystal6-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="6" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal6-2_pos_neg_top" />
+          <rotationref ref="crystal6-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-6" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal7-2_pos_pos_bot" />
+          <rotationref ref="crystal7-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="7" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal7-2_pos_neg_bot" />
+          <rotationref ref="crystal7-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-7" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal7-2_pos_pos_top" />
+          <rotationref ref="crystal7-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="7" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal7-2_pos_neg_top" />
+          <rotationref ref="crystal7-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-7" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal8-2_pos_pos_bot" />
+          <rotationref ref="crystal8-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="8" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal8-2_pos_neg_bot" />
+          <rotationref ref="crystal8-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-8" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal8-2_pos_pos_top" />
+          <rotationref ref="crystal8-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="8" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal8-2_pos_neg_top" />
+          <rotationref ref="crystal8-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-8" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal9-2_pos_pos_bot" />
+          <rotationref ref="crystal9-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="9" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal9-2_pos_neg_bot" />
+          <rotationref ref="crystal9-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-9" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal9-2_pos_pos_top" />
+          <rotationref ref="crystal9-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="9" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal9-2_pos_neg_top" />
+          <rotationref ref="crystal9-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-9" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal10-2_pos_pos_bot" />
+          <rotationref ref="crystal10-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="10" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal10-2_pos_neg_bot" />
+          <rotationref ref="crystal10-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-10" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal10-2_pos_pos_top" />
+          <rotationref ref="crystal10-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="10" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal10-2_pos_neg_top" />
+          <rotationref ref="crystal10-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-10" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-2_pos_pos_bot" />
+          <rotationref ref="crystal11-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="11" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-2_pos_neg_bot" />
+          <rotationref ref="crystal11-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-11" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-2_pos_pos_top" />
+          <rotationref ref="crystal11-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="11" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-2_pos_neg_top" />
+          <rotationref ref="crystal11-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-11" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-2_pos_pos_bot" />
+          <rotationref ref="crystal12-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="12" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-2_pos_neg_bot" />
+          <rotationref ref="crystal12-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-12" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-2_pos_pos_top" />
+          <rotationref ref="crystal12-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="12" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-2_pos_neg_top" />
+          <rotationref ref="crystal12-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-12" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-2_pos_pos_bot" />
+          <rotationref ref="crystal13-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="13" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-2_pos_neg_bot" />
+          <rotationref ref="crystal13-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-13" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-2_pos_pos_top" />
+          <rotationref ref="crystal13-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="13" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-2_pos_neg_top" />
+          <rotationref ref="crystal13-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-13" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-2_pos_pos_bot" />
+          <rotationref ref="crystal14-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="14" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-2_pos_neg_bot" />
+          <rotationref ref="crystal14-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-14" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-2_pos_pos_top" />
+          <rotationref ref="crystal14-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="14" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-2_pos_neg_top" />
+          <rotationref ref="crystal14-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-14" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-2_pos_pos_bot" />
+          <rotationref ref="crystal15-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="15" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-2_pos_neg_bot" />
+          <rotationref ref="crystal15-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-15" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-2_pos_pos_top" />
+          <rotationref ref="crystal15-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="15" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-2_pos_neg_top" />
+          <rotationref ref="crystal15-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-15" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-2_pos_pos_bot" />
+          <rotationref ref="crystal16-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="16" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-2_pos_neg_bot" />
+          <rotationref ref="crystal16-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-16" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-2_pos_pos_top" />
+          <rotationref ref="crystal16-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="16" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-2_pos_neg_top" />
+          <rotationref ref="crystal16-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-16" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-2_pos_pos_bot" />
+          <rotationref ref="crystal17-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="17" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-2_pos_neg_bot" />
+          <rotationref ref="crystal17-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-17" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-2_pos_pos_top" />
+          <rotationref ref="crystal17-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="17" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-2_pos_neg_top" />
+          <rotationref ref="crystal17-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-17" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-2_pos_pos_bot" />
+          <rotationref ref="crystal18-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="18" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-2_pos_neg_bot" />
+          <rotationref ref="crystal18-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-18" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-2_pos_pos_top" />
+          <rotationref ref="crystal18-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="18" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-2_pos_neg_top" />
+          <rotationref ref="crystal18-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-18" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-2_pos_pos_bot" />
+          <rotationref ref="crystal19-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="19" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-2_pos_neg_bot" />
+          <rotationref ref="crystal19-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-19" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-2_pos_pos_top" />
+          <rotationref ref="crystal19-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="19" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-2_pos_neg_top" />
+          <rotationref ref="crystal19-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-19" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-2_pos_pos_bot" />
+          <rotationref ref="crystal20-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="20" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-2_pos_neg_bot" />
+          <rotationref ref="crystal20-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-20" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-2_pos_pos_top" />
+          <rotationref ref="crystal20-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="20" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-2_pos_neg_top" />
+          <rotationref ref="crystal20-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-20" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-2_pos_pos_bot" />
+          <rotationref ref="crystal21-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="21" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-2_pos_neg_bot" />
+          <rotationref ref="crystal21-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-21" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-2_pos_pos_top" />
+          <rotationref ref="crystal21-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="21" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-2_pos_neg_top" />
+          <rotationref ref="crystal21-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-21" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-2_pos_pos_bot" />
+          <rotationref ref="crystal22-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="22" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-2_pos_neg_bot" />
+          <rotationref ref="crystal22-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-22" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-2_pos_pos_top" />
+          <rotationref ref="crystal22-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="22" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-2_pos_neg_top" />
+          <rotationref ref="crystal22-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-22" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-2_pos_pos_bot" />
+          <rotationref ref="crystal23-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="23" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-2_pos_neg_bot" />
+          <rotationref ref="crystal23-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-23" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-2_pos_pos_top" />
+          <rotationref ref="crystal23-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="23" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-2_pos_neg_top" />
+          <rotationref ref="crystal23-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-23" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-3_pos_pos_bot" />
+          <rotationref ref="crystal1-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="1" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-3_pos_neg_bot" />
+          <rotationref ref="crystal1-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-1" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-3_pos_pos_top" />
+          <rotationref ref="crystal1-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="1" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-3_pos_neg_top" />
+          <rotationref ref="crystal1-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-1" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal2-3_pos_pos_bot" />
+          <rotationref ref="crystal2-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="2" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal2-3_pos_neg_bot" />
+          <rotationref ref="crystal2-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-2" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal2-3_pos_pos_top" />
+          <rotationref ref="crystal2-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="2" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal2-3_pos_neg_top" />
+          <rotationref ref="crystal2-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-2" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal3-3_pos_pos_bot" />
+          <rotationref ref="crystal3-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="3" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal3-3_pos_neg_bot" />
+          <rotationref ref="crystal3-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-3" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal3-3_pos_pos_top" />
+          <rotationref ref="crystal3-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="3" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal3-3_pos_neg_top" />
+          <rotationref ref="crystal3-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-3" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal4-3_pos_pos_bot" />
+          <rotationref ref="crystal4-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="4" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal4-3_pos_neg_bot" />
+          <rotationref ref="crystal4-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-4" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal4-3_pos_pos_top" />
+          <rotationref ref="crystal4-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="4" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal4-3_pos_neg_top" />
+          <rotationref ref="crystal4-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-4" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal5-3_pos_pos_bot" />
+          <rotationref ref="crystal5-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="5" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal5-3_pos_neg_bot" />
+          <rotationref ref="crystal5-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-5" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal5-3_pos_pos_top" />
+          <rotationref ref="crystal5-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="5" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal5-3_pos_neg_top" />
+          <rotationref ref="crystal5-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-5" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal6-3_pos_pos_bot" />
+          <rotationref ref="crystal6-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="6" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal6-3_pos_neg_bot" />
+          <rotationref ref="crystal6-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-6" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal6-3_pos_pos_top" />
+          <rotationref ref="crystal6-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="6" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal6-3_pos_neg_top" />
+          <rotationref ref="crystal6-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-6" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal7-3_pos_pos_bot" />
+          <rotationref ref="crystal7-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="7" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal7-3_pos_neg_bot" />
+          <rotationref ref="crystal7-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-7" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal7-3_pos_pos_top" />
+          <rotationref ref="crystal7-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="7" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal7-3_pos_neg_top" />
+          <rotationref ref="crystal7-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-7" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal8-3_pos_pos_bot" />
+          <rotationref ref="crystal8-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="8" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal8-3_pos_neg_bot" />
+          <rotationref ref="crystal8-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-8" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal8-3_pos_pos_top" />
+          <rotationref ref="crystal8-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="8" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal8-3_pos_neg_top" />
+          <rotationref ref="crystal8-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-8" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal9-3_pos_pos_bot" />
+          <rotationref ref="crystal9-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="9" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal9-3_pos_neg_bot" />
+          <rotationref ref="crystal9-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-9" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal9-3_pos_pos_top" />
+          <rotationref ref="crystal9-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="9" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal9-3_pos_neg_top" />
+          <rotationref ref="crystal9-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-9" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal10-3_pos_pos_bot" />
+          <rotationref ref="crystal10-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="10" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal10-3_pos_neg_bot" />
+          <rotationref ref="crystal10-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-10" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal10-3_pos_pos_top" />
+          <rotationref ref="crystal10-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="10" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal10-3_pos_neg_top" />
+          <rotationref ref="crystal10-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-10" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-3_pos_pos_bot" />
+          <rotationref ref="crystal11-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="11" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-3_pos_neg_bot" />
+          <rotationref ref="crystal11-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-11" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-3_pos_pos_top" />
+          <rotationref ref="crystal11-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="11" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-3_pos_neg_top" />
+          <rotationref ref="crystal11-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-11" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-3_pos_pos_bot" />
+          <rotationref ref="crystal12-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="12" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-3_pos_neg_bot" />
+          <rotationref ref="crystal12-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-12" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-3_pos_pos_top" />
+          <rotationref ref="crystal12-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="12" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-3_pos_neg_top" />
+          <rotationref ref="crystal12-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-12" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-3_pos_pos_bot" />
+          <rotationref ref="crystal13-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="13" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-3_pos_neg_bot" />
+          <rotationref ref="crystal13-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-13" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-3_pos_pos_top" />
+          <rotationref ref="crystal13-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="13" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-3_pos_neg_top" />
+          <rotationref ref="crystal13-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-13" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-3_pos_pos_bot" />
+          <rotationref ref="crystal14-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="14" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-3_pos_neg_bot" />
+          <rotationref ref="crystal14-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-14" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-3_pos_pos_top" />
+          <rotationref ref="crystal14-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="14" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-3_pos_neg_top" />
+          <rotationref ref="crystal14-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-14" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-3_pos_pos_bot" />
+          <rotationref ref="crystal15-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="15" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-3_pos_neg_bot" />
+          <rotationref ref="crystal15-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-15" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-3_pos_pos_top" />
+          <rotationref ref="crystal15-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="15" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-3_pos_neg_top" />
+          <rotationref ref="crystal15-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-15" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-3_pos_pos_bot" />
+          <rotationref ref="crystal16-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="16" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-3_pos_neg_bot" />
+          <rotationref ref="crystal16-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-16" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-3_pos_pos_top" />
+          <rotationref ref="crystal16-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="16" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-3_pos_neg_top" />
+          <rotationref ref="crystal16-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-16" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-3_pos_pos_bot" />
+          <rotationref ref="crystal17-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="17" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-3_pos_neg_bot" />
+          <rotationref ref="crystal17-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-17" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-3_pos_pos_top" />
+          <rotationref ref="crystal17-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="17" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-3_pos_neg_top" />
+          <rotationref ref="crystal17-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-17" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-3_pos_pos_bot" />
+          <rotationref ref="crystal18-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="18" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-3_pos_neg_bot" />
+          <rotationref ref="crystal18-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-18" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-3_pos_pos_top" />
+          <rotationref ref="crystal18-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="18" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-3_pos_neg_top" />
+          <rotationref ref="crystal18-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-18" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-3_pos_pos_bot" />
+          <rotationref ref="crystal19-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="19" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-3_pos_neg_bot" />
+          <rotationref ref="crystal19-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-19" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-3_pos_pos_top" />
+          <rotationref ref="crystal19-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="19" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-3_pos_neg_top" />
+          <rotationref ref="crystal19-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-19" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-3_pos_pos_bot" />
+          <rotationref ref="crystal20-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="20" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-3_pos_neg_bot" />
+          <rotationref ref="crystal20-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-20" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-3_pos_pos_top" />
+          <rotationref ref="crystal20-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="20" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-3_pos_neg_top" />
+          <rotationref ref="crystal20-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-20" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-3_pos_pos_bot" />
+          <rotationref ref="crystal21-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="21" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-3_pos_neg_bot" />
+          <rotationref ref="crystal21-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-21" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-3_pos_pos_top" />
+          <rotationref ref="crystal21-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="21" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-3_pos_neg_top" />
+          <rotationref ref="crystal21-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-21" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-3_pos_pos_bot" />
+          <rotationref ref="crystal22-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="22" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-3_pos_neg_bot" />
+          <rotationref ref="crystal22-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-22" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-3_pos_pos_top" />
+          <rotationref ref="crystal22-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="22" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-3_pos_neg_top" />
+          <rotationref ref="crystal22-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-22" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-3_pos_pos_bot" />
+          <rotationref ref="crystal23-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="23" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-3_pos_neg_bot" />
+          <rotationref ref="crystal23-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-23" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-3_pos_pos_top" />
+          <rotationref ref="crystal23-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="23" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-3_pos_neg_top" />
+          <rotationref ref="crystal23-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-23" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-4_pos_pos_bot" />
+          <rotationref ref="crystal1-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="1" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-4_pos_neg_bot" />
+          <rotationref ref="crystal1-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-1" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-4_pos_pos_top" />
+          <rotationref ref="crystal1-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="1" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-4_pos_neg_top" />
+          <rotationref ref="crystal1-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-1" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal2-4_pos_pos_bot" />
+          <rotationref ref="crystal2-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="2" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal2-4_pos_neg_bot" />
+          <rotationref ref="crystal2-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-2" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal2-4_pos_pos_top" />
+          <rotationref ref="crystal2-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="2" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal2-4_pos_neg_top" />
+          <rotationref ref="crystal2-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-2" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal3-4_pos_pos_bot" />
+          <rotationref ref="crystal3-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="3" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal3-4_pos_neg_bot" />
+          <rotationref ref="crystal3-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-3" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal3-4_pos_pos_top" />
+          <rotationref ref="crystal3-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="3" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal3-4_pos_neg_top" />
+          <rotationref ref="crystal3-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-3" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal4-4_pos_pos_bot" />
+          <rotationref ref="crystal4-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="4" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal4-4_pos_neg_bot" />
+          <rotationref ref="crystal4-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-4" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal4-4_pos_pos_top" />
+          <rotationref ref="crystal4-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="4" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal4-4_pos_neg_top" />
+          <rotationref ref="crystal4-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-4" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal5-4_pos_pos_bot" />
+          <rotationref ref="crystal5-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="5" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal5-4_pos_neg_bot" />
+          <rotationref ref="crystal5-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-5" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal5-4_pos_pos_top" />
+          <rotationref ref="crystal5-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="5" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal5-4_pos_neg_top" />
+          <rotationref ref="crystal5-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-5" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal6-4_pos_pos_bot" />
+          <rotationref ref="crystal6-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="6" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal6-4_pos_neg_bot" />
+          <rotationref ref="crystal6-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-6" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal6-4_pos_pos_top" />
+          <rotationref ref="crystal6-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="6" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal6-4_pos_neg_top" />
+          <rotationref ref="crystal6-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-6" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal7-4_pos_pos_bot" />
+          <rotationref ref="crystal7-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="7" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal7-4_pos_neg_bot" />
+          <rotationref ref="crystal7-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-7" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal7-4_pos_pos_top" />
+          <rotationref ref="crystal7-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="7" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal7-4_pos_neg_top" />
+          <rotationref ref="crystal7-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-7" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal8-4_pos_pos_bot" />
+          <rotationref ref="crystal8-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="8" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal8-4_pos_neg_bot" />
+          <rotationref ref="crystal8-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-8" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal8-4_pos_pos_top" />
+          <rotationref ref="crystal8-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="8" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal8-4_pos_neg_top" />
+          <rotationref ref="crystal8-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-8" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal9-4_pos_pos_bot" />
+          <rotationref ref="crystal9-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="9" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal9-4_pos_neg_bot" />
+          <rotationref ref="crystal9-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-9" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal9-4_pos_pos_top" />
+          <rotationref ref="crystal9-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="9" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal9-4_pos_neg_top" />
+          <rotationref ref="crystal9-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-9" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal10-4_pos_pos_bot" />
+          <rotationref ref="crystal10-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="10" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal10-4_pos_neg_bot" />
+          <rotationref ref="crystal10-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-10" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal10-4_pos_pos_top" />
+          <rotationref ref="crystal10-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="10" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal10-4_pos_neg_top" />
+          <rotationref ref="crystal10-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-10" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-4_pos_pos_bot" />
+          <rotationref ref="crystal11-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="11" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-4_pos_neg_bot" />
+          <rotationref ref="crystal11-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-11" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-4_pos_pos_top" />
+          <rotationref ref="crystal11-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="11" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-4_pos_neg_top" />
+          <rotationref ref="crystal11-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-11" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-4_pos_pos_bot" />
+          <rotationref ref="crystal12-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="12" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-4_pos_neg_bot" />
+          <rotationref ref="crystal12-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-12" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-4_pos_pos_top" />
+          <rotationref ref="crystal12-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="12" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-4_pos_neg_top" />
+          <rotationref ref="crystal12-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-12" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-4_pos_pos_bot" />
+          <rotationref ref="crystal13-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="13" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-4_pos_neg_bot" />
+          <rotationref ref="crystal13-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-13" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-4_pos_pos_top" />
+          <rotationref ref="crystal13-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="13" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-4_pos_neg_top" />
+          <rotationref ref="crystal13-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-13" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-4_pos_pos_bot" />
+          <rotationref ref="crystal14-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="14" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-4_pos_neg_bot" />
+          <rotationref ref="crystal14-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-14" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-4_pos_pos_top" />
+          <rotationref ref="crystal14-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="14" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-4_pos_neg_top" />
+          <rotationref ref="crystal14-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-14" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-4_pos_pos_bot" />
+          <rotationref ref="crystal15-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="15" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-4_pos_neg_bot" />
+          <rotationref ref="crystal15-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-15" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-4_pos_pos_top" />
+          <rotationref ref="crystal15-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="15" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-4_pos_neg_top" />
+          <rotationref ref="crystal15-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-15" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-4_pos_pos_bot" />
+          <rotationref ref="crystal16-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="16" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-4_pos_neg_bot" />
+          <rotationref ref="crystal16-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-16" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-4_pos_pos_top" />
+          <rotationref ref="crystal16-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="16" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-4_pos_neg_top" />
+          <rotationref ref="crystal16-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-16" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-4_pos_pos_bot" />
+          <rotationref ref="crystal17-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="17" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-4_pos_neg_bot" />
+          <rotationref ref="crystal17-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-17" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-4_pos_pos_top" />
+          <rotationref ref="crystal17-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="17" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-4_pos_neg_top" />
+          <rotationref ref="crystal17-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-17" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-4_pos_pos_bot" />
+          <rotationref ref="crystal18-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="18" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-4_pos_neg_bot" />
+          <rotationref ref="crystal18-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-18" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-4_pos_pos_top" />
+          <rotationref ref="crystal18-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="18" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-4_pos_neg_top" />
+          <rotationref ref="crystal18-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-18" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-4_pos_pos_bot" />
+          <rotationref ref="crystal19-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="19" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-4_pos_neg_bot" />
+          <rotationref ref="crystal19-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-19" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-4_pos_pos_top" />
+          <rotationref ref="crystal19-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="19" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-4_pos_neg_top" />
+          <rotationref ref="crystal19-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-19" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-4_pos_pos_bot" />
+          <rotationref ref="crystal20-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="20" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-4_pos_neg_bot" />
+          <rotationref ref="crystal20-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-20" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-4_pos_pos_top" />
+          <rotationref ref="crystal20-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="20" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-4_pos_neg_top" />
+          <rotationref ref="crystal20-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-20" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-4_pos_pos_bot" />
+          <rotationref ref="crystal21-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="21" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-4_pos_neg_bot" />
+          <rotationref ref="crystal21-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-21" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-4_pos_pos_top" />
+          <rotationref ref="crystal21-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="21" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-4_pos_neg_top" />
+          <rotationref ref="crystal21-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-21" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-4_pos_pos_bot" />
+          <rotationref ref="crystal22-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="22" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-4_pos_neg_bot" />
+          <rotationref ref="crystal22-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-22" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-4_pos_pos_top" />
+          <rotationref ref="crystal22-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="22" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-4_pos_neg_top" />
+          <rotationref ref="crystal22-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-22" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-4_pos_pos_bot" />
+          <rotationref ref="crystal23-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="23" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-4_pos_neg_bot" />
+          <rotationref ref="crystal23-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-23" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-4_pos_pos_top" />
+          <rotationref ref="crystal23-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="23" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-4_pos_neg_top" />
+          <rotationref ref="crystal23-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-23" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-5_pos_pos_bot" />
+          <rotationref ref="crystal1-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="1" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-5_pos_neg_bot" />
+          <rotationref ref="crystal1-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-1" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-5_pos_pos_top" />
+          <rotationref ref="crystal1-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="1" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-5_pos_neg_top" />
+          <rotationref ref="crystal1-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-1" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal2-5_pos_pos_bot" />
+          <rotationref ref="crystal2-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="2" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal2-5_pos_neg_bot" />
+          <rotationref ref="crystal2-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-2" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal2-5_pos_pos_top" />
+          <rotationref ref="crystal2-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="2" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal2-5_pos_neg_top" />
+          <rotationref ref="crystal2-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-2" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal3-5_pos_pos_bot" />
+          <rotationref ref="crystal3-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="3" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal3-5_pos_neg_bot" />
+          <rotationref ref="crystal3-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-3" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal3-5_pos_pos_top" />
+          <rotationref ref="crystal3-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="3" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal3-5_pos_neg_top" />
+          <rotationref ref="crystal3-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-3" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal4-5_pos_pos_bot" />
+          <rotationref ref="crystal4-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="4" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal4-5_pos_neg_bot" />
+          <rotationref ref="crystal4-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-4" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal4-5_pos_pos_top" />
+          <rotationref ref="crystal4-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="4" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal4-5_pos_neg_top" />
+          <rotationref ref="crystal4-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-4" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal5-5_pos_pos_bot" />
+          <rotationref ref="crystal5-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="5" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal5-5_pos_neg_bot" />
+          <rotationref ref="crystal5-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-5" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal5-5_pos_pos_top" />
+          <rotationref ref="crystal5-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="5" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal5-5_pos_neg_top" />
+          <rotationref ref="crystal5-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-5" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal6-5_pos_pos_bot" />
+          <rotationref ref="crystal6-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="6" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal6-5_pos_neg_bot" />
+          <rotationref ref="crystal6-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-6" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal6-5_pos_pos_top" />
+          <rotationref ref="crystal6-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="6" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal6-5_pos_neg_top" />
+          <rotationref ref="crystal6-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-6" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal7-5_pos_pos_bot" />
+          <rotationref ref="crystal7-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="7" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal7-5_pos_neg_bot" />
+          <rotationref ref="crystal7-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-7" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal7-5_pos_pos_top" />
+          <rotationref ref="crystal7-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="7" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal7-5_pos_neg_top" />
+          <rotationref ref="crystal7-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-7" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal8-5_pos_pos_bot" />
+          <rotationref ref="crystal8-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="8" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal8-5_pos_neg_bot" />
+          <rotationref ref="crystal8-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-8" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal8-5_pos_pos_top" />
+          <rotationref ref="crystal8-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="8" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal8-5_pos_neg_top" />
+          <rotationref ref="crystal8-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-8" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal9-5_pos_pos_bot" />
+          <rotationref ref="crystal9-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="9" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal9-5_pos_neg_bot" />
+          <rotationref ref="crystal9-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-9" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal9-5_pos_pos_top" />
+          <rotationref ref="crystal9-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="9" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal9-5_pos_neg_top" />
+          <rotationref ref="crystal9-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-9" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal10-5_pos_pos_bot" />
+          <rotationref ref="crystal10-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="10" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal10-5_pos_neg_bot" />
+          <rotationref ref="crystal10-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-10" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal10-5_pos_pos_top" />
+          <rotationref ref="crystal10-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="10" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal10-5_pos_neg_top" />
+          <rotationref ref="crystal10-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-10" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-5_pos_pos_bot" />
+          <rotationref ref="crystal11-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="11" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-5_pos_neg_bot" />
+          <rotationref ref="crystal11-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-11" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-5_pos_pos_top" />
+          <rotationref ref="crystal11-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="11" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-5_pos_neg_top" />
+          <rotationref ref="crystal11-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-11" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-5_pos_pos_bot" />
+          <rotationref ref="crystal12-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="12" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-5_pos_neg_bot" />
+          <rotationref ref="crystal12-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-12" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-5_pos_pos_top" />
+          <rotationref ref="crystal12-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="12" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-5_pos_neg_top" />
+          <rotationref ref="crystal12-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-12" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-5_pos_pos_bot" />
+          <rotationref ref="crystal13-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="13" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-5_pos_neg_bot" />
+          <rotationref ref="crystal13-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-13" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-5_pos_pos_top" />
+          <rotationref ref="crystal13-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="13" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-5_pos_neg_top" />
+          <rotationref ref="crystal13-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-13" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-5_pos_pos_bot" />
+          <rotationref ref="crystal14-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="14" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-5_pos_neg_bot" />
+          <rotationref ref="crystal14-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-14" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-5_pos_pos_top" />
+          <rotationref ref="crystal14-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="14" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-5_pos_neg_top" />
+          <rotationref ref="crystal14-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-14" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-5_pos_pos_bot" />
+          <rotationref ref="crystal15-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="15" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-5_pos_neg_bot" />
+          <rotationref ref="crystal15-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-15" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-5_pos_pos_top" />
+          <rotationref ref="crystal15-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="15" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-5_pos_neg_top" />
+          <rotationref ref="crystal15-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-15" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-5_pos_pos_bot" />
+          <rotationref ref="crystal16-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="16" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-5_pos_neg_bot" />
+          <rotationref ref="crystal16-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-16" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-5_pos_pos_top" />
+          <rotationref ref="crystal16-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="16" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-5_pos_neg_top" />
+          <rotationref ref="crystal16-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-16" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-5_pos_pos_bot" />
+          <rotationref ref="crystal17-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="17" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-5_pos_neg_bot" />
+          <rotationref ref="crystal17-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-17" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-5_pos_pos_top" />
+          <rotationref ref="crystal17-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="17" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-5_pos_neg_top" />
+          <rotationref ref="crystal17-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-17" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-5_pos_pos_bot" />
+          <rotationref ref="crystal18-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="18" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-5_pos_neg_bot" />
+          <rotationref ref="crystal18-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-18" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-5_pos_pos_top" />
+          <rotationref ref="crystal18-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="18" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-5_pos_neg_top" />
+          <rotationref ref="crystal18-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-18" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-5_pos_pos_bot" />
+          <rotationref ref="crystal19-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="19" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-5_pos_neg_bot" />
+          <rotationref ref="crystal19-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-19" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-5_pos_pos_top" />
+          <rotationref ref="crystal19-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="19" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-5_pos_neg_top" />
+          <rotationref ref="crystal19-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-19" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-5_pos_pos_bot" />
+          <rotationref ref="crystal20-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="20" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-5_pos_neg_bot" />
+          <rotationref ref="crystal20-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-20" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-5_pos_pos_top" />
+          <rotationref ref="crystal20-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="20" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-5_pos_neg_top" />
+          <rotationref ref="crystal20-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-20" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-5_pos_pos_bot" />
+          <rotationref ref="crystal21-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="21" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-5_pos_neg_bot" />
+          <rotationref ref="crystal21-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-21" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-5_pos_pos_top" />
+          <rotationref ref="crystal21-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="21" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-5_pos_neg_top" />
+          <rotationref ref="crystal21-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-21" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-5_pos_pos_bot" />
+          <rotationref ref="crystal22-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="22" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-5_pos_neg_bot" />
+          <rotationref ref="crystal22-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-22" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-5_pos_pos_top" />
+          <rotationref ref="crystal22-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="22" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-5_pos_neg_top" />
+          <rotationref ref="crystal22-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-22" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-5_pos_pos_bot" />
+          <rotationref ref="crystal23-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="23" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-5_pos_neg_bot" />
+          <rotationref ref="crystal23-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-23" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-5_pos_pos_top" />
+          <rotationref ref="crystal23-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="23" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-5_pos_neg_top" />
+          <rotationref ref="crystal23-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-23" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol name="front_flange_1">
+          <volumeref ref="front_flange" />
+          <positionref ref="front_flange_1inworld_volumepos" />
+        </physvol>
+        <physvol name="back_flange_1">
+          <volumeref ref="back_flange" />
+          <positionref ref="back_flange_1inworld_volumepos" />
+        </physvol>
+        <physvol name="ECAL_chamber_1">
+          <volumeref ref="ECAL_chamber" />
+          <positionref ref="ECAL_chamber_1inworld_volumepos" />
+        </physvol>
+        <physvol name="al_honeycomb_1">
+          <volumeref ref="al_honeycomb" />
+          <positionref ref="al_honeycomb_1inworld_volumepos" />
+        </physvol>
+        <physvol name="layer_1_top_1">
+          <volumeref ref="layer_1_top" />
+          <positionref ref="layer_1_top_1inworld_volumepos" />
+        </physvol>
+        <physvol name="layer_2_top_1">
+          <volumeref ref="layer_2_top" />
+          <positionref ref="layer_2_top_1inworld_volumepos" />
+        </physvol>
+        <physvol name="layer_3_top_1">
+          <volumeref ref="layer_3_top" />
+          <positionref ref="layer_3_top_1inworld_volumepos" />
+        </physvol>
+        <physvol name="layer_4_top_1">
+          <volumeref ref="layer_4_top" />
+          <positionref ref="layer_4_top_1inworld_volumepos" />
+        </physvol>
+        <physvol name="layer_1_bottom_1">
+          <volumeref ref="layer_1_bottom" />
+          <positionref ref="layer_1_bottom_1inworld_volumepos" />
+        </physvol>
+        <physvol name="layer_2_bottom_1">
+          <volumeref ref="layer_2_bottom" />
+          <positionref ref="layer_2_bottom_1inworld_volumepos" />
+        </physvol>
+        <physvol name="layer_3_bottom_1">
+          <volumeref ref="layer_3_bottom" />
+          <positionref ref="layer_3_bottom_1inworld_volumepos" />
+        </physvol>
+        <physvol name="layer_4_bottom_1">
+          <volumeref ref="layer_4_bottom" />
+          <positionref ref="layer_4_bottom_1inworld_volumepos" />
+        </physvol>
+        <physvol name="layer_5T_left_1">
+          <volumeref ref="layer_5T_left" />
+          <positionref ref="layer_5T_left_1inworld_volumepos" />
+        </physvol>
+        <physvol name="layer_5B_left_1">
+          <volumeref ref="layer_5B_left" />
+          <positionref ref="layer_5B_left_1inworld_volumepos" />
+        </physvol>
+        <physvol name="steel_bar_1">
+          <volumeref ref="steel_bar" />
+          <positionref ref="steel_bar_1inworld_volumepos" />
+        </physvol>
+        <physvol name="cu_Tpipe_inner_left_1">
+          <volumeref ref="cu_Tpipe_inner_left" />
+          <positionref ref="cu_Tpipe_inner_left_1inworld_volumepos" />
+          <rotationref ref="cu_Tpipe_inner_left_1inworld_volumerot" />
+        </physvol>
+        <physvol name="cu_Tpipe_inner_right_1">
+          <volumeref ref="cu_Tpipe_inner_right" />
+          <positionref ref="cu_Tpipe_inner_right_1inworld_volumepos" />
+          <rotationref ref="cu_Tpipe_inner_right_1inworld_volumerot" />
+        </physvol>
+        <physvol name="cu_Bpipe_inner_left_1">
+          <volumeref ref="cu_Bpipe_inner_left" />
+          <positionref ref="cu_Bpipe_inner_left_1inworld_volumepos" />
+          <rotationref ref="cu_Bpipe_inner_left_1inworld_volumerot" />
+        </physvol>
+        <physvol name="cu_Bpipe_inner_right_1">
+          <volumeref ref="cu_Bpipe_inner_right" />
+          <positionref ref="cu_Bpipe_inner_right_1inworld_volumepos" />
+          <rotationref ref="cu_Bpipe_inner_right_1inworld_volumerot" />
+        </physvol>
+        <physvol name="cu_Tpipe_outer_right1_1">
+          <volumeref ref="cu_Tpipe_outer_right1" />
+          <positionref ref="cu_Tpipe_outer_right1_1inworld_volumepos" />
+          <rotationref ref="cu_Tpipe_outer_right1_1inworld_volumerot" />
+        </physvol>
+        <physvol name="cu_Tpipe_outer_right2_1">
+          <volumeref ref="cu_Tpipe_outer_right2" />
+          <positionref ref="cu_Tpipe_outer_right2_1inworld_volumepos" />
+        </physvol>
+        <physvol name="cu_Tpipe_outer_right3_1">
+          <volumeref ref="cu_Tpipe_outer_right3" />
+          <positionref ref="cu_Tpipe_outer_right3_1inworld_volumepos" />
+          <rotationref ref="cu_Tpipe_outer_right3_1inworld_volumerot" />
+        </physvol>
+        <physvol name="cu_Bpipe_outer_right_1">
+          <volumeref ref="cu_Bpipe_outer_right" />
+          <positionref ref="cu_Bpipe_outer_right_1inworld_volumepos" />
+          <rotationref ref="cu_Bpipe_outer_right_1inworld_volumerot" />
+        </physvol>
+        <physvol name="cu_Bpipe_outer_right1_1">
+          <volumeref ref="cu_Bpipe_outer_right1" />
+          <positionref ref="cu_Bpipe_outer_right1_1inworld_volumepos" />
+          <rotationref ref="cu_Bpipe_outer_right1_1inworld_volumerot" />
+        </physvol>
+        <physvol name="cu_Bpipe_outer_right2_1">
+          <volumeref ref="cu_Bpipe_outer_right2" />
+          <positionref ref="cu_Bpipe_outer_right2_1inworld_volumepos" />
+        </physvol>
+        <physvol name="al_pipe_across_top1_1">
+          <volumeref ref="al_pipe_across_top1" />
+          <positionref ref="al_pipe_across_top1_1inworld_volumepos" />
+          <rotationref ref="al_pipe_across_top1_1inworld_volumerot" />
+        </physvol>
+        <physvol name="al_pipe_across_top2_1">
+          <volumeref ref="al_pipe_across_top2" />
+          <positionref ref="al_pipe_across_top2_1inworld_volumepos" />
+          <rotationref ref="al_pipe_across_top2_1inworld_volumerot" />
+        </physvol>
+        <physvol name="al_pipe_across_bottom1_1">
+          <volumeref ref="al_pipe_across_bottom1" />
+          <positionref ref="al_pipe_across_bottom1_1inworld_volumepos" />
+          <rotationref ref="al_pipe_across_bottom1_1inworld_volumerot" />
+        </physvol>
+        <physvol name="al_pipe_across_bottom2_1">
+          <volumeref ref="al_pipe_across_bottom2" />
+          <positionref ref="al_pipe_across_bottom2_1inworld_volumepos" />
+          <rotationref ref="al_pipe_across_bottom2_1inworld_volumerot" />
+        </physvol>
+        <physvol name="cu_plate_top_left_1">
+          <volumeref ref="cu_plate_top_left" />
+          <positionref ref="cu_plate_top_left_1inworld_volumepos" />
+        </physvol>
+        <physvol name="cu_plate_bottom_left_1">
+          <volumeref ref="cu_plate_bottom_left" />
+          <positionref ref="cu_plate_bottom_left_1inworld_volumepos" />
+        </physvol>
+        <physvol name="cu_plate_top_right_1">
+          <volumeref ref="cu_plate_top_right" />
+          <positionref ref="cu_plate_top_right_1inworld_volumepos" />
+        </physvol>
+        <physvol name="cu_plate_bottom_right_1">
+          <volumeref ref="cu_plate_bottom_right" />
+          <positionref ref="cu_plate_bottom_right_1inworld_volumepos" />
+        </physvol>
+        <physvol name="cu_plate_top_middle_1">
+          <volumeref ref="cu_plate_top_middle" />
+          <positionref ref="cu_plate_top_middle_1inworld_volumepos" />
+        </physvol>
+        <physvol name="cu_plate_bottom_middle_1">
+          <volumeref ref="cu_plate_bottom_middle" />
+          <positionref ref="cu_plate_bottom_middle_1inworld_volumepos" />
+        </physvol>
+        <visref ref="WorldVis" />
+      </volume>
+    </structure>
+    <setup name="Default" version="1.0">
+      <world ref="world_volume" />
+    </setup>
+  </gdml>
+  <fields>
+    <field_map_3d name="HPSDipoleFieldMap3D" lunit="mm" funit="tesla" filename="fieldmap/334acm3_8kg_corrected_unfolded_scaled_1.07326.dat" xoffset="21.17" yoffset="0.0" zoffset="457.2" />
+  </fields>
+</lcdd>
+

--- a/detector-data/detectors/HPS_Run2021Pass0_v1_fixed/SamplingFractions/Ecal.properties
+++ b/detector-data/detectors/HPS_Run2021Pass0_v1_fixed/SamplingFractions/Ecal.properties
@@ -1,0 +1,1 @@
+samplingFraction: 1.0

--- a/detector-data/detectors/HPS_Run2021Pass0_v1_fixed/SamplingFractions/Hodoscope.properties
+++ b/detector-data/detectors/HPS_Run2021Pass0_v1_fixed/SamplingFractions/Hodoscope.properties
@@ -1,0 +1,1 @@
+samplingFraction: 1.0

--- a/detector-data/detectors/HPS_Run2021Pass0_v1_fixed/compact.xml
+++ b/detector-data/detectors/HPS_Run2021Pass0_v1_fixed/compact.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <lccdd xmlns:compact="http://www.lcsim.org/schemas/compact/1.0" xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/compact/1.0/compact.xsd">
 
-<info name="HPS_Run2021Pass0_v1_1pt92GeV">
+<info name="HPS_Run2021Pass0_v1_fixed">
     <comment>HPS detector for 2021 run with fieldmap,
     Tracker at nominal opening angle, no SVT survey,
     this detector uses the corrected fieldmap scaled for 3.74 GeV beam.
@@ -33,7 +33,7 @@
     <constant name="dipoleMagnetHeight" value="100*cm" />
     <constant name="dipoleMagnetWidth" value="100*cm" />
     <constant name="dipoleMagnetLength" value="108*cm" />
-    <constant name="constBFieldY" value="-0.437" /><!-- set for 1.92 GeV running -->
+    <constant name="constBFieldY" value="-1.08" /><!-- set for 4.5GeV running -->
 
 
     <!-- ECAL crystal dimensions -->
@@ -534,14 +534,14 @@
         <millepede_constant name="22362" value="0.0" /> <!-- rw -->
 
         <!-- L3 Top/Bottom translations and angles -->
-        <millepede_constant name="11163" value="0.0 + 0.000678 - -0.059459 - 0.012216 - 0.006668 - 0.002504 + -0.7" /> <!-- u  -> global Y   -->
+        <millepede_constant name="11163" value="0.0 + 0.000678 - -0.059459 - 0.012216 - 0.006668 - 0.002504" /> <!-- u  -> global Y   -->
         <millepede_constant name="11263" value="0.0" /> <!-- v  -> X+svtAngle -->
         <millepede_constant name="11363" value="0.0" /> <!-- w  -> Z+svtAngle -->
         <millepede_constant name="12163" value="0.0" /> <!-- ru -->
         <millepede_constant name="12263" value="0.0" /> <!-- rv -->
         <millepede_constant name="12363" value="0.0" /> <!-- rw -->
 
-        <millepede_constant name="21163" value="0.0 + -0.046884 + -0.010228 - 0.075913 - 0.001767 - 0.023862 + -0.7" /> <!-- u -->
+        <millepede_constant name="21163" value="0.0 + -0.046884 + -0.010228 - 0.075913 - 0.001767 - 0.023862" /> <!-- u -->
         <millepede_constant name="21263" value="0.0" /> <!-- v -->
         <millepede_constant name="21363" value="0.0" /> <!-- w -->
         <millepede_constant name="22163" value="0.0" /> <!-- ru -->
@@ -549,14 +549,14 @@
         <millepede_constant name="22363" value="0.0" /> <!-- rw -->
 
         <!-- L4 Top/Bottom translations and angles -->
-        <millepede_constant name="11164" value="0.0 + -0.007361 - -0.033468 - -0.017968 - -0.013564 - 0.001690 + -0.7" /> <!-- u  -> global Y   -->
+        <millepede_constant name="11164" value="0.0 + -0.007361 - -0.033468 - -0.017968 - -0.013564 - 0.001690" /> <!-- u  -> global Y   -->
         <millepede_constant name="11264" value="0.0" /> <!-- v  -> X+svtAngle -->
         <millepede_constant name="11364" value="0.0" /> <!-- w  -> Z+svtAngle -->
         <millepede_constant name="12164" value="0.0" /> <!-- ru -->
         <millepede_constant name="12264" value="0.0" /> <!-- rv -->
         <millepede_constant name="12364" value="0.0" /> <!-- rw -->
 
-        <millepede_constant name="21164" value="0.0 + -0.033974 + -0.006749 - 0.051528 - -0.004088 - 0.021074 - 0.001095 + -0.7" /> <!-- u -->
+        <millepede_constant name="21164" value="0.0 + -0.033974 + -0.006749 - 0.051528 - -0.004088 - 0.021074 - 0.001095" /> <!-- u -->
         <millepede_constant name="21264" value="0.0" /> <!-- v -->
         <millepede_constant name="21364" value="0.0" /> <!-- w -->
         <millepede_constant name="22164" value="0.0" /> <!-- ru -->
@@ -772,7 +772,7 @@
   </readouts>
 
   <fields>
-      <field type="FieldMap3D" name="HPSDipoleFieldMap3D" filename="fieldmap/166acm2_4kg_corrected_unfolded_scaled_1.090896.dat" url="https://github.com/JeffersonLab/hps-fieldmaps/raw/master/166acm2_4kg_corrected_unfolded_scaled_1.090896.tar.gz" xoffset="2.117*cm" yoffset="0.0*cm" zoffset="45.72*cm" />
+    <field type="FieldMap3D" name="HPSDipoleFieldMap3D" filename="fieldmap/334acm3_8kg_corrected_unfolded_scaled_1.07326.dat" url="https://github.com/JeffersonLab/hps-fieldmaps/raw/master/334acm3_8kg_corrected_unfolded_scaled_1.07326.tar.gz" xoffset="2.117*cm" yoffset="0.0*cm" zoffset="45.72*cm" />
   </fields>
 
   <!--

--- a/detector-data/detectors/HPS_Run2021Pass0_v1_fixed/detector.properties
+++ b/detector-data/detectors/HPS_Run2021Pass0_v1_fixed/detector.properties
@@ -1,0 +1,1 @@
+name: HPS_Run2021Pass0_v1_fixed

--- a/detector-data/detectors/HPS_Run2021Pass2FEE/HPS_Run2021Pass2FEE.lcdd
+++ b/detector-data/detectors/HPS_Run2021Pass2FEE/HPS_Run2021Pass2FEE.lcdd
@@ -2,7 +2,7 @@
 <lcdd xmlns:lcdd="http://www.lcsim.org/schemas/lcdd/1.0" xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/lcdd/1.0/lcdd.xsd">
   <header>
     <detector name="HPS_Run2021Pass2FEE" />
-    <generator name="lcsim" version="1.0" file="/sdf/group/hps/users/sgaiser/src/hps-java/detector-data/detectors/HPS_Run2021Pass2FEE/compact.xml" checksum="1727512758" />
+    <generator name="lcsim" version="1.0" file="/sdf/group/hps/users/sgaiser/src/hps-java/detector-data/detectors/HPS_Run2021Pass2FEE/compact.xml" checksum="3580162258" />
     <author name="NONE" />
     <comment>HPS detector for 2021 run with fieldmap, Tracker at nominal opening angle, no SVT survey, this detector uses the corrected fieldmap scaled to -1.022T for 3.7 GeV. Includes L0 and Hodoscope. ECAL with survey alignment for HPSEcal3 (global y/z translations). This detector has the full hierarchical alignment structure</comment>
   </header>
@@ -274,7 +274,7 @@
       <rotation name="module_L2t_halfmodule_stereo_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
       <position name="module_L2t_halfmodule_stereo_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
       <rotation name="module_L2t_halfmodule_stereo_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
-      <position name="module_L3b_halfmodule_axial_position" x="-44.86653535485047" y="137.05263425928803" z="-25.698042753919832" unit="mm" />
+      <position name="module_L3b_halfmodule_axial_position" x="-44.86653535485047" y="137.05361145897064" z="-24.99804343600532" unit="mm" />
       <rotation name="module_L3b_halfmodule_axial_rotation" x="-1.5694003267948962" y="-0.030540399450088122" z="1.5707963267948963" unit="radian" />
       <position name="module_L3b_halfmodule_axial_sensor_position" x="-3.414999999999999" y="30.0" z="-0.50725" unit="mm" />
       <rotation name="module_L3b_halfmodule_axial_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
@@ -286,7 +286,7 @@
       <rotation name="module_L3b_halfmodule_axial_cf_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
       <position name="module_L3b_halfmodule_axial_hybrid_position" x="-3.414999999999999" y="-55.0" z="0.12649999999999995" unit="mm" />
       <rotation name="module_L3b_halfmodule_axial_hybrid_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
-      <position name="module_L3b_halfmodule_stereo_position" x="-45.31712792075798" y="145.4286090945948" z="-21.88543549059398" unit="mm" />
+      <position name="module_L3b_halfmodule_stereo_position" x="-45.31712792075798" y="145.4295862942774" z="-21.18543617267947" unit="mm" />
       <rotation name="module_L3b_halfmodule_stereo_rotation" x="1.5721923267948963" y="0.03054039945008801" z="1.6707963267948964" unit="radian" />
       <position name="module_L3b_halfmodule_stereo_sensor_position" x="-3.414999999999999" y="30.0" z="-0.50725" unit="mm" />
       <rotation name="module_L3b_halfmodule_stereo_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
@@ -298,7 +298,7 @@
       <rotation name="module_L3b_halfmodule_stereo_cf_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
       <position name="module_L3b_halfmodule_stereo_hybrid_position" x="-3.414999999999999" y="-55.0" z="0.12649999999999995" unit="mm" />
       <rotation name="module_L3b_halfmodule_stereo_hybrid_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
-      <position name="module_L3t_halfmodule_axial_position" x="-45.61670040744279" y="161.22560021920657" z="25.632647003698295" unit="mm" />
+      <position name="module_L3t_halfmodule_axial_position" x="-45.61670040744279" y="161.2253258192136" z="24.9326470574807" unit="mm" />
       <rotation name="module_L3t_halfmodule_axial_rotation" x="1.5711883267948965" y="0.03043330642417559" z="1.5707963267948966" unit="radian" />
       <position name="module_L3t_halfmodule_axial_sensor_position" x="-3.414999999999999" y="30.0" z="-0.50725" unit="mm" />
       <rotation name="module_L3t_halfmodule_axial_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
@@ -310,7 +310,7 @@
       <rotation name="module_L3t_halfmodule_axial_cf_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
       <position name="module_L3t_halfmodule_axial_hybrid_position" x="-3.414999999999999" y="-55.0" z="0.12649999999999995" unit="mm" />
       <rotation name="module_L3t_halfmodule_axial_hybrid_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
-      <position name="module_L3t_halfmodule_stereo_position" x="-45.550254290278474" y="152.84174390474504" z="21.816268962512165" unit="mm" />
+      <position name="module_L3t_halfmodule_stereo_position" x="-45.550254290278474" y="152.84146950475207" z="21.11626901629457" unit="mm" />
       <rotation name="module_L3t_halfmodule_stereo_rotation" x="-1.5704043267948962" y="-0.030433306424175535" z="1.6707963267948964" unit="radian" />
       <position name="module_L3t_halfmodule_stereo_sensor_position" x="-3.414999999999999" y="30.0" z="-0.50725" unit="mm" />
       <rotation name="module_L3t_halfmodule_stereo_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
@@ -322,7 +322,7 @@
       <rotation name="module_L3t_halfmodule_stereo_cf_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
       <position name="module_L3t_halfmodule_stereo_hybrid_position" x="-3.414999999999999" y="-55.0" z="0.12649999999999995" unit="mm" />
       <rotation name="module_L3t_halfmodule_stereo_hybrid_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
-      <position name="module_L4b_halfmodule_axial_position" x="-41.81297014635422" y="37.09717854332278" z="-27.123898372427487" unit="mm" />
+      <position name="module_L4b_halfmodule_axial_position" x="-41.81297014635422" y="37.098155743005385" z="-26.423899054512976" unit="mm" />
       <rotation name="module_L4b_halfmodule_axial_rotation" x="-1.5694003267948962" y="-0.030540399450088122" z="1.5707963267948963" unit="radian" />
       <position name="module_L4b_halfmodule_axial_sensor_position" x="-3.414999999999999" y="30.0" z="-0.50725" unit="mm" />
       <rotation name="module_L4b_halfmodule_axial_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
@@ -334,7 +334,7 @@
       <rotation name="module_L4b_halfmodule_axial_cf_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
       <position name="module_L4b_halfmodule_axial_hybrid_position" x="-3.414999999999999" y="-55.0" z="0.12649999999999995" unit="mm" />
       <rotation name="module_L4b_halfmodule_axial_hybrid_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
-      <position name="module_L4b_halfmodule_stereo_position" x="-42.265007725812566" y="45.47316371484888" z="-23.272264430185697" unit="mm" />
+      <position name="module_L4b_halfmodule_stereo_position" x="-42.265007725812566" y="45.47414091453148" z="-22.572265112271186" unit="mm" />
       <rotation name="module_L4b_halfmodule_stereo_rotation" x="1.5721923267948963" y="0.03054039945008801" z="1.6707963267948964" unit="radian" />
       <position name="module_L4b_halfmodule_stereo_sensor_position" x="-3.414999999999999" y="30.0" z="-0.50725" unit="mm" />
       <rotation name="module_L4b_halfmodule_stereo_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
@@ -346,7 +346,7 @@
       <rotation name="module_L4b_halfmodule_stereo_cf_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
       <position name="module_L4b_halfmodule_stereo_hybrid_position" x="-3.414999999999999" y="-55.0" z="0.12649999999999995" unit="mm" />
       <rotation name="module_L4b_halfmodule_stereo_hybrid_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
-      <position name="module_L4t_halfmodule_axial_position" x="-42.57383952504715" y="61.27247766363083" z="27.110685740297292" unit="mm" />
+      <position name="module_L4t_halfmodule_axial_position" x="-42.57383952504715" y="61.272203263637856" z="26.41068579407969" unit="mm" />
       <rotation name="module_L4t_halfmodule_axial_rotation" x="1.5711883267948965" y="0.03043330642417559" z="1.5707963267948966" unit="radian" />
       <position name="module_L4t_halfmodule_axial_sensor_position" x="-3.414999999999999" y="30.0" z="-0.50725" unit="mm" />
       <rotation name="module_L4t_halfmodule_axial_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
@@ -358,7 +358,7 @@
       <rotation name="module_L4t_halfmodule_axial_cf_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
       <position name="module_L4t_halfmodule_axial_hybrid_position" x="-3.414999999999999" y="-55.0" z="0.12649999999999995" unit="mm" />
       <rotation name="module_L4t_halfmodule_axial_hybrid_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
-      <position name="module_L4t_halfmodule_stereo_position" x="-42.51021339381717" y="52.88853510689392" z="23.293301915130098" unit="mm" />
+      <position name="module_L4t_halfmodule_stereo_position" x="-42.51021339381717" y="52.888260706900944" z="22.593301968912495" unit="mm" />
       <rotation name="module_L4t_halfmodule_stereo_rotation" x="-1.5704043267948962" y="-0.030433306424175535" z="1.6707963267948964" unit="radian" />
       <position name="module_L4t_halfmodule_stereo_sensor_position" x="-3.414999999999999" y="30.0" z="-0.50725" unit="mm" />
       <rotation name="module_L4t_halfmodule_stereo_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />

--- a/detector-data/detectors/HPS_Run2021Pass2FEE/compact.xml
+++ b/detector-data/detectors/HPS_Run2021Pass2FEE/compact.xml
@@ -534,14 +534,14 @@
         <millepede_constant name="22362" value="0.0" /> <!-- rw -->
 
         <!-- L3 Top/Bottom translations and angles -->
-        <millepede_constant name="11163" value="0.0 + 0.000678 - -0.059459" /> <!-- u  -> global Y   -->
+        <millepede_constant name="11163" value="0.0 + 0.000678 - -0.059459 + -0.7" /> <!-- u  -> global Y   -->
         <millepede_constant name="11263" value="0.0" /> <!-- v  -> X+svtAngle -->
         <millepede_constant name="11363" value="0.0" /> <!-- w  -> Z+svtAngle -->
         <millepede_constant name="12163" value="0.0" /> <!-- ru -->
         <millepede_constant name="12263" value="0.0" /> <!-- rv -->
         <millepede_constant name="12363" value="0.0" /> <!-- rw -->
 
-        <millepede_constant name="21163" value="0.0 + -0.046884 + -0.010228 - 0.075913" /> <!-- u -->
+        <millepede_constant name="21163" value="0.0 + -0.046884 + -0.010228 - 0.075913 + -0.7" /> <!-- u -->
         <millepede_constant name="21263" value="0.0" /> <!-- v -->
         <millepede_constant name="21363" value="0.0" /> <!-- w -->
         <millepede_constant name="22163" value="0.0" /> <!-- ru -->
@@ -549,14 +549,14 @@
         <millepede_constant name="22363" value="0.0" /> <!-- rw -->
 
         <!-- L4 Top/Bottom translations and angles -->
-        <millepede_constant name="11164" value="0.0 + -0.007361 - -0.033468" /> <!-- u  -> global Y   -->
+        <millepede_constant name="11164" value="0.0 + -0.007361 - -0.033468 + -0.7" /> <!-- u  -> global Y   -->
         <millepede_constant name="11264" value="0.0" /> <!-- v  -> X+svtAngle -->
         <millepede_constant name="11364" value="0.0" /> <!-- w  -> Z+svtAngle -->
         <millepede_constant name="12164" value="0.0" /> <!-- ru -->
         <millepede_constant name="12264" value="0.0" /> <!-- rv -->
         <millepede_constant name="12364" value="0.0" /> <!-- rw -->
 
-        <millepede_constant name="21164" value="0.0 + -0.033974 + -0.006749 - 0.051528" /> <!-- u -->
+        <millepede_constant name="21164" value="0.0 + -0.033974 + -0.006749 - 0.051528 + -0.7" /> <!-- u -->
         <millepede_constant name="21264" value="0.0" /> <!-- v -->
         <millepede_constant name="21364" value="0.0" /> <!-- w -->
         <millepede_constant name="22164" value="0.0" /> <!-- ru -->

--- a/detector-data/detectors/HPS_Run2021Pass2FEE_1pt92/HPS_Run2021Pass2FEE_1pt92.lcdd
+++ b/detector-data/detectors/HPS_Run2021Pass2FEE_1pt92/HPS_Run2021Pass2FEE_1pt92.lcdd
@@ -2,7 +2,7 @@
 <lcdd xmlns:lcdd="http://www.lcsim.org/schemas/lcdd/1.0" xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/lcdd/1.0/lcdd.xsd">
   <header>
     <detector name="HPS_Run2021Pass2FEE_1pt92" />
-    <generator name="lcsim" version="1.0" file="/sdf/group/hps/users/sgaiser/src/hps-java/detector-data/detectors/HPS_Run2021Pass2FEE_1pt92/compact.xml" checksum="182259210" />
+    <generator name="lcsim" version="1.0" file="/sdf/group/hps/users/sgaiser/src/hps-java/detector-data/detectors/HPS_Run2021Pass2FEE_1pt92/compact.xml" checksum="24310890" />
     <author name="NONE" />
     <comment>HPS detector for 2021 run with fieldmap for 1.92GeV running, Tracker at nominal opening angle, no SVT survey, this detector uses the corrected fieldmap scaled to -1.022T for 3.7 GeV. Includes L0 and Hodoscope. ECAL with survey alignment for HPSEcal3 (global y/z translations). This detector has the full hierarchical alignment structure</comment>
   </header>
@@ -274,7 +274,7 @@
       <rotation name="module_L2t_halfmodule_stereo_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
       <position name="module_L2t_halfmodule_stereo_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
       <rotation name="module_L2t_halfmodule_stereo_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
-      <position name="module_L3b_halfmodule_axial_position" x="-44.86653535485047" y="137.05263425928803" z="-25.698042753919832" unit="mm" />
+      <position name="module_L3b_halfmodule_axial_position" x="-44.86653535485047" y="137.05361145897064" z="-24.99804343600532" unit="mm" />
       <rotation name="module_L3b_halfmodule_axial_rotation" x="-1.5694003267948962" y="-0.030540399450088122" z="1.5707963267948963" unit="radian" />
       <position name="module_L3b_halfmodule_axial_sensor_position" x="-3.414999999999999" y="30.0" z="-0.50725" unit="mm" />
       <rotation name="module_L3b_halfmodule_axial_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
@@ -286,7 +286,7 @@
       <rotation name="module_L3b_halfmodule_axial_cf_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
       <position name="module_L3b_halfmodule_axial_hybrid_position" x="-3.414999999999999" y="-55.0" z="0.12649999999999995" unit="mm" />
       <rotation name="module_L3b_halfmodule_axial_hybrid_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
-      <position name="module_L3b_halfmodule_stereo_position" x="-45.31712792075798" y="145.4286090945948" z="-21.88543549059398" unit="mm" />
+      <position name="module_L3b_halfmodule_stereo_position" x="-45.31712792075798" y="145.4295862942774" z="-21.18543617267947" unit="mm" />
       <rotation name="module_L3b_halfmodule_stereo_rotation" x="1.5721923267948963" y="0.03054039945008801" z="1.6707963267948964" unit="radian" />
       <position name="module_L3b_halfmodule_stereo_sensor_position" x="-3.414999999999999" y="30.0" z="-0.50725" unit="mm" />
       <rotation name="module_L3b_halfmodule_stereo_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
@@ -298,7 +298,7 @@
       <rotation name="module_L3b_halfmodule_stereo_cf_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
       <position name="module_L3b_halfmodule_stereo_hybrid_position" x="-3.414999999999999" y="-55.0" z="0.12649999999999995" unit="mm" />
       <rotation name="module_L3b_halfmodule_stereo_hybrid_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
-      <position name="module_L3t_halfmodule_axial_position" x="-45.61670040744279" y="161.22560021920657" z="25.632647003698295" unit="mm" />
+      <position name="module_L3t_halfmodule_axial_position" x="-45.61670040744279" y="161.2253258192136" z="24.9326470574807" unit="mm" />
       <rotation name="module_L3t_halfmodule_axial_rotation" x="1.5711883267948965" y="0.03043330642417559" z="1.5707963267948966" unit="radian" />
       <position name="module_L3t_halfmodule_axial_sensor_position" x="-3.414999999999999" y="30.0" z="-0.50725" unit="mm" />
       <rotation name="module_L3t_halfmodule_axial_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
@@ -310,7 +310,7 @@
       <rotation name="module_L3t_halfmodule_axial_cf_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
       <position name="module_L3t_halfmodule_axial_hybrid_position" x="-3.414999999999999" y="-55.0" z="0.12649999999999995" unit="mm" />
       <rotation name="module_L3t_halfmodule_axial_hybrid_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
-      <position name="module_L3t_halfmodule_stereo_position" x="-45.550254290278474" y="152.84174390474504" z="21.816268962512165" unit="mm" />
+      <position name="module_L3t_halfmodule_stereo_position" x="-45.550254290278474" y="152.84146950475207" z="21.11626901629457" unit="mm" />
       <rotation name="module_L3t_halfmodule_stereo_rotation" x="-1.5704043267948962" y="-0.030433306424175535" z="1.6707963267948964" unit="radian" />
       <position name="module_L3t_halfmodule_stereo_sensor_position" x="-3.414999999999999" y="30.0" z="-0.50725" unit="mm" />
       <rotation name="module_L3t_halfmodule_stereo_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
@@ -322,7 +322,7 @@
       <rotation name="module_L3t_halfmodule_stereo_cf_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
       <position name="module_L3t_halfmodule_stereo_hybrid_position" x="-3.414999999999999" y="-55.0" z="0.12649999999999995" unit="mm" />
       <rotation name="module_L3t_halfmodule_stereo_hybrid_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
-      <position name="module_L4b_halfmodule_axial_position" x="-41.81297014635422" y="37.09717854332278" z="-27.123898372427487" unit="mm" />
+      <position name="module_L4b_halfmodule_axial_position" x="-41.81297014635422" y="37.098155743005385" z="-26.423899054512976" unit="mm" />
       <rotation name="module_L4b_halfmodule_axial_rotation" x="-1.5694003267948962" y="-0.030540399450088122" z="1.5707963267948963" unit="radian" />
       <position name="module_L4b_halfmodule_axial_sensor_position" x="-3.414999999999999" y="30.0" z="-0.50725" unit="mm" />
       <rotation name="module_L4b_halfmodule_axial_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
@@ -334,7 +334,7 @@
       <rotation name="module_L4b_halfmodule_axial_cf_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
       <position name="module_L4b_halfmodule_axial_hybrid_position" x="-3.414999999999999" y="-55.0" z="0.12649999999999995" unit="mm" />
       <rotation name="module_L4b_halfmodule_axial_hybrid_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
-      <position name="module_L4b_halfmodule_stereo_position" x="-42.265007725812566" y="45.47316371484888" z="-23.272264430185697" unit="mm" />
+      <position name="module_L4b_halfmodule_stereo_position" x="-42.265007725812566" y="45.47414091453148" z="-22.572265112271186" unit="mm" />
       <rotation name="module_L4b_halfmodule_stereo_rotation" x="1.5721923267948963" y="0.03054039945008801" z="1.6707963267948964" unit="radian" />
       <position name="module_L4b_halfmodule_stereo_sensor_position" x="-3.414999999999999" y="30.0" z="-0.50725" unit="mm" />
       <rotation name="module_L4b_halfmodule_stereo_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
@@ -346,7 +346,7 @@
       <rotation name="module_L4b_halfmodule_stereo_cf_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
       <position name="module_L4b_halfmodule_stereo_hybrid_position" x="-3.414999999999999" y="-55.0" z="0.12649999999999995" unit="mm" />
       <rotation name="module_L4b_halfmodule_stereo_hybrid_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
-      <position name="module_L4t_halfmodule_axial_position" x="-42.57383952504715" y="61.27247766363083" z="27.110685740297292" unit="mm" />
+      <position name="module_L4t_halfmodule_axial_position" x="-42.57383952504715" y="61.272203263637856" z="26.41068579407969" unit="mm" />
       <rotation name="module_L4t_halfmodule_axial_rotation" x="1.5711883267948965" y="0.03043330642417559" z="1.5707963267948966" unit="radian" />
       <position name="module_L4t_halfmodule_axial_sensor_position" x="-3.414999999999999" y="30.0" z="-0.50725" unit="mm" />
       <rotation name="module_L4t_halfmodule_axial_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
@@ -358,7 +358,7 @@
       <rotation name="module_L4t_halfmodule_axial_cf_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
       <position name="module_L4t_halfmodule_axial_hybrid_position" x="-3.414999999999999" y="-55.0" z="0.12649999999999995" unit="mm" />
       <rotation name="module_L4t_halfmodule_axial_hybrid_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
-      <position name="module_L4t_halfmodule_stereo_position" x="-42.51021339381717" y="52.88853510689392" z="23.293301915130098" unit="mm" />
+      <position name="module_L4t_halfmodule_stereo_position" x="-42.51021339381717" y="52.888260706900944" z="22.593301968912495" unit="mm" />
       <rotation name="module_L4t_halfmodule_stereo_rotation" x="-1.5704043267948962" y="-0.030433306424175535" z="1.6707963267948964" unit="radian" />
       <position name="module_L4t_halfmodule_stereo_sensor_position" x="-3.414999999999999" y="30.0" z="-0.50725" unit="mm" />
       <rotation name="module_L4t_halfmodule_stereo_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />

--- a/detector-data/detectors/HPS_Run2021Pass2FEE_1pt92/compact.xml
+++ b/detector-data/detectors/HPS_Run2021Pass2FEE_1pt92/compact.xml
@@ -534,14 +534,14 @@
         <millepede_constant name="22362" value="0.0" /> <!-- rw -->
 
         <!-- L3 Top/Bottom translations and angles -->
-        <millepede_constant name="11163" value="0.0 + 0.000678 - -0.059459" /> <!-- u  -> global Y   -->
+        <millepede_constant name="11163" value="0.0 + 0.000678 - -0.059459 + -0.7" /> <!-- u  -> global Y   -->
         <millepede_constant name="11263" value="0.0" /> <!-- v  -> X+svtAngle -->
         <millepede_constant name="11363" value="0.0" /> <!-- w  -> Z+svtAngle -->
         <millepede_constant name="12163" value="0.0" /> <!-- ru -->
         <millepede_constant name="12263" value="0.0" /> <!-- rv -->
         <millepede_constant name="12363" value="0.0" /> <!-- rw -->
 
-        <millepede_constant name="21163" value="0.0 + -0.046884 + -0.010228 - 0.075913" /> <!-- u -->
+        <millepede_constant name="21163" value="0.0 + -0.046884 + -0.010228 - 0.075913 + -0.7" /> <!-- u -->
         <millepede_constant name="21263" value="0.0" /> <!-- v -->
         <millepede_constant name="21363" value="0.0" /> <!-- w -->
         <millepede_constant name="22163" value="0.0" /> <!-- ru -->
@@ -549,14 +549,14 @@
         <millepede_constant name="22363" value="0.0" /> <!-- rw -->
 
         <!-- L4 Top/Bottom translations and angles -->
-        <millepede_constant name="11164" value="0.0 + -0.007361 - -0.033468" /> <!-- u  -> global Y   -->
+        <millepede_constant name="11164" value="0.0 + -0.007361 - -0.033468 + -0.7" /> <!-- u  -> global Y   -->
         <millepede_constant name="11264" value="0.0" /> <!-- v  -> X+svtAngle -->
         <millepede_constant name="11364" value="0.0" /> <!-- w  -> Z+svtAngle -->
         <millepede_constant name="12164" value="0.0" /> <!-- ru -->
         <millepede_constant name="12264" value="0.0" /> <!-- rv -->
         <millepede_constant name="12364" value="0.0" /> <!-- rw -->
 
-        <millepede_constant name="21164" value="0.0 + -0.033974 + -0.006749 - 0.051528" /> <!-- u -->
+        <millepede_constant name="21164" value="0.0 + -0.033974 + -0.006749 - 0.051528 + -0.7" /> <!-- u -->
         <millepede_constant name="21264" value="0.0" /> <!-- v -->
         <millepede_constant name="21364" value="0.0" /> <!-- w -->
         <millepede_constant name="22164" value="0.0" /> <!-- ru -->

--- a/detector-data/detectors/HPS_Run2021Pass2FEE_1pt92_fixed/HPS_Run2021Pass2FEE_1pt92_fixed.lcdd
+++ b/detector-data/detectors/HPS_Run2021Pass2FEE_1pt92_fixed/HPS_Run2021Pass2FEE_1pt92_fixed.lcdd
@@ -1,0 +1,10070 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lcdd xmlns:lcdd="http://www.lcsim.org/schemas/lcdd/1.0" xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/lcdd/1.0/lcdd.xsd">
+  <header>
+    <detector name="HPS_Run2021Pass2FEE_1pt92_fixed" />
+    <generator name="lcsim" version="1.0" file="/sdf/group/hps/users/sgaiser/src/hps-java/detector-data/detectors/HPS_Run2021Pass2FEE_1pt92/compact.xml" checksum="182259210" />
+    <author name="NONE" />
+    <comment>HPS detector for 2021 run with fieldmap for 1.92GeV running, Tracker at nominal opening angle, no SVT survey, this detector uses the corrected fieldmap scaled to -1.022T for 3.7 GeV. Includes L0 and Hodoscope. ECAL with survey alignment for HPSEcal3 (global y/z translations). This detector has the full hierarchical alignment structure</comment>
+  </header>
+  <iddict>
+    <idspec name="HodoscopeForeHits" length="46">
+      <idfield signed="false" label="system" length="6" start="0" />
+      <idfield signed="false" label="barrel" length="3" start="6" />
+      <idfield signed="false" label="layer" length="4" start="9" />
+      <idfield signed="false" label="module" length="12" start="13" />
+      <idfield signed="false" label="sensor" length="1" start="25" />
+      <idfield signed="true" label="side" length="2" start="32" />
+      <idfield signed="false" label="strip" length="12" start="34" />
+    </idspec>
+    <idspec name="TrackerHitsFieldDef" length="46">
+      <idfield signed="false" label="system" length="6" start="0" />
+      <idfield signed="false" label="barrel" length="3" start="6" />
+      <idfield signed="false" label="layer" length="4" start="9" />
+      <idfield signed="false" label="module" length="12" start="13" />
+      <idfield signed="false" label="sensor" length="1" start="25" />
+      <idfield signed="true" label="side" length="2" start="32" />
+      <idfield signed="false" label="strip" length="12" start="34" />
+    </idspec>
+    <idspec name="TrackerHits" length="46">
+      <idfield signed="false" label="system" length="6" start="0" />
+      <idfield signed="false" label="barrel" length="3" start="6" />
+      <idfield signed="false" label="layer" length="4" start="9" />
+      <idfield signed="false" label="module" length="12" start="13" />
+      <idfield signed="false" label="sensor" length="1" start="25" />
+      <idfield signed="true" label="side" length="2" start="32" />
+      <idfield signed="false" label="strip" length="12" start="34" />
+    </idspec>
+    <idspec name="HodoscopeHits" length="23">
+      <idfield signed="false" label="system" length="6" start="0" />
+      <idfield signed="false" label="barrel" length="3" start="6" />
+      <idfield signed="false" label="layer" length="4" start="9" />
+      <idfield signed="false" label="ix" length="4" start="13" />
+      <idfield signed="true" label="iy" length="3" start="17" />
+      <idfield signed="true" label="hole" length="3" start="20" />
+    </idspec>
+    <idspec name="EcalHits" length="22">
+      <idfield signed="false" label="system" length="6" start="0" />
+      <idfield signed="false" label="layer" length="2" start="6" />
+      <idfield signed="true" label="ix" length="8" start="8" />
+      <idfield signed="true" label="iy" length="6" start="16" />
+    </idspec>
+    <idspec name="TrackerHitsECal" length="46">
+      <idfield signed="false" label="system" length="6" start="0" />
+      <idfield signed="false" label="barrel" length="3" start="6" />
+      <idfield signed="false" label="layer" length="4" start="9" />
+      <idfield signed="false" label="module" length="12" start="13" />
+      <idfield signed="false" label="sensor" length="1" start="25" />
+      <idfield signed="true" label="side" length="2" start="32" />
+      <idfield signed="false" label="strip" length="12" start="34" />
+    </idspec>
+  </iddict>
+  <sensitive_detectors>
+    <tracker name="Tracker" ecut="0.0" eunit="MeV" verbose="0" hits_collection="TrackerHits">
+      <idspecref ref="TrackerHits" />
+    </tracker>
+    <tracker name="ECalScoring" ecut="0.0" eunit="MeV" verbose="0" hits_collection="TrackerHitsECal">
+      <idspecref ref="TrackerHitsECal" />
+      <hit_processor type="ScoringTrackerHitProcessor" />
+    </tracker>
+    <calorimeter name="Ecal" ecut="0.0" eunit="MeV" verbose="0" hits_collection="EcalHits">
+      <idspecref ref="EcalHits" />
+      <grid_xyz grid_size_x="0.0" grid_size_y="0.0" grid_size_z="0.0" />
+    </calorimeter>
+    <tracker name="Hodoscope" ecut="0.0" eunit="MeV" verbose="0" hits_collection="HodoscopeHits">
+      <idspecref ref="HodoscopeHits" />
+    </tracker>
+  </sensitive_detectors>
+  <limits />
+  <regions>
+    <region name="TrackingRegion" store_secondaries="true" kill_tracks="false" cut="10.0" lunit="mm" threshold="1.0" eunit="MeV" />
+  </regions>
+  <display>
+    <vis name="InvisibleWithDaughters" line_style="unbroken" drawing_style="wireframe" show_daughters="true" visible="false">
+      <color R="0.0" G="0.0" B="0.0" alpha="0.0" />
+    </vis>
+    <vis name="SensorVis" line_style="unbroken" drawing_style="wireframe" show_daughters="true" visible="true">
+      <color R="1.0" G="0.0" B="0.0" alpha="1.0" />
+    </vis>
+    <vis name="SvtBoxVis" line_style="unbroken" drawing_style="wireframe" show_daughters="true" visible="true">
+      <color R="1.0" G="1.0" B="0.0" alpha="1.0" />
+    </vis>
+    <vis name="ComponentVis" line_style="unbroken" drawing_style="solid" show_daughters="false" visible="false">
+      <color R="0.0" G="0.2" B="0.4" alpha="0.0" />
+    </vis>
+    <vis name="HybridVis" line_style="unbroken" drawing_style="solid" show_daughters="true" visible="true">
+      <color R="0.0" G="1.0" B="0.0" alpha="1.0" />
+    </vis>
+    <vis name="ColdBlockVis" line_style="dashed" drawing_style="solid" show_daughters="true" visible="true">
+      <color R="0.75" G="0.73" B="0.75" alpha="1.0" />
+    </vis>
+    <vis name="ECALVis" line_style="unbroken" drawing_style="wireframe" show_daughters="true" visible="true">
+      <color R="0.8" G="0.5" B="0.1" alpha="1.0" />
+    </vis>
+    <vis name="HodoscopeVis" line_style="unbroken" drawing_style="solid" show_daughters="true" visible="true">
+      <color R="0.0" G="0.3372549" B="0.50980395" alpha="1.0" />
+    </vis>
+    <vis name="BasePlateVis" line_style="dashed" drawing_style="solid" show_daughters="true" visible="true">
+      <color R="0.35" G="0.35" B="0.35" alpha="1.0" />
+    </vis>
+    <vis name="BeamPlaneVis" line_style="unbroken" drawing_style="solid" show_daughters="false" visible="true">
+      <color R="1.0" G="1.0" B="1.0" alpha="1.0" />
+    </vis>
+    <vis name="HalfModuleVis" line_style="dashed" drawing_style="wireframe" show_daughters="true" visible="true">
+      <color R="1.0" G="1.0" B="1.0" alpha="1.0" />
+    </vis>
+    <vis name="CarbonFiberVis" line_style="unbroken" drawing_style="solid" show_daughters="true" visible="true">
+      <color R="0.88" G="0.88" B="0.88" alpha="1.0" />
+    </vis>
+    <vis name="ModuleVis" line_style="dotted" drawing_style="wireframe" show_daughters="true" visible="true">
+      <color R="1.0" G="1.0" B="1.0" alpha="1.0" />
+    </vis>
+    <vis name="SupportPlateVis" line_style="dashed" drawing_style="solid" show_daughters="true" visible="true">
+      <color R="0.45" G="0.45" B="0.45" alpha="1.0" />
+    </vis>
+    <vis name="LayerVis" line_style="unbroken" drawing_style="wireframe" show_daughters="true" visible="false">
+      <color R="0.0" G="0.0" B="1.0" alpha="0.0" />
+    </vis>
+    <vis name="ChamberVis" line_style="unbroken" drawing_style="wireframe" show_daughters="true" visible="true">
+      <color R="1.0" G="0.0" B="1.0" alpha="1.0" />
+    </vis>
+    <vis name="InvisibleNoDaughters" line_style="unbroken" drawing_style="wireframe" show_daughters="false" visible="false">
+      <color R="0.0" G="0.0" B="0.0" alpha="0.0" />
+    </vis>
+    <vis name="ActiveSensorVis" line_style="unbroken" drawing_style="solid" show_daughters="true" visible="true">
+      <color R="1.0" G="0.0" B="0.0" alpha="1.0" />
+    </vis>
+    <vis name="KaptonVis" line_style="unbroken" drawing_style="solid" show_daughters="true" visible="true">
+      <color R="0.91" G="0.77" B="0.06" alpha="1.0" />
+    </vis>
+    <vis name="SupportVolumeVis" line_style="dashed" drawing_style="wireframe" show_daughters="true" visible="true">
+      <color R="0.75" G="0.73" B="0.75" alpha="1.0" />
+    </vis>
+    <vis name="WorldVis" line_style="unbroken" drawing_style="wireframe" show_daughters="true" visible="false">
+      <color R="1.0" G="1.0" B="1.0" alpha="1.0" />
+    </vis>
+    <vis name="TrackingVis" line_style="unbroken" drawing_style="wireframe" show_daughters="true" visible="false">
+      <color R="1.0" G="1.0" B="1.0" alpha="1.0" />
+    </vis>
+  </display>
+  <gdml>
+    <define>
+      <rotation name="identity_rot" x="0.0" y="0.0" z="0.0" unit="radian" />
+      <rotation name="reflect_rot" x="3.141592653589793" y="0.0" z="0.0" unit="radian" />
+      <position name="identity_pos" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <constant name="bot_tr_x" value="-0.405" />
+      <constant name="x_rot_top" value="0.0" />
+      <constant name="hodoscopeXMin2" value="48.0" />
+      <constant name="hodoscopeXMin1" value="43.548" />
+      <constant name="scoringThickness" value="0.001" />
+      <constant name="ecal_back" value="8.0" />
+      <constant name="pivot" value="791.0" />
+      <constant name="bot_tr_y" value="-0.9125" />
+      <constant name="hodoscopeThickness" value="10.0" />
+      <constant name="bot_tr_z" value="2.6225" />
+      <constant name="bot_rot_beta" value="0.0" />
+      <constant name="dipoleMagnetWidth" value="1000.0" />
+      <constant name="top_rot_beta" value="0.0" />
+      <constant name="SA1" value="0.1" />
+      <constant name="x_rot_top_add" value="0.0" />
+      <constant name="SA2" value="0.05" />
+      <constant name="tracking_region_min" value="50.0" />
+      <constant name="y02t" value="21.419865625949214" />
+      <constant name="world_side" value="5000.0" />
+      <constant name="sensorLength" value="98.33" />
+      <constant name="sensorWidth" value="38.3399" />
+      <constant name="y02b" value="-21.419865625949214" />
+      <constant name="bot_rot_gamma" value="0.0013469727279283583" />
+      <constant name="x_rot_bot" value="0.0" />
+      <constant name="dipoleMagnetHeight" value="1000.0" />
+      <constant name="z02t" value="146.185" />
+      <constant name="top_rot_alpha" value="6.4964212772E-4" />
+      <constant name="y_rot" value="0.03052" />
+      <constant name="tracking_region_zmax" value="1368.0" />
+      <constant name="constBFieldY" value="-1.08" />
+      <constant name="top_tr_z" value="4.9375" />
+      <constant name="top_tr_y" value="2.725" />
+      <constant name="top_tr_x" value="-0.71" />
+      <constant name="dipoleMagnetLength" value="1080.0" />
+      <constant name="top_rot_gamma" value="-4.6882347412E-4" />
+      <constant name="y01t" value="21.419865625949214" />
+      <constant name="x_rot_bot_add" value="0.0" />
+      <constant name="zst" value="1.0" />
+      <constant name="bot_rot_alpha" value="5.150274940439E-4" />
+      <constant name="hodoscopePixelHeight" value="59.225" />
+      <constant name="beam_angle" value="0.03052" />
+      <constant name="z02b" value="161.185" />
+      <constant name="y01b" value="-21.419865625949214" />
+      <constant name="electronGapLeftEdge" value="382.492" />
+      <constant name="ecal_front" value="6.65" />
+      <constant name="z01t" value="138.815" />
+      <constant name="world_x" value="5000.0" />
+      <constant name="hodoscopeScoreDisplacement" value="1.0" />
+      <constant name="world_y" value="5000.0" />
+      <constant name="dipoleMagnetPositionX" value="21.17" />
+      <constant name="world_z" value="5000.0" />
+      <constant name="dipoleMagnetPositionZ" value="457.2" />
+      <constant name="tracking_region_radius" value="2000.0" />
+      <constant name="moduleWidth" value="40.34" />
+      <constant name="x_off" value="0.0" />
+      <constant name="electronGapRightEdge" value="474.962" />
+      <constant name="hodoscopeZ" value="1098.5" />
+      <constant name="moduleLength" value="100.0" />
+      <constant name="PI" value="3.14159265359" />
+      <constant name="ecal_dface" value="1448.0" />
+      <constant name="ecal_z" value="80.0" />
+      <constant name="z01b" value="153.815" />
+      <position name="tracking_region_pos" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <position name="base_position" x="21.336" y="0.0" z="349.9358" unit="mm" />
+      <rotation name="base_rotation" x="1.5707963267948963" y="-0.0" z="0.0" unit="radian" />
+      <position name="base_plate_position" x="0.0" y="0.0" z="-82.423" unit="mm" />
+      <rotation name="base_plate_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="support_plate_bottom_L14_position" x="-43.91306765955236" y="158.27805970493353" z="-64.29618504855034" unit="mm" />
+      <rotation name="support_plate_bottom_L14_rotation" x="0.0013959999999999999" y="3.3881317890172014E-21" z="3.111052254139705" unit="radian" />
+      <position name="support_plate_top_L14_position" x="-43.92289273297252" y="158.275538638572" z="63.9526433720102" unit="mm" />
+      <rotation name="support_plate_top_L14_rotation" x="-3.1412006535897934" y="4.235164736271502E-21" z="0.030433306424175563" unit="radian" />
+      <position name="support_plate_bottom_L46_position" x="0.14270823091617224" y="-354.5345474665431" z="-65.573" unit="mm" />
+      <rotation name="support_plate_bottom_L46_rotation" x="0.0" y="-0.0" z="3.1111093540316292" unit="radian" />
+      <position name="support_plate_top_L46_position" x="0.14255566889328364" y="-354.53517226223204" z="65.573" unit="mm" />
+      <rotation name="support_plate_top_L46_rotation" x="3.141592653589793" y="-0.0" z="0.030483299558163937" unit="radian" />
+      <position name="module_L1b_halfmodule_axial_position" x="-19.4763620296784" y="288.43080680314125" z="-7.868322240733008" unit="mm" />
+      <rotation name="module_L1b_halfmodule_axial_rotation" x="-1.5694003267948962" y="-0.030540399450088122" z="1.5707963267948963" unit="radian" />
+      <position name="module_L1b_halfmodule_axial_sensor_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L1b_halfmodule_axial_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L1b_halfmodule_axial_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L1b_halfmodule_axial_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L1b_halfmodule_stereo_position" x="-18.950975318076487" y="296.04516725251904" z="-7.754181868972481" unit="mm" />
+      <rotation name="module_L1b_halfmodule_stereo_rotation" x="1.5721923267948965" y="0.03054039945008829" z="-1.4707963267948965" unit="radian" />
+      <position name="module_L1b_halfmodule_stereo_sensor_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L1b_halfmodule_stereo_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L1b_halfmodule_stereo_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L1b_halfmodule_stereo_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L1t_halfmodule_axial_position" x="-20.1794485390661" y="311.555035823137" z="7.876275502193266" unit="mm" />
+      <rotation name="module_L1t_halfmodule_axial_rotation" x="1.5711883267948965" y="0.03043330642417559" z="1.5707963267948966" unit="radian" />
+      <position name="module_L1t_halfmodule_axial_sensor_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L1t_halfmodule_axial_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L1t_halfmodule_axial_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L1t_halfmodule_axial_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L1t_halfmodule_stereo_position" x="-19.160254276741043" y="303.9879330807766" z="7.848654605882075" unit="mm" />
+      <rotation name="module_L1t_halfmodule_stereo_rotation" x="-1.5704043267948966" y="-0.030433306424175424" z="-1.4707963267948967" unit="radian" />
+      <position name="module_L1t_halfmodule_stereo_sensor_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L1t_halfmodule_stereo_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L1t_halfmodule_stereo_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L1t_halfmodule_stereo_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L2b_halfmodule_axial_position" x="-18.19946284499224" y="238.4458742857045" z="-8.273756692661564" unit="mm" />
+      <rotation name="module_L2b_halfmodule_axial_rotation" x="-1.5694003267948962" y="-0.030540399450088122" z="1.5707963267948963" unit="radian" />
+      <position name="module_L2b_halfmodule_axial_sensor_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L2b_halfmodule_axial_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L2b_halfmodule_axial_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L2b_halfmodule_axial_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L2b_halfmodule_stereo_position" x="-17.668736538396516" y="246.06038524800337" z="-8.168650212703746" unit="mm" />
+      <rotation name="module_L2b_halfmodule_stereo_rotation" x="1.5721923267948965" y="0.03054039945008829" z="-1.4707963267948965" unit="radian" />
+      <position name="module_L2b_halfmodule_stereo_sensor_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L2b_halfmodule_stereo_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L2b_halfmodule_stereo_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L2b_halfmodule_stereo_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L2t_halfmodule_axial_position" x="-18.90790233353613" y="261.57065544697707" z="8.074617394037915" unit="mm" />
+      <rotation name="module_L2t_halfmodule_axial_rotation" x="1.5711883267948965" y="0.03043330642417559" z="1.5707963267948966" unit="radian" />
+      <position name="module_L2t_halfmodule_axial_sensor_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L2t_halfmodule_axial_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L2t_halfmodule_axial_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L2t_halfmodule_axial_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L2t_halfmodule_stereo_position" x="-17.891118829887205" y="254.00349980902942" z="8.099278216849733" unit="mm" />
+      <rotation name="module_L2t_halfmodule_stereo_rotation" x="-1.5704043267948966" y="-0.030433306424175424" z="-1.4707963267948967" unit="radian" />
+      <position name="module_L2t_halfmodule_stereo_sensor_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L2t_halfmodule_stereo_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L2t_halfmodule_stereo_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L2t_halfmodule_stereo_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3b_halfmodule_axial_position" x="-44.86653535485047" y="137.05263425928803" z="-25.698042753919832" unit="mm" />
+      <rotation name="module_L3b_halfmodule_axial_rotation" x="-1.5694003267948962" y="-0.030540399450088122" z="1.5707963267948963" unit="radian" />
+      <position name="module_L3b_halfmodule_axial_sensor_position" x="-3.414999999999999" y="30.0" z="-0.50725" unit="mm" />
+      <rotation name="module_L3b_halfmodule_axial_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3b_halfmodule_axial_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L3b_halfmodule_axial_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3b_halfmodule_axial_lamination_position" x="-3.414999999999999" y="30.0" z="-0.69225" unit="mm" />
+      <rotation name="module_L3b_halfmodule_axial_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3b_halfmodule_axial_cf_position" x="-3.414999999999999" y="30.0" z="-0.81875" unit="mm" />
+      <rotation name="module_L3b_halfmodule_axial_cf_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3b_halfmodule_axial_hybrid_position" x="-3.414999999999999" y="-55.0" z="0.12649999999999995" unit="mm" />
+      <rotation name="module_L3b_halfmodule_axial_hybrid_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3b_halfmodule_stereo_position" x="-45.31712792075798" y="145.4286090945948" z="-21.88543549059398" unit="mm" />
+      <rotation name="module_L3b_halfmodule_stereo_rotation" x="1.5721923267948963" y="0.03054039945008801" z="1.6707963267948964" unit="radian" />
+      <position name="module_L3b_halfmodule_stereo_sensor_position" x="-3.414999999999999" y="30.0" z="-0.50725" unit="mm" />
+      <rotation name="module_L3b_halfmodule_stereo_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3b_halfmodule_stereo_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L3b_halfmodule_stereo_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3b_halfmodule_stereo_lamination_position" x="-3.414999999999999" y="30.0" z="-0.69225" unit="mm" />
+      <rotation name="module_L3b_halfmodule_stereo_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3b_halfmodule_stereo_cf_position" x="-3.414999999999999" y="30.0" z="-0.81875" unit="mm" />
+      <rotation name="module_L3b_halfmodule_stereo_cf_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3b_halfmodule_stereo_hybrid_position" x="-3.414999999999999" y="-55.0" z="0.12649999999999995" unit="mm" />
+      <rotation name="module_L3b_halfmodule_stereo_hybrid_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3t_halfmodule_axial_position" x="-45.61670040744279" y="161.22560021920657" z="25.632647003698295" unit="mm" />
+      <rotation name="module_L3t_halfmodule_axial_rotation" x="1.5711883267948965" y="0.03043330642417559" z="1.5707963267948966" unit="radian" />
+      <position name="module_L3t_halfmodule_axial_sensor_position" x="-3.414999999999999" y="30.0" z="-0.50725" unit="mm" />
+      <rotation name="module_L3t_halfmodule_axial_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3t_halfmodule_axial_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L3t_halfmodule_axial_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3t_halfmodule_axial_lamination_position" x="-3.414999999999999" y="30.0" z="-0.69225" unit="mm" />
+      <rotation name="module_L3t_halfmodule_axial_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3t_halfmodule_axial_cf_position" x="-3.414999999999999" y="30.0" z="-0.81875" unit="mm" />
+      <rotation name="module_L3t_halfmodule_axial_cf_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3t_halfmodule_axial_hybrid_position" x="-3.414999999999999" y="-55.0" z="0.12649999999999995" unit="mm" />
+      <rotation name="module_L3t_halfmodule_axial_hybrid_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3t_halfmodule_stereo_position" x="-45.550254290278474" y="152.84174390474504" z="21.816268962512165" unit="mm" />
+      <rotation name="module_L3t_halfmodule_stereo_rotation" x="-1.5704043267948962" y="-0.030433306424175535" z="1.6707963267948964" unit="radian" />
+      <position name="module_L3t_halfmodule_stereo_sensor_position" x="-3.414999999999999" y="30.0" z="-0.50725" unit="mm" />
+      <rotation name="module_L3t_halfmodule_stereo_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3t_halfmodule_stereo_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L3t_halfmodule_stereo_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3t_halfmodule_stereo_lamination_position" x="-3.414999999999999" y="30.0" z="-0.69225" unit="mm" />
+      <rotation name="module_L3t_halfmodule_stereo_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3t_halfmodule_stereo_cf_position" x="-3.414999999999999" y="30.0" z="-0.81875" unit="mm" />
+      <rotation name="module_L3t_halfmodule_stereo_cf_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3t_halfmodule_stereo_hybrid_position" x="-3.414999999999999" y="-55.0" z="0.12649999999999995" unit="mm" />
+      <rotation name="module_L3t_halfmodule_stereo_hybrid_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4b_halfmodule_axial_position" x="-41.81297014635422" y="37.09717854332278" z="-27.123898372427487" unit="mm" />
+      <rotation name="module_L4b_halfmodule_axial_rotation" x="-1.5694003267948962" y="-0.030540399450088122" z="1.5707963267948963" unit="radian" />
+      <position name="module_L4b_halfmodule_axial_sensor_position" x="-3.414999999999999" y="30.0" z="-0.50725" unit="mm" />
+      <rotation name="module_L4b_halfmodule_axial_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4b_halfmodule_axial_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L4b_halfmodule_axial_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4b_halfmodule_axial_lamination_position" x="-3.414999999999999" y="30.0" z="-0.69225" unit="mm" />
+      <rotation name="module_L4b_halfmodule_axial_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4b_halfmodule_axial_cf_position" x="-3.414999999999999" y="30.0" z="-0.81875" unit="mm" />
+      <rotation name="module_L4b_halfmodule_axial_cf_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4b_halfmodule_axial_hybrid_position" x="-3.414999999999999" y="-55.0" z="0.12649999999999995" unit="mm" />
+      <rotation name="module_L4b_halfmodule_axial_hybrid_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4b_halfmodule_stereo_position" x="-42.265007725812566" y="45.47316371484888" z="-23.272264430185697" unit="mm" />
+      <rotation name="module_L4b_halfmodule_stereo_rotation" x="1.5721923267948963" y="0.03054039945008801" z="1.6707963267948964" unit="radian" />
+      <position name="module_L4b_halfmodule_stereo_sensor_position" x="-3.414999999999999" y="30.0" z="-0.50725" unit="mm" />
+      <rotation name="module_L4b_halfmodule_stereo_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4b_halfmodule_stereo_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L4b_halfmodule_stereo_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4b_halfmodule_stereo_lamination_position" x="-3.414999999999999" y="30.0" z="-0.69225" unit="mm" />
+      <rotation name="module_L4b_halfmodule_stereo_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4b_halfmodule_stereo_cf_position" x="-3.414999999999999" y="30.0" z="-0.81875" unit="mm" />
+      <rotation name="module_L4b_halfmodule_stereo_cf_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4b_halfmodule_stereo_hybrid_position" x="-3.414999999999999" y="-55.0" z="0.12649999999999995" unit="mm" />
+      <rotation name="module_L4b_halfmodule_stereo_hybrid_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4t_halfmodule_axial_position" x="-42.57383952504715" y="61.27247766363083" z="27.110685740297292" unit="mm" />
+      <rotation name="module_L4t_halfmodule_axial_rotation" x="1.5711883267948965" y="0.03043330642417559" z="1.5707963267948966" unit="radian" />
+      <position name="module_L4t_halfmodule_axial_sensor_position" x="-3.414999999999999" y="30.0" z="-0.50725" unit="mm" />
+      <rotation name="module_L4t_halfmodule_axial_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4t_halfmodule_axial_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L4t_halfmodule_axial_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4t_halfmodule_axial_lamination_position" x="-3.414999999999999" y="30.0" z="-0.69225" unit="mm" />
+      <rotation name="module_L4t_halfmodule_axial_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4t_halfmodule_axial_cf_position" x="-3.414999999999999" y="30.0" z="-0.81875" unit="mm" />
+      <rotation name="module_L4t_halfmodule_axial_cf_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4t_halfmodule_axial_hybrid_position" x="-3.414999999999999" y="-55.0" z="0.12649999999999995" unit="mm" />
+      <rotation name="module_L4t_halfmodule_axial_hybrid_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4t_halfmodule_stereo_position" x="-42.51021339381717" y="52.88853510689392" z="23.293301915130098" unit="mm" />
+      <rotation name="module_L4t_halfmodule_stereo_rotation" x="-1.5704043267948962" y="-0.030433306424175535" z="1.6707963267948964" unit="radian" />
+      <position name="module_L4t_halfmodule_stereo_sensor_position" x="-3.414999999999999" y="30.0" z="-0.50725" unit="mm" />
+      <rotation name="module_L4t_halfmodule_stereo_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4t_halfmodule_stereo_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L4t_halfmodule_stereo_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4t_halfmodule_stereo_lamination_position" x="-3.414999999999999" y="30.0" z="-0.69225" unit="mm" />
+      <rotation name="module_L4t_halfmodule_stereo_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4t_halfmodule_stereo_cf_position" x="-3.414999999999999" y="30.0" z="-0.81875" unit="mm" />
+      <rotation name="module_L4t_halfmodule_stereo_cf_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4t_halfmodule_stereo_hybrid_position" x="-3.414999999999999" y="-55.0" z="0.12649999999999995" unit="mm" />
+      <rotation name="module_L4t_halfmodule_stereo_hybrid_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5b_halfmodule_axial_hole_position" x="-56.217250308986" y="-162.97132249781242" z="-26.654184000000008" unit="mm" />
+      <rotation name="module_L5b_halfmodule_axial_hole_rotation" x="-1.5707963267948966" y="-0.030483299558163958" z="1.5707963267948963" unit="radian" />
+      <position name="module_L5b_halfmodule_axial_hole_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L5b_halfmodule_axial_hole_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5b_halfmodule_axial_hole_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L5b_halfmodule_axial_hole_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5b_halfmodule_axial_hole_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L5b_halfmodule_axial_hole_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5b_halfmodule_axial_slot_position" x="44.72623159126889" y="-159.89327863637723" z="-26.790875000000007" unit="mm" />
+      <rotation name="module_L5b_halfmodule_axial_slot_rotation" x="-1.5707963267948968" y="-0.030483299558164013" z="-1.5707963267948963" unit="radian" />
+      <position name="module_L5b_halfmodule_axial_slot_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L5b_halfmodule_axial_slot_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5b_halfmodule_axial_slot_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L5b_halfmodule_axial_slot_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5b_halfmodule_axial_slot_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L5b_halfmodule_axial_slot_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5b_halfmodule_stereo_hole_position" x="-56.38945519192267" y="-155.65717305182127" z="-29.194184000000007" unit="mm" />
+      <rotation name="module_L5b_halfmodule_stereo_hole_rotation" x="1.5707963267948963" y="0.030483299558163958" z="1.6207963267948968" unit="radian" />
+      <position name="module_L5b_halfmodule_stereo_hole_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L5b_halfmodule_stereo_hole_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5b_halfmodule_stereo_hole_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L5b_halfmodule_stereo_hole_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5b_halfmodule_stereo_hole_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L5b_halfmodule_stereo_hole_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5b_halfmodule_stereo_slot_position" x="44.454054765676254" y="-152.582177609349" z="-24.171189451990195" unit="mm" />
+      <rotation name="module_L5b_halfmodule_stereo_slot_rotation" x="1.5707963267948963" y="0.030483299558163958" z="-1.520796326794897" unit="radian" />
+      <position name="module_L5b_halfmodule_stereo_slot_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L5b_halfmodule_stereo_slot_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5b_halfmodule_stereo_slot_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L5b_halfmodule_stereo_slot_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5b_halfmodule_stereo_slot_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L5b_halfmodule_stereo_slot_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5t_halfmodule_axial_hole_position" x="-56.924231591268885" y="-139.79172136362277" z="26.541846000000007" unit="mm" />
+      <rotation name="module_L5t_halfmodule_axial_hole_rotation" x="1.5707963267948966" y="0.030483299558163958" z="1.5707963267948963" unit="radian" />
+      <position name="module_L5t_halfmodule_axial_hole_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L5t_halfmodule_axial_hole_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5t_halfmodule_axial_hole_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L5t_halfmodule_axial_hole_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5t_halfmodule_axial_hole_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L5t_halfmodule_axial_hole_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5t_halfmodule_axial_slot_position" x="44.01925030898598" y="-136.71367750218758" z="26.52839000000001" unit="mm" />
+      <rotation name="module_L5t_halfmodule_axial_slot_rotation" x="1.5707963267948968" y="0.030483299558164013" z="-1.5707963267948963" unit="radian" />
+      <position name="module_L5t_halfmodule_axial_slot_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L5t_halfmodule_axial_slot_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5t_halfmodule_axial_slot_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L5t_halfmodule_axial_slot_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5t_halfmodule_axial_slot_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L5t_halfmodule_axial_slot_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5t_halfmodule_stereo_hole_position" x="-56.6479631235949" y="-147.10269762525203" z="29.15400018808746" unit="mm" />
+      <rotation name="module_L5t_halfmodule_stereo_hole_rotation" x="-1.5707963267948963" y="-0.030483299558163958" z="1.6207963267948968" unit="radian" />
+      <position name="module_L5t_halfmodule_stereo_hole_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L5t_halfmodule_stereo_hole_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5t_halfmodule_stereo_hole_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L5t_halfmodule_stereo_hole_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5t_halfmodule_stereo_hole_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L5t_halfmodule_stereo_hole_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5t_halfmodule_stereo_slot_position" x="44.1969126796318" y="-144.02766053439723" z="24.15831247094711" unit="mm" />
+      <rotation name="module_L5t_halfmodule_stereo_slot_rotation" x="-1.5707963267948966" y="-0.030483299558163847" z="-1.520796326794897" unit="radian" />
+      <position name="module_L5t_halfmodule_stereo_slot_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L5t_halfmodule_stereo_slot_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5t_halfmodule_stereo_slot_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L5t_halfmodule_stereo_slot_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5t_halfmodule_stereo_slot_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L5t_halfmodule_stereo_slot_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6b_halfmodule_axial_hole_position" x="-50.12153455494366" y="-362.8784065379883" z="-29.752676000000015" unit="mm" />
+      <rotation name="module_L6b_halfmodule_axial_hole_rotation" x="-1.5707963267948966" y="-0.030483299558163958" z="1.5707963267948963" unit="radian" />
+      <position name="module_L6b_halfmodule_axial_hole_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L6b_halfmodule_axial_hole_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6b_halfmodule_axial_hole_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L6b_halfmodule_axial_hole_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6b_halfmodule_axial_hole_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L6b_halfmodule_axial_hole_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6b_halfmodule_axial_slot_position" x="50.82194734531124" y="-359.8003626765531" z="-29.763803000000017" unit="mm" />
+      <rotation name="module_L6b_halfmodule_axial_slot_rotation" x="-1.5707963267948968" y="-0.030483299558164013" z="-1.5707963267948963" unit="radian" />
+      <position name="module_L6b_halfmodule_axial_slot_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L6b_halfmodule_axial_slot_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6b_halfmodule_axial_slot_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L6b_halfmodule_axial_slot_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6b_halfmodule_axial_slot_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L6b_halfmodule_axial_slot_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6b_halfmodule_stereo_hole_position" x="-50.29343375742253" y="-355.5642477709609" z="-32.18203835284337" unit="mm" />
+      <rotation name="module_L6b_halfmodule_stereo_hole_rotation" x="1.5707963267948963" y="0.030483299558163958" z="1.6207963267948968" unit="radian" />
+      <position name="module_L6b_halfmodule_stereo_hole_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L6b_halfmodule_stereo_hole_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6b_halfmodule_stereo_hole_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L6b_halfmodule_stereo_hole_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6b_halfmodule_stereo_hole_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L6b_halfmodule_stereo_hole_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6b_halfmodule_stereo_slot_position" x="50.549000898353505" y="-352.48928511739297" z="-27.13754570547856" unit="mm" />
+      <rotation name="module_L6b_halfmodule_stereo_slot_rotation" x="1.5707963267948963" y="0.030483299558163958" z="-1.520796326794897" unit="radian" />
+      <position name="module_L6b_halfmodule_stereo_slot_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L6b_halfmodule_stereo_slot_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6b_halfmodule_stereo_slot_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L6b_halfmodule_stereo_slot_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6b_halfmodule_stereo_slot_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L6b_halfmodule_stereo_slot_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6t_halfmodule_axial_hole_position" x="-50.82851583722654" y="-339.6988054037986" z="29.47463400000001" unit="mm" />
+      <rotation name="module_L6t_halfmodule_axial_hole_rotation" x="1.5707963267948966" y="0.030483299558163958" z="1.5707963267948963" unit="radian" />
+      <position name="module_L6t_halfmodule_axial_hole_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L6t_halfmodule_axial_hole_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6t_halfmodule_axial_hole_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L6t_halfmodule_axial_hole_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6t_halfmodule_axial_hole_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L6t_halfmodule_axial_hole_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6t_halfmodule_axial_slot_position" x="50.11496606302833" y="-336.6207615423634" z="29.49411100000001" unit="mm" />
+      <rotation name="module_L6t_halfmodule_axial_slot_rotation" x="1.5707963267948968" y="0.030483299558164013" z="-1.5707963267948963" unit="radian" />
+      <position name="module_L6t_halfmodule_axial_slot_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L6t_halfmodule_axial_slot_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6t_halfmodule_axial_slot_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L6t_halfmodule_axial_slot_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6t_halfmodule_axial_slot_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L6t_halfmodule_axial_slot_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6t_halfmodule_stereo_hole_position" x="-50.553114355064075" y="-347.0098081021961" z="32.10353887731831" unit="mm" />
+      <rotation name="module_L6t_halfmodule_stereo_hole_rotation" x="-1.5707963267948963" y="-0.030483299558163958" z="1.6207963267948968" unit="radian" />
+      <position name="module_L6t_halfmodule_stereo_hole_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L6t_halfmodule_stereo_hole_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6t_halfmodule_stereo_hole_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L6t_halfmodule_stereo_hole_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6t_halfmodule_stereo_hole_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L6t_halfmodule_stereo_hole_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6t_halfmodule_stereo_slot_position" x="50.29059672518935" y="-343.934806526942" z="27.084565297856848" unit="mm" />
+      <rotation name="module_L6t_halfmodule_stereo_slot_rotation" x="-1.5707963267948966" y="-0.030483299558163847" z="-1.520796326794897" unit="radian" />
+      <position name="module_L6t_halfmodule_stereo_slot_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L6t_halfmodule_stereo_slot_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6t_halfmodule_stereo_slot_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L6t_halfmodule_stereo_slot_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6t_halfmodule_stereo_slot_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L6t_halfmodule_stereo_slot_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7b_halfmodule_axial_hole_position" x="-44.02581880090134" y="-562.7854905781641" z="-32.83617600000001" unit="mm" />
+      <rotation name="module_L7b_halfmodule_axial_hole_rotation" x="-1.5707963267948966" y="-0.030483299558163958" z="1.5707963267948963" unit="radian" />
+      <position name="module_L7b_halfmodule_axial_hole_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L7b_halfmodule_axial_hole_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7b_halfmodule_axial_hole_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L7b_halfmodule_axial_hole_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7b_halfmodule_axial_hole_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L7b_halfmodule_axial_hole_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7b_halfmodule_axial_slot_position" x="56.917663099353554" y="-559.7074467167289" z="-32.84424400000001" unit="mm" />
+      <rotation name="module_L7b_halfmodule_axial_slot_rotation" x="-1.5707963267948968" y="-0.030483299558164013" z="-1.5707963267948963" unit="radian" />
+      <position name="module_L7b_halfmodule_axial_slot_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L7b_halfmodule_axial_slot_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7b_halfmodule_axial_slot_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L7b_halfmodule_axial_slot_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7b_halfmodule_axial_slot_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L7b_halfmodule_axial_slot_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7b_halfmodule_stereo_hole_position" x="-44.1996401085108" y="-555.4713904213984" z="-35.108553437824405" unit="mm" />
+      <rotation name="module_L7b_halfmodule_stereo_hole_rotation" x="1.5707963267948963" y="0.030483299558163958" z="1.6207963267948968" unit="radian" />
+      <position name="module_L7b_halfmodule_stereo_hole_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L7b_halfmodule_stereo_hole_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7b_halfmodule_stereo_hole_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L7b_halfmodule_stereo_hole_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7b_halfmodule_stereo_hole_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L7b_halfmodule_stereo_hole_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7b_halfmodule_stereo_slot_position" x="56.644874962801275" y="-552.3963643302499" z="-30.105653745053743" unit="mm" />
+      <rotation name="module_L7b_halfmodule_stereo_slot_rotation" x="1.5707963267948963" y="0.030483299558163958" z="-1.520796326794897" unit="radian" />
+      <position name="module_L7b_halfmodule_stereo_slot_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L7b_halfmodule_stereo_slot_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7b_halfmodule_stereo_slot_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L7b_halfmodule_stereo_slot_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7b_halfmodule_stereo_slot_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L7b_halfmodule_stereo_slot_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7t_halfmodule_axial_hole_position" x="-44.732800083184195" y="-539.6058894439745" z="32.40270000000001" unit="mm" />
+      <rotation name="module_L7t_halfmodule_axial_hole_rotation" x="1.5707963267948966" y="0.030483299558163958" z="1.5707963267948963" unit="radian" />
+      <position name="module_L7t_halfmodule_axial_hole_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L7t_halfmodule_axial_hole_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7t_halfmodule_axial_hole_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L7t_halfmodule_axial_hole_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7t_halfmodule_axial_hole_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L7t_halfmodule_axial_hole_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7t_halfmodule_axial_slot_position" x="56.21068181707067" y="-536.5278455825394" z="32.43682600000001" unit="mm" />
+      <rotation name="module_L7t_halfmodule_axial_slot_rotation" x="1.5707963267948968" y="0.030483299558164013" z="-1.5707963267948963" unit="radian" />
+      <position name="module_L7t_halfmodule_axial_slot_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L7t_halfmodule_axial_slot_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7t_halfmodule_axial_slot_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L7t_halfmodule_axial_slot_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7t_halfmodule_axial_slot_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L7t_halfmodule_axial_slot_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7t_halfmodule_stereo_hole_position" x="-44.46460424724372" y="-546.9171118623054" z="34.936632139758935" unit="mm" />
+      <rotation name="module_L7t_halfmodule_stereo_hole_rotation" x="-1.5707963267948963" y="-0.030483299558163958" z="1.6207963267948968" unit="radian" />
+      <position name="module_L7t_halfmodule_stereo_hole_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L7t_halfmodule_stereo_hole_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7t_halfmodule_stereo_hole_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L7t_halfmodule_stereo_hole_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7t_halfmodule_stereo_hole_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L7t_halfmodule_stereo_hole_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7t_halfmodule_stereo_slot_position" x="56.37942540210259" y="-543.8421005730052" z="29.924027590708015" unit="mm" />
+      <rotation name="module_L7t_halfmodule_stereo_slot_rotation" x="-1.5707963267948966" y="-0.030483299558163847" z="-1.520796326794897" unit="radian" />
+      <position name="module_L7t_halfmodule_stereo_slot_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L7t_halfmodule_stereo_slot_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7t_halfmodule_stereo_slot_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L7t_halfmodule_stereo_slot_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7t_halfmodule_stereo_slot_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L7t_halfmodule_stereo_slot_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="BeamLeftVolume_component0_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="BeamLeftVolume_component0_rotation" x="0.0" y="0.0" z="0.0" unit="radian" />
+      <position name="BeamLeftVolume_component0Sensor0Position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="BeamLeftVolume_component0Sensor0Rotation" x="0.0" y="0.0" z="0.0" unit="radian" />
+      <position name="ElectronGapVolume_component0_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="ElectronGapVolume_component0_rotation" x="0.0" y="0.0" z="0.0" unit="radian" />
+      <position name="ElectronGapVolume_component0Sensor0Position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="ElectronGapVolume_component0Sensor0Rotation" x="0.0" y="0.0" z="0.0" unit="radian" />
+      <position name="BeamRightVolume_component0_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="BeamRightVolume_component0_rotation" x="0.0" y="0.0" z="0.0" unit="radian" />
+      <position name="BeamRightVolume_component0Sensor0Position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="BeamRightVolume_component0Sensor0Rotation" x="0.0" y="0.0" z="0.0" unit="radian" />
+      <position name="ECalScoring_BeamLeft_layer1_module0_position" x="214.099" y="122.8" z="1443.001" unit="mm" />
+      <rotation name="ECalScoring_BeamLeft_layer1_module0_rotation" x="0.0" y="0.0" z="-1.570796326795" unit="radian" />
+      <position name="ECalScoring_ElectronGap_layer1_module0_position" x="-23.38199999999999" y="130.465" z="1443.001" unit="mm" />
+      <rotation name="ECalScoring_ElectronGap_layer1_module0_rotation" x="0.0" y="0.0" z="-1.570796326795" unit="radian" />
+      <position name="ECalScoring_BeamRight_layer1_module0_position" x="-216.31099999999998" y="121.3" z="1443.001" unit="mm" />
+      <rotation name="ECalScoring_BeamRight_layer1_module0_rotation" x="0.0" y="0.0" z="-1.570796326795" unit="radian" />
+      <position name="ECalScoring_BeamLeft_layer2_module0_position" x="214.099" y="-122.8" z="1443.001" unit="mm" />
+      <rotation name="ECalScoring_BeamLeft_layer2_module0_rotation" x="0.0" y="0.0" z="-4.7123889803850005" unit="radian" />
+      <position name="ECalScoring_ElectronGap_layer2_module0_position" x="-23.38199999999999" y="-130.465" z="1443.001" unit="mm" />
+      <rotation name="ECalScoring_ElectronGap_layer2_module0_rotation" x="0.0" y="0.0" z="-4.7123889803850005" unit="radian" />
+      <position name="ECalScoring_BeamRight_layer2_module0_position" x="-216.31099999999998" y="-121.3" z="1443.001" unit="mm" />
+      <rotation name="ECalScoring_BeamRight_layer2_module0_rotation" x="0.0" y="0.0" z="-4.7123889803850005" unit="radian" />
+      <position name="crystal1-1_pos_pos_bot" x="50.20495188328156" y="-29.07473927539554" z="1528.1626281236922" unit="mm" />
+      <rotation name="crystal1-1_rot_pos_bot" x="-0.0084372997827221" y="-0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal1-1_pos_neg_bot" x="35.15547333249048" y="-29.07473927539554" z="1528.1626281236922" unit="mm" />
+      <rotation name="crystal1-1_rot_neg_bot" x="-0.0084372997827221" y="0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal1-1_pos_pos_top" x="50.20495188328156" y="29.974739275395542" z="1528.1626281236922" unit="mm" />
+      <rotation name="crystal1-1_rot_pos_top" x="0.0084372997827221" y="-0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal1-1_pos_neg_top" x="35.15547333249048" y="29.974739275395542" z="1528.1626281236922" unit="mm" />
+      <rotation name="crystal1-1_rot_neg_top" x="0.0084372997827221" y="0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal2-1_pos_pos_bot" x="65.05802548582456" y="-29.07473927539554" z="1528.2520480856124" unit="mm" />
+      <rotation name="crystal2-1_rot_pos_bot" x="-0.0084372997827221" y="-0.0253118993481663" z="0.0" unit="radian" />
+      <position name="crystal2-1_pos_pos_top" x="65.05802548582456" y="29.974739275395542" z="1528.2520480856124" unit="mm" />
+      <rotation name="crystal2-1_rot_pos_top" x="0.0084372997827221" y="-0.0253118993481663" z="0.0" unit="radian" />
+      <position name="crystal3-1_pos_pos_bot" x="79.9180994782841" y="-29.07473927539554" z="1528.3186477918262" unit="mm" />
+      <rotation name="crystal3-1_rot_pos_bot" x="-0.0084372997827221" y="-0.042186498913610496" z="0.0" unit="radian" />
+      <position name="crystal3-1_pos_pos_top" x="79.9180994782841" y="29.974739275395542" z="1528.3186477918262" unit="mm" />
+      <rotation name="crystal3-1_rot_pos_top" x="0.0084372997827221" y="-0.042186498913610496" z="0.0" unit="radian" />
+      <position name="crystal4-1_pos_pos_bot" x="94.78858692586502" y="-29.07473927539554" z="1528.3624082783765" unit="mm" />
+      <rotation name="crystal4-1_rot_pos_bot" x="-0.0084372997827221" y="-0.0590610984790547" z="0.0" unit="radian" />
+      <position name="crystal4-1_pos_pos_top" x="94.78858692586502" y="29.974739275395542" z="1528.3624082783765" unit="mm" />
+      <rotation name="crystal4-1_rot_pos_top" x="0.0084372997827221" y="-0.0590610984790547" z="0.0" unit="radian" />
+      <position name="crystal5-1_pos_pos_bot" x="109.67291416309662" y="-29.07473927539554" z="1528.3833170846683" unit="mm" />
+      <rotation name="crystal5-1_rot_pos_bot" x="-0.0084372997827221" y="-0.0759356980444989" z="0.0" unit="radian" />
+      <position name="crystal5-1_pos_pos_top" x="109.67291416309662" y="29.974739275395542" z="1528.3833170846683" unit="mm" />
+      <rotation name="crystal5-1_rot_pos_top" x="0.0084372997827221" y="-0.0759356980444989" z="0.0" unit="radian" />
+      <position name="crystal6-1_pos_pos_bot" x="124.57452638340096" y="-29.07473927539554" z="1528.381368257016" unit="mm" />
+      <rotation name="crystal6-1_rot_pos_bot" x="-0.0084372997827221" y="-0.0928102976099431" z="0.0" unit="radian" />
+      <position name="crystal6-1_pos_pos_top" x="124.57452638340096" y="29.974739275395542" z="1528.381368257016" unit="mm" />
+      <rotation name="crystal6-1_rot_pos_top" x="0.0084372997827221" y="-0.0928102976099431" z="0.0" unit="radian" />
+      <position name="crystal7-1_pos_pos_bot" x="139.4968932952259" y="-29.07473927539554" z="1528.3565623503396" unit="mm" />
+      <rotation name="crystal7-1_rot_pos_bot" x="-0.0084372997827221" y="-0.10968489717538729" z="0.0" unit="radian" />
+      <position name="crystal7-1_pos_pos_top" x="139.4968932952259" y="29.974739275395542" z="1528.3565623503396" unit="mm" />
+      <rotation name="crystal7-1_rot_pos_top" x="0.0084372997827221" y="-0.10968489717538729" z="0.0" unit="radian" />
+      <position name="crystal8-1_pos_pos_bot" x="154.44351486445828" y="-29.07473927539554" z="1528.3089064280052" unit="mm" />
+      <rotation name="crystal8-1_rot_pos_bot" x="-0.0084372997827221" y="-0.1265594967408315" z="0.0" unit="radian" />
+      <position name="crystal8-1_pos_pos_top" x="154.44351486445828" y="29.974739275395542" z="1528.3089064280052" unit="mm" />
+      <rotation name="crystal8-1_rot_pos_top" x="0.0084372997827221" y="-0.1265594967408315" z="0.0" unit="radian" />
+      <position name="crystal9-1_pos_pos_bot" x="169.41792716339802" y="-29.07473927539554" z="1528.2384140598156" unit="mm" />
+      <rotation name="crystal9-1_rot_pos_bot" x="-0.0084372997827221" y="-0.14343409630627568" z="0.0" unit="radian" />
+      <position name="crystal9-1_pos_pos_top" x="169.41792716339802" y="29.974739275395542" z="1528.2384140598156" unit="mm" />
+      <rotation name="crystal9-1_rot_pos_top" x="0.0084372997827221" y="-0.14343409630627568" z="0.0" unit="radian" />
+      <position name="crystal10-1_pos_pos_bot" x="184.42370834727978" y="-29.07473927539554" z="1528.1451053181452" unit="mm" />
+      <rotation name="crystal10-1_rot_pos_bot" x="-0.0084372997827221" y="-0.1603086958717199" z="0.0" unit="radian" />
+      <position name="crystal10-1_pos_pos_top" x="184.42370834727978" y="29.974739275395542" z="1528.1451053181452" unit="mm" />
+      <rotation name="crystal10-1_rot_pos_top" x="0.0084372997827221" y="-0.1603086958717199" z="0.0" unit="radian" />
+      <position name="crystal11-1_pos_pos_bot" x="199.46448478017476" y="-29.07473927539554" z="1528.0290067722244" unit="mm" />
+      <rotation name="crystal11-1_rot_pos_bot" x="-0.0084372997827221" y="-0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal11-1_pos_neg_bot" x="-114.1040595644027" y="-29.07473927539554" z="1528.0290067722244" unit="mm" />
+      <rotation name="crystal11-1_rot_neg_bot" x="-0.0084372997827221" y="0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal11-1_pos_pos_top" x="199.46448478017476" y="29.974739275395542" z="1528.0290067722244" unit="mm" />
+      <rotation name="crystal11-1_rot_pos_top" x="0.0084372997827221" y="-0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal11-1_pos_neg_top" x="-114.1040595644027" y="29.974739275395542" z="1528.0290067722244" unit="mm" />
+      <rotation name="crystal11-1_rot_neg_top" x="0.0084372997827221" y="0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal12-1_pos_pos_bot" x="214.5439373331128" y="-29.07473927539554" z="1527.8901514805746" unit="mm" />
+      <rotation name="crystal12-1_rot_pos_bot" x="-0.0084372997827221" y="-0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal12-1_pos_neg_bot" x="-129.1835121173408" y="-29.07473927539554" z="1527.8901514805746" unit="mm" />
+      <rotation name="crystal12-1_rot_neg_bot" x="-0.0084372997827221" y="0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal12-1_pos_pos_top" x="214.5439373331128" y="29.974739275395542" z="1527.8901514805746" unit="mm" />
+      <rotation name="crystal12-1_rot_pos_top" x="0.0084372997827221" y="-0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal12-1_pos_neg_top" x="-129.1835121173408" y="29.974739275395542" z="1527.8901514805746" unit="mm" />
+      <rotation name="crystal12-1_rot_neg_top" x="0.0084372997827221" y="0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal13-1_pos_pos_bot" x="229.66580787843168" y="-29.07473927539554" z="1527.7285789815953" unit="mm" />
+      <rotation name="crystal13-1_rot_pos_bot" x="-0.0084372997827221" y="-0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal13-1_pos_neg_bot" x="-144.30538266265967" y="-29.07473927539554" z="1527.7285789815953" unit="mm" />
+      <rotation name="crystal13-1_rot_neg_bot" x="-0.0084372997827221" y="0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal13-1_pos_pos_top" x="229.66580787843168" y="29.974739275395542" z="1527.7285789815953" unit="mm" />
+      <rotation name="crystal13-1_rot_pos_top" x="0.0084372997827221" y="-0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal13-1_pos_neg_top" x="-144.30538266265967" y="29.974739275395542" z="1527.7285789815953" unit="mm" />
+      <rotation name="crystal13-1_rot_neg_top" x="0.0084372997827221" y="0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal14-1_pos_pos_bot" x="244.83390600570817" y="-29.07473927539554" z="1527.5443352823047" unit="mm" />
+      <rotation name="crystal14-1_rot_pos_bot" x="-0.0084372997827221" y="-0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal14-1_pos_neg_bot" x="-159.47348078993616" y="-29.07473927539554" z="1527.5443352823047" unit="mm" />
+      <rotation name="crystal14-1_rot_neg_bot" x="-0.0084372997827221" y="0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal14-1_pos_pos_top" x="244.83390600570817" y="29.974739275395542" z="1527.5443352823047" unit="mm" />
+      <rotation name="crystal14-1_rot_pos_top" x="0.0084372997827221" y="-0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal14-1_pos_neg_top" x="-159.47348078993616" y="29.974739275395542" z="1527.5443352823047" unit="mm" />
+      <rotation name="crystal14-1_rot_neg_top" x="0.0084372997827221" y="0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal15-1_pos_pos_bot" x="260.0521159861688" y="-29.07473927539554" z="1527.3374728452397" unit="mm" />
+      <rotation name="crystal15-1_rot_pos_bot" x="-0.0084372997827221" y="-0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal15-1_pos_neg_bot" x="-174.6916907703968" y="-29.07473927539554" z="1527.3374728452397" unit="mm" />
+      <rotation name="crystal15-1_rot_neg_bot" x="-0.0084372997827221" y="0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal15-1_pos_pos_top" x="260.0521159861688" y="29.974739275395542" z="1527.3374728452397" unit="mm" />
+      <rotation name="crystal15-1_rot_pos_top" x="0.0084372997827221" y="-0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal15-1_pos_neg_top" x="-174.6916907703968" y="29.974739275395542" z="1527.3374728452397" unit="mm" />
+      <rotation name="crystal15-1_rot_neg_top" x="0.0084372997827221" y="0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal16-1_pos_pos_bot" x="275.32440401422616" y="-29.07473927539554" z="1527.108050573519" unit="mm" />
+      <rotation name="crystal16-1_rot_pos_bot" x="-0.0084372997827221" y="-0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal16-1_pos_neg_bot" x="-189.96397879845415" y="-29.07473927539554" z="1527.108050573519" unit="mm" />
+      <rotation name="crystal16-1_rot_neg_bot" x="-0.0084372997827221" y="0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal16-1_pos_pos_top" x="275.32440401422616" y="29.974739275395542" z="1527.108050573519" unit="mm" />
+      <rotation name="crystal16-1_rot_pos_top" x="0.0084372997827221" y="-0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal16-1_pos_neg_top" x="-189.96397879845415" y="29.974739275395542" z="1527.108050573519" unit="mm" />
+      <rotation name="crystal16-1_rot_neg_top" x="0.0084372997827221" y="0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal17-1_pos_pos_bot" x="290.6548257567732" y="-29.07473927539554" z="1526.8561337940675" unit="mm" />
+      <rotation name="crystal17-1_rot_pos_bot" x="-0.0084372997827221" y="-0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal17-1_pos_neg_bot" x="-205.2944005410012" y="-29.07473927539554" z="1526.8561337940675" unit="mm" />
+      <rotation name="crystal17-1_rot_neg_bot" x="-0.0084372997827221" y="0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal17-1_pos_pos_top" x="290.6548257567732" y="29.974739275395542" z="1526.8561337940675" unit="mm" />
+      <rotation name="crystal17-1_rot_pos_top" x="0.0084372997827221" y="-0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal17-1_pos_neg_top" x="-205.2944005410012" y="29.974739275395542" z="1526.8561337940675" unit="mm" />
+      <rotation name="crystal17-1_rot_neg_top" x="0.0084372997827221" y="0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal18-1_pos_pos_bot" x="306.0475342431027" y="-29.07473927539554" z="1526.581794239018" unit="mm" />
+      <rotation name="crystal18-1_rot_pos_bot" x="-0.0084372997827221" y="-0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal18-1_pos_neg_bot" x="-220.68710902733068" y="-29.07473927539554" z="1526.581794239018" unit="mm" />
+      <rotation name="crystal18-1_rot_neg_bot" x="-0.0084372997827221" y="0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal18-1_pos_pos_top" x="306.0475342431027" y="29.974739275395542" z="1526.581794239018" unit="mm" />
+      <rotation name="crystal18-1_rot_pos_top" x="0.0084372997827221" y="-0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal18-1_pos_neg_top" x="-220.68710902733068" y="29.974739275395542" z="1526.581794239018" unit="mm" />
+      <rotation name="crystal18-1_rot_neg_top" x="0.0084372997827221" y="0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal19-1_pos_pos_bot" x="321.5067881308382" y="-29.07473927539554" z="1526.2851100252847" unit="mm" />
+      <rotation name="crystal19-1_rot_pos_bot" x="-0.0084372997827221" y="-0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal19-1_pos_neg_bot" x="-236.14636291506616" y="-29.07473927539554" z="1526.2851100252847" unit="mm" />
+      <rotation name="crystal19-1_rot_neg_bot" x="-0.0084372997827221" y="0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal19-1_pos_pos_top" x="321.5067881308382" y="29.974739275395542" z="1526.2851100252847" unit="mm" />
+      <rotation name="crystal19-1_rot_pos_top" x="0.0084372997827221" y="-0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal19-1_pos_neg_top" x="-236.14636291506616" y="29.974739275395542" z="1526.2851100252847" unit="mm" />
+      <rotation name="crystal19-1_rot_neg_top" x="0.0084372997827221" y="0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal20-1_pos_pos_bot" x="337.03696038609246" y="-29.07473927539554" z="1525.9661656323178" unit="mm" />
+      <rotation name="crystal20-1_rot_pos_bot" x="-0.0084372997827221" y="-0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal20-1_pos_neg_bot" x="-251.67653517032045" y="-29.07473927539554" z="1525.9661656323178" unit="mm" />
+      <rotation name="crystal20-1_rot_neg_bot" x="-0.0084372997827221" y="0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal20-1_pos_pos_top" x="337.03696038609246" y="29.974739275395542" z="1525.9661656323178" unit="mm" />
+      <rotation name="crystal20-1_rot_pos_top" x="0.0084372997827221" y="-0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal20-1_pos_neg_top" x="-251.67653517032045" y="29.974739275395542" z="1525.9661656323178" unit="mm" />
+      <rotation name="crystal20-1_rot_neg_top" x="0.0084372997827221" y="0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal21-1_pos_pos_bot" x="352.64254741924634" y="-29.07473927539554" z="1525.625051878052" unit="mm" />
+      <rotation name="crystal21-1_rot_pos_bot" x="-0.0084372997827221" y="-0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal21-1_pos_neg_bot" x="-267.28212220347433" y="-29.07473927539554" z="1525.625051878052" unit="mm" />
+      <rotation name="crystal21-1_rot_neg_bot" x="-0.0084372997827221" y="0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal21-1_pos_pos_top" x="352.64254741924634" y="29.974739275395542" z="1525.625051878052" unit="mm" />
+      <rotation name="crystal21-1_rot_pos_top" x="0.0084372997827221" y="-0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal21-1_pos_neg_top" x="-267.28212220347433" y="29.974739275395542" z="1525.625051878052" unit="mm" />
+      <rotation name="crystal21-1_rot_neg_top" x="0.0084372997827221" y="0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal22-1_pos_pos_bot" x="368.32817872130425" y="-29.07473927539554" z="1525.2618658930442" unit="mm" />
+      <rotation name="crystal22-1_rot_pos_bot" x="-0.0084372997827221" y="-0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal22-1_pos_neg_bot" x="-282.96775350553224" y="-29.07473927539554" z="1525.2618658930442" unit="mm" />
+      <rotation name="crystal22-1_rot_neg_bot" x="-0.0084372997827221" y="0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal22-1_pos_pos_top" x="368.32817872130425" y="29.974739275395542" z="1525.2618658930442" unit="mm" />
+      <rotation name="crystal22-1_rot_pos_top" x="0.0084372997827221" y="-0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal22-1_pos_neg_top" x="-282.96775350553224" y="29.974739275395542" z="1525.2618658930442" unit="mm" />
+      <rotation name="crystal22-1_rot_neg_top" x="0.0084372997827221" y="0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal23-1_pos_pos_bot" x="384.09862704978" y="-29.07473927539554" z="1524.8767110928152" unit="mm" />
+      <rotation name="crystal23-1_rot_pos_bot" x="-0.0084372997827221" y="-0.3796784902224945" z="0.0" unit="radian" />
+      <position name="crystal23-1_pos_neg_bot" x="-298.738201834008" y="-29.07473927539554" z="1524.8767110928152" unit="mm" />
+      <rotation name="crystal23-1_rot_neg_bot" x="-0.0084372997827221" y="0.3796784902224945" z="0.0" unit="radian" />
+      <position name="crystal23-1_pos_pos_top" x="384.09862704978" y="29.974739275395542" z="1524.8767110928152" unit="mm" />
+      <rotation name="crystal23-1_rot_pos_top" x="0.0084372997827221" y="-0.3796784902224945" z="0.0" unit="radian" />
+      <position name="crystal23-1_pos_neg_top" x="-298.738201834008" y="29.974739275395542" z="1524.8767110928152" unit="mm" />
+      <rotation name="crystal23-1_rot_neg_top" x="0.0084372997827221" y="0.3796784902224945" z="0.0" unit="radian" />
+      <position name="crystal1-2_pos_pos_bot" x="50.20495188328156" y="-44.077812877938534" z="1528.2520480856124" unit="mm" />
+      <rotation name="crystal1-2_rot_pos_bot" x="-0.0253118993481663" y="-0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal1-2_pos_neg_bot" x="35.15547333249048" y="-44.077812877938534" z="1528.2520480856124" unit="mm" />
+      <rotation name="crystal1-2_rot_neg_bot" x="-0.0253118993481663" y="0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal1-2_pos_pos_top" x="50.20495188328156" y="44.97781287793853" z="1528.2520480856124" unit="mm" />
+      <rotation name="crystal1-2_rot_pos_top" x="0.0253118993481663" y="-0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal1-2_pos_neg_top" x="35.15547333249048" y="44.97781287793853" z="1528.2520480856124" unit="mm" />
+      <rotation name="crystal1-2_rot_neg_top" x="0.0253118993481663" y="0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal2-2_pos_pos_bot" x="65.05802548582456" y="-44.077812877938534" z="1528.3414680475323" unit="mm" />
+      <rotation name="crystal2-2_rot_pos_bot" x="-0.0253118993481663" y="-0.0253118993481663" z="0.0" unit="radian" />
+      <position name="crystal2-2_pos_neg_bot" x="20.302399729947485" y="-44.077812877938534" z="1528.3414680475323" unit="mm" />
+      <rotation name="crystal2-2_rot_neg_bot" x="-0.0253118993481663" y="0.0253118993481663" z="0.0" unit="radian" />
+      <position name="crystal2-2_pos_pos_top" x="65.05802548582456" y="44.97781287793853" z="1528.3414680475323" unit="mm" />
+      <rotation name="crystal2-2_rot_pos_top" x="0.0253118993481663" y="-0.0253118993481663" z="0.0" unit="radian" />
+      <position name="crystal2-2_pos_neg_top" x="20.302399729947485" y="44.97781287793853" z="1528.3414680475323" unit="mm" />
+      <rotation name="crystal2-2_rot_neg_top" x="0.0253118993481663" y="0.0253118993481663" z="0.0" unit="radian" />
+      <position name="crystal3-2_pos_pos_bot" x="79.9180994782841" y="-44.077812877938534" z="1528.4080677537463" unit="mm" />
+      <rotation name="crystal3-2_rot_pos_bot" x="-0.0253118993481663" y="-0.042186498913610496" z="0.0" unit="radian" />
+      <position name="crystal3-2_pos_neg_bot" x="5.442325737487934" y="-44.077812877938534" z="1528.4080677537463" unit="mm" />
+      <rotation name="crystal3-2_rot_neg_bot" x="-0.0253118993481663" y="0.042186498913610496" z="0.0" unit="radian" />
+      <position name="crystal3-2_pos_pos_top" x="79.9180994782841" y="44.97781287793853" z="1528.4080677537463" unit="mm" />
+      <rotation name="crystal3-2_rot_pos_top" x="0.0253118993481663" y="-0.042186498913610496" z="0.0" unit="radian" />
+      <position name="crystal3-2_pos_neg_top" x="5.442325737487934" y="44.97781287793853" z="1528.4080677537463" unit="mm" />
+      <rotation name="crystal3-2_rot_neg_top" x="0.0253118993481663" y="0.042186498913610496" z="0.0" unit="radian" />
+      <position name="crystal4-2_pos_pos_bot" x="94.78858692586502" y="-44.077812877938534" z="1528.4518282402964" unit="mm" />
+      <rotation name="crystal4-2_rot_pos_bot" x="-0.0253118993481663" y="-0.0590610984790547" z="0.0" unit="radian" />
+      <position name="crystal4-2_pos_neg_bot" x="-9.42816171009298" y="-44.077812877938534" z="1528.4518282402964" unit="mm" />
+      <rotation name="crystal4-2_rot_neg_bot" x="-0.0253118993481663" y="0.0590610984790547" z="0.0" unit="radian" />
+      <position name="crystal4-2_pos_pos_top" x="94.78858692586502" y="44.97781287793853" z="1528.4518282402964" unit="mm" />
+      <rotation name="crystal4-2_rot_pos_top" x="0.0253118993481663" y="-0.0590610984790547" z="0.0" unit="radian" />
+      <position name="crystal4-2_pos_neg_top" x="-9.42816171009298" y="44.97781287793853" z="1528.4518282402964" unit="mm" />
+      <rotation name="crystal4-2_rot_neg_top" x="0.0253118993481663" y="0.0590610984790547" z="0.0" unit="radian" />
+      <position name="crystal5-2_pos_pos_bot" x="109.67291416309662" y="-44.077812877938534" z="1528.4727370465882" unit="mm" />
+      <rotation name="crystal5-2_rot_pos_bot" x="-0.0253118993481663" y="-0.0759356980444989" z="0.0" unit="radian" />
+      <position name="crystal5-2_pos_neg_bot" x="-24.31248894732458" y="-44.077812877938534" z="1528.4727370465882" unit="mm" />
+      <rotation name="crystal5-2_rot_neg_bot" x="-0.0253118993481663" y="0.0759356980444989" z="0.0" unit="radian" />
+      <position name="crystal5-2_pos_pos_top" x="109.67291416309662" y="44.97781287793853" z="1528.4727370465882" unit="mm" />
+      <rotation name="crystal5-2_rot_pos_top" x="0.0253118993481663" y="-0.0759356980444989" z="0.0" unit="radian" />
+      <position name="crystal5-2_pos_neg_top" x="-24.31248894732458" y="44.97781287793853" z="1528.4727370465882" unit="mm" />
+      <rotation name="crystal5-2_rot_neg_top" x="0.0253118993481663" y="0.0759356980444989" z="0.0" unit="radian" />
+      <position name="crystal6-2_pos_pos_bot" x="124.57452638340096" y="-44.077812877938534" z="1528.4707882189361" unit="mm" />
+      <rotation name="crystal6-2_rot_pos_bot" x="-0.0253118993481663" y="-0.0928102976099431" z="0.0" unit="radian" />
+      <position name="crystal6-2_pos_neg_bot" x="-39.214101167628925" y="-44.077812877938534" z="1528.4707882189361" unit="mm" />
+      <rotation name="crystal6-2_rot_neg_bot" x="-0.0253118993481663" y="0.0928102976099431" z="0.0" unit="radian" />
+      <position name="crystal6-2_pos_pos_top" x="124.57452638340096" y="44.97781287793853" z="1528.4707882189361" unit="mm" />
+      <rotation name="crystal6-2_rot_pos_top" x="0.0253118993481663" y="-0.0928102976099431" z="0.0" unit="radian" />
+      <position name="crystal6-2_pos_neg_top" x="-39.214101167628925" y="44.97781287793853" z="1528.4707882189361" unit="mm" />
+      <rotation name="crystal6-2_rot_neg_top" x="0.0253118993481663" y="0.0928102976099431" z="0.0" unit="radian" />
+      <position name="crystal7-2_pos_pos_bot" x="139.4968932952259" y="-44.077812877938534" z="1528.4459823122595" unit="mm" />
+      <rotation name="crystal7-2_rot_pos_bot" x="-0.0253118993481663" y="-0.10968489717538729" z="0.0" unit="radian" />
+      <position name="crystal7-2_pos_neg_bot" x="-54.13646807945388" y="-44.077812877938534" z="1528.4459823122595" unit="mm" />
+      <rotation name="crystal7-2_rot_neg_bot" x="-0.0253118993481663" y="0.10968489717538729" z="0.0" unit="radian" />
+      <position name="crystal7-2_pos_pos_top" x="139.4968932952259" y="44.97781287793853" z="1528.4459823122595" unit="mm" />
+      <rotation name="crystal7-2_rot_pos_top" x="0.0253118993481663" y="-0.10968489717538729" z="0.0" unit="radian" />
+      <position name="crystal7-2_pos_neg_top" x="-54.13646807945388" y="44.97781287793853" z="1528.4459823122595" unit="mm" />
+      <rotation name="crystal7-2_rot_neg_top" x="0.0253118993481663" y="0.10968489717538729" z="0.0" unit="radian" />
+      <position name="crystal8-2_pos_pos_bot" x="154.44351486445828" y="-44.077812877938534" z="1528.3983263899254" unit="mm" />
+      <rotation name="crystal8-2_rot_pos_bot" x="-0.0253118993481663" y="-0.1265594967408315" z="0.0" unit="radian" />
+      <position name="crystal8-2_pos_neg_bot" x="-69.08308964868624" y="-44.077812877938534" z="1528.3983263899254" unit="mm" />
+      <rotation name="crystal8-2_rot_neg_bot" x="-0.0253118993481663" y="0.1265594967408315" z="0.0" unit="radian" />
+      <position name="crystal8-2_pos_pos_top" x="154.44351486445828" y="44.97781287793853" z="1528.3983263899254" unit="mm" />
+      <rotation name="crystal8-2_rot_pos_top" x="0.0253118993481663" y="-0.1265594967408315" z="0.0" unit="radian" />
+      <position name="crystal8-2_pos_neg_top" x="-69.08308964868624" y="44.97781287793853" z="1528.3983263899254" unit="mm" />
+      <rotation name="crystal8-2_rot_neg_top" x="0.0253118993481663" y="0.1265594967408315" z="0.0" unit="radian" />
+      <position name="crystal9-2_pos_pos_bot" x="169.41792716339802" y="-44.077812877938534" z="1528.3278340217357" unit="mm" />
+      <rotation name="crystal9-2_rot_pos_bot" x="-0.0253118993481663" y="-0.14343409630627568" z="0.0" unit="radian" />
+      <position name="crystal9-2_pos_neg_bot" x="-84.057501947626" y="-44.077812877938534" z="1528.3278340217357" unit="mm" />
+      <rotation name="crystal9-2_rot_neg_bot" x="-0.0253118993481663" y="0.14343409630627568" z="0.0" unit="radian" />
+      <position name="crystal9-2_pos_pos_top" x="169.41792716339802" y="44.97781287793853" z="1528.3278340217357" unit="mm" />
+      <rotation name="crystal9-2_rot_pos_top" x="0.0253118993481663" y="-0.14343409630627568" z="0.0" unit="radian" />
+      <position name="crystal9-2_pos_neg_top" x="-84.057501947626" y="44.97781287793853" z="1528.3278340217357" unit="mm" />
+      <rotation name="crystal9-2_rot_neg_top" x="0.0253118993481663" y="0.14343409630627568" z="0.0" unit="radian" />
+      <position name="crystal10-2_pos_pos_bot" x="184.42370834727978" y="-44.077812877938534" z="1528.2345252800653" unit="mm" />
+      <rotation name="crystal10-2_rot_pos_bot" x="-0.0253118993481663" y="-0.1603086958717199" z="0.0" unit="radian" />
+      <position name="crystal10-2_pos_neg_bot" x="-99.06328313150773" y="-44.077812877938534" z="1528.2345252800653" unit="mm" />
+      <rotation name="crystal10-2_rot_neg_bot" x="-0.0253118993481663" y="0.1603086958717199" z="0.0" unit="radian" />
+      <position name="crystal10-2_pos_pos_top" x="184.42370834727978" y="44.97781287793853" z="1528.2345252800653" unit="mm" />
+      <rotation name="crystal10-2_rot_pos_top" x="0.0253118993481663" y="-0.1603086958717199" z="0.0" unit="radian" />
+      <position name="crystal10-2_pos_neg_top" x="-99.06328313150773" y="44.97781287793853" z="1528.2345252800653" unit="mm" />
+      <rotation name="crystal10-2_rot_neg_top" x="0.0253118993481663" y="0.1603086958717199" z="0.0" unit="radian" />
+      <position name="crystal11-2_pos_pos_bot" x="199.46448478017476" y="-44.077812877938534" z="1528.1184267341444" unit="mm" />
+      <rotation name="crystal11-2_rot_pos_bot" x="-0.0253118993481663" y="-0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal11-2_pos_neg_bot" x="-114.1040595644027" y="-44.077812877938534" z="1528.1184267341444" unit="mm" />
+      <rotation name="crystal11-2_rot_neg_bot" x="-0.0253118993481663" y="0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal11-2_pos_pos_top" x="199.46448478017476" y="44.97781287793853" z="1528.1184267341444" unit="mm" />
+      <rotation name="crystal11-2_rot_pos_top" x="0.0253118993481663" y="-0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal11-2_pos_neg_top" x="-114.1040595644027" y="44.97781287793853" z="1528.1184267341444" unit="mm" />
+      <rotation name="crystal11-2_rot_neg_top" x="0.0253118993481663" y="0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal12-2_pos_pos_bot" x="214.5439373331128" y="-44.077812877938534" z="1527.9795714424947" unit="mm" />
+      <rotation name="crystal12-2_rot_pos_bot" x="-0.0253118993481663" y="-0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal12-2_pos_neg_bot" x="-129.1835121173408" y="-44.077812877938534" z="1527.9795714424947" unit="mm" />
+      <rotation name="crystal12-2_rot_neg_bot" x="-0.0253118993481663" y="0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal12-2_pos_pos_top" x="214.5439373331128" y="44.97781287793853" z="1527.9795714424947" unit="mm" />
+      <rotation name="crystal12-2_rot_pos_top" x="0.0253118993481663" y="-0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal12-2_pos_neg_top" x="-129.1835121173408" y="44.97781287793853" z="1527.9795714424947" unit="mm" />
+      <rotation name="crystal12-2_rot_neg_top" x="0.0253118993481663" y="0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal13-2_pos_pos_bot" x="229.66580787843168" y="-44.077812877938534" z="1527.8179989435152" unit="mm" />
+      <rotation name="crystal13-2_rot_pos_bot" x="-0.0253118993481663" y="-0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal13-2_pos_neg_bot" x="-144.30538266265967" y="-44.077812877938534" z="1527.8179989435152" unit="mm" />
+      <rotation name="crystal13-2_rot_neg_bot" x="-0.0253118993481663" y="0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal13-2_pos_pos_top" x="229.66580787843168" y="44.97781287793853" z="1527.8179989435152" unit="mm" />
+      <rotation name="crystal13-2_rot_pos_top" x="0.0253118993481663" y="-0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal13-2_pos_neg_top" x="-144.30538266265967" y="44.97781287793853" z="1527.8179989435152" unit="mm" />
+      <rotation name="crystal13-2_rot_neg_top" x="0.0253118993481663" y="0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal14-2_pos_pos_bot" x="244.83390600570817" y="-44.077812877938534" z="1527.6337552442246" unit="mm" />
+      <rotation name="crystal14-2_rot_pos_bot" x="-0.0253118993481663" y="-0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal14-2_pos_neg_bot" x="-159.47348078993616" y="-44.077812877938534" z="1527.6337552442246" unit="mm" />
+      <rotation name="crystal14-2_rot_neg_bot" x="-0.0253118993481663" y="0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal14-2_pos_pos_top" x="244.83390600570817" y="44.97781287793853" z="1527.6337552442246" unit="mm" />
+      <rotation name="crystal14-2_rot_pos_top" x="0.0253118993481663" y="-0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal14-2_pos_neg_top" x="-159.47348078993616" y="44.97781287793853" z="1527.6337552442246" unit="mm" />
+      <rotation name="crystal14-2_rot_neg_top" x="0.0253118993481663" y="0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal15-2_pos_pos_bot" x="260.0521159861688" y="-44.077812877938534" z="1527.42689280716" unit="mm" />
+      <rotation name="crystal15-2_rot_pos_bot" x="-0.0253118993481663" y="-0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal15-2_pos_neg_bot" x="-174.6916907703968" y="-44.077812877938534" z="1527.42689280716" unit="mm" />
+      <rotation name="crystal15-2_rot_neg_bot" x="-0.0253118993481663" y="0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal15-2_pos_pos_top" x="260.0521159861688" y="44.97781287793853" z="1527.42689280716" unit="mm" />
+      <rotation name="crystal15-2_rot_pos_top" x="0.0253118993481663" y="-0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal15-2_pos_neg_top" x="-174.6916907703968" y="44.97781287793853" z="1527.42689280716" unit="mm" />
+      <rotation name="crystal15-2_rot_neg_top" x="0.0253118993481663" y="0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal16-2_pos_pos_bot" x="275.32440401422616" y="-44.077812877938534" z="1527.1974705354392" unit="mm" />
+      <rotation name="crystal16-2_rot_pos_bot" x="-0.0253118993481663" y="-0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal16-2_pos_neg_bot" x="-189.96397879845415" y="-44.077812877938534" z="1527.1974705354392" unit="mm" />
+      <rotation name="crystal16-2_rot_neg_bot" x="-0.0253118993481663" y="0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal16-2_pos_pos_top" x="275.32440401422616" y="44.97781287793853" z="1527.1974705354392" unit="mm" />
+      <rotation name="crystal16-2_rot_pos_top" x="0.0253118993481663" y="-0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal16-2_pos_neg_top" x="-189.96397879845415" y="44.97781287793853" z="1527.1974705354392" unit="mm" />
+      <rotation name="crystal16-2_rot_neg_top" x="0.0253118993481663" y="0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal17-2_pos_pos_bot" x="290.6548257567732" y="-44.077812877938534" z="1526.9455537559877" unit="mm" />
+      <rotation name="crystal17-2_rot_pos_bot" x="-0.0253118993481663" y="-0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal17-2_pos_neg_bot" x="-205.2944005410012" y="-44.077812877938534" z="1526.9455537559877" unit="mm" />
+      <rotation name="crystal17-2_rot_neg_bot" x="-0.0253118993481663" y="0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal17-2_pos_pos_top" x="290.6548257567732" y="44.97781287793853" z="1526.9455537559877" unit="mm" />
+      <rotation name="crystal17-2_rot_pos_top" x="0.0253118993481663" y="-0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal17-2_pos_neg_top" x="-205.2944005410012" y="44.97781287793853" z="1526.9455537559877" unit="mm" />
+      <rotation name="crystal17-2_rot_neg_top" x="0.0253118993481663" y="0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal18-2_pos_pos_bot" x="306.0475342431027" y="-44.077812877938534" z="1526.6712142009383" unit="mm" />
+      <rotation name="crystal18-2_rot_pos_bot" x="-0.0253118993481663" y="-0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal18-2_pos_neg_bot" x="-220.68710902733068" y="-44.077812877938534" z="1526.6712142009383" unit="mm" />
+      <rotation name="crystal18-2_rot_neg_bot" x="-0.0253118993481663" y="0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal18-2_pos_pos_top" x="306.0475342431027" y="44.97781287793853" z="1526.6712142009383" unit="mm" />
+      <rotation name="crystal18-2_rot_pos_top" x="0.0253118993481663" y="-0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal18-2_pos_neg_top" x="-220.68710902733068" y="44.97781287793853" z="1526.6712142009383" unit="mm" />
+      <rotation name="crystal18-2_rot_neg_top" x="0.0253118993481663" y="0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal19-2_pos_pos_bot" x="321.5067881308382" y="-44.077812877938534" z="1526.3745299872046" unit="mm" />
+      <rotation name="crystal19-2_rot_pos_bot" x="-0.0253118993481663" y="-0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal19-2_pos_neg_bot" x="-236.14636291506616" y="-44.077812877938534" z="1526.3745299872046" unit="mm" />
+      <rotation name="crystal19-2_rot_neg_bot" x="-0.0253118993481663" y="0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal19-2_pos_pos_top" x="321.5067881308382" y="44.97781287793853" z="1526.3745299872046" unit="mm" />
+      <rotation name="crystal19-2_rot_pos_top" x="0.0253118993481663" y="-0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal19-2_pos_neg_top" x="-236.14636291506616" y="44.97781287793853" z="1526.3745299872046" unit="mm" />
+      <rotation name="crystal19-2_rot_neg_top" x="0.0253118993481663" y="0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal20-2_pos_pos_bot" x="337.03696038609246" y="-44.077812877938534" z="1526.055585594238" unit="mm" />
+      <rotation name="crystal20-2_rot_pos_bot" x="-0.0253118993481663" y="-0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal20-2_pos_neg_bot" x="-251.67653517032045" y="-44.077812877938534" z="1526.055585594238" unit="mm" />
+      <rotation name="crystal20-2_rot_neg_bot" x="-0.0253118993481663" y="0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal20-2_pos_pos_top" x="337.03696038609246" y="44.97781287793853" z="1526.055585594238" unit="mm" />
+      <rotation name="crystal20-2_rot_pos_top" x="0.0253118993481663" y="-0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal20-2_pos_neg_top" x="-251.67653517032045" y="44.97781287793853" z="1526.055585594238" unit="mm" />
+      <rotation name="crystal20-2_rot_neg_top" x="0.0253118993481663" y="0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal21-2_pos_pos_bot" x="352.64254741924634" y="-44.077812877938534" z="1525.7144718399722" unit="mm" />
+      <rotation name="crystal21-2_rot_pos_bot" x="-0.0253118993481663" y="-0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal21-2_pos_neg_bot" x="-267.28212220347433" y="-44.077812877938534" z="1525.7144718399722" unit="mm" />
+      <rotation name="crystal21-2_rot_neg_bot" x="-0.0253118993481663" y="0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal21-2_pos_pos_top" x="352.64254741924634" y="44.97781287793853" z="1525.7144718399722" unit="mm" />
+      <rotation name="crystal21-2_rot_pos_top" x="0.0253118993481663" y="-0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal21-2_pos_neg_top" x="-267.28212220347433" y="44.97781287793853" z="1525.7144718399722" unit="mm" />
+      <rotation name="crystal21-2_rot_neg_top" x="0.0253118993481663" y="0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal22-2_pos_pos_bot" x="368.32817872130425" y="-44.077812877938534" z="1525.351285854964" unit="mm" />
+      <rotation name="crystal22-2_rot_pos_bot" x="-0.0253118993481663" y="-0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal22-2_pos_neg_bot" x="-282.96775350553224" y="-44.077812877938534" z="1525.351285854964" unit="mm" />
+      <rotation name="crystal22-2_rot_neg_bot" x="-0.0253118993481663" y="0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal22-2_pos_pos_top" x="368.32817872130425" y="44.97781287793853" z="1525.351285854964" unit="mm" />
+      <rotation name="crystal22-2_rot_pos_top" x="0.0253118993481663" y="-0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal22-2_pos_neg_top" x="-282.96775350553224" y="44.97781287793853" z="1525.351285854964" unit="mm" />
+      <rotation name="crystal22-2_rot_neg_top" x="0.0253118993481663" y="0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal23-2_pos_pos_bot" x="384.09862704978" y="-44.077812877938534" z="1524.9661310547353" unit="mm" />
+      <rotation name="crystal23-2_rot_pos_bot" x="-0.0253118993481663" y="-0.3796784902224945" z="0.0" unit="radian" />
+      <position name="crystal23-2_pos_neg_bot" x="-298.738201834008" y="-44.077812877938534" z="1524.9661310547353" unit="mm" />
+      <rotation name="crystal23-2_rot_neg_bot" x="-0.0253118993481663" y="0.3796784902224945" z="0.0" unit="radian" />
+      <position name="crystal23-2_pos_pos_top" x="384.09862704978" y="44.97781287793853" z="1524.9661310547353" unit="mm" />
+      <rotation name="crystal23-2_rot_pos_top" x="0.0253118993481663" y="-0.3796784902224945" z="0.0" unit="radian" />
+      <position name="crystal23-2_pos_neg_top" x="-298.738201834008" y="44.97781287793853" z="1524.9661310547353" unit="mm" />
+      <rotation name="crystal23-2_rot_neg_top" x="0.0253118993481663" y="0.3796784902224945" z="0.0" unit="radian" />
+      <position name="crystal1-3_pos_pos_bot" x="50.20495188328156" y="-59.08788687039808" z="1528.3186477918262" unit="mm" />
+      <rotation name="crystal1-3_rot_pos_bot" x="-0.042186498913610496" y="-0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal1-3_pos_neg_bot" x="35.15547333249048" y="-59.08788687039808" z="1528.3186477918262" unit="mm" />
+      <rotation name="crystal1-3_rot_neg_bot" x="-0.042186498913610496" y="0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal1-3_pos_pos_top" x="50.20495188328156" y="59.987886870398086" z="1528.3186477918262" unit="mm" />
+      <rotation name="crystal1-3_rot_pos_top" x="0.042186498913610496" y="-0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal1-3_pos_neg_top" x="35.15547333249048" y="59.987886870398086" z="1528.3186477918262" unit="mm" />
+      <rotation name="crystal1-3_rot_neg_top" x="0.042186498913610496" y="0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal2-3_pos_pos_bot" x="65.05802548582456" y="-59.08788687039808" z="1528.4080677537463" unit="mm" />
+      <rotation name="crystal2-3_rot_pos_bot" x="-0.042186498913610496" y="-0.0253118993481663" z="0.0" unit="radian" />
+      <position name="crystal2-3_pos_neg_bot" x="20.302399729947485" y="-59.08788687039808" z="1528.4080677537463" unit="mm" />
+      <rotation name="crystal2-3_rot_neg_bot" x="-0.042186498913610496" y="0.0253118993481663" z="0.0" unit="radian" />
+      <position name="crystal2-3_pos_pos_top" x="65.05802548582456" y="59.987886870398086" z="1528.4080677537463" unit="mm" />
+      <rotation name="crystal2-3_rot_pos_top" x="0.042186498913610496" y="-0.0253118993481663" z="0.0" unit="radian" />
+      <position name="crystal2-3_pos_neg_top" x="20.302399729947485" y="59.987886870398086" z="1528.4080677537463" unit="mm" />
+      <rotation name="crystal2-3_rot_neg_top" x="0.042186498913610496" y="0.0253118993481663" z="0.0" unit="radian" />
+      <position name="crystal3-3_pos_pos_bot" x="79.9180994782841" y="-59.08788687039808" z="1528.47466745996" unit="mm" />
+      <rotation name="crystal3-3_rot_pos_bot" x="-0.042186498913610496" y="-0.042186498913610496" z="0.0" unit="radian" />
+      <position name="crystal3-3_pos_neg_bot" x="5.442325737487934" y="-59.08788687039808" z="1528.47466745996" unit="mm" />
+      <rotation name="crystal3-3_rot_neg_bot" x="-0.042186498913610496" y="0.042186498913610496" z="0.0" unit="radian" />
+      <position name="crystal3-3_pos_pos_top" x="79.9180994782841" y="59.987886870398086" z="1528.47466745996" unit="mm" />
+      <rotation name="crystal3-3_rot_pos_top" x="0.042186498913610496" y="-0.042186498913610496" z="0.0" unit="radian" />
+      <position name="crystal3-3_pos_neg_top" x="5.442325737487934" y="59.987886870398086" z="1528.47466745996" unit="mm" />
+      <rotation name="crystal3-3_rot_neg_top" x="0.042186498913610496" y="0.042186498913610496" z="0.0" unit="radian" />
+      <position name="crystal4-3_pos_pos_bot" x="94.78858692586502" y="-59.08788687039808" z="1528.5184279465104" unit="mm" />
+      <rotation name="crystal4-3_rot_pos_bot" x="-0.042186498913610496" y="-0.0590610984790547" z="0.0" unit="radian" />
+      <position name="crystal4-3_pos_neg_bot" x="-9.42816171009298" y="-59.08788687039808" z="1528.5184279465104" unit="mm" />
+      <rotation name="crystal4-3_rot_neg_bot" x="-0.042186498913610496" y="0.0590610984790547" z="0.0" unit="radian" />
+      <position name="crystal4-3_pos_pos_top" x="94.78858692586502" y="59.987886870398086" z="1528.5184279465104" unit="mm" />
+      <rotation name="crystal4-3_rot_pos_top" x="0.042186498913610496" y="-0.0590610984790547" z="0.0" unit="radian" />
+      <position name="crystal4-3_pos_neg_top" x="-9.42816171009298" y="59.987886870398086" z="1528.5184279465104" unit="mm" />
+      <rotation name="crystal4-3_rot_neg_top" x="0.042186498913610496" y="0.0590610984790547" z="0.0" unit="radian" />
+      <position name="crystal5-3_pos_pos_bot" x="109.67291416309662" y="-59.08788687039808" z="1528.5393367528022" unit="mm" />
+      <rotation name="crystal5-3_rot_pos_bot" x="-0.042186498913610496" y="-0.0759356980444989" z="0.0" unit="radian" />
+      <position name="crystal5-3_pos_neg_bot" x="-24.31248894732458" y="-59.08788687039808" z="1528.5393367528022" unit="mm" />
+      <rotation name="crystal5-3_rot_neg_bot" x="-0.042186498913610496" y="0.0759356980444989" z="0.0" unit="radian" />
+      <position name="crystal5-3_pos_pos_top" x="109.67291416309662" y="59.987886870398086" z="1528.5393367528022" unit="mm" />
+      <rotation name="crystal5-3_rot_pos_top" x="0.042186498913610496" y="-0.0759356980444989" z="0.0" unit="radian" />
+      <position name="crystal5-3_pos_neg_top" x="-24.31248894732458" y="59.987886870398086" z="1528.5393367528022" unit="mm" />
+      <rotation name="crystal5-3_rot_neg_top" x="0.042186498913610496" y="0.0759356980444989" z="0.0" unit="radian" />
+      <position name="crystal6-3_pos_pos_bot" x="124.57452638340096" y="-59.08788687039808" z="1528.53738792515" unit="mm" />
+      <rotation name="crystal6-3_rot_pos_bot" x="-0.042186498913610496" y="-0.0928102976099431" z="0.0" unit="radian" />
+      <position name="crystal6-3_pos_neg_bot" x="-39.214101167628925" y="-59.08788687039808" z="1528.53738792515" unit="mm" />
+      <rotation name="crystal6-3_rot_neg_bot" x="-0.042186498913610496" y="0.0928102976099431" z="0.0" unit="radian" />
+      <position name="crystal6-3_pos_pos_top" x="124.57452638340096" y="59.987886870398086" z="1528.53738792515" unit="mm" />
+      <rotation name="crystal6-3_rot_pos_top" x="0.042186498913610496" y="-0.0928102976099431" z="0.0" unit="radian" />
+      <position name="crystal6-3_pos_neg_top" x="-39.214101167628925" y="59.987886870398086" z="1528.53738792515" unit="mm" />
+      <rotation name="crystal6-3_rot_neg_top" x="0.042186498913610496" y="0.0928102976099431" z="0.0" unit="radian" />
+      <position name="crystal7-3_pos_pos_bot" x="139.4968932952259" y="-59.08788687039808" z="1528.5125820184735" unit="mm" />
+      <rotation name="crystal7-3_rot_pos_bot" x="-0.042186498913610496" y="-0.10968489717538729" z="0.0" unit="radian" />
+      <position name="crystal7-3_pos_neg_bot" x="-54.13646807945388" y="-59.08788687039808" z="1528.5125820184735" unit="mm" />
+      <rotation name="crystal7-3_rot_neg_bot" x="-0.042186498913610496" y="0.10968489717538729" z="0.0" unit="radian" />
+      <position name="crystal7-3_pos_pos_top" x="139.4968932952259" y="59.987886870398086" z="1528.5125820184735" unit="mm" />
+      <rotation name="crystal7-3_rot_pos_top" x="0.042186498913610496" y="-0.10968489717538729" z="0.0" unit="radian" />
+      <position name="crystal7-3_pos_neg_top" x="-54.13646807945388" y="59.987886870398086" z="1528.5125820184735" unit="mm" />
+      <rotation name="crystal7-3_rot_neg_top" x="0.042186498913610496" y="0.10968489717538729" z="0.0" unit="radian" />
+      <position name="crystal8-3_pos_pos_bot" x="154.44351486445828" y="-59.08788687039808" z="1528.4649260961392" unit="mm" />
+      <rotation name="crystal8-3_rot_pos_bot" x="-0.042186498913610496" y="-0.1265594967408315" z="0.0" unit="radian" />
+      <position name="crystal8-3_pos_neg_bot" x="-69.08308964868624" y="-59.08788687039808" z="1528.4649260961392" unit="mm" />
+      <rotation name="crystal8-3_rot_neg_bot" x="-0.042186498913610496" y="0.1265594967408315" z="0.0" unit="radian" />
+      <position name="crystal8-3_pos_pos_top" x="154.44351486445828" y="59.987886870398086" z="1528.4649260961392" unit="mm" />
+      <rotation name="crystal8-3_rot_pos_top" x="0.042186498913610496" y="-0.1265594967408315" z="0.0" unit="radian" />
+      <position name="crystal8-3_pos_neg_top" x="-69.08308964868624" y="59.987886870398086" z="1528.4649260961392" unit="mm" />
+      <rotation name="crystal8-3_rot_neg_top" x="0.042186498913610496" y="0.1265594967408315" z="0.0" unit="radian" />
+      <position name="crystal9-3_pos_pos_bot" x="169.41792716339802" y="-59.08788687039808" z="1528.3944337279495" unit="mm" />
+      <rotation name="crystal9-3_rot_pos_bot" x="-0.042186498913610496" y="-0.14343409630627568" z="0.0" unit="radian" />
+      <position name="crystal9-3_pos_neg_bot" x="-84.057501947626" y="-59.08788687039808" z="1528.3944337279495" unit="mm" />
+      <rotation name="crystal9-3_rot_neg_bot" x="-0.042186498913610496" y="0.14343409630627568" z="0.0" unit="radian" />
+      <position name="crystal9-3_pos_pos_top" x="169.41792716339802" y="59.987886870398086" z="1528.3944337279495" unit="mm" />
+      <rotation name="crystal9-3_rot_pos_top" x="0.042186498913610496" y="-0.14343409630627568" z="0.0" unit="radian" />
+      <position name="crystal9-3_pos_neg_top" x="-84.057501947626" y="59.987886870398086" z="1528.3944337279495" unit="mm" />
+      <rotation name="crystal9-3_rot_neg_top" x="0.042186498913610496" y="0.14343409630627568" z="0.0" unit="radian" />
+      <position name="crystal10-3_pos_pos_bot" x="184.42370834727978" y="-59.08788687039808" z="1528.301124986279" unit="mm" />
+      <rotation name="crystal10-3_rot_pos_bot" x="-0.042186498913610496" y="-0.1603086958717199" z="0.0" unit="radian" />
+      <position name="crystal10-3_pos_neg_bot" x="-99.06328313150773" y="-59.08788687039808" z="1528.301124986279" unit="mm" />
+      <rotation name="crystal10-3_rot_neg_bot" x="-0.042186498913610496" y="0.1603086958717199" z="0.0" unit="radian" />
+      <position name="crystal10-3_pos_pos_top" x="184.42370834727978" y="59.987886870398086" z="1528.301124986279" unit="mm" />
+      <rotation name="crystal10-3_rot_pos_top" x="0.042186498913610496" y="-0.1603086958717199" z="0.0" unit="radian" />
+      <position name="crystal10-3_pos_neg_top" x="-99.06328313150773" y="59.987886870398086" z="1528.301124986279" unit="mm" />
+      <rotation name="crystal10-3_rot_neg_top" x="0.042186498913610496" y="0.1603086958717199" z="0.0" unit="radian" />
+      <position name="crystal11-3_pos_pos_bot" x="199.46448478017476" y="-59.08788687039808" z="1528.1850264403583" unit="mm" />
+      <rotation name="crystal11-3_rot_pos_bot" x="-0.042186498913610496" y="-0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal11-3_pos_neg_bot" x="-114.1040595644027" y="-59.08788687039808" z="1528.1850264403583" unit="mm" />
+      <rotation name="crystal11-3_rot_neg_bot" x="-0.042186498913610496" y="0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal11-3_pos_pos_top" x="199.46448478017476" y="59.987886870398086" z="1528.1850264403583" unit="mm" />
+      <rotation name="crystal11-3_rot_pos_top" x="0.042186498913610496" y="-0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal11-3_pos_neg_top" x="-114.1040595644027" y="59.987886870398086" z="1528.1850264403583" unit="mm" />
+      <rotation name="crystal11-3_rot_neg_top" x="0.042186498913610496" y="0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal12-3_pos_pos_bot" x="214.5439373331128" y="-59.08788687039808" z="1528.0461711487085" unit="mm" />
+      <rotation name="crystal12-3_rot_pos_bot" x="-0.042186498913610496" y="-0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal12-3_pos_neg_bot" x="-129.1835121173408" y="-59.08788687039808" z="1528.0461711487085" unit="mm" />
+      <rotation name="crystal12-3_rot_neg_bot" x="-0.042186498913610496" y="0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal12-3_pos_pos_top" x="214.5439373331128" y="59.987886870398086" z="1528.0461711487085" unit="mm" />
+      <rotation name="crystal12-3_rot_pos_top" x="0.042186498913610496" y="-0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal12-3_pos_neg_top" x="-129.1835121173408" y="59.987886870398086" z="1528.0461711487085" unit="mm" />
+      <rotation name="crystal12-3_rot_neg_top" x="0.042186498913610496" y="0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal13-3_pos_pos_bot" x="229.66580787843168" y="-59.08788687039808" z="1527.8845986497292" unit="mm" />
+      <rotation name="crystal13-3_rot_pos_bot" x="-0.042186498913610496" y="-0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal13-3_pos_neg_bot" x="-144.30538266265967" y="-59.08788687039808" z="1527.8845986497292" unit="mm" />
+      <rotation name="crystal13-3_rot_neg_bot" x="-0.042186498913610496" y="0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal13-3_pos_pos_top" x="229.66580787843168" y="59.987886870398086" z="1527.8845986497292" unit="mm" />
+      <rotation name="crystal13-3_rot_pos_top" x="0.042186498913610496" y="-0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal13-3_pos_neg_top" x="-144.30538266265967" y="59.987886870398086" z="1527.8845986497292" unit="mm" />
+      <rotation name="crystal13-3_rot_neg_top" x="0.042186498913610496" y="0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal14-3_pos_pos_bot" x="244.83390600570817" y="-59.08788687039808" z="1527.7003549504386" unit="mm" />
+      <rotation name="crystal14-3_rot_pos_bot" x="-0.042186498913610496" y="-0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal14-3_pos_neg_bot" x="-159.47348078993616" y="-59.08788687039808" z="1527.7003549504386" unit="mm" />
+      <rotation name="crystal14-3_rot_neg_bot" x="-0.042186498913610496" y="0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal14-3_pos_pos_top" x="244.83390600570817" y="59.987886870398086" z="1527.7003549504386" unit="mm" />
+      <rotation name="crystal14-3_rot_pos_top" x="0.042186498913610496" y="-0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal14-3_pos_neg_top" x="-159.47348078993616" y="59.987886870398086" z="1527.7003549504386" unit="mm" />
+      <rotation name="crystal14-3_rot_neg_top" x="0.042186498913610496" y="0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal15-3_pos_pos_bot" x="260.0521159861688" y="-59.08788687039808" z="1527.4934925133737" unit="mm" />
+      <rotation name="crystal15-3_rot_pos_bot" x="-0.042186498913610496" y="-0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal15-3_pos_neg_bot" x="-174.6916907703968" y="-59.08788687039808" z="1527.4934925133737" unit="mm" />
+      <rotation name="crystal15-3_rot_neg_bot" x="-0.042186498913610496" y="0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal15-3_pos_pos_top" x="260.0521159861688" y="59.987886870398086" z="1527.4934925133737" unit="mm" />
+      <rotation name="crystal15-3_rot_pos_top" x="0.042186498913610496" y="-0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal15-3_pos_neg_top" x="-174.6916907703968" y="59.987886870398086" z="1527.4934925133737" unit="mm" />
+      <rotation name="crystal15-3_rot_neg_top" x="0.042186498913610496" y="0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal16-3_pos_pos_bot" x="275.32440401422616" y="-59.08788687039808" z="1527.264070241653" unit="mm" />
+      <rotation name="crystal16-3_rot_pos_bot" x="-0.042186498913610496" y="-0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal16-3_pos_neg_bot" x="-189.96397879845415" y="-59.08788687039808" z="1527.264070241653" unit="mm" />
+      <rotation name="crystal16-3_rot_neg_bot" x="-0.042186498913610496" y="0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal16-3_pos_pos_top" x="275.32440401422616" y="59.987886870398086" z="1527.264070241653" unit="mm" />
+      <rotation name="crystal16-3_rot_pos_top" x="0.042186498913610496" y="-0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal16-3_pos_neg_top" x="-189.96397879845415" y="59.987886870398086" z="1527.264070241653" unit="mm" />
+      <rotation name="crystal16-3_rot_neg_top" x="0.042186498913610496" y="0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal17-3_pos_pos_bot" x="290.6548257567732" y="-59.08788687039808" z="1527.0121534622015" unit="mm" />
+      <rotation name="crystal17-3_rot_pos_bot" x="-0.042186498913610496" y="-0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal17-3_pos_neg_bot" x="-205.2944005410012" y="-59.08788687039808" z="1527.0121534622015" unit="mm" />
+      <rotation name="crystal17-3_rot_neg_bot" x="-0.042186498913610496" y="0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal17-3_pos_pos_top" x="290.6548257567732" y="59.987886870398086" z="1527.0121534622015" unit="mm" />
+      <rotation name="crystal17-3_rot_pos_top" x="0.042186498913610496" y="-0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal17-3_pos_neg_top" x="-205.2944005410012" y="59.987886870398086" z="1527.0121534622015" unit="mm" />
+      <rotation name="crystal17-3_rot_neg_top" x="0.042186498913610496" y="0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal18-3_pos_pos_bot" x="306.0475342431027" y="-59.08788687039808" z="1526.737813907152" unit="mm" />
+      <rotation name="crystal18-3_rot_pos_bot" x="-0.042186498913610496" y="-0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal18-3_pos_neg_bot" x="-220.68710902733068" y="-59.08788687039808" z="1526.737813907152" unit="mm" />
+      <rotation name="crystal18-3_rot_neg_bot" x="-0.042186498913610496" y="0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal18-3_pos_pos_top" x="306.0475342431027" y="59.987886870398086" z="1526.737813907152" unit="mm" />
+      <rotation name="crystal18-3_rot_pos_top" x="0.042186498913610496" y="-0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal18-3_pos_neg_top" x="-220.68710902733068" y="59.987886870398086" z="1526.737813907152" unit="mm" />
+      <rotation name="crystal18-3_rot_neg_top" x="0.042186498913610496" y="0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal19-3_pos_pos_bot" x="321.5067881308382" y="-59.08788687039808" z="1526.4411296934186" unit="mm" />
+      <rotation name="crystal19-3_rot_pos_bot" x="-0.042186498913610496" y="-0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal19-3_pos_neg_bot" x="-236.14636291506616" y="-59.08788687039808" z="1526.4411296934186" unit="mm" />
+      <rotation name="crystal19-3_rot_neg_bot" x="-0.042186498913610496" y="0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal19-3_pos_pos_top" x="321.5067881308382" y="59.987886870398086" z="1526.4411296934186" unit="mm" />
+      <rotation name="crystal19-3_rot_pos_top" x="0.042186498913610496" y="-0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal19-3_pos_neg_top" x="-236.14636291506616" y="59.987886870398086" z="1526.4411296934186" unit="mm" />
+      <rotation name="crystal19-3_rot_neg_top" x="0.042186498913610496" y="0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal20-3_pos_pos_bot" x="337.03696038609246" y="-59.08788687039808" z="1526.1221853004517" unit="mm" />
+      <rotation name="crystal20-3_rot_pos_bot" x="-0.042186498913610496" y="-0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal20-3_pos_neg_bot" x="-251.67653517032045" y="-59.08788687039808" z="1526.1221853004517" unit="mm" />
+      <rotation name="crystal20-3_rot_neg_bot" x="-0.042186498913610496" y="0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal20-3_pos_pos_top" x="337.03696038609246" y="59.987886870398086" z="1526.1221853004517" unit="mm" />
+      <rotation name="crystal20-3_rot_pos_top" x="0.042186498913610496" y="-0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal20-3_pos_neg_top" x="-251.67653517032045" y="59.987886870398086" z="1526.1221853004517" unit="mm" />
+      <rotation name="crystal20-3_rot_neg_top" x="0.042186498913610496" y="0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal21-3_pos_pos_bot" x="352.64254741924634" y="-59.08788687039808" z="1525.781071546186" unit="mm" />
+      <rotation name="crystal21-3_rot_pos_bot" x="-0.042186498913610496" y="-0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal21-3_pos_neg_bot" x="-267.28212220347433" y="-59.08788687039808" z="1525.781071546186" unit="mm" />
+      <rotation name="crystal21-3_rot_neg_bot" x="-0.042186498913610496" y="0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal21-3_pos_pos_top" x="352.64254741924634" y="59.987886870398086" z="1525.781071546186" unit="mm" />
+      <rotation name="crystal21-3_rot_pos_top" x="0.042186498913610496" y="-0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal21-3_pos_neg_top" x="-267.28212220347433" y="59.987886870398086" z="1525.781071546186" unit="mm" />
+      <rotation name="crystal21-3_rot_neg_top" x="0.042186498913610496" y="0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal22-3_pos_pos_bot" x="368.32817872130425" y="-59.08788687039808" z="1525.417885561178" unit="mm" />
+      <rotation name="crystal22-3_rot_pos_bot" x="-0.042186498913610496" y="-0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal22-3_pos_neg_bot" x="-282.96775350553224" y="-59.08788687039808" z="1525.417885561178" unit="mm" />
+      <rotation name="crystal22-3_rot_neg_bot" x="-0.042186498913610496" y="0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal22-3_pos_pos_top" x="368.32817872130425" y="59.987886870398086" z="1525.417885561178" unit="mm" />
+      <rotation name="crystal22-3_rot_pos_top" x="0.042186498913610496" y="-0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal22-3_pos_neg_top" x="-282.96775350553224" y="59.987886870398086" z="1525.417885561178" unit="mm" />
+      <rotation name="crystal22-3_rot_neg_top" x="0.042186498913610496" y="0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal23-3_pos_pos_bot" x="384.09862704978" y="-59.08788687039808" z="1525.032730760949" unit="mm" />
+      <rotation name="crystal23-3_rot_pos_bot" x="-0.042186498913610496" y="-0.3796784902224945" z="0.0" unit="radian" />
+      <position name="crystal23-3_pos_neg_bot" x="-298.738201834008" y="-59.08788687039808" z="1525.032730760949" unit="mm" />
+      <rotation name="crystal23-3_rot_neg_bot" x="-0.042186498913610496" y="0.3796784902224945" z="0.0" unit="radian" />
+      <position name="crystal23-3_pos_pos_top" x="384.09862704978" y="59.987886870398086" z="1525.032730760949" unit="mm" />
+      <rotation name="crystal23-3_rot_pos_top" x="0.042186498913610496" y="-0.3796784902224945" z="0.0" unit="radian" />
+      <position name="crystal23-3_pos_neg_top" x="-298.738201834008" y="59.987886870398086" z="1525.032730760949" unit="mm" />
+      <rotation name="crystal23-3_rot_neg_top" x="0.042186498913610496" y="0.3796784902224945" z="0.0" unit="radian" />
+      <position name="crystal1-4_pos_pos_bot" x="50.20495188328156" y="-74.108374317979" z="1528.3624082783765" unit="mm" />
+      <rotation name="crystal1-4_rot_pos_bot" x="-0.0590610984790547" y="-0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal1-4_pos_neg_bot" x="35.15547333249048" y="-74.108374317979" z="1528.3624082783765" unit="mm" />
+      <rotation name="crystal1-4_rot_neg_bot" x="-0.0590610984790547" y="0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal1-4_pos_pos_top" x="50.20495188328156" y="75.008374317979" z="1528.3624082783765" unit="mm" />
+      <rotation name="crystal1-4_rot_pos_top" x="0.0590610984790547" y="-0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal1-4_pos_neg_top" x="35.15547333249048" y="75.008374317979" z="1528.3624082783765" unit="mm" />
+      <rotation name="crystal1-4_rot_neg_top" x="0.0590610984790547" y="0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal2-4_pos_pos_bot" x="65.05802548582456" y="-74.108374317979" z="1528.4518282402964" unit="mm" />
+      <rotation name="crystal2-4_rot_pos_bot" x="-0.0590610984790547" y="-0.0253118993481663" z="0.0" unit="radian" />
+      <position name="crystal2-4_pos_neg_bot" x="20.302399729947485" y="-74.108374317979" z="1528.4518282402964" unit="mm" />
+      <rotation name="crystal2-4_rot_neg_bot" x="-0.0590610984790547" y="0.0253118993481663" z="0.0" unit="radian" />
+      <position name="crystal2-4_pos_pos_top" x="65.05802548582456" y="75.008374317979" z="1528.4518282402964" unit="mm" />
+      <rotation name="crystal2-4_rot_pos_top" x="0.0590610984790547" y="-0.0253118993481663" z="0.0" unit="radian" />
+      <position name="crystal2-4_pos_neg_top" x="20.302399729947485" y="75.008374317979" z="1528.4518282402964" unit="mm" />
+      <rotation name="crystal2-4_rot_neg_top" x="0.0590610984790547" y="0.0253118993481663" z="0.0" unit="radian" />
+      <position name="crystal3-4_pos_pos_bot" x="79.9180994782841" y="-74.108374317979" z="1528.5184279465104" unit="mm" />
+      <rotation name="crystal3-4_rot_pos_bot" x="-0.0590610984790547" y="-0.042186498913610496" z="0.0" unit="radian" />
+      <position name="crystal3-4_pos_neg_bot" x="5.442325737487934" y="-74.108374317979" z="1528.5184279465104" unit="mm" />
+      <rotation name="crystal3-4_rot_neg_bot" x="-0.0590610984790547" y="0.042186498913610496" z="0.0" unit="radian" />
+      <position name="crystal3-4_pos_pos_top" x="79.9180994782841" y="75.008374317979" z="1528.5184279465104" unit="mm" />
+      <rotation name="crystal3-4_rot_pos_top" x="0.0590610984790547" y="-0.042186498913610496" z="0.0" unit="radian" />
+      <position name="crystal3-4_pos_neg_top" x="5.442325737487934" y="75.008374317979" z="1528.5184279465104" unit="mm" />
+      <rotation name="crystal3-4_rot_neg_top" x="0.0590610984790547" y="0.042186498913610496" z="0.0" unit="radian" />
+      <position name="crystal4-4_pos_pos_bot" x="94.78858692586502" y="-74.108374317979" z="1528.5621884330608" unit="mm" />
+      <rotation name="crystal4-4_rot_pos_bot" x="-0.0590610984790547" y="-0.0590610984790547" z="0.0" unit="radian" />
+      <position name="crystal4-4_pos_neg_bot" x="-9.42816171009298" y="-74.108374317979" z="1528.5621884330608" unit="mm" />
+      <rotation name="crystal4-4_rot_neg_bot" x="-0.0590610984790547" y="0.0590610984790547" z="0.0" unit="radian" />
+      <position name="crystal4-4_pos_pos_top" x="94.78858692586502" y="75.008374317979" z="1528.5621884330608" unit="mm" />
+      <rotation name="crystal4-4_rot_pos_top" x="0.0590610984790547" y="-0.0590610984790547" z="0.0" unit="radian" />
+      <position name="crystal4-4_pos_neg_top" x="-9.42816171009298" y="75.008374317979" z="1528.5621884330608" unit="mm" />
+      <rotation name="crystal4-4_rot_neg_top" x="0.0590610984790547" y="0.0590610984790547" z="0.0" unit="radian" />
+      <position name="crystal5-4_pos_pos_bot" x="109.67291416309662" y="-74.108374317979" z="1528.5830972393524" unit="mm" />
+      <rotation name="crystal5-4_rot_pos_bot" x="-0.0590610984790547" y="-0.0759356980444989" z="0.0" unit="radian" />
+      <position name="crystal5-4_pos_neg_bot" x="-24.31248894732458" y="-74.108374317979" z="1528.5830972393524" unit="mm" />
+      <rotation name="crystal5-4_rot_neg_bot" x="-0.0590610984790547" y="0.0759356980444989" z="0.0" unit="radian" />
+      <position name="crystal5-4_pos_pos_top" x="109.67291416309662" y="75.008374317979" z="1528.5830972393524" unit="mm" />
+      <rotation name="crystal5-4_rot_pos_top" x="0.0590610984790547" y="-0.0759356980444989" z="0.0" unit="radian" />
+      <position name="crystal5-4_pos_neg_top" x="-24.31248894732458" y="75.008374317979" z="1528.5830972393524" unit="mm" />
+      <rotation name="crystal5-4_rot_neg_top" x="0.0590610984790547" y="0.0759356980444989" z="0.0" unit="radian" />
+      <position name="crystal6-4_pos_pos_bot" x="124.57452638340096" y="-74.108374317979" z="1528.5811484117003" unit="mm" />
+      <rotation name="crystal6-4_rot_pos_bot" x="-0.0590610984790547" y="-0.0928102976099431" z="0.0" unit="radian" />
+      <position name="crystal6-4_pos_neg_bot" x="-39.214101167628925" y="-74.108374317979" z="1528.5811484117003" unit="mm" />
+      <rotation name="crystal6-4_rot_neg_bot" x="-0.0590610984790547" y="0.0928102976099431" z="0.0" unit="radian" />
+      <position name="crystal6-4_pos_pos_top" x="124.57452638340096" y="75.008374317979" z="1528.5811484117003" unit="mm" />
+      <rotation name="crystal6-4_rot_pos_top" x="0.0590610984790547" y="-0.0928102976099431" z="0.0" unit="radian" />
+      <position name="crystal6-4_pos_neg_top" x="-39.214101167628925" y="75.008374317979" z="1528.5811484117003" unit="mm" />
+      <rotation name="crystal6-4_rot_neg_top" x="0.0590610984790547" y="0.0928102976099431" z="0.0" unit="radian" />
+      <position name="crystal7-4_pos_pos_bot" x="139.4968932952259" y="-74.108374317979" z="1528.5563425050236" unit="mm" />
+      <rotation name="crystal7-4_rot_pos_bot" x="-0.0590610984790547" y="-0.10968489717538729" z="0.0" unit="radian" />
+      <position name="crystal7-4_pos_neg_bot" x="-54.13646807945388" y="-74.108374317979" z="1528.5563425050236" unit="mm" />
+      <rotation name="crystal7-4_rot_neg_bot" x="-0.0590610984790547" y="0.10968489717538729" z="0.0" unit="radian" />
+      <position name="crystal7-4_pos_pos_top" x="139.4968932952259" y="75.008374317979" z="1528.5563425050236" unit="mm" />
+      <rotation name="crystal7-4_rot_pos_top" x="0.0590610984790547" y="-0.10968489717538729" z="0.0" unit="radian" />
+      <position name="crystal7-4_pos_neg_top" x="-54.13646807945388" y="75.008374317979" z="1528.5563425050236" unit="mm" />
+      <rotation name="crystal7-4_rot_neg_top" x="0.0590610984790547" y="0.10968489717538729" z="0.0" unit="radian" />
+      <position name="crystal8-4_pos_pos_bot" x="154.44351486445828" y="-74.108374317979" z="1528.5086865826895" unit="mm" />
+      <rotation name="crystal8-4_rot_pos_bot" x="-0.0590610984790547" y="-0.1265594967408315" z="0.0" unit="radian" />
+      <position name="crystal8-4_pos_neg_bot" x="-69.08308964868624" y="-74.108374317979" z="1528.5086865826895" unit="mm" />
+      <rotation name="crystal8-4_rot_neg_bot" x="-0.0590610984790547" y="0.1265594967408315" z="0.0" unit="radian" />
+      <position name="crystal8-4_pos_pos_top" x="154.44351486445828" y="75.008374317979" z="1528.5086865826895" unit="mm" />
+      <rotation name="crystal8-4_rot_pos_top" x="0.0590610984790547" y="-0.1265594967408315" z="0.0" unit="radian" />
+      <position name="crystal8-4_pos_neg_top" x="-69.08308964868624" y="75.008374317979" z="1528.5086865826895" unit="mm" />
+      <rotation name="crystal8-4_rot_neg_top" x="0.0590610984790547" y="0.1265594967408315" z="0.0" unit="radian" />
+      <position name="crystal9-4_pos_pos_bot" x="169.41792716339802" y="-74.108374317979" z="1528.4381942144998" unit="mm" />
+      <rotation name="crystal9-4_rot_pos_bot" x="-0.0590610984790547" y="-0.14343409630627568" z="0.0" unit="radian" />
+      <position name="crystal9-4_pos_neg_bot" x="-84.057501947626" y="-74.108374317979" z="1528.4381942144998" unit="mm" />
+      <rotation name="crystal9-4_rot_neg_bot" x="-0.0590610984790547" y="0.14343409630627568" z="0.0" unit="radian" />
+      <position name="crystal9-4_pos_pos_top" x="169.41792716339802" y="75.008374317979" z="1528.4381942144998" unit="mm" />
+      <rotation name="crystal9-4_rot_pos_top" x="0.0590610984790547" y="-0.14343409630627568" z="0.0" unit="radian" />
+      <position name="crystal9-4_pos_neg_top" x="-84.057501947626" y="75.008374317979" z="1528.4381942144998" unit="mm" />
+      <rotation name="crystal9-4_rot_neg_top" x="0.0590610984790547" y="0.14343409630627568" z="0.0" unit="radian" />
+      <position name="crystal10-4_pos_pos_bot" x="184.42370834727978" y="-74.108374317979" z="1528.3448854728294" unit="mm" />
+      <rotation name="crystal10-4_rot_pos_bot" x="-0.0590610984790547" y="-0.1603086958717199" z="0.0" unit="radian" />
+      <position name="crystal10-4_pos_neg_bot" x="-99.06328313150773" y="-74.108374317979" z="1528.3448854728294" unit="mm" />
+      <rotation name="crystal10-4_rot_neg_bot" x="-0.0590610984790547" y="0.1603086958717199" z="0.0" unit="radian" />
+      <position name="crystal10-4_pos_pos_top" x="184.42370834727978" y="75.008374317979" z="1528.3448854728294" unit="mm" />
+      <rotation name="crystal10-4_rot_pos_top" x="0.0590610984790547" y="-0.1603086958717199" z="0.0" unit="radian" />
+      <position name="crystal10-4_pos_neg_top" x="-99.06328313150773" y="75.008374317979" z="1528.3448854728294" unit="mm" />
+      <rotation name="crystal10-4_rot_neg_top" x="0.0590610984790547" y="0.1603086958717199" z="0.0" unit="radian" />
+      <position name="crystal11-4_pos_pos_bot" x="199.46448478017476" y="-74.108374317979" z="1528.2287869269085" unit="mm" />
+      <rotation name="crystal11-4_rot_pos_bot" x="-0.0590610984790547" y="-0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal11-4_pos_neg_bot" x="-114.1040595644027" y="-74.108374317979" z="1528.2287869269085" unit="mm" />
+      <rotation name="crystal11-4_rot_neg_bot" x="-0.0590610984790547" y="0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal11-4_pos_pos_top" x="199.46448478017476" y="75.008374317979" z="1528.2287869269085" unit="mm" />
+      <rotation name="crystal11-4_rot_pos_top" x="0.0590610984790547" y="-0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal11-4_pos_neg_top" x="-114.1040595644027" y="75.008374317979" z="1528.2287869269085" unit="mm" />
+      <rotation name="crystal11-4_rot_neg_top" x="0.0590610984790547" y="0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal12-4_pos_pos_bot" x="214.5439373331128" y="-74.108374317979" z="1528.0899316352588" unit="mm" />
+      <rotation name="crystal12-4_rot_pos_bot" x="-0.0590610984790547" y="-0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal12-4_pos_neg_bot" x="-129.1835121173408" y="-74.108374317979" z="1528.0899316352588" unit="mm" />
+      <rotation name="crystal12-4_rot_neg_bot" x="-0.0590610984790547" y="0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal12-4_pos_pos_top" x="214.5439373331128" y="75.008374317979" z="1528.0899316352588" unit="mm" />
+      <rotation name="crystal12-4_rot_pos_top" x="0.0590610984790547" y="-0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal12-4_pos_neg_top" x="-129.1835121173408" y="75.008374317979" z="1528.0899316352588" unit="mm" />
+      <rotation name="crystal12-4_rot_neg_top" x="0.0590610984790547" y="0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal13-4_pos_pos_bot" x="229.66580787843168" y="-74.108374317979" z="1527.9283591362796" unit="mm" />
+      <rotation name="crystal13-4_rot_pos_bot" x="-0.0590610984790547" y="-0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal13-4_pos_neg_bot" x="-144.30538266265967" y="-74.108374317979" z="1527.9283591362796" unit="mm" />
+      <rotation name="crystal13-4_rot_neg_bot" x="-0.0590610984790547" y="0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal13-4_pos_pos_top" x="229.66580787843168" y="75.008374317979" z="1527.9283591362796" unit="mm" />
+      <rotation name="crystal13-4_rot_pos_top" x="0.0590610984790547" y="-0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal13-4_pos_neg_top" x="-144.30538266265967" y="75.008374317979" z="1527.9283591362796" unit="mm" />
+      <rotation name="crystal13-4_rot_neg_top" x="0.0590610984790547" y="0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal14-4_pos_pos_bot" x="244.83390600570817" y="-74.108374317979" z="1527.744115436989" unit="mm" />
+      <rotation name="crystal14-4_rot_pos_bot" x="-0.0590610984790547" y="-0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal14-4_pos_neg_bot" x="-159.47348078993616" y="-74.108374317979" z="1527.744115436989" unit="mm" />
+      <rotation name="crystal14-4_rot_neg_bot" x="-0.0590610984790547" y="0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal14-4_pos_pos_top" x="244.83390600570817" y="75.008374317979" z="1527.744115436989" unit="mm" />
+      <rotation name="crystal14-4_rot_pos_top" x="0.0590610984790547" y="-0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal14-4_pos_neg_top" x="-159.47348078993616" y="75.008374317979" z="1527.744115436989" unit="mm" />
+      <rotation name="crystal14-4_rot_neg_top" x="0.0590610984790547" y="0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal15-4_pos_pos_bot" x="260.0521159861688" y="-74.108374317979" z="1527.537252999924" unit="mm" />
+      <rotation name="crystal15-4_rot_pos_bot" x="-0.0590610984790547" y="-0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal15-4_pos_neg_bot" x="-174.6916907703968" y="-74.108374317979" z="1527.537252999924" unit="mm" />
+      <rotation name="crystal15-4_rot_neg_bot" x="-0.0590610984790547" y="0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal15-4_pos_pos_top" x="260.0521159861688" y="75.008374317979" z="1527.537252999924" unit="mm" />
+      <rotation name="crystal15-4_rot_pos_top" x="0.0590610984790547" y="-0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal15-4_pos_neg_top" x="-174.6916907703968" y="75.008374317979" z="1527.537252999924" unit="mm" />
+      <rotation name="crystal15-4_rot_neg_top" x="0.0590610984790547" y="0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal16-4_pos_pos_bot" x="275.32440401422616" y="-74.108374317979" z="1527.3078307282033" unit="mm" />
+      <rotation name="crystal16-4_rot_pos_bot" x="-0.0590610984790547" y="-0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal16-4_pos_neg_bot" x="-189.96397879845415" y="-74.108374317979" z="1527.3078307282033" unit="mm" />
+      <rotation name="crystal16-4_rot_neg_bot" x="-0.0590610984790547" y="0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal16-4_pos_pos_top" x="275.32440401422616" y="75.008374317979" z="1527.3078307282033" unit="mm" />
+      <rotation name="crystal16-4_rot_pos_top" x="0.0590610984790547" y="-0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal16-4_pos_neg_top" x="-189.96397879845415" y="75.008374317979" z="1527.3078307282033" unit="mm" />
+      <rotation name="crystal16-4_rot_neg_top" x="0.0590610984790547" y="0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal17-4_pos_pos_bot" x="290.6548257567732" y="-74.108374317979" z="1527.0559139487518" unit="mm" />
+      <rotation name="crystal17-4_rot_pos_bot" x="-0.0590610984790547" y="-0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal17-4_pos_neg_bot" x="-205.2944005410012" y="-74.108374317979" z="1527.0559139487518" unit="mm" />
+      <rotation name="crystal17-4_rot_neg_bot" x="-0.0590610984790547" y="0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal17-4_pos_pos_top" x="290.6548257567732" y="75.008374317979" z="1527.0559139487518" unit="mm" />
+      <rotation name="crystal17-4_rot_pos_top" x="0.0590610984790547" y="-0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal17-4_pos_neg_top" x="-205.2944005410012" y="75.008374317979" z="1527.0559139487518" unit="mm" />
+      <rotation name="crystal17-4_rot_neg_top" x="0.0590610984790547" y="0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal18-4_pos_pos_bot" x="306.0475342431027" y="-74.108374317979" z="1526.7815743937024" unit="mm" />
+      <rotation name="crystal18-4_rot_pos_bot" x="-0.0590610984790547" y="-0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal18-4_pos_neg_bot" x="-220.68710902733068" y="-74.108374317979" z="1526.7815743937024" unit="mm" />
+      <rotation name="crystal18-4_rot_neg_bot" x="-0.0590610984790547" y="0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal18-4_pos_pos_top" x="306.0475342431027" y="75.008374317979" z="1526.7815743937024" unit="mm" />
+      <rotation name="crystal18-4_rot_pos_top" x="0.0590610984790547" y="-0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal18-4_pos_neg_top" x="-220.68710902733068" y="75.008374317979" z="1526.7815743937024" unit="mm" />
+      <rotation name="crystal18-4_rot_neg_top" x="0.0590610984790547" y="0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal19-4_pos_pos_bot" x="321.5067881308382" y="-74.108374317979" z="1526.4848901799687" unit="mm" />
+      <rotation name="crystal19-4_rot_pos_bot" x="-0.0590610984790547" y="-0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal19-4_pos_neg_bot" x="-236.14636291506616" y="-74.108374317979" z="1526.4848901799687" unit="mm" />
+      <rotation name="crystal19-4_rot_neg_bot" x="-0.0590610984790547" y="0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal19-4_pos_pos_top" x="321.5067881308382" y="75.008374317979" z="1526.4848901799687" unit="mm" />
+      <rotation name="crystal19-4_rot_pos_top" x="0.0590610984790547" y="-0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal19-4_pos_neg_top" x="-236.14636291506616" y="75.008374317979" z="1526.4848901799687" unit="mm" />
+      <rotation name="crystal19-4_rot_neg_top" x="0.0590610984790547" y="0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal20-4_pos_pos_bot" x="337.03696038609246" y="-74.108374317979" z="1526.165945787002" unit="mm" />
+      <rotation name="crystal20-4_rot_pos_bot" x="-0.0590610984790547" y="-0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal20-4_pos_neg_bot" x="-251.67653517032045" y="-74.108374317979" z="1526.165945787002" unit="mm" />
+      <rotation name="crystal20-4_rot_neg_bot" x="-0.0590610984790547" y="0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal20-4_pos_pos_top" x="337.03696038609246" y="75.008374317979" z="1526.165945787002" unit="mm" />
+      <rotation name="crystal20-4_rot_pos_top" x="0.0590610984790547" y="-0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal20-4_pos_neg_top" x="-251.67653517032045" y="75.008374317979" z="1526.165945787002" unit="mm" />
+      <rotation name="crystal20-4_rot_neg_top" x="0.0590610984790547" y="0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal21-4_pos_pos_bot" x="352.64254741924634" y="-74.108374317979" z="1525.8248320327364" unit="mm" />
+      <rotation name="crystal21-4_rot_pos_bot" x="-0.0590610984790547" y="-0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal21-4_pos_neg_bot" x="-267.28212220347433" y="-74.108374317979" z="1525.8248320327364" unit="mm" />
+      <rotation name="crystal21-4_rot_neg_bot" x="-0.0590610984790547" y="0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal21-4_pos_pos_top" x="352.64254741924634" y="75.008374317979" z="1525.8248320327364" unit="mm" />
+      <rotation name="crystal21-4_rot_pos_top" x="0.0590610984790547" y="-0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal21-4_pos_neg_top" x="-267.28212220347433" y="75.008374317979" z="1525.8248320327364" unit="mm" />
+      <rotation name="crystal21-4_rot_neg_top" x="0.0590610984790547" y="0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal22-4_pos_pos_bot" x="368.32817872130425" y="-74.108374317979" z="1525.4616460477282" unit="mm" />
+      <rotation name="crystal22-4_rot_pos_bot" x="-0.0590610984790547" y="-0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal22-4_pos_neg_bot" x="-282.96775350553224" y="-74.108374317979" z="1525.4616460477282" unit="mm" />
+      <rotation name="crystal22-4_rot_neg_bot" x="-0.0590610984790547" y="0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal22-4_pos_pos_top" x="368.32817872130425" y="75.008374317979" z="1525.4616460477282" unit="mm" />
+      <rotation name="crystal22-4_rot_pos_top" x="0.0590610984790547" y="-0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal22-4_pos_neg_top" x="-282.96775350553224" y="75.008374317979" z="1525.4616460477282" unit="mm" />
+      <rotation name="crystal22-4_rot_neg_top" x="0.0590610984790547" y="0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal23-4_pos_pos_bot" x="384.09862704978" y="-74.108374317979" z="1525.0764912474995" unit="mm" />
+      <rotation name="crystal23-4_rot_pos_bot" x="-0.0590610984790547" y="-0.3796784902224945" z="0.0" unit="radian" />
+      <position name="crystal23-4_pos_neg_bot" x="-298.738201834008" y="-74.108374317979" z="1525.0764912474995" unit="mm" />
+      <rotation name="crystal23-4_rot_neg_bot" x="-0.0590610984790547" y="0.3796784902224945" z="0.0" unit="radian" />
+      <position name="crystal23-4_pos_pos_top" x="384.09862704978" y="75.008374317979" z="1525.0764912474995" unit="mm" />
+      <rotation name="crystal23-4_rot_pos_top" x="0.0590610984790547" y="-0.3796784902224945" z="0.0" unit="radian" />
+      <position name="crystal23-4_pos_neg_top" x="-298.738201834008" y="75.008374317979" z="1525.0764912474995" unit="mm" />
+      <rotation name="crystal23-4_rot_neg_top" x="0.0590610984790547" y="0.3796784902224945" z="0.0" unit="radian" />
+      <position name="crystal1-5_pos_pos_bot" x="50.20495188328156" y="-89.1427015552106" z="1528.3833170846683" unit="mm" />
+      <rotation name="crystal1-5_rot_pos_bot" x="-0.0759356980444989" y="-0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal1-5_pos_neg_bot" x="35.15547333249048" y="-89.1427015552106" z="1528.3833170846683" unit="mm" />
+      <rotation name="crystal1-5_rot_neg_bot" x="-0.0759356980444989" y="0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal1-5_pos_pos_top" x="50.20495188328156" y="90.0427015552106" z="1528.3833170846683" unit="mm" />
+      <rotation name="crystal1-5_rot_pos_top" x="0.0759356980444989" y="-0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal1-5_pos_neg_top" x="35.15547333249048" y="90.0427015552106" z="1528.3833170846683" unit="mm" />
+      <rotation name="crystal1-5_rot_neg_top" x="0.0759356980444989" y="0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal2-5_pos_pos_bot" x="65.05802548582456" y="-89.1427015552106" z="1528.4727370465882" unit="mm" />
+      <rotation name="crystal2-5_rot_pos_bot" x="-0.0759356980444989" y="-0.0253118993481663" z="0.0" unit="radian" />
+      <position name="crystal2-5_pos_neg_bot" x="20.302399729947485" y="-89.1427015552106" z="1528.4727370465882" unit="mm" />
+      <rotation name="crystal2-5_rot_neg_bot" x="-0.0759356980444989" y="0.0253118993481663" z="0.0" unit="radian" />
+      <position name="crystal2-5_pos_pos_top" x="65.05802548582456" y="90.0427015552106" z="1528.4727370465882" unit="mm" />
+      <rotation name="crystal2-5_rot_pos_top" x="0.0759356980444989" y="-0.0253118993481663" z="0.0" unit="radian" />
+      <position name="crystal2-5_pos_neg_top" x="20.302399729947485" y="90.0427015552106" z="1528.4727370465882" unit="mm" />
+      <rotation name="crystal2-5_rot_neg_top" x="0.0759356980444989" y="0.0253118993481663" z="0.0" unit="radian" />
+      <position name="crystal3-5_pos_pos_bot" x="79.9180994782841" y="-89.1427015552106" z="1528.5393367528022" unit="mm" />
+      <rotation name="crystal3-5_rot_pos_bot" x="-0.0759356980444989" y="-0.042186498913610496" z="0.0" unit="radian" />
+      <position name="crystal3-5_pos_neg_bot" x="5.442325737487934" y="-89.1427015552106" z="1528.5393367528022" unit="mm" />
+      <rotation name="crystal3-5_rot_neg_bot" x="-0.0759356980444989" y="0.042186498913610496" z="0.0" unit="radian" />
+      <position name="crystal3-5_pos_pos_top" x="79.9180994782841" y="90.0427015552106" z="1528.5393367528022" unit="mm" />
+      <rotation name="crystal3-5_rot_pos_top" x="0.0759356980444989" y="-0.042186498913610496" z="0.0" unit="radian" />
+      <position name="crystal3-5_pos_neg_top" x="5.442325737487934" y="90.0427015552106" z="1528.5393367528022" unit="mm" />
+      <rotation name="crystal3-5_rot_neg_top" x="0.0759356980444989" y="0.042186498913610496" z="0.0" unit="radian" />
+      <position name="crystal4-5_pos_pos_bot" x="94.78858692586502" y="-89.1427015552106" z="1528.5830972393524" unit="mm" />
+      <rotation name="crystal4-5_rot_pos_bot" x="-0.0759356980444989" y="-0.0590610984790547" z="0.0" unit="radian" />
+      <position name="crystal4-5_pos_neg_bot" x="-9.42816171009298" y="-89.1427015552106" z="1528.5830972393524" unit="mm" />
+      <rotation name="crystal4-5_rot_neg_bot" x="-0.0759356980444989" y="0.0590610984790547" z="0.0" unit="radian" />
+      <position name="crystal4-5_pos_pos_top" x="94.78858692586502" y="90.0427015552106" z="1528.5830972393524" unit="mm" />
+      <rotation name="crystal4-5_rot_pos_top" x="0.0759356980444989" y="-0.0590610984790547" z="0.0" unit="radian" />
+      <position name="crystal4-5_pos_neg_top" x="-9.42816171009298" y="90.0427015552106" z="1528.5830972393524" unit="mm" />
+      <rotation name="crystal4-5_rot_neg_top" x="0.0759356980444989" y="0.0590610984790547" z="0.0" unit="radian" />
+      <position name="crystal5-5_pos_pos_bot" x="109.67291416309662" y="-89.1427015552106" z="1528.6040060456442" unit="mm" />
+      <rotation name="crystal5-5_rot_pos_bot" x="-0.0759356980444989" y="-0.0759356980444989" z="0.0" unit="radian" />
+      <position name="crystal5-5_pos_neg_bot" x="-24.31248894732458" y="-89.1427015552106" z="1528.6040060456442" unit="mm" />
+      <rotation name="crystal5-5_rot_neg_bot" x="-0.0759356980444989" y="0.0759356980444989" z="0.0" unit="radian" />
+      <position name="crystal5-5_pos_pos_top" x="109.67291416309662" y="90.0427015552106" z="1528.6040060456442" unit="mm" />
+      <rotation name="crystal5-5_rot_pos_top" x="0.0759356980444989" y="-0.0759356980444989" z="0.0" unit="radian" />
+      <position name="crystal5-5_pos_neg_top" x="-24.31248894732458" y="90.0427015552106" z="1528.6040060456442" unit="mm" />
+      <rotation name="crystal5-5_rot_neg_top" x="0.0759356980444989" y="0.0759356980444989" z="0.0" unit="radian" />
+      <position name="crystal6-5_pos_pos_bot" x="124.57452638340096" y="-89.1427015552106" z="1528.602057217992" unit="mm" />
+      <rotation name="crystal6-5_rot_pos_bot" x="-0.0759356980444989" y="-0.0928102976099431" z="0.0" unit="radian" />
+      <position name="crystal6-5_pos_neg_bot" x="-39.214101167628925" y="-89.1427015552106" z="1528.602057217992" unit="mm" />
+      <rotation name="crystal6-5_rot_neg_bot" x="-0.0759356980444989" y="0.0928102976099431" z="0.0" unit="radian" />
+      <position name="crystal6-5_pos_pos_top" x="124.57452638340096" y="90.0427015552106" z="1528.602057217992" unit="mm" />
+      <rotation name="crystal6-5_rot_pos_top" x="0.0759356980444989" y="-0.0928102976099431" z="0.0" unit="radian" />
+      <position name="crystal6-5_pos_neg_top" x="-39.214101167628925" y="90.0427015552106" z="1528.602057217992" unit="mm" />
+      <rotation name="crystal6-5_rot_neg_top" x="0.0759356980444989" y="0.0928102976099431" z="0.0" unit="radian" />
+      <position name="crystal7-5_pos_pos_bot" x="139.4968932952259" y="-89.1427015552106" z="1528.5772513113154" unit="mm" />
+      <rotation name="crystal7-5_rot_pos_bot" x="-0.0759356980444989" y="-0.10968489717538729" z="0.0" unit="radian" />
+      <position name="crystal7-5_pos_neg_bot" x="-54.13646807945388" y="-89.1427015552106" z="1528.5772513113154" unit="mm" />
+      <rotation name="crystal7-5_rot_neg_bot" x="-0.0759356980444989" y="0.10968489717538729" z="0.0" unit="radian" />
+      <position name="crystal7-5_pos_pos_top" x="139.4968932952259" y="90.0427015552106" z="1528.5772513113154" unit="mm" />
+      <rotation name="crystal7-5_rot_pos_top" x="0.0759356980444989" y="-0.10968489717538729" z="0.0" unit="radian" />
+      <position name="crystal7-5_pos_neg_top" x="-54.13646807945388" y="90.0427015552106" z="1528.5772513113154" unit="mm" />
+      <rotation name="crystal7-5_rot_neg_top" x="0.0759356980444989" y="0.10968489717538729" z="0.0" unit="radian" />
+      <position name="crystal8-5_pos_pos_bot" x="154.44351486445828" y="-89.1427015552106" z="1528.5295953889813" unit="mm" />
+      <rotation name="crystal8-5_rot_pos_bot" x="-0.0759356980444989" y="-0.1265594967408315" z="0.0" unit="radian" />
+      <position name="crystal8-5_pos_neg_bot" x="-69.08308964868624" y="-89.1427015552106" z="1528.5295953889813" unit="mm" />
+      <rotation name="crystal8-5_rot_neg_bot" x="-0.0759356980444989" y="0.1265594967408315" z="0.0" unit="radian" />
+      <position name="crystal8-5_pos_pos_top" x="154.44351486445828" y="90.0427015552106" z="1528.5295953889813" unit="mm" />
+      <rotation name="crystal8-5_rot_pos_top" x="0.0759356980444989" y="-0.1265594967408315" z="0.0" unit="radian" />
+      <position name="crystal8-5_pos_neg_top" x="-69.08308964868624" y="90.0427015552106" z="1528.5295953889813" unit="mm" />
+      <rotation name="crystal8-5_rot_neg_top" x="0.0759356980444989" y="0.1265594967408315" z="0.0" unit="radian" />
+      <position name="crystal9-5_pos_pos_bot" x="169.41792716339802" y="-89.1427015552106" z="1528.4591030207916" unit="mm" />
+      <rotation name="crystal9-5_rot_pos_bot" x="-0.0759356980444989" y="-0.14343409630627568" z="0.0" unit="radian" />
+      <position name="crystal9-5_pos_neg_bot" x="-84.057501947626" y="-89.1427015552106" z="1528.4591030207916" unit="mm" />
+      <rotation name="crystal9-5_rot_neg_bot" x="-0.0759356980444989" y="0.14343409630627568" z="0.0" unit="radian" />
+      <position name="crystal9-5_pos_pos_top" x="169.41792716339802" y="90.0427015552106" z="1528.4591030207916" unit="mm" />
+      <rotation name="crystal9-5_rot_pos_top" x="0.0759356980444989" y="-0.14343409630627568" z="0.0" unit="radian" />
+      <position name="crystal9-5_pos_neg_top" x="-84.057501947626" y="90.0427015552106" z="1528.4591030207916" unit="mm" />
+      <rotation name="crystal9-5_rot_neg_top" x="0.0759356980444989" y="0.14343409630627568" z="0.0" unit="radian" />
+      <position name="crystal10-5_pos_pos_bot" x="184.42370834727978" y="-89.1427015552106" z="1528.3657942791212" unit="mm" />
+      <rotation name="crystal10-5_rot_pos_bot" x="-0.0759356980444989" y="-0.1603086958717199" z="0.0" unit="radian" />
+      <position name="crystal10-5_pos_neg_bot" x="-99.06328313150773" y="-89.1427015552106" z="1528.3657942791212" unit="mm" />
+      <rotation name="crystal10-5_rot_neg_bot" x="-0.0759356980444989" y="0.1603086958717199" z="0.0" unit="radian" />
+      <position name="crystal10-5_pos_pos_top" x="184.42370834727978" y="90.0427015552106" z="1528.3657942791212" unit="mm" />
+      <rotation name="crystal10-5_rot_pos_top" x="0.0759356980444989" y="-0.1603086958717199" z="0.0" unit="radian" />
+      <position name="crystal10-5_pos_neg_top" x="-99.06328313150773" y="90.0427015552106" z="1528.3657942791212" unit="mm" />
+      <rotation name="crystal10-5_rot_neg_top" x="0.0759356980444989" y="0.1603086958717199" z="0.0" unit="radian" />
+      <position name="crystal11-5_pos_pos_bot" x="199.46448478017476" y="-89.1427015552106" z="1528.2496957332003" unit="mm" />
+      <rotation name="crystal11-5_rot_pos_bot" x="-0.0759356980444989" y="-0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal11-5_pos_neg_bot" x="-114.1040595644027" y="-89.1427015552106" z="1528.2496957332003" unit="mm" />
+      <rotation name="crystal11-5_rot_neg_bot" x="-0.0759356980444989" y="0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal11-5_pos_pos_top" x="199.46448478017476" y="90.0427015552106" z="1528.2496957332003" unit="mm" />
+      <rotation name="crystal11-5_rot_pos_top" x="0.0759356980444989" y="-0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal11-5_pos_neg_top" x="-114.1040595644027" y="90.0427015552106" z="1528.2496957332003" unit="mm" />
+      <rotation name="crystal11-5_rot_neg_top" x="0.0759356980444989" y="0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal12-5_pos_pos_bot" x="214.5439373331128" y="-89.1427015552106" z="1528.1108404415506" unit="mm" />
+      <rotation name="crystal12-5_rot_pos_bot" x="-0.0759356980444989" y="-0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal12-5_pos_neg_bot" x="-129.1835121173408" y="-89.1427015552106" z="1528.1108404415506" unit="mm" />
+      <rotation name="crystal12-5_rot_neg_bot" x="-0.0759356980444989" y="0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal12-5_pos_pos_top" x="214.5439373331128" y="90.0427015552106" z="1528.1108404415506" unit="mm" />
+      <rotation name="crystal12-5_rot_pos_top" x="0.0759356980444989" y="-0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal12-5_pos_neg_top" x="-129.1835121173408" y="90.0427015552106" z="1528.1108404415506" unit="mm" />
+      <rotation name="crystal12-5_rot_neg_top" x="0.0759356980444989" y="0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal13-5_pos_pos_bot" x="229.66580787843168" y="-89.1427015552106" z="1527.9492679425712" unit="mm" />
+      <rotation name="crystal13-5_rot_pos_bot" x="-0.0759356980444989" y="-0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal13-5_pos_neg_bot" x="-144.30538266265967" y="-89.1427015552106" z="1527.9492679425712" unit="mm" />
+      <rotation name="crystal13-5_rot_neg_bot" x="-0.0759356980444989" y="0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal13-5_pos_pos_top" x="229.66580787843168" y="90.0427015552106" z="1527.9492679425712" unit="mm" />
+      <rotation name="crystal13-5_rot_pos_top" x="0.0759356980444989" y="-0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal13-5_pos_neg_top" x="-144.30538266265967" y="90.0427015552106" z="1527.9492679425712" unit="mm" />
+      <rotation name="crystal13-5_rot_neg_top" x="0.0759356980444989" y="0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal14-5_pos_pos_bot" x="244.83390600570817" y="-89.1427015552106" z="1527.7650242432805" unit="mm" />
+      <rotation name="crystal14-5_rot_pos_bot" x="-0.0759356980444989" y="-0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal14-5_pos_neg_bot" x="-159.47348078993616" y="-89.1427015552106" z="1527.7650242432805" unit="mm" />
+      <rotation name="crystal14-5_rot_neg_bot" x="-0.0759356980444989" y="0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal14-5_pos_pos_top" x="244.83390600570817" y="90.0427015552106" z="1527.7650242432805" unit="mm" />
+      <rotation name="crystal14-5_rot_pos_top" x="0.0759356980444989" y="-0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal14-5_pos_neg_top" x="-159.47348078993616" y="90.0427015552106" z="1527.7650242432805" unit="mm" />
+      <rotation name="crystal14-5_rot_neg_top" x="0.0759356980444989" y="0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal15-5_pos_pos_bot" x="260.0521159861688" y="-89.1427015552106" z="1527.5581618062158" unit="mm" />
+      <rotation name="crystal15-5_rot_pos_bot" x="-0.0759356980444989" y="-0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal15-5_pos_neg_bot" x="-174.6916907703968" y="-89.1427015552106" z="1527.5581618062158" unit="mm" />
+      <rotation name="crystal15-5_rot_neg_bot" x="-0.0759356980444989" y="0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal15-5_pos_pos_top" x="260.0521159861688" y="90.0427015552106" z="1527.5581618062158" unit="mm" />
+      <rotation name="crystal15-5_rot_pos_top" x="0.0759356980444989" y="-0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal15-5_pos_neg_top" x="-174.6916907703968" y="90.0427015552106" z="1527.5581618062158" unit="mm" />
+      <rotation name="crystal15-5_rot_neg_top" x="0.0759356980444989" y="0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal16-5_pos_pos_bot" x="275.32440401422616" y="-89.1427015552106" z="1527.328739534495" unit="mm" />
+      <rotation name="crystal16-5_rot_pos_bot" x="-0.0759356980444989" y="-0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal16-5_pos_neg_bot" x="-189.96397879845415" y="-89.1427015552106" z="1527.328739534495" unit="mm" />
+      <rotation name="crystal16-5_rot_neg_bot" x="-0.0759356980444989" y="0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal16-5_pos_pos_top" x="275.32440401422616" y="90.0427015552106" z="1527.328739534495" unit="mm" />
+      <rotation name="crystal16-5_rot_pos_top" x="0.0759356980444989" y="-0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal16-5_pos_neg_top" x="-189.96397879845415" y="90.0427015552106" z="1527.328739534495" unit="mm" />
+      <rotation name="crystal16-5_rot_neg_top" x="0.0759356980444989" y="0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal17-5_pos_pos_bot" x="290.6548257567732" y="-89.1427015552106" z="1527.0768227550436" unit="mm" />
+      <rotation name="crystal17-5_rot_pos_bot" x="-0.0759356980444989" y="-0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal17-5_pos_neg_bot" x="-205.2944005410012" y="-89.1427015552106" z="1527.0768227550436" unit="mm" />
+      <rotation name="crystal17-5_rot_neg_bot" x="-0.0759356980444989" y="0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal17-5_pos_pos_top" x="290.6548257567732" y="90.0427015552106" z="1527.0768227550436" unit="mm" />
+      <rotation name="crystal17-5_rot_pos_top" x="0.0759356980444989" y="-0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal17-5_pos_neg_top" x="-205.2944005410012" y="90.0427015552106" z="1527.0768227550436" unit="mm" />
+      <rotation name="crystal17-5_rot_neg_top" x="0.0759356980444989" y="0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal18-5_pos_pos_bot" x="306.0475342431027" y="-89.1427015552106" z="1526.8024831999942" unit="mm" />
+      <rotation name="crystal18-5_rot_pos_bot" x="-0.0759356980444989" y="-0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal18-5_pos_neg_bot" x="-220.68710902733068" y="-89.1427015552106" z="1526.8024831999942" unit="mm" />
+      <rotation name="crystal18-5_rot_neg_bot" x="-0.0759356980444989" y="0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal18-5_pos_pos_top" x="306.0475342431027" y="90.0427015552106" z="1526.8024831999942" unit="mm" />
+      <rotation name="crystal18-5_rot_pos_top" x="0.0759356980444989" y="-0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal18-5_pos_neg_top" x="-220.68710902733068" y="90.0427015552106" z="1526.8024831999942" unit="mm" />
+      <rotation name="crystal18-5_rot_neg_top" x="0.0759356980444989" y="0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal19-5_pos_pos_bot" x="321.5067881308382" y="-89.1427015552106" z="1526.5057989862605" unit="mm" />
+      <rotation name="crystal19-5_rot_pos_bot" x="-0.0759356980444989" y="-0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal19-5_pos_neg_bot" x="-236.14636291506616" y="-89.1427015552106" z="1526.5057989862605" unit="mm" />
+      <rotation name="crystal19-5_rot_neg_bot" x="-0.0759356980444989" y="0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal19-5_pos_pos_top" x="321.5067881308382" y="90.0427015552106" z="1526.5057989862605" unit="mm" />
+      <rotation name="crystal19-5_rot_pos_top" x="0.0759356980444989" y="-0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal19-5_pos_neg_top" x="-236.14636291506616" y="90.0427015552106" z="1526.5057989862605" unit="mm" />
+      <rotation name="crystal19-5_rot_neg_top" x="0.0759356980444989" y="0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal20-5_pos_pos_bot" x="337.03696038609246" y="-89.1427015552106" z="1526.186854593294" unit="mm" />
+      <rotation name="crystal20-5_rot_pos_bot" x="-0.0759356980444989" y="-0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal20-5_pos_neg_bot" x="-251.67653517032045" y="-89.1427015552106" z="1526.186854593294" unit="mm" />
+      <rotation name="crystal20-5_rot_neg_bot" x="-0.0759356980444989" y="0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal20-5_pos_pos_top" x="337.03696038609246" y="90.0427015552106" z="1526.186854593294" unit="mm" />
+      <rotation name="crystal20-5_rot_pos_top" x="0.0759356980444989" y="-0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal20-5_pos_neg_top" x="-251.67653517032045" y="90.0427015552106" z="1526.186854593294" unit="mm" />
+      <rotation name="crystal20-5_rot_neg_top" x="0.0759356980444989" y="0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal21-5_pos_pos_bot" x="352.64254741924634" y="-89.1427015552106" z="1525.8457408390282" unit="mm" />
+      <rotation name="crystal21-5_rot_pos_bot" x="-0.0759356980444989" y="-0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal21-5_pos_neg_bot" x="-267.28212220347433" y="-89.1427015552106" z="1525.8457408390282" unit="mm" />
+      <rotation name="crystal21-5_rot_neg_bot" x="-0.0759356980444989" y="0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal21-5_pos_pos_top" x="352.64254741924634" y="90.0427015552106" z="1525.8457408390282" unit="mm" />
+      <rotation name="crystal21-5_rot_pos_top" x="0.0759356980444989" y="-0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal21-5_pos_neg_top" x="-267.28212220347433" y="90.0427015552106" z="1525.8457408390282" unit="mm" />
+      <rotation name="crystal21-5_rot_neg_top" x="0.0759356980444989" y="0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal22-5_pos_pos_bot" x="368.32817872130425" y="-89.1427015552106" z="1525.48255485402" unit="mm" />
+      <rotation name="crystal22-5_rot_pos_bot" x="-0.0759356980444989" y="-0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal22-5_pos_neg_bot" x="-282.96775350553224" y="-89.1427015552106" z="1525.48255485402" unit="mm" />
+      <rotation name="crystal22-5_rot_neg_bot" x="-0.0759356980444989" y="0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal22-5_pos_pos_top" x="368.32817872130425" y="90.0427015552106" z="1525.48255485402" unit="mm" />
+      <rotation name="crystal22-5_rot_pos_top" x="0.0759356980444989" y="-0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal22-5_pos_neg_top" x="-282.96775350553224" y="90.0427015552106" z="1525.48255485402" unit="mm" />
+      <rotation name="crystal22-5_rot_neg_top" x="0.0759356980444989" y="0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal23-5_pos_pos_bot" x="384.09862704978" y="-89.1427015552106" z="1525.0974000537913" unit="mm" />
+      <rotation name="crystal23-5_rot_pos_bot" x="-0.0759356980444989" y="-0.3796784902224945" z="0.0" unit="radian" />
+      <position name="crystal23-5_pos_neg_bot" x="-298.738201834008" y="-89.1427015552106" z="1525.0974000537913" unit="mm" />
+      <rotation name="crystal23-5_rot_neg_bot" x="-0.0759356980444989" y="0.3796784902224945" z="0.0" unit="radian" />
+      <position name="crystal23-5_pos_pos_top" x="384.09862704978" y="90.0427015552106" z="1525.0974000537913" unit="mm" />
+      <rotation name="crystal23-5_rot_pos_top" x="0.0759356980444989" y="-0.3796784902224945" z="0.0" unit="radian" />
+      <position name="crystal23-5_pos_neg_top" x="-298.738201834008" y="90.0427015552106" z="1525.0974000537913" unit="mm" />
+      <rotation name="crystal23-5_rot_neg_top" x="0.0759356980444989" y="0.3796784902224945" z="0.0" unit="radian" />
+      <rotation name="hodo_rot" x="0.0" y="0.0" z="0.0" unit="radian" />
+      <position name="hodo_pos_L1TP0" x="73.63" y="44.2" z="1103.5" unit="mm" />
+      <position name="hodo_forecover_pos_L1TP0" x="73.63" y="44.2" z="1098.625" unit="mm" />
+      <position name="hodo_postcover_pos_L1TP0" x="73.63" y="44.2" z="1108.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L1TP0" x="65.75500000000001" y="44.2" z="1103.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L1TP0" x="81.50500000000001" y="44.2" z="1103.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L1TP0" x="73.63" y="74.17500000000001" z="1103.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L1TP0" x="73.63" y="14.225000000000003" z="1103.5" unit="mm" />
+      <position name="hodo_pos_L1BP0" x="73.63" y="-44.2" z="1103.5" unit="mm" />
+      <position name="hodo_forecover_pos_L1BP0" x="73.63" y="-44.2" z="1098.625" unit="mm" />
+      <position name="hodo_postcover_pos_L1BP0" x="73.63" y="-44.2" z="1108.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L1BP0" x="65.75500000000001" y="-44.2" z="1103.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L1BP0" x="81.50500000000001" y="-44.2" z="1103.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L1BP0" x="73.63" y="-14.225000000000003" z="1103.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L1BP0" x="73.63" y="-74.17500000000001" z="1103.5" unit="mm" />
+      <position name="hodo_pos_L1TP1" x="98.63" y="44.2" z="1103.5" unit="mm" />
+      <position name="hodo_forecover_pos_L1TP1" x="98.63" y="44.2" z="1098.625" unit="mm" />
+      <position name="hodo_postcover_pos_L1TP1" x="98.63" y="44.2" z="1108.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L1TP1" x="81.555" y="44.2" z="1103.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L1TP1" x="115.70500000000001" y="44.2" z="1103.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L1TP1" x="98.63" y="74.17500000000001" z="1103.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L1TP1" x="98.63" y="14.225000000000003" z="1103.5" unit="mm" />
+      <position name="hodo_pos_L1BP1" x="98.63" y="-44.2" z="1103.5" unit="mm" />
+      <position name="hodo_forecover_pos_L1BP1" x="98.63" y="-44.2" z="1098.625" unit="mm" />
+      <position name="hodo_postcover_pos_L1BP1" x="98.63" y="-44.2" z="1108.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L1BP1" x="81.555" y="-44.2" z="1103.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L1BP1" x="115.70500000000001" y="-44.2" z="1103.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L1BP1" x="98.63" y="-14.225000000000003" z="1103.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L1BP1" x="98.63" y="-74.17500000000001" z="1103.5" unit="mm" />
+      <position name="hodo_pos_L1TP2" x="137.78" y="44.2" z="1103.5" unit="mm" />
+      <position name="hodo_forecover_pos_L1TP2" x="137.78" y="44.2" z="1098.625" unit="mm" />
+      <position name="hodo_postcover_pos_L1TP2" x="137.78" y="44.2" z="1108.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L1TP2" x="115.75500000000001" y="44.2" z="1103.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L1TP2" x="159.805" y="44.2" z="1103.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L1TP2" x="137.78" y="74.17500000000001" z="1103.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L1TP2" x="137.78" y="14.225000000000003" z="1103.5" unit="mm" />
+      <position name="hodo_pos_L1BP2" x="137.78" y="-44.2" z="1103.5" unit="mm" />
+      <position name="hodo_forecover_pos_L1BP2" x="137.78" y="-44.2" z="1098.625" unit="mm" />
+      <position name="hodo_postcover_pos_L1BP2" x="137.78" y="-44.2" z="1108.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L1BP2" x="115.75500000000001" y="-44.2" z="1103.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L1BP2" x="159.805" y="-44.2" z="1103.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L1BP2" x="137.78" y="-14.225000000000003" z="1103.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L1BP2" x="137.78" y="-74.17500000000001" z="1103.5" unit="mm" />
+      <position name="hodo_pos_L1TP3" x="181.88" y="44.2" z="1103.5" unit="mm" />
+      <position name="hodo_forecover_pos_L1TP3" x="181.88" y="44.2" z="1098.625" unit="mm" />
+      <position name="hodo_postcover_pos_L1TP3" x="181.88" y="44.2" z="1108.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L1TP3" x="159.855" y="44.2" z="1103.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L1TP3" x="203.905" y="44.2" z="1103.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L1TP3" x="181.88" y="74.17500000000001" z="1103.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L1TP3" x="181.88" y="14.225000000000003" z="1103.5" unit="mm" />
+      <position name="hodo_pos_L1BP3" x="181.88" y="-44.2" z="1103.5" unit="mm" />
+      <position name="hodo_forecover_pos_L1BP3" x="181.88" y="-44.2" z="1098.625" unit="mm" />
+      <position name="hodo_postcover_pos_L1BP3" x="181.88" y="-44.2" z="1108.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L1BP3" x="159.855" y="-44.2" z="1103.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L1BP3" x="203.905" y="-44.2" z="1103.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L1BP3" x="181.88" y="-14.225000000000003" z="1103.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L1BP3" x="181.88" y="-74.17500000000001" z="1103.5" unit="mm" />
+      <position name="hodo_pos_L1TP4" x="225.98000000000002" y="44.2" z="1103.5" unit="mm" />
+      <position name="hodo_forecover_pos_L1TP4" x="225.98000000000002" y="44.2" z="1098.625" unit="mm" />
+      <position name="hodo_postcover_pos_L1TP4" x="225.98000000000002" y="44.2" z="1108.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L1TP4" x="203.955" y="44.2" z="1103.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L1TP4" x="248.00500000000002" y="44.2" z="1103.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L1TP4" x="225.98000000000002" y="74.17500000000001" z="1103.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L1TP4" x="225.98000000000002" y="14.225000000000003" z="1103.5" unit="mm" />
+      <position name="hodo_pos_L1BP4" x="225.98000000000002" y="-44.2" z="1103.5" unit="mm" />
+      <position name="hodo_forecover_pos_L1BP4" x="225.98000000000002" y="-44.2" z="1098.625" unit="mm" />
+      <position name="hodo_postcover_pos_L1BP4" x="225.98000000000002" y="-44.2" z="1108.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L1BP4" x="203.955" y="-44.2" z="1103.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L1BP4" x="248.00500000000002" y="-44.2" z="1103.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L1BP4" x="225.98000000000002" y="-14.225000000000003" z="1103.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L1BP4" x="225.98000000000002" y="-74.17500000000001" z="1103.5" unit="mm" />
+      <position name="hodo_pos_L2TP0" x="78.61999999999999" y="44.2" z="1115.5" unit="mm" />
+      <position name="hodo_forecover_pos_L2TP0" x="78.61999999999999" y="44.2" z="1110.625" unit="mm" />
+      <position name="hodo_postcover_pos_L2TP0" x="78.61999999999999" y="44.2" z="1120.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L2TP0" x="69.095" y="44.2" z="1115.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L2TP0" x="88.145" y="44.2" z="1115.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L2TP0" x="78.61999999999999" y="74.17500000000001" z="1115.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L2TP0" x="78.61999999999999" y="14.225000000000003" z="1115.5" unit="mm" />
+      <position name="hodo_pos_L2BP0" x="78.61999999999999" y="-44.2" z="1115.5" unit="mm" />
+      <position name="hodo_forecover_pos_L2BP0" x="78.61999999999999" y="-44.2" z="1110.625" unit="mm" />
+      <position name="hodo_postcover_pos_L2BP0" x="78.61999999999999" y="-44.2" z="1120.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L2BP0" x="69.095" y="-44.2" z="1115.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L2BP0" x="88.145" y="-44.2" z="1115.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L2BP0" x="78.61999999999999" y="-14.225000000000003" z="1115.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L2BP0" x="78.61999999999999" y="-74.17500000000001" z="1115.5" unit="mm" />
+      <position name="hodo_pos_L2TP1" x="110.22" y="44.2" z="1115.5" unit="mm" />
+      <position name="hodo_forecover_pos_L2TP1" x="110.22" y="44.2" z="1110.625" unit="mm" />
+      <position name="hodo_postcover_pos_L2TP1" x="110.22" y="44.2" z="1120.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L2TP1" x="88.19500000000001" y="44.2" z="1115.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L2TP1" x="132.245" y="44.2" z="1115.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L2TP1" x="110.22" y="74.17500000000001" z="1115.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L2TP1" x="110.22" y="14.225000000000003" z="1115.5" unit="mm" />
+      <position name="hodo_pos_L2BP1" x="110.22" y="-44.2" z="1115.5" unit="mm" />
+      <position name="hodo_forecover_pos_L2BP1" x="110.22" y="-44.2" z="1110.625" unit="mm" />
+      <position name="hodo_postcover_pos_L2BP1" x="110.22" y="-44.2" z="1120.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L2BP1" x="88.19500000000001" y="-44.2" z="1115.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L2BP1" x="132.245" y="-44.2" z="1115.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L2BP1" x="110.22" y="-14.225000000000003" z="1115.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L2BP1" x="110.22" y="-74.17500000000001" z="1115.5" unit="mm" />
+      <position name="hodo_pos_L2TP2" x="154.32000000000002" y="44.2" z="1115.5" unit="mm" />
+      <position name="hodo_forecover_pos_L2TP2" x="154.32000000000002" y="44.2" z="1110.625" unit="mm" />
+      <position name="hodo_postcover_pos_L2TP2" x="154.32000000000002" y="44.2" z="1120.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L2TP2" x="132.29500000000002" y="44.2" z="1115.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L2TP2" x="176.34500000000003" y="44.2" z="1115.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L2TP2" x="154.32000000000002" y="74.17500000000001" z="1115.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L2TP2" x="154.32000000000002" y="14.225000000000003" z="1115.5" unit="mm" />
+      <position name="hodo_pos_L2BP2" x="154.32000000000002" y="-44.2" z="1115.5" unit="mm" />
+      <position name="hodo_forecover_pos_L2BP2" x="154.32000000000002" y="-44.2" z="1110.625" unit="mm" />
+      <position name="hodo_postcover_pos_L2BP2" x="154.32000000000002" y="-44.2" z="1120.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L2BP2" x="132.29500000000002" y="-44.2" z="1115.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L2BP2" x="176.34500000000003" y="-44.2" z="1115.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L2BP2" x="154.32000000000002" y="-14.225000000000003" z="1115.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L2BP2" x="154.32000000000002" y="-74.17500000000001" z="1115.5" unit="mm" />
+      <position name="hodo_pos_L2TP3" x="198.42000000000004" y="44.2" z="1115.5" unit="mm" />
+      <position name="hodo_forecover_pos_L2TP3" x="198.42000000000004" y="44.2" z="1110.625" unit="mm" />
+      <position name="hodo_postcover_pos_L2TP3" x="198.42000000000004" y="44.2" z="1120.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L2TP3" x="176.39500000000004" y="44.2" z="1115.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L2TP3" x="220.44500000000005" y="44.2" z="1115.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L2TP3" x="198.42000000000004" y="74.17500000000001" z="1115.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L2TP3" x="198.42000000000004" y="14.225000000000003" z="1115.5" unit="mm" />
+      <position name="hodo_pos_L2BP3" x="198.42000000000004" y="-44.2" z="1115.5" unit="mm" />
+      <position name="hodo_forecover_pos_L2BP3" x="198.42000000000004" y="-44.2" z="1110.625" unit="mm" />
+      <position name="hodo_postcover_pos_L2BP3" x="198.42000000000004" y="-44.2" z="1120.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L2BP3" x="176.39500000000004" y="-44.2" z="1115.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L2BP3" x="220.44500000000005" y="-44.2" z="1115.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L2BP3" x="198.42000000000004" y="-14.225000000000003" z="1115.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L2BP3" x="198.42000000000004" y="-74.17500000000001" z="1115.5" unit="mm" />
+      <position name="hodo_pos_L2TP4" x="235.92000000000002" y="44.2" z="1115.5" unit="mm" />
+      <position name="hodo_forecover_pos_L2TP4" x="235.92000000000002" y="44.2" z="1110.625" unit="mm" />
+      <position name="hodo_postcover_pos_L2TP4" x="235.92000000000002" y="44.2" z="1120.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L2TP4" x="220.495" y="44.2" z="1115.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L2TP4" x="251.34500000000003" y="44.2" z="1115.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L2TP4" x="235.92000000000002" y="74.17500000000001" z="1115.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L2TP4" x="235.92000000000002" y="14.225000000000003" z="1115.5" unit="mm" />
+      <position name="hodo_pos_L2BP4" x="235.92000000000002" y="-44.2" z="1115.5" unit="mm" />
+      <position name="hodo_forecover_pos_L2BP4" x="235.92000000000002" y="-44.2" z="1110.625" unit="mm" />
+      <position name="hodo_postcover_pos_L2BP4" x="235.92000000000002" y="-44.2" z="1120.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L2BP4" x="220.495" y="-44.2" z="1115.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L2BP4" x="251.34500000000003" y="-44.2" z="1115.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L2BP4" x="235.92000000000002" y="-14.225000000000003" z="1115.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L2BP4" x="235.92000000000002" y="-74.17500000000001" z="1115.5" unit="mm" />
+      <position name="hodo_bufferT_pos" x="153.99" y="54.2" z="1109.5" unit="mm" />
+      <position name="hodo_bufferB_pos" x="153.99" y="-54.2" z="1109.5" unit="mm" />
+      <position name="front_flange_1inworld_volumepos" x="2.1420000000000003" y="0" z="137.80000000000001" unit="cm" />
+      <position name="back_flange_1inworld_volumepos" x="-12.608499999999999" y="0" z="180.80000000000001" unit="cm" />
+      <position name="ECAL_chamber_1inworld_volumepos" x="-11.940800000000001" y="0" z="159.30000000000001" unit="cm" />
+      <position name="al_honeycomb_1inworld_volumepos" x="-18.858000000000001" y="0" z="155.80000000000001" unit="cm" />
+      <position name="layer_1_top_1inworld_volumepos" x="4.1920000000000002" y="8.0999999999999996" z="152.80000000000001" unit="cm" />
+      <position name="layer_2_top_1inworld_volumepos" x="4.1920000000000002" y="6.6899999999999995" z="152.80000000000001" unit="cm" />
+      <position name="layer_3_top_1inworld_volumepos" x="4.1920000000000002" y="5.2799999999999994" z="152.80000000000001" unit="cm" />
+      <position name="layer_4_top_1inworld_volumepos" x="4.1920000000000002" y="3.8699999999999992" z="152.80000000000001" unit="cm" />
+      <position name="layer_1_bottom_1inworld_volumepos" x="4.1920000000000002" y="-4.0999999999999996" z="152.80000000000001" unit="cm" />
+      <position name="layer_2_bottom_1inworld_volumepos" x="4.1920000000000002" y="-5.5099999999999998" z="152.80000000000001" unit="cm" />
+      <position name="layer_3_bottom_1inworld_volumepos" x="4.1920000000000002" y="-6.9199999999999999" z="152.80000000000001" unit="cm" />
+      <position name="layer_4_bottom_1inworld_volumepos" x="4.1920000000000002" y="-8.3300000000000001" z="152.80000000000001" unit="cm" />
+      <position name="layer_5T_left_1inworld_volumepos" x="4.1920000000000002" y="2.46" z="152.80000000000001" unit="cm" />
+      <position name="layer_5B_left_1inworld_volumepos" x="4.1920000000000002" y="-2.6899999999999995" z="152.80000000000001" unit="cm" />
+      <position name="steel_bar_1inworld_volumepos" x="-35.357999999999997" y="0.90000000000000002" z="152.80000000000001" unit="cm" />
+      <position name="cu_Tpipe_inner_left_1inworld_volumepos" x="1.6420000000000003" y="2.7000000000000002" z="152.80000000000001" unit="cm" />
+      <rotation name="cu_Tpipe_inner_left_1inworld_volumerot" x="0" y="-0.95599999999999996" z="0" unit="deg" />
+      <position name="cu_Tpipe_inner_right_1inworld_volumepos" x="-9.1580000000000013" y="2.7000000000000002" z="152.80000000000001" unit="cm" />
+      <rotation name="cu_Tpipe_inner_right_1inworld_volumerot" x="0" y="9.6799999999999997" z="0" unit="deg" />
+      <position name="cu_Bpipe_inner_left_1inworld_volumepos" x="1.6420000000000003" y="-2.7000000000000002" z="152.80000000000001" unit="cm" />
+      <rotation name="cu_Bpipe_inner_left_1inworld_volumerot" x="0" y="-0.95599999999999996" z="0" unit="deg" />
+      <position name="cu_Bpipe_inner_right_1inworld_volumepos" x="-9.1580000000000013" y="-2.7000000000000002" z="152.80000000000001" unit="cm" />
+      <rotation name="cu_Bpipe_inner_right_1inworld_volumerot" x="0" y="9.6799999999999997" z="0" unit="deg" />
+      <position name="cu_Tpipe_outer_right1_1inworld_volumepos" x="-10.858000000000001" y="1.3999999999999999" z="154.30000000000001" unit="cm" />
+      <rotation name="cu_Tpipe_outer_right1_1inworld_volumerot" x="0" y="10" z="0" unit="deg" />
+      <position name="cu_Tpipe_outer_right2_1inworld_volumepos" x="-27.858000000000001" y="1.3999999999999999" z="154.30000000000001" unit="cm" />
+      <position name="cu_Tpipe_outer_right3_1inworld_volumepos" x="-34.857999999999997" y="1.5" z="142.10000000000002" unit="cm" />
+      <rotation name="cu_Tpipe_outer_right3_1inworld_volumerot" x="-0" y="90" z="0" unit="deg" />
+      <position name="cu_Bpipe_outer_right_1inworld_volumepos" x="-34.857999999999997" y="-1.5" z="142.10000000000002" unit="cm" />
+      <rotation name="cu_Bpipe_outer_right_1inworld_volumerot" x="-0" y="90" z="0" unit="deg" />
+      <position name="cu_Bpipe_outer_right1_1inworld_volumepos" x="-10.858000000000001" y="-1.3999999999999999" z="154.30000000000001" unit="cm" />
+      <rotation name="cu_Bpipe_outer_right1_1inworld_volumerot" x="0" y="10" z="0" unit="deg" />
+      <position name="cu_Bpipe_outer_right2_1inworld_volumepos" x="-27.858000000000001" y="-1.3999999999999999" z="154.30000000000001" unit="cm" />
+      <position name="al_pipe_across_top1_1inworld_volumepos" x="2.1420000000000003" y="9" z="142.10000000000002" unit="cm" />
+      <rotation name="al_pipe_across_top1_1inworld_volumerot" x="-90" y="86.999999999999957" z="180" unit="deg" />
+      <position name="al_pipe_across_top2_1inworld_volumepos" x="2.1420000000000003" y="4" z="142.10000000000002" unit="cm" />
+      <rotation name="al_pipe_across_top2_1inworld_volumerot" x="-90" y="89.000000000000099" z="180" unit="deg" />
+      <position name="al_pipe_across_bottom1_1inworld_volumepos" x="2.1420000000000003" y="-9" z="142.10000000000002" unit="cm" />
+      <rotation name="al_pipe_across_bottom1_1inworld_volumerot" x="90" y="86.999999999999957" z="0" unit="deg" />
+      <position name="al_pipe_across_bottom2_1inworld_volumepos" x="2.1420000000000003" y="-4" z="142.10000000000002" unit="cm" />
+      <rotation name="al_pipe_across_bottom2_1inworld_volumerot" x="90" y="89.000000000000099" z="0" unit="deg" />
+      <position name="cu_plate_top_left_1inworld_volumepos" x="22.141999999999999" y="1.6000000000000001" z="152.80000000000001" unit="cm" />
+      <position name="cu_plate_bottom_left_1inworld_volumepos" x="22.141999999999999" y="-1.6000000000000001" z="152.80000000000001" unit="cm" />
+      <position name="cu_plate_top_right_1inworld_volumepos" x="-20.858000000000001" y="1.6000000000000001" z="152.80000000000001" unit="cm" />
+      <position name="cu_plate_bottom_right_1inworld_volumepos" x="-20.858000000000001" y="-1.6000000000000001" z="152.80000000000001" unit="cm" />
+      <position name="cu_plate_top_middle_1inworld_volumepos" x="-3.3579999999999997" y="3.1000000000000001" z="152.80000000000001" unit="cm" />
+      <position name="cu_plate_bottom_middle_1inworld_volumepos" x="-3.3579999999999997" y="-3.1000000000000001" z="152.80000000000001" unit="cm" />
+      <position name="hodo_flange_1intracking_volumepos" x="2.1170000000000004" y="0" z="134.30000000000001" unit="cm" />
+      <position name="arms1_block1_1intracking_volumepos" x="21.517000000000003" y="14.938225000000001" z="132.70000000000002" unit="cm" />
+      <position name="arms1_block2_1intracking_volumepos" x="9.5170000000000012" y="14.938225000000001" z="132.70000000000002" unit="cm" />
+      <position name="arms1_block3_1intracking_volumepos" x="21.517000000000003" y="-14.938225000000001" z="132.70000000000002" unit="cm" />
+      <position name="arms1_block4_1intracking_volumepos" x="9.5170000000000012" y="-14.938225000000001" z="132.70000000000002" unit="cm" />
+      <position name="cross_bar_top_1intracking_volumepos" x="15.517000000000003" y="16.34" z="132.70000000000002" unit="cm" />
+      <position name="cross_bar_bottom_1intracking_volumepos" x="15.517000000000003" y="-16.34" z="132.70000000000002" unit="cm" />
+      <position name="support_arm_bottom_left_plus_block_1intracking_volumepos" x="21.517000000000003" y="-12.771562277258594" z="121.10000000000001" unit="cm" />
+      <position name="support_arm_bottom_right_1intracking_volumepos" x="9.5170000000000012" y="-12.771562277258594" z="121.10000000000001" unit="cm" />
+      <position name="support_arm_top_left_1intracking_volumepos" x="21.517000000000003" y="12.771562277258594" z="121.10000000000001" unit="cm" />
+      <rotation name="support_arm_top_left_1intracking_volumerot" x="0" y="-0" z="180" unit="deg" />
+      <position name="support_arm_top_right_1intracking_volumepos" x="9.5170000000000012" y="12.771562277258594" z="121.10000000000001" unit="cm" />
+      <rotation name="support_arm_top_right_1intracking_volumerot" x="0" y="-0" z="180" unit="deg" />
+      <position name="u_support_bar_bottom_1intracking_volumepos" x="15.517000000000003" y="-9.8400000000000034" z="110.899" unit="cm" />
+      <position name="u_support_bar_upper1_1intracking_volumepos" x="15.517000000000003" y="-8.5400000000000027" z="110.65000000000001" unit="cm" />
+      <position name="u_support_bar_upper2_1intracking_volumepos" x="15.517000000000003" y="-8.5400000000000027" z="111.2" unit="cm" />
+      <position name="u_support_bar_top_1intracking_volumepos" x="15.517000000000003" y="9.8400000000000034" z="110.899" unit="cm" />
+      <position name="u_support_bar_upper3_1intracking_volumepos" x="15.517000000000003" y="8.5400000000000027" z="110.65000000000001" unit="cm" />
+      <position name="u_support_bar_upper4_1intracking_volumepos" x="15.517000000000003" y="8.5400000000000027" z="111.2" unit="cm" />
+      <constant name="svt_chamber_box_z" value="609.6" />
+      <constant name="svt_chamber_flare1_z" value="1285.621" />
+      <constant name="svt_chamber_flare2_z" value="1478.407" />
+      <constant name="svt_chamber_flange_z" value="1614.297" />
+      <constant name="svt_chamber_x" value="21.17" />
+      <constant name="svt_chamber_z" value="1318-1623.822" />
+    </define>
+    <materials>
+      <element Z="1" formula="H" name="H">
+        <atom type="A" unit="g/mol" value="1.00794" />
+      </element>
+      <element Z="82" formula="Pb" name="Pb">
+        <atom type="A" unit="g/mol" value="207.217" />
+      </element>
+      <element Z="74" formula="W" name="W">
+        <atom type="A" unit="g/mol" value="183.842" />
+      </element>
+      <element Z="8" formula="O" name="O">
+        <atom type="A" unit="g/mol" value="15.9994" />
+      </element>
+      <element Z="6" formula="C" name="C">
+        <atom type="A" unit="g/mol" value="12.0107" />
+      </element>
+      <element Z="22" formula="Ti" name="Ti">
+        <atom type="A" unit="g/mol" value="47.8667" />
+      </element>
+      <material name="Vacuum">
+        <D type="density" unit="g/cm3" value="0.00000001" />
+        <fraction n="1" ref="H" />
+      </material>
+      <material name="WorldMaterial">
+        <D type="density" unit="g/cm3" value="0.0000000000000001" />
+        <fraction n="1.0" ref="Vacuum" />
+      </material>
+      <material name="TrackingMaterial">
+        <D type="density" unit="g/cm3" value="0.0000000000000001" />
+        <fraction n="1.0" ref="Vacuum" />
+      </material>
+      <material name="LeadTungstate">
+        <D value="8.28" unit="g/cm3" type="density" />
+        <composite n="1" ref="Pb" />
+        <composite n="1" ref="W" />
+        <composite n="4" ref="O" />
+      </material>
+      <material name="EJ204_PlasticScintillator">
+        <D value="1.032" unit="g/cm3" type="density" />
+        <fraction n="0.523618" ref="H" />
+        <fraction n="0.476382" ref="C" />
+      </material>
+      <material name="TitaniumDioxide">
+        <D value="4.23" unit="g/cm3" type="density" />
+        <composite n="1" ref="Ti" />
+        <composite n="2" ref="O" />
+      </material>
+      <material name="Mylar">
+        <D value="1.4" unit="g/cm3" type="density" />
+        <fraction n="0.041958" ref="H" />
+        <fraction n="0.625017" ref="C" />
+        <fraction n="0.333025" ref="O" />
+      </material>
+      <material name="GenericFoam">
+        <D value="0.052" unit="g/cm3" type="density" />
+        <fraction n="0.5" ref="H" />
+        <fraction n="0.5" ref="C" />
+      </material>
+      <element name="Al" formula="Al" Z="13">
+        <atom type="A" unit="g/mol" value="26.9815" />
+      </element>
+      <material name="Aluminum">
+        <RL type="X0" unit="cm" value="8.89632" />
+        <NIL type="lambda" unit="cm" value="38.8766" />
+        <D type="density" unit="g/cm3" value="2.699" />
+        <composite n="1" ref="Al" />
+      </material>
+      <element name="Si" formula="Si" Z="14">
+        <atom type="A" unit="g/mol" value="28.0854" />
+      </element>
+      <material name="Silicon">
+        <RL type="X0" unit="cm" value="9.36607" />
+        <NIL type="lambda" unit="cm" value="45.7531" />
+        <D type="density" unit="g/cm3" value="2.33" />
+        <composite n="1" ref="Si" />
+      </material>
+      <element name="N" formula="N" Z="7">
+        <atom type="A" unit="g/mol" value="14.0068" />
+      </element>
+      <material name="Kapton">
+        <D value="1.43" unit="g/cm3" />
+        <composite n="22" ref="C" />
+        <composite n="10" ref="H" />
+        <composite n="2" ref="N" />
+        <composite n="5" ref="O" />
+      </material>
+      <material name="Epoxy">
+        <D type="density" value="1.3" unit="g/cm3" />
+        <composite n="44" ref="H" />
+        <composite n="15" ref="C" />
+        <composite n="7" ref="O" />
+      </material>
+      <material name="CarbonFiber">
+        <D type="density" value="1.5" unit="g/cm3" />
+        <fraction n="0.65" ref="C" />
+        <fraction n="0.35" ref="Epoxy" />
+      </material>
+      <element name="Cl" formula="Cl" Z="17">
+        <atom type="A" unit="g/mol" value="35.4526" />
+      </element>
+      <material name="Quartz">
+        <D type="density" value="2.2" unit="g/cm3" />
+        <composite n="1" ref="Si" />
+        <composite n="2" ref="O" />
+      </material>
+      <material name="G10">
+        <D type="density" value="1.7" unit="g/cm3" />
+        <fraction n="0.08" ref="Cl" />
+        <fraction n="0.773" ref="Quartz" />
+        <fraction n="0.147" ref="Epoxy" />
+      </material>
+      <material name="Polystyrene">
+        <D value="1.032" unit="g/cm3" />
+        <composite n="19" ref="C" />
+        <composite n="21" ref="H" />
+      </material>
+      <material name="Carbon">
+        <RL type="X0" unit="cm" value="21.3485" />
+        <NIL type="lambda" unit="cm" value="40.1008" />
+        <D type="density" unit="g/cm3" value="2" />
+        <composite n="1" ref="C" />
+      </material>
+      <material name="G4_Al" Z="13">
+        <D unit="g/cm3" value="2.6989999999999998" />
+        <atom unit="g/mole" value="26.981538" />
+      </material>
+      <material name="AlHoneycomb" Z="13">
+        <D unit="g/cm3" value="0.13" />
+        <atom unit="g/mole" value="26.981538" />
+      </material>
+      <element name="MANGANESE_elm" formula="MN" Z="25">
+        <atom unit="g/mole" value="54.938048999999999" />
+      </element>
+      <element name="SILICON_elm" formula="SI" Z="14">
+        <atom unit="g/mole" value="28.0855" />
+      </element>
+      <element name="CHROMIUM_elm" formula="CR" Z="24">
+        <atom unit="g/mole" value="51.996099999999998" />
+      </element>
+      <element name="NICKEL_elm" formula="NI" Z="28">
+        <atom unit="g/mole" value="58.693399999999997" />
+      </element>
+      <element name="IRON_elm" formula="FE" Z="26">
+        <atom unit="g/mole" value="55.844999999999999" />
+      </element>
+      <material name="StainlessSteel">
+        <D unit="g/cm3" value="8.0199999999999996" />
+        <fraction n="0.18999999761581421" ref="CHROMIUM_elm" />
+        <fraction n="0.68000000715255737" ref="IRON_elm" />
+        <fraction n="0.019999999552965164" ref="MANGANESE_elm" />
+        <fraction n="0.10000000149011612" ref="NICKEL_elm" />
+        <fraction n="0.0099999997764825821" ref="SILICON_elm" />
+      </material>
+      <material name="G4_Cu" Z="29">
+        <D unit="g/cm3" value="8.9600000000000009" />
+        <atom unit="g/mole" value="63.545645059999998" />
+      </material>
+      <element name="OXYGEN_elm" formula="O" Z="8">
+        <atom unit="g/mole" value="15.9994" />
+      </element>
+      <element name="CARBON_elm" formula="C" Z="6">
+        <atom unit="g/mole" value="12.0107" />
+      </element>
+      <element name="HYDROGEN_elm" formula="H" Z="1">
+        <atom unit="g/mole" value="1.0079400000000001" />
+      </element>
+      <material name="G10_FR4">
+        <D unit="g/cm3" value="1.8500000000000001" />
+        <fraction n="0.40416482090950012" ref="CARBON_elm" />
+        <fraction n="0.067835167050361633" ref="HYDROGEN_elm" />
+        <fraction n="0.28119435906410217" ref="OXYGEN_elm" />
+        <fraction n="0.24680563807487488" ref="SILICON_elm" />
+      </material>
+      <material name="SiO2">
+        <D unit="g/cm3" value="2.2000000000000002" />
+        <fraction n="0.53256505727767944" ref="OXYGEN_elm" />
+        <fraction n="0.46743491291999817" ref="SILICON_elm" />
+      </material>
+      <element Z="26" formula="Fe" name="Iron">
+        <atom value="55.845" />
+      </element>
+      <element Z="24" formula="Cr" name="Chromium">
+        <atom value="51.9961" />
+      </element>
+      <element Z="28" formula="Ni" name="Nickel">
+        <atom value="58.6934" />
+      </element>
+      <material formula=" " name="Stainless_304">
+        <D value="8.00" />
+        <fraction n="0.733078" ref="Iron" />
+        <fraction n="0.191516" ref="Chromium" />
+        <fraction n="0.075406" ref="Nickel" />
+      </material>
+      <material Z="1" name="G4_Galactic" state="gas">
+        <T unit="K" value="2.73" />
+        <P unit="pascal" value="3e-18" />
+        <!-- <MEE unit="eV" value="21.8"/> -->
+        <D unit="g/cm3" value="2e-25" />
+        <atom unit="g/mole" value="1.01" />
+      </material>
+    </materials>
+    <solids>
+      <box name="world_box" x="world_x" y="world_y" z="world_z" />
+      <tube name="tracking_cylinder" deltaphi="6.283185307179586" rmin="0.0" rmax="tracking_region_radius" z="2*tracking_region_zmax" />
+      <box name="baseBox" x="406.4" y="1282.6999999999998" z="171.196" />
+      <box name="base_plateBox" x="406.4" y="1282.6999999999998" z="6.35" />
+      <box name="support_plate_bottom_L14Box" x="234.95" y="456.4" z="9.524999999999999" />
+      <box name="support_plate_top_L14Box" x="234.95" y="456.4" z="9.524999999999999" />
+      <box name="support_plate_bottom_L46Box" x="342.9" y="533.4" z="12.7" />
+      <box name="support_plate_top_L46Box" x="342.9" y="533.4" z="12.7" />
+      <box name="module_L1b_halfmodule_axialBox" x="14.525" y="30.0" z="0.2" />
+      <box name="module_L1b_halfmodule_axial_sensorBox" x="14.525" y="30.0" z="0.2" />
+      <box name="module_L1b_halfmodule_axial_sensor_activeBox" x="14.025" y="30.0" z="0.2" />
+      <box name="module_L1b_halfmodule_stereoBox" x="14.525" y="30.0" z="0.2" />
+      <box name="module_L1b_halfmodule_stereo_sensorBox" x="14.525" y="30.0" z="0.2" />
+      <box name="module_L1b_halfmodule_stereo_sensor_activeBox" x="14.025" y="30.0" z="0.2" />
+      <box name="module_L1t_halfmodule_axialBox" x="14.525" y="30.0" z="0.2" />
+      <box name="module_L1t_halfmodule_axial_sensorBox" x="14.525" y="30.0" z="0.2" />
+      <box name="module_L1t_halfmodule_axial_sensor_activeBox" x="14.025" y="30.0" z="0.2" />
+      <box name="module_L1t_halfmodule_stereoBox" x="14.525" y="30.0" z="0.2" />
+      <box name="module_L1t_halfmodule_stereo_sensorBox" x="14.525" y="30.0" z="0.2" />
+      <box name="module_L1t_halfmodule_stereo_sensor_activeBox" x="14.025" y="30.0" z="0.2" />
+      <box name="module_L2b_halfmodule_axialBox" x="14.525" y="30.0" z="0.2" />
+      <box name="module_L2b_halfmodule_axial_sensorBox" x="14.525" y="30.0" z="0.2" />
+      <box name="module_L2b_halfmodule_axial_sensor_activeBox" x="14.025" y="30.0" z="0.2" />
+      <box name="module_L2b_halfmodule_stereoBox" x="14.525" y="30.0" z="0.2" />
+      <box name="module_L2b_halfmodule_stereo_sensorBox" x="14.525" y="30.0" z="0.2" />
+      <box name="module_L2b_halfmodule_stereo_sensor_activeBox" x="14.025" y="30.0" z="0.2" />
+      <box name="module_L2t_halfmodule_axialBox" x="14.525" y="30.0" z="0.2" />
+      <box name="module_L2t_halfmodule_axial_sensorBox" x="14.525" y="30.0" z="0.2" />
+      <box name="module_L2t_halfmodule_axial_sensor_activeBox" x="14.025" y="30.0" z="0.2" />
+      <box name="module_L2t_halfmodule_stereoBox" x="14.525" y="30.0" z="0.2" />
+      <box name="module_L2t_halfmodule_stereo_sensorBox" x="14.525" y="30.0" z="0.2" />
+      <box name="module_L2t_halfmodule_stereo_sensor_activeBox" x="14.025" y="30.0" z="0.2" />
+      <box name="module_L3b_halfmodule_axialBox" x="47.17" y="200.0" z="1.8405" />
+      <box name="module_L3b_halfmodule_axial_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L3b_halfmodule_axial_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L3b_halfmodule_axial_laminationBox" x="38.0" y="100.0" z="0.05" />
+      <box name="module_L3b_halfmodule_axial_cfBox" x="36.02" y="100.0" z="0.203" />
+      <box name="module_L3b_halfmodule_axial_hybridBox" x="40.34" y="70.0" z="1.5875" />
+      <box name="module_L3b_halfmodule_stereoBox" x="47.17" y="200.0" z="1.8405" />
+      <box name="module_L3b_halfmodule_stereo_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L3b_halfmodule_stereo_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L3b_halfmodule_stereo_laminationBox" x="38.0" y="100.0" z="0.05" />
+      <box name="module_L3b_halfmodule_stereo_cfBox" x="36.02" y="100.0" z="0.203" />
+      <box name="module_L3b_halfmodule_stereo_hybridBox" x="40.34" y="70.0" z="1.5875" />
+      <box name="module_L3t_halfmodule_axialBox" x="47.17" y="200.0" z="1.8405" />
+      <box name="module_L3t_halfmodule_axial_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L3t_halfmodule_axial_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L3t_halfmodule_axial_laminationBox" x="38.0" y="100.0" z="0.05" />
+      <box name="module_L3t_halfmodule_axial_cfBox" x="36.02" y="100.0" z="0.203" />
+      <box name="module_L3t_halfmodule_axial_hybridBox" x="40.34" y="70.0" z="1.5875" />
+      <box name="module_L3t_halfmodule_stereoBox" x="47.17" y="200.0" z="1.8405" />
+      <box name="module_L3t_halfmodule_stereo_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L3t_halfmodule_stereo_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L3t_halfmodule_stereo_laminationBox" x="38.0" y="100.0" z="0.05" />
+      <box name="module_L3t_halfmodule_stereo_cfBox" x="36.02" y="100.0" z="0.203" />
+      <box name="module_L3t_halfmodule_stereo_hybridBox" x="40.34" y="70.0" z="1.5875" />
+      <box name="module_L4b_halfmodule_axialBox" x="47.17" y="200.0" z="1.8405" />
+      <box name="module_L4b_halfmodule_axial_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L4b_halfmodule_axial_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L4b_halfmodule_axial_laminationBox" x="38.0" y="100.0" z="0.05" />
+      <box name="module_L4b_halfmodule_axial_cfBox" x="36.02" y="100.0" z="0.203" />
+      <box name="module_L4b_halfmodule_axial_hybridBox" x="40.34" y="70.0" z="1.5875" />
+      <box name="module_L4b_halfmodule_stereoBox" x="47.17" y="200.0" z="1.8405" />
+      <box name="module_L4b_halfmodule_stereo_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L4b_halfmodule_stereo_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L4b_halfmodule_stereo_laminationBox" x="38.0" y="100.0" z="0.05" />
+      <box name="module_L4b_halfmodule_stereo_cfBox" x="36.02" y="100.0" z="0.203" />
+      <box name="module_L4b_halfmodule_stereo_hybridBox" x="40.34" y="70.0" z="1.5875" />
+      <box name="module_L4t_halfmodule_axialBox" x="47.17" y="200.0" z="1.8405" />
+      <box name="module_L4t_halfmodule_axial_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L4t_halfmodule_axial_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L4t_halfmodule_axial_laminationBox" x="38.0" y="100.0" z="0.05" />
+      <box name="module_L4t_halfmodule_axial_cfBox" x="36.02" y="100.0" z="0.203" />
+      <box name="module_L4t_halfmodule_axial_hybridBox" x="40.34" y="70.0" z="1.5875" />
+      <box name="module_L4t_halfmodule_stereoBox" x="47.17" y="200.0" z="1.8405" />
+      <box name="module_L4t_halfmodule_stereo_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L4t_halfmodule_stereo_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L4t_halfmodule_stereo_laminationBox" x="38.0" y="100.0" z="0.05" />
+      <box name="module_L4t_halfmodule_stereo_cfBox" x="36.02" y="100.0" z="0.203" />
+      <box name="module_L4t_halfmodule_stereo_hybridBox" x="40.34" y="70.0" z="1.5875" />
+      <box name="module_L5b_halfmodule_axial_holeBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L5b_halfmodule_axial_hole_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L5b_halfmodule_axial_hole_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L5b_halfmodule_axial_hole_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L5b_halfmodule_axial_slotBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L5b_halfmodule_axial_slot_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L5b_halfmodule_axial_slot_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L5b_halfmodule_axial_slot_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L5b_halfmodule_stereo_holeBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L5b_halfmodule_stereo_hole_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L5b_halfmodule_stereo_hole_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L5b_halfmodule_stereo_hole_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L5b_halfmodule_stereo_slotBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L5b_halfmodule_stereo_slot_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L5b_halfmodule_stereo_slot_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L5b_halfmodule_stereo_slot_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L5t_halfmodule_axial_holeBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L5t_halfmodule_axial_hole_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L5t_halfmodule_axial_hole_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L5t_halfmodule_axial_hole_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L5t_halfmodule_axial_slotBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L5t_halfmodule_axial_slot_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L5t_halfmodule_axial_slot_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L5t_halfmodule_axial_slot_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L5t_halfmodule_stereo_holeBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L5t_halfmodule_stereo_hole_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L5t_halfmodule_stereo_hole_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L5t_halfmodule_stereo_hole_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L5t_halfmodule_stereo_slotBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L5t_halfmodule_stereo_slot_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L5t_halfmodule_stereo_slot_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L5t_halfmodule_stereo_slot_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L6b_halfmodule_axial_holeBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L6b_halfmodule_axial_hole_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L6b_halfmodule_axial_hole_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L6b_halfmodule_axial_hole_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L6b_halfmodule_axial_slotBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L6b_halfmodule_axial_slot_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L6b_halfmodule_axial_slot_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L6b_halfmodule_axial_slot_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L6b_halfmodule_stereo_holeBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L6b_halfmodule_stereo_hole_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L6b_halfmodule_stereo_hole_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L6b_halfmodule_stereo_hole_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L6b_halfmodule_stereo_slotBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L6b_halfmodule_stereo_slot_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L6b_halfmodule_stereo_slot_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L6b_halfmodule_stereo_slot_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L6t_halfmodule_axial_holeBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L6t_halfmodule_axial_hole_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L6t_halfmodule_axial_hole_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L6t_halfmodule_axial_hole_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L6t_halfmodule_axial_slotBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L6t_halfmodule_axial_slot_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L6t_halfmodule_axial_slot_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L6t_halfmodule_axial_slot_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L6t_halfmodule_stereo_holeBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L6t_halfmodule_stereo_hole_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L6t_halfmodule_stereo_hole_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L6t_halfmodule_stereo_hole_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L6t_halfmodule_stereo_slotBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L6t_halfmodule_stereo_slot_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L6t_halfmodule_stereo_slot_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L6t_halfmodule_stereo_slot_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L7b_halfmodule_axial_holeBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L7b_halfmodule_axial_hole_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L7b_halfmodule_axial_hole_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L7b_halfmodule_axial_hole_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L7b_halfmodule_axial_slotBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L7b_halfmodule_axial_slot_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L7b_halfmodule_axial_slot_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L7b_halfmodule_axial_slot_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L7b_halfmodule_stereo_holeBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L7b_halfmodule_stereo_hole_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L7b_halfmodule_stereo_hole_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L7b_halfmodule_stereo_hole_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L7b_halfmodule_stereo_slotBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L7b_halfmodule_stereo_slot_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L7b_halfmodule_stereo_slot_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L7b_halfmodule_stereo_slot_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L7t_halfmodule_axial_holeBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L7t_halfmodule_axial_hole_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L7t_halfmodule_axial_hole_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L7t_halfmodule_axial_hole_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L7t_halfmodule_axial_slotBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L7t_halfmodule_axial_slot_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L7t_halfmodule_axial_slot_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L7t_halfmodule_axial_slot_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L7t_halfmodule_stereo_holeBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L7t_halfmodule_stereo_hole_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L7t_halfmodule_stereo_hole_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L7t_halfmodule_stereo_hole_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L7t_halfmodule_stereo_slotBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L7t_halfmodule_stereo_slot_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L7t_halfmodule_stereo_slot_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L7t_halfmodule_stereo_slot_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="BeamLeftBox" x="211.6" y="382.492" z="0.001" />
+      <box name="BeamLeftVolume_component0Box" x="211.6" y="382.492" z="0.001" />
+      <box name="BeamLeftVolume_component0Sensor0Box" x="211.6" y="382.492" z="0.001" />
+      <box name="ElectronGapBox" x="196.26999999999998" y="92.46999999999997" z="0.001" />
+      <box name="ElectronGapVolume_component0Box" x="196.26999999999998" y="92.46999999999997" z="0.001" />
+      <box name="ElectronGapVolume_component0Sensor0Box" x="196.26999999999998" y="92.46999999999997" z="0.001" />
+      <box name="BeamRightBox" x="214.6" y="293.38800000000003" z="0.001" />
+      <box name="BeamRightVolume_component0Box" x="214.6" y="293.38800000000003" z="0.001" />
+      <box name="BeamRightVolume_component0Sensor0Box" x="214.6" y="293.38800000000003" z="0.001" />
+      <trd name="crystal_trap" x1="13.3" x2="16.0" y1="13.3" y2="16.0" z="160.0" />
+      <box name="hodo_pixel_L1TP0" x="15.7" y="59.9" z="9.5" />
+      <box name="hodo_cover_L1TP0" x="15.7" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L1TP0" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L1TP0" x="15.799999999999999" y="0.05" z="10.0" />
+      <box name="hodo_pixel_L1BP0" x="15.7" y="59.9" z="9.5" />
+      <box name="hodo_cover_L1BP0" x="15.7" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L1BP0" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L1BP0" x="15.799999999999999" y="0.05" z="10.0" />
+      <box name="hodo_pixel_L1TP1" x="34.1" y="59.9" z="9.5" />
+      <box name="hodo_cover_L1TP1" x="34.1" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L1TP1" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L1TP1" x="34.2" y="0.05" z="10.0" />
+      <box name="hodo_pixel_L1BP1" x="34.1" y="59.9" z="9.5" />
+      <box name="hodo_cover_L1BP1" x="34.1" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L1BP1" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L1BP1" x="34.2" y="0.05" z="10.0" />
+      <box name="hodo_pixel_L1TP2" x="44.0" y="59.9" z="9.5" />
+      <box name="hodo_cover_L1TP2" x="44.0" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L1TP2" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L1TP2" x="44.1" y="0.05" z="10.0" />
+      <box name="hodo_pixel_L1BP2" x="44.0" y="59.9" z="9.5" />
+      <box name="hodo_cover_L1BP2" x="44.0" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L1BP2" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L1BP2" x="44.1" y="0.05" z="10.0" />
+      <box name="hodo_pixel_L1TP3" x="44.0" y="59.9" z="9.5" />
+      <box name="hodo_cover_L1TP3" x="44.0" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L1TP3" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L1TP3" x="44.1" y="0.05" z="10.0" />
+      <box name="hodo_pixel_L1BP3" x="44.0" y="59.9" z="9.5" />
+      <box name="hodo_cover_L1BP3" x="44.0" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L1BP3" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L1BP3" x="44.1" y="0.05" z="10.0" />
+      <box name="hodo_pixel_L1TP4" x="44.0" y="59.9" z="9.5" />
+      <box name="hodo_cover_L1TP4" x="44.0" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L1TP4" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L1TP4" x="44.1" y="0.05" z="10.0" />
+      <box name="hodo_pixel_L1BP4" x="44.0" y="59.9" z="9.5" />
+      <box name="hodo_cover_L1BP4" x="44.0" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L1BP4" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L1BP4" x="44.1" y="0.05" z="10.0" />
+      <box name="hodo_pixel_L2TP0" x="19.0" y="59.9" z="9.5" />
+      <box name="hodo_cover_L2TP0" x="19.0" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L2TP0" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L2TP0" x="19.1" y="0.05" z="10.0" />
+      <box name="hodo_pixel_L2BP0" x="19.0" y="59.9" z="9.5" />
+      <box name="hodo_cover_L2BP0" x="19.0" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L2BP0" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L2BP0" x="19.1" y="0.05" z="10.0" />
+      <box name="hodo_pixel_L2TP1" x="44.0" y="59.9" z="9.5" />
+      <box name="hodo_cover_L2TP1" x="44.0" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L2TP1" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L2TP1" x="44.1" y="0.05" z="10.0" />
+      <box name="hodo_pixel_L2BP1" x="44.0" y="59.9" z="9.5" />
+      <box name="hodo_cover_L2BP1" x="44.0" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L2BP1" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L2BP1" x="44.1" y="0.05" z="10.0" />
+      <box name="hodo_pixel_L2TP2" x="44.0" y="59.9" z="9.5" />
+      <box name="hodo_cover_L2TP2" x="44.0" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L2TP2" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L2TP2" x="44.1" y="0.05" z="10.0" />
+      <box name="hodo_pixel_L2BP2" x="44.0" y="59.9" z="9.5" />
+      <box name="hodo_cover_L2BP2" x="44.0" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L2BP2" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L2BP2" x="44.1" y="0.05" z="10.0" />
+      <box name="hodo_pixel_L2TP3" x="44.0" y="59.9" z="9.5" />
+      <box name="hodo_cover_L2TP3" x="44.0" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L2TP3" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L2TP3" x="44.1" y="0.05" z="10.0" />
+      <box name="hodo_pixel_L2BP3" x="44.0" y="59.9" z="9.5" />
+      <box name="hodo_cover_L2BP3" x="44.0" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L2BP3" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L2BP3" x="44.1" y="0.05" z="10.0" />
+      <box name="hodo_pixel_L2TP4" x="30.8" y="59.9" z="9.5" />
+      <box name="hodo_cover_L2TP4" x="30.8" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L2TP4" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L2TP4" x="30.900000000000002" y="0.05" z="10.0" />
+      <box name="hodo_pixel_L2BP4" x="30.8" y="59.9" z="9.5" />
+      <box name="hodo_cover_L2BP4" x="30.8" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L2BP4" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L2BP4" x="30.900000000000002" y="0.05" z="10.0" />
+      <box name="hodo_buffer" x="187.64" y="80.0" z="2.0" />
+      <box name="world_volume_solid" x="2000" y="2000" z="2000" lunit="cm" />
+      <box name="front_flange_box_shape" x="76.835000000000008" y="45.719999999999999" z="2" lunit="cm" />
+      <trap name="front_chamber_trap_shape" z="3" theta="-0.98799999999999999" phi="0" x1="33.119799999999998" x2="33.119799999999998" x3="33.406400000000005" x4="33.406400000000005" y1="1.6000000000000001" y2="1.6000000000000001" alpha1="0" alpha2="0" aunit="deg" lunit="cm" />
+      <subtraction name="front_minus_chamber_shape">
+        <first ref="front_flange_box_shape" />
+        <second ref="front_chamber_trap_shape" />
+        <position name="front_minus_chamber_shapefront_chamber_trap_shapepos" x="-14.6309" y="0" z="0" unit="cm" />
+      </subtraction>
+      <eltube name="flange_photontube_inside_shape" dx="1.1000000000000001" dy="1.1000000000000001" dz="3" lunit="cm" />
+      <subtraction name="front_minus_photontube_shape">
+        <first ref="front_minus_chamber_shape" />
+        <second ref="flange_photontube_inside_shape" />
+        <position name="front_minus_photontube_shapeflange_photontube_inside_shapepos" x="2.0007000000000001" y="0" z="0" unit="cm" />
+        <rotation name="front_minus_photontube_shapeflange_photontube_inside_shaperot" x="0" y="1.7480000000000002" z="0" unit="deg" />
+      </subtraction>
+      <trap name="front_egap_trap_shape" z="3" theta="-4.7960000000000003" phi="0" x1="2.5683000000000002" x2="2.5683000000000002" x3="2.9716000000000005" x4="2.9716000000000005" y1="5.266" y2="5.266" alpha1="0" alpha2="0" aunit="deg" lunit="cm" />
+      <subtraction name="front_minus_egap_shape">
+        <first ref="front_minus_photontube_shape" />
+        <second ref="front_egap_trap_shape" />
+        <position name="front_minus_egap_shapefront_egap_trap_shapepos" x="-4.4683000000000002" y="0" z="0" unit="cm" />
+      </subtraction>
+      <eltube name="flange_egap_inside_tube_shape" dx="2.633" dy="2.633" dz="3" lunit="cm" />
+      <subtraction name="front_minus_egapleft_shape">
+        <first ref="front_minus_egap_shape" />
+        <second ref="flange_egap_inside_tube_shape" />
+        <position name="front_minus_egapleft_shapeflange_egap_inside_tube_shapepos" x="-3.0832999999999999" y="0" z="0" unit="cm" />
+        <rotation name="front_minus_egapleft_shapeflange_egap_inside_tube_shaperot" x="0" y="-0.95599999999999996" z="0" unit="deg" />
+      </subtraction>
+      <eltube name="flange_egap_inside_tube2_shape" dx="2.633" dy="2.633" dz="3" lunit="cm" />
+      <subtraction name="front_flange_shape">
+        <first ref="front_minus_egapleft_shape" />
+        <second ref="flange_egap_inside_tube2_shape" />
+        <position name="front_flange_shapeflange_egap_inside_tube2_shapepos" x="-5.8532000000000002" y="0" z="0" unit="cm" />
+        <rotation name="front_flange_shapeflange_egap_inside_tube2_shaperot" x="0" y="-8.5939999999999994" z="0" unit="deg" />
+      </subtraction>
+      <box name="back_flange_box_shape" x="50.5" y="16" z="2" lunit="cm" />
+      <trap name="back_chamber_trap_shape" z="3" theta="-0.98799999999999999" phi="0" x1="37.227899999999998" x2="37.227899999999998" x3="37.514499999999998" x4="37.514499999999998" y1="1.6000000000000001" y2="1.6000000000000001" alpha1="0" alpha2="0" aunit="deg" lunit="cm" />
+      <subtraction name="back_minus_chamber_shape">
+        <first ref="back_flange_box_shape" />
+        <second ref="back_chamber_trap_shape" />
+        <position name="back_minus_chamber_shapeback_chamber_trap_shapepos" x="-0.62210000000000043" y="0" z="0" unit="cm" />
+      </subtraction>
+      <eltube name="flange_photontube_inside2_shape" dx="1.1000000000000001" dy="1.1000000000000001" dz="3" lunit="cm" />
+      <subtraction name="back_minus_photontube_shape">
+        <first ref="back_minus_chamber_shape" />
+        <second ref="flange_photontube_inside2_shape" />
+        <position name="back_minus_photontube_shapeflange_photontube_inside2_shapepos" x="18.063500000000001" y="0" z="0" unit="cm" />
+        <rotation name="back_minus_photontube_shapeflange_photontube_inside2_shaperot" x="0" y="1.7480000000000002" z="0" unit="deg" />
+      </subtraction>
+      <trap name="back_egap_trap_shape" z="3" theta="-4.7960000000000003" phi="0" x1="8.3492999999999995" x2="8.3492999999999995" x3="8.7525999999999993" x4="8.7525999999999993" y1="5.266" y2="5.266" alpha1="0" alpha2="0" aunit="deg" lunit="cm" />
+      <subtraction name="back_minus_egap_shape">
+        <first ref="back_minus_photontube_shape" />
+        <second ref="back_egap_trap_shape" />
+        <position name="back_minus_egap_shapeback_egap_trap_shapepos" x="6.674199999999999" y="0" z="0" unit="cm" />
+      </subtraction>
+      <eltube name="flange_egap_inside_tube3_shape" dx="2.633" dy="2.633" dz="3" lunit="cm" />
+      <subtraction name="back_minus_egapleft_shape">
+        <first ref="back_minus_egap_shape" />
+        <second ref="flange_egap_inside_tube3_shape" />
+        <position name="back_minus_egapleft_shapeflange_egap_inside_tube3_shapepos" x="10.9497" y="0" z="0" unit="cm" />
+        <rotation name="back_minus_egapleft_shapeflange_egap_inside_tube3_shaperot" x="0" y="-0.95599999999999996" z="0" unit="deg" />
+      </subtraction>
+      <eltube name="flange_egap_inside_tube4_shape" dx="2.633" dy="2.633" dz="3" lunit="cm" />
+      <subtraction name="back_flange_shape">
+        <first ref="back_minus_egapleft_shape" />
+        <second ref="flange_egap_inside_tube4_shape" />
+        <position name="back_flange_shapeflange_egap_inside_tube4_shapepos" x="2.3986999999999994" y="0" z="0" unit="cm" />
+        <rotation name="back_flange_shapeflange_egap_inside_tube4_shaperot" x="0" y="-8.5939999999999994" z="0" unit="deg" />
+      </subtraction>
+      <trap name="chamber_trap_shape" z="45" theta="-1.8640000000000001" phi="0" x1="37.700000000000003" x2="37.700000000000003" x3="40.629000000000005" x4="40.629000000000005" y1="2.8000000000000003" y2="2.8000000000000003" alpha1="0" alpha2="0" aunit="deg" lunit="cm" />
+      <box name="chamber_cutaway_box_shape" x="50" y="1" z="30" lunit="cm" />
+      <subtraction name="chamber_trim1_shape">
+        <first ref="chamber_trap_shape" />
+        <second ref="chamber_cutaway_box_shape" />
+        <position name="chamber_trim1_shapechamber_cutaway_box_shapepos" x="0" y="1.6000000000000001" z="-9" unit="cm" />
+      </subtraction>
+      <box name="chamber_cutaway_box2_shape" x="50" y="1" z="30" lunit="cm" />
+      <subtraction name="chamber_trim2_shape">
+        <first ref="chamber_trim1_shape" />
+        <second ref="chamber_cutaway_box2_shape" />
+        <position name="chamber_trim2_shapechamber_cutaway_box2_shapepos" x="0" y="-1.6000000000000001" z="-9" unit="cm" />
+      </subtraction>
+      <eltube name="photontube_outside_shape" dx="1.3" dy="1.3" dz="23.5" lunit="cm" />
+      <union name="chamber_with_photontube_shape">
+        <first ref="chamber_trim2_shape" />
+        <second ref="photontube_outside_shape" />
+        <position name="chamber_with_photontube_shapephotontube_outside_shapepos" x="16.739699999999999" y="0" z="0" unit="cm" />
+        <rotation name="chamber_with_photontube_shapephotontube_outside_shaperot" x="0" y="1.7480000000000002" z="0" unit="deg" />
+      </union>
+      <trap name="egap_outside_trap_upper_shape" z="45" theta="-4.7960000000000003" phi="0" x1="10.691200000000002" x2="5.2344000000000008" x3="16.741099999999999" x4="11.284300000000002" y1="3.2330000000000001" y2="3.2330000000000001" alpha1="0.26900000000000002" alpha2="0.26900000000000002" aunit="deg" lunit="cm" />
+      <union name="chamber_with_egap_upper_shape">
+        <first ref="chamber_with_photontube_shape" />
+        <second ref="egap_outside_trap_upper_shape" />
+        <position name="chamber_with_egap_upper_shapeegap_outside_trap_upper_shapepos" x="7.7018000000000004" y="1.6165" z="0" unit="cm" />
+      </union>
+      <trap name="egap_outside_trap_lower_shape" z="45" theta="-4.7960000000000003" phi="0" x1="5.2344000000000008" x2="10.691200000000002" x3="11.284300000000002" x4="16.741099999999999" y1="3.2330000000000001" y2="3.2330000000000001" alpha1="-0.26900000000000002" alpha2="-0.26900000000000002" aunit="deg" lunit="cm" />
+      <union name="chamber_with_egap_lower_shape">
+        <first ref="chamber_with_egap_upper_shape" />
+        <second ref="egap_outside_trap_lower_shape" />
+        <position name="chamber_with_egap_lower_shapeegap_outside_trap_lower_shapepos" x="7.7018000000000004" y="-1.6165" z="0" unit="cm" />
+      </union>
+      <box name="chamber_cutaway_box3_shape" x="50" y="1" z="30" lunit="cm" />
+      <subtraction name="chamber_with_egap_trimtop_shape">
+        <first ref="chamber_with_egap_lower_shape" />
+        <second ref="chamber_cutaway_box3_shape" />
+        <position name="chamber_with_egap_trimtop_shapechamber_cutaway_box3_shapepos" x="0" y="3.4329999999999998" z="-9" unit="cm" />
+      </subtraction>
+      <box name="chamber_cutaway_box4_shape" x="50" y="1" z="30" lunit="cm" />
+      <subtraction name="chamber_with_egap_trimbot_shape">
+        <first ref="chamber_with_egap_trimtop_shape" />
+        <second ref="chamber_cutaway_box4_shape" />
+        <position name="chamber_with_egap_trimbot_shapechamber_cutaway_box4_shapepos" x="0" y="-3.4329999999999998" z="-9" unit="cm" />
+      </subtraction>
+      <box name="back_end_box_shape" x="76.835000000000008" y="45.719999999999999" z="5" lunit="cm" />
+      <subtraction name="chamber_outside_trim1_shape">
+        <first ref="chamber_with_egap_trimbot_shape" />
+        <second ref="back_end_box_shape" />
+        <position name="chamber_outside_trim1_shapeback_end_box_shapepos" x="0" y="0" z="-23" unit="cm" />
+      </subtraction>
+      <box name="back_end_box2_shape" x="76.835000000000008" y="45.719999999999999" z="5" lunit="cm" />
+      <subtraction name="chamber_outside_trim2_shape">
+        <first ref="chamber_outside_trim1_shape" />
+        <second ref="back_end_box2_shape" />
+        <position name="chamber_outside_trim2_shapeback_end_box2_shapepos" x="0" y="0" z="23" unit="cm" />
+      </subtraction>
+      <eltube name="photontube_inside_shape" dx="1.1000000000000001" dy="1.1000000000000001" dz="23.5" lunit="cm" />
+      <subtraction name="chamber_minus_photontube_shape">
+        <first ref="chamber_outside_trim2_shape" />
+        <second ref="photontube_inside_shape" />
+        <position name="chamber_minus_photontube_shapephotontube_inside_shapepos" x="16.739699999999999" y="0" z="0" unit="cm" />
+        <rotation name="chamber_minus_photontube_shapephotontube_inside_shaperot" x="0" y="1.7480000000000002" z="0" unit="deg" />
+      </subtraction>
+      <trap name="chamber_inside_trap_shape" z="45.000100000000003" theta="-0.98799999999999999" phi="0" x1="33.1676" x2="33.1676" x3="37.466699999999996" x4="37.466699999999996" y1="1.6000000000000001" y2="1.6000000000000001" alpha1="0" alpha2="0" aunit="deg" lunit="cm" />
+      <subtraction name="chamber_minus_inside_shape">
+        <first ref="chamber_minus_photontube_shape" />
+        <second ref="chamber_inside_trap_shape" />
+        <position name="chamber_minus_inside_shapechamber_inside_trap_shapepos" x="-0.91889999999999938" y="0" z="0" unit="cm" />
+      </subtraction>
+      <trap name="egap_inside_trap_shape" z="45.000100000000003" theta="-4.7960000000000003" phi="0" x1="2.6355000000000004" x2="2.6355000000000004" x3="8.6853999999999996" x4="8.6853999999999996" y1="5.266" y2="5.266" alpha1="0" alpha2="0" aunit="deg" lunit="cm" />
+      <subtraction name="chamber_minus_egapinside_shape">
+        <first ref="chamber_minus_inside_shape" />
+        <second ref="egap_inside_trap_shape" />
+        <position name="chamber_minus_egapinside_shapeegap_inside_trap_shapepos" x="7.8105000000000011" y="0" z="0" unit="cm" />
+      </subtraction>
+      <eltube name="egap_inside_tube_shape" dx="2.633" dy="2.633" dz="24" lunit="cm" />
+      <subtraction name="chamber_minus_egap_left_shape">
+        <first ref="chamber_minus_egapinside_shape" />
+        <second ref="egap_inside_tube_shape" />
+        <position name="chamber_minus_egap_left_shapeegap_inside_tube_shapepos" x="10.640750000000001" y="0" z="0" unit="cm" />
+        <rotation name="chamber_minus_egap_left_shapeegap_inside_tube_shaperot" x="0" y="-0.95599999999999996" z="0" unit="deg" />
+      </subtraction>
+      <tube name="egap_inside_tube2_shape" rmin="0" rmax="2.633" z="48" startphi="0" deltaphi="360" aunit="deg" lunit="cm" />
+      <subtraction name="ECAL_chamber_shape">
+        <first ref="chamber_minus_egap_left_shape" />
+        <second ref="egap_inside_tube2_shape" />
+        <position name="ECAL_chamber_shapeegap_inside_tube2_shapepos" x="4.9802999999999997" y="0" z="0" unit="cm" />
+        <rotation name="ECAL_chamber_shapeegap_inside_tube2_shaperot" x="0" y="-8.5939999999999994" z="0" unit="deg" />
+      </subtraction>
+      <box name="al_honeycomb_shape" x="6" y="1.6000000000000001" z="6" lunit="cm" />
+      <box name="ecal_box_outer1_shape" x="80" y="1.3999999999999999" z="20.100000000000001" lunit="cm" />
+      <box name="ecal_box_inner1_shape" x="78" y="2" z="21" lunit="cm" />
+      <subtraction name="ecal_box_minus_inner1_shape">
+        <first ref="ecal_box_outer1_shape" />
+        <second ref="ecal_box_inner1_shape" />
+        <position name="ecal_box_minus_inner1_shapeecal_box_inner1_shapepos" x="0" y="0.16" z="1.8500000000000001" unit="cm" />
+      </subtraction>
+      <box name="ecal_box_inner2_shape" x="68" y="1.2" z="7.4199999999999999" lunit="cm" />
+      <subtraction name="ecal_box_minus_inner2_shape">
+        <first ref="ecal_box_minus_inner1_shape" />
+        <second ref="ecal_box_inner2_shape" />
+        <position name="ecal_box_minus_inner2_shapeecal_box_inner2_shapepos" x="0" y="0.16" z="-10.050000000000001" unit="cm" />
+      </subtraction>
+      <para name="ppd_0_shape" x="0.59999999999999998" y="1.3999999999999999" z="1.5" alpha="0" theta="0" phi="0" aunit="deg" lunit="cm" />
+      <union name="box_with_ppd_shape">
+        <first ref="ecal_box_minus_inner2_shape" />
+        <second ref="ppd_0_shape" />
+        <position name="box_with_ppd_shapeppd_0_shapepos" x="0" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <para name="ppd_1_shape" x="0.59999999999999998" y="1.3999999999999999" z="1.5" alpha="0" theta="-3.8700000000000001" phi="0" aunit="deg" lunit="cm" />
+      <union name="box_with_ppd1_shape">
+        <first ref="box_with_ppd_shape" />
+        <second ref="ppd_1_shape" />
+        <position name="box_with_ppd1_shapeppd_1_shapepos" x="-5.2400000000000002" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <para name="ppd_2_shape" x="0.59999999999999998" y="1.3999999999999999" z="1.5" alpha="0" theta="-7.7400000000000002" phi="0" aunit="deg" lunit="cm" />
+      <union name="box_with_ppd2_shape">
+        <first ref="box_with_ppd1_shape" />
+        <second ref="ppd_2_shape" />
+        <position name="box_with_ppd2_shapeppd_2_shapepos" x="-10.5" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <para name="ppd_3_shape" x="0.59999999999999998" y="1.3999999999999999" z="1.5" alpha="0" theta="-11.619999999999999" phi="0" aunit="deg" lunit="cm" />
+      <union name="box_with_ppd3_shape">
+        <first ref="box_with_ppd2_shape" />
+        <second ref="ppd_3_shape" />
+        <position name="box_with_ppd3_shapeppd_3_shapepos" x="-15.800000000000001" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <para name="ppd_4_shape" x="0.59999999999999998" y="1.3999999999999999" z="1.5" alpha="0" theta="-15.49" phi="0" aunit="deg" lunit="cm" />
+      <union name="box_with_ppd4_shape">
+        <first ref="box_with_ppd3_shape" />
+        <second ref="ppd_4_shape" />
+        <position name="box_with_ppd4_shapeppd_4_shapepos" x="-21.170000000000002" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <para name="ppd_5_shape" x="0.59999999999999998" y="1.3999999999999999" z="1.5" alpha="0" theta="-19.359999999999999" phi="0" aunit="deg" lunit="cm" />
+      <union name="box_with_ppd5_shape">
+        <first ref="box_with_ppd4_shape" />
+        <second ref="ppd_5_shape" />
+        <position name="box_with_ppd5_shapeppd_5_shapepos" x="-26.640000000000001" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <para name="ppd_6_shape" x="0.59999999999999998" y="1.3999999999999999" z="1.5" alpha="0" theta="3.8700000000000001" phi="0" aunit="deg" lunit="cm" />
+      <union name="box_with_ppd6_shape">
+        <first ref="box_with_ppd5_shape" />
+        <second ref="ppd_6_shape" />
+        <position name="box_with_ppd6_shapeppd_6_shapepos" x="5.2400000000000002" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <para name="ppd_7_shape" x="0.59999999999999998" y="1.3999999999999999" z="1.5" alpha="0" theta="7.7400000000000002" phi="0" aunit="deg" lunit="cm" />
+      <union name="box_with_ppd7_shape">
+        <first ref="box_with_ppd6_shape" />
+        <second ref="ppd_7_shape" />
+        <position name="box_with_ppd7_shapeppd_7_shapepos" x="10.5" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <para name="ppd_8_shape" x="0.59999999999999998" y="1.3999999999999999" z="1.5" alpha="0" theta="11.619999999999999" phi="0" aunit="deg" lunit="cm" />
+      <union name="box_with_ppd8_shape">
+        <first ref="box_with_ppd7_shape" />
+        <second ref="ppd_8_shape" />
+        <position name="box_with_ppd8_shapeppd_8_shapepos" x="15.800000000000001" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <para name="ppd_9_shape" x="0.59999999999999998" y="1.3999999999999999" z="1.5" alpha="0" theta="15.49" phi="0" aunit="deg" lunit="cm" />
+      <union name="box_with_ppd9_shape">
+        <first ref="box_with_ppd8_shape" />
+        <second ref="ppd_9_shape" />
+        <position name="box_with_ppd9_shapeppd_9_shapepos" x="21.170000000000002" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <para name="ppd_10_shape" x="0.59999999999999998" y="1.3999999999999999" z="1.5" alpha="0" theta="19.359999999999999" phi="0" aunit="deg" lunit="cm" />
+      <union name="layer_1_top_shape">
+        <first ref="box_with_ppd9_shape" />
+        <second ref="ppd_10_shape" />
+        <position name="layer_1_top_shapeppd_10_shapepos" x="26.640000000000001" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <union name="layer_2_top_shape">
+        <first ref="box_with_ppd9_shape" />
+        <second ref="ppd_10_shape" />
+        <position name="layer_2_top_shapeppd_10_shapepos" x="26.640000000000001" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <union name="layer_3_top_shape">
+        <first ref="box_with_ppd9_shape" />
+        <second ref="ppd_10_shape" />
+        <position name="layer_3_top_shapeppd_10_shapepos" x="26.640000000000001" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <union name="layer_4_top_shape">
+        <first ref="box_with_ppd9_shape" />
+        <second ref="ppd_10_shape" />
+        <position name="layer_4_top_shapeppd_10_shapepos" x="26.640000000000001" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <union name="layer_1_bottom_shape">
+        <first ref="box_with_ppd9_shape" />
+        <second ref="ppd_10_shape" />
+        <position name="layer_1_bottom_shapeppd_10_shapepos" x="26.640000000000001" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <union name="layer_2_bottom_shape">
+        <first ref="box_with_ppd9_shape" />
+        <second ref="ppd_10_shape" />
+        <position name="layer_2_bottom_shapeppd_10_shapepos" x="26.640000000000001" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <union name="layer_3_bottom_shape">
+        <first ref="box_with_ppd9_shape" />
+        <second ref="ppd_10_shape" />
+        <position name="layer_3_bottom_shapeppd_10_shapepos" x="26.640000000000001" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <union name="layer_4_bottom_shape">
+        <first ref="box_with_ppd9_shape" />
+        <second ref="ppd_10_shape" />
+        <position name="layer_4_bottom_shapeppd_10_shapepos" x="26.640000000000001" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <para name="ppd_left2_shape" x="0.40000000000000002" y="1.3999999999999999" z="20.100000000000001" alpha="0" theta="0.96999999999999997" phi="0" aunit="deg" lunit="cm" />
+      <union name="layer_5a1_1_shape">
+        <first ref="ecal_box_minus_inner2_shape" />
+        <second ref="ppd_left2_shape" />
+        <position name="layer_5a1_1_shapeppd_left2_shapepos" x="-1.903" y="0" z="0" unit="cm" />
+      </union>
+      <para name="ppd_left1_shape" x="0.502" y="1.3999999999999999" z="1.5" alpha="0" theta="0.96999999999999997" phi="0" aunit="deg" lunit="cm" />
+      <union name="layer_5a1_shape">
+        <first ref="layer_5a1_1_shape" />
+        <second ref="ppd_left1_shape" />
+        <position name="layer_5a1_shapeppd_left1_shapepos" x="-1.6499999999999999" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <trd name="electron_hole_left_shape" x1="38.177" x2="38.856999999999999" y1="4" y2="4" z="20.199999999999999" lunit="cm" />
+      <subtraction name="layer_5a2_shape">
+        <first ref="layer_5a1_shape" />
+        <second ref="electron_hole_left_shape" />
+        <position name="layer_5a2_shapeelectron_hole_left_shapepos" x="-21.361499999999999" y="0" z="0" unit="cm" />
+      </subtraction>
+      <union name="layer_5a3_shape">
+        <first ref="layer_5a2_shape" />
+        <second ref="ppd_6_shape" />
+        <position name="layer_5a3_shapeppd_6_shapepos" x="5.2400000000000002" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <union name="layer_5a4_shape">
+        <first ref="layer_5a3_shape" />
+        <second ref="ppd_7_shape" />
+        <position name="layer_5a4_shapeppd_7_shapepos" x="10.5" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <union name="layer_5a5_shape">
+        <first ref="layer_5a4_shape" />
+        <second ref="ppd_8_shape" />
+        <position name="layer_5a5_shapeppd_8_shapepos" x="15.800000000000001" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <union name="layer_5a6_shape">
+        <first ref="layer_5a5_shape" />
+        <second ref="ppd_9_shape" />
+        <position name="layer_5a6_shapeppd_9_shapepos" x="21.170000000000002" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <union name="layer_5a7_shape">
+        <first ref="layer_5a6_shape" />
+        <second ref="ppd_10_shape" />
+        <position name="layer_5a7_shapeppd_10_shapepos" x="26.640000000000001" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <union name="layer_5T_left_shape">
+        <first ref="layer_5a7_shape" />
+        <second ref="ppd_0_shape" />
+        <position name="layer_5T_left_shapeppd_0_shapepos" x="0" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <union name="layer_5B_left_shape">
+        <first ref="layer_5a7_shape" />
+        <second ref="ppd_0_shape" />
+        <position name="layer_5B_left_shapeppd_0_shapepos" x="0" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <box name="steel_bar_shape" x="3" y="1.5" z="20" lunit="cm" />
+      <tube name="cu_Tpipe_inner_left_shape" rmin="0.29999999999999999" rmax="0.40000000000000002" z="20.100000000000001" startphi="0" deltaphi="360" aunit="deg" lunit="cm" />
+      <tube name="cu_Tpipe_inner_right_shape" rmin="0.29999999999999999" rmax="0.40000000000000002" z="20.100000000000001" startphi="0" deltaphi="360" aunit="deg" lunit="cm" />
+      <tube name="cu_Bpipe_inner_left_shape" rmin="0.29999999999999999" rmax="0.40000000000000002" z="20.100000000000001" startphi="0" deltaphi="360" aunit="deg" lunit="cm" />
+      <tube name="cu_Bpipe_inner_right_shape" rmin="0.29999999999999999" rmax="0.40000000000000002" z="20.100000000000001" startphi="0" deltaphi="360" aunit="deg" lunit="cm" />
+      <eltube name="cu_Tpipe_outer_right1_shape" dx="0.5" dy="0.10000000000000001" dz="10" lunit="cm" />
+      <eltube name="cu_Tpipe_outer_right2_shape" dx="0.5" dy="0.10000000000000001" dz="10" lunit="cm" />
+      <tube name="cu_Tpipe_outer_right3_shape" rmin="0.29999999999999999" rmax="0.40000000000000002" z="8" startphi="0" deltaphi="360" aunit="deg" lunit="cm" />
+      <tube name="cu_Bpipe_outer_right_shape" rmin="0.29999999999999999" rmax="0.40000000000000002" z="8" startphi="0" deltaphi="360" aunit="deg" lunit="cm" />
+      <eltube name="cu_Bpipe_outer_right1_shape" dx="0.5" dy="0.10000000000000001" dz="10" lunit="cm" />
+      <eltube name="cu_Bpipe_outer_right2_shape" dx="0.5" dy="0.10000000000000001" dz="10" lunit="cm" />
+      <tube name="al_pipe_across_top1_shape" rmin="0.29999999999999999" rmax="0.40000000000000002" z="66" startphi="0" deltaphi="360" aunit="deg" lunit="cm" />
+      <tube name="al_pipe_across_top2_shape" rmin="0.29999999999999999" rmax="0.40000000000000002" z="74" startphi="0" deltaphi="360" aunit="deg" lunit="cm" />
+      <tube name="al_pipe_across_bottom1_shape" rmin="0.29999999999999999" rmax="0.40000000000000002" z="70" startphi="0" deltaphi="360" aunit="deg" lunit="cm" />
+      <tube name="al_pipe_across_bottom2_shape" rmin="0.29999999999999999" rmax="0.40000000000000002" z="78" startphi="0" deltaphi="360" aunit="deg" lunit="cm" />
+      <para name="cu_plate_top_left_shape" x="40" y="0.10000000000000001" z="20" alpha="0" theta="0.96999999999999997" phi="0" aunit="deg" lunit="cm" />
+      <para name="cu_plate_bottom_left_shape" x="40" y="0.10000000000000001" z="20" alpha="0" theta="0.96999999999999997" phi="0" aunit="deg" lunit="cm" />
+      <para name="cu_plate_top_right_shape" x="22" y="0.10000000000000001" z="20" alpha="0" theta="9.6799999999999997" phi="180" aunit="deg" lunit="cm" />
+      <para name="cu_plate_bottom_right_shape" x="22" y="0.10000000000000001" z="20" alpha="0" theta="-9.6799999999999997" phi="0" aunit="deg" lunit="cm" />
+      <trd name="cu_plate_top_middle_shape" x1="7" x2="9.8000000000000007" y1="0.10000000000000001" y2="0.10000000000000001" z="20" lunit="cm" />
+      <trd name="cu_plate_bottom_middle_shape" x1="7" x2="9.8000000000000007" y1="0.10000000000000001" y2="0.10000000000000001" z="20" lunit="cm" />
+      <box name="tracking_volume_solid" x="2000" y="2000" z="2000" lunit="cm" />
+      <box name="hodo_flange_outer_shape" x="76.835000000000008" y="45.719999999999999" z="5" lunit="cm" />
+      <box name="hodo_flange_inner_shape" x="65.035000000000011" y="33.480000000000004" z="5.0010000000000003" lunit="cm" />
+      <subtraction name="hodo_flange_only_shape">
+        <first ref="hodo_flange_outer_shape" />
+        <second ref="hodo_flange_inner_shape" />
+      </subtraction>
+      <box name="Flange_extrusion_1_shape" x="2.5" y="3.5" z="1.5" lunit="cm" />
+      <union name="hodo_flange_ex1_shape">
+        <first ref="hodo_flange_only_shape" />
+        <second ref="Flange_extrusion_1_shape" />
+        <position name="hodo_flange_ex1_shapeFlange_extrusion_1_shapepos" x="19.400000000000002" y="14.990000000000002" z="-0.10000000000000001" unit="cm" />
+      </union>
+      <box name="Flange_extrusion_2_shape" x="2.5" y="3.5" z="1.5" lunit="cm" />
+      <union name="hodo_flange_ex2_shape">
+        <first ref="hodo_flange_ex1_shape" />
+        <second ref="Flange_extrusion_2_shape" />
+        <position name="hodo_flange_ex2_shapeFlange_extrusion_2_shapepos" x="19.400000000000002" y="-14.990000000000002" z="-0.10000000000000001" unit="cm" />
+      </union>
+      <box name="Flange_extrusion_3_shape" x="2.5" y="3.5" z="1.5" lunit="cm" />
+      <union name="hodo_flange_ex3_shape">
+        <first ref="hodo_flange_ex2_shape" />
+        <second ref="Flange_extrusion_3_shape" />
+        <position name="hodo_flange_ex3_shapeFlange_extrusion_3_shapepos" x="7.4000000000000004" y="14.990000000000002" z="-0.10000000000000001" unit="cm" />
+      </union>
+      <box name="Flange_extrusion_4_shape" x="2.5" y="3.5" z="1.5" lunit="cm" />
+      <union name="hodo_flange_shape">
+        <first ref="hodo_flange_ex3_shape" />
+        <second ref="Flange_extrusion_4_shape" />
+        <position name="hodo_flange_shapeFlange_extrusion_4_shapepos" x="7.4000000000000004" y="-14.990000000000002" z="-0.10000000000000001" unit="cm" />
+      </union>
+      <trap name="arms1_block1_shape" z="1.5" theta="3.9490533936242498" phi="90" x1="2.5" x2="2.5" x3="2.5" x4="2.5" y1="3.7071000000000001" y2="3.5" alpha1="0" alpha2="0" aunit="deg" lunit="cm" />
+      <trap name="arms1_block2_shape" z="1.5" theta="3.9490533936242498" phi="90" x1="2.5" x2="2.5" x3="2.5" x4="2.5" y1="3.7071000000000001" y2="3.5" alpha1="0" alpha2="0" aunit="deg" lunit="cm" />
+      <trap name="arms1_block3_shape" z="1.5" theta="-3.9490533936242498" phi="90" x1="2.5" x2="2.5" x3="2.5" x4="2.5" y1="3.7071000000000001" y2="3.5" alpha1="0" alpha2="0" aunit="deg" lunit="cm" />
+      <trap name="arms1_block4_shape" z="1.5" theta="-3.9490533936242498" phi="90" x1="2.5" x2="2.5" x3="2.5" x4="2.5" y1="3.7071000000000001" y2="3.5" alpha1="0" alpha2="0" aunit="deg" lunit="cm" />
+      <box name="cross_bar_top_shape" x="9.5" y="0.80000000000000004" z="1.5" lunit="cm" />
+      <box name="cross_bar_bottom_shape" x="9.5" y="0.80000000000000004" z="1.5" lunit="cm" />
+      <trap name="support_arm_bottom_left_arm_shape" z="21.700000000000003" theta="-9.8039344658558196" phi="90" x1="0.60000000000000009" x2="0.60000000000000009" x3="0.60000000000000009" x4="0.60000000000000009" y1="2.2938300486668619" y2="3.2271000000000001" alpha1="0" alpha2="0" aunit="deg" lunit="cm" />
+      <box name="support_arm_bottom_left_notch_shape" x="2" y="1.7800000000000002" z="1.401" lunit="cm" />
+      <box name="end_block_bottom_left_block_shape" x="2" y="0.78000000000000003" z="1.4000000000000001" lunit="cm" />
+      <box name="end_block_bottom_left_subs_shape" x="2.0010000000000003" y="1" z="1.401" lunit="cm" />
+      <subtraction name="support_arm_bottom_left_with_notch_shape">
+        <first ref="support_arm_bottom_left_arm_shape" />
+        <second ref="support_arm_bottom_left_notch_shape" />
+        <position name="support_arm_bottom_left_with_notch_shapesupport_arm_bottom_left_notch_shapepos" x="0" y="2.9215622772585932" z="-10.151000000000002" unit="cm" />
+      </subtraction>
+      <subtraction name="end_block_bottom_left_shape">
+        <first ref="end_block_bottom_left_block_shape" />
+        <second ref="end_block_bottom_left_subs_shape" />
+        <position name="end_block_bottom_left_shapeend_block_bottom_left_subs_shapepos" x="0" y="0.60999999999999999" z="-0.30099999999999999" unit="cm" />
+      </subtraction>
+      <union name="support_arm_bottom_left_plus_block_shape">
+        <first ref="support_arm_bottom_left_with_notch_shape" />
+        <second ref="end_block_bottom_left_shape" />
+        <position name="support_arm_bottom_left_plus_block_shapeend_block_bottom_left_shapepos" x="0" y="2.4215622772585932" z="-10.15" unit="cm" />
+      </union>
+      <union name="support_arm_bottom_right_shape">
+        <first ref="support_arm_bottom_left_with_notch_shape" />
+        <second ref="end_block_bottom_left_shape" />
+        <position name="support_arm_bottom_right_shapeend_block_bottom_left_shapepos" x="0" y="2.4215622772585932" z="-10.15" unit="cm" />
+      </union>
+      <union name="support_arm_top_left_shape">
+        <first ref="support_arm_bottom_left_with_notch_shape" />
+        <second ref="end_block_bottom_left_shape" />
+        <position name="support_arm_top_left_shapeend_block_bottom_left_shapepos" x="0" y="2.4215622772585932" z="-10.15" unit="cm" />
+      </union>
+      <union name="support_arm_top_right_shape">
+        <first ref="support_arm_bottom_left_with_notch_shape" />
+        <second ref="end_block_bottom_left_shape" />
+        <position name="support_arm_top_right_shapeend_block_bottom_left_shapepos" x="0" y="2.4215622772585932" z="-10.15" unit="cm" />
+      </union>
+      <box name="u_support_bar_bottom_shape" x="16" y="0.80000000000000004" z="0.90000000000000002" lunit="cm" />
+      <box name="u_support_bar_upper1_shape" x="16" y="1.8" z="0.40000000000000002" lunit="cm" />
+      <box name="u_support_bar_upper2_shape" x="16" y="1.8" z="0.30000000000000004" lunit="cm" />
+      <box name="u_support_bar_top_shape" x="16" y="0.80000000000000004" z="0.90000000000000002" lunit="cm" />
+      <box name="u_support_bar_upper3_shape" x="16" y="1.8" z="0.40000000000000002" lunit="cm" />
+      <box name="u_support_bar_upper4_shape" x="16" y="1.8" z="0.30000000000000004" lunit="cm" />
+      <box lunit="mm" name="svt_chamber_outer_box" x="454.152" y="203.2" z="1219.2" />
+      <box lunit="mm" name="svt_chamber_inner_box" x="416.052" y="177.8" z="1221.2" />
+      <subtraction name="svt_chamber_box">
+        <first ref="svt_chamber_outer_box" />
+        <second ref="svt_chamber_inner_box" />
+      </subtraction>
+      <trd lunit="mm" name="svt_chamber_outer_flare1" x1="454.152" x2="454.152" y1="203.2" y2="254.832" z="132.842" />
+      <trd lunit="mm" name="svt_chamber_inner_flare1" x1="416.052" x2="416.052" y1="172.864" y2="234.368" z="158.242" />
+      <subtraction name="svt_chamber_flare1">
+        <first ref="svt_chamber_outer_flare1" />
+        <second ref="svt_chamber_inner_flare1" />
+      </subtraction>
+      <trd lunit="mm" name="svt_chamber_outer_flare2" x1="454.152" x2="679.704" y1="254.832" y2="353.06" z="252.73" />
+      <trd lunit="mm" name="svt_chamber_inner_flare2" x1="404.718" x2="652.938" y1="224.496" y2="332.596" z="278.13" />
+      <subtraction name="svt_chamber_flare2">
+        <first ref="svt_chamber_outer_flare2" />
+        <second ref="svt_chamber_inner_flare2" />
+      </subtraction>
+      <box lunit="mm" name="svt_chamber_outer_flange" x="768.35" y="457.2" z="19.05" />
+      <box lunit="mm" name="svt_chamber_inner_flange" x="654.05" y="342.9" z="25.4" />
+      <subtraction name="svt_chamber_flange">
+        <first ref="svt_chamber_outer_flange" />
+        <second ref="svt_chamber_inner_flange" />
+      </subtraction>
+      <box lunit="mm" name="WorldBox" x="80000" y="80000" z="80000" />
+    </solids>
+    <structure>
+      <volume name="base_plate_volume">
+        <materialref ref="Aluminum" />
+        <solidref ref="base_plateBox" />
+        <visref ref="BasePlateVis" />
+      </volume>
+      <volume name="support_plate_bottom_L14_volume">
+        <materialref ref="Aluminum" />
+        <solidref ref="support_plate_bottom_L14Box" />
+        <visref ref="SupportPlateVis" />
+      </volume>
+      <volume name="support_plate_top_L14_volume">
+        <materialref ref="Aluminum" />
+        <solidref ref="support_plate_top_L14Box" />
+        <visref ref="SupportPlateVis" />
+      </volume>
+      <volume name="support_plate_bottom_L46_volume">
+        <materialref ref="Aluminum" />
+        <solidref ref="support_plate_bottom_L46Box" />
+        <visref ref="SupportPlateVis" />
+      </volume>
+      <volume name="support_plate_top_L46_volume">
+        <materialref ref="Aluminum" />
+        <solidref ref="support_plate_top_L46Box" />
+        <visref ref="SupportPlateVis" />
+      </volume>
+      <volume name="module_L1b_halfmodule_axial_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L1b_halfmodule_axial_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L1b_halfmodule_axial_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L1b_halfmodule_axial_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L1b_halfmodule_axial_sensor_active_volume" />
+          <positionref ref="module_L1b_halfmodule_axial_sensor_active_position" />
+          <rotationref ref="module_L1b_halfmodule_axial_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L1b_halfmodule_axial_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L1b_halfmodule_axialBox" />
+        <physvol>
+          <volumeref ref="module_L1b_halfmodule_axial_sensor_volume" />
+          <positionref ref="module_L1b_halfmodule_axial_sensor_position" />
+          <rotationref ref="module_L1b_halfmodule_axial_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <visref ref="HalfModuleVis" />
+      </volume>
+      <volume name="module_L1b_halfmodule_stereo_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L1b_halfmodule_stereo_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L1b_halfmodule_stereo_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L1b_halfmodule_stereo_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L1b_halfmodule_stereo_sensor_active_volume" />
+          <positionref ref="module_L1b_halfmodule_stereo_sensor_active_position" />
+          <rotationref ref="module_L1b_halfmodule_stereo_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L1b_halfmodule_stereo_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L1b_halfmodule_stereoBox" />
+        <physvol>
+          <volumeref ref="module_L1b_halfmodule_stereo_sensor_volume" />
+          <positionref ref="module_L1b_halfmodule_stereo_sensor_position" />
+          <rotationref ref="module_L1b_halfmodule_stereo_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <visref ref="HalfModuleVis" />
+      </volume>
+      <volume name="module_L1t_halfmodule_axial_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L1t_halfmodule_axial_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L1t_halfmodule_axial_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L1t_halfmodule_axial_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L1t_halfmodule_axial_sensor_active_volume" />
+          <positionref ref="module_L1t_halfmodule_axial_sensor_active_position" />
+          <rotationref ref="module_L1t_halfmodule_axial_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L1t_halfmodule_axial_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L1t_halfmodule_axialBox" />
+        <physvol>
+          <volumeref ref="module_L1t_halfmodule_axial_sensor_volume" />
+          <positionref ref="module_L1t_halfmodule_axial_sensor_position" />
+          <rotationref ref="module_L1t_halfmodule_axial_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <visref ref="HalfModuleVis" />
+      </volume>
+      <volume name="module_L1t_halfmodule_stereo_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L1t_halfmodule_stereo_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L1t_halfmodule_stereo_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L1t_halfmodule_stereo_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L1t_halfmodule_stereo_sensor_active_volume" />
+          <positionref ref="module_L1t_halfmodule_stereo_sensor_active_position" />
+          <rotationref ref="module_L1t_halfmodule_stereo_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L1t_halfmodule_stereo_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L1t_halfmodule_stereoBox" />
+        <physvol>
+          <volumeref ref="module_L1t_halfmodule_stereo_sensor_volume" />
+          <positionref ref="module_L1t_halfmodule_stereo_sensor_position" />
+          <rotationref ref="module_L1t_halfmodule_stereo_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <visref ref="HalfModuleVis" />
+      </volume>
+      <volume name="module_L2b_halfmodule_axial_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L2b_halfmodule_axial_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L2b_halfmodule_axial_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L2b_halfmodule_axial_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L2b_halfmodule_axial_sensor_active_volume" />
+          <positionref ref="module_L2b_halfmodule_axial_sensor_active_position" />
+          <rotationref ref="module_L2b_halfmodule_axial_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L2b_halfmodule_axial_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L2b_halfmodule_axialBox" />
+        <physvol>
+          <volumeref ref="module_L2b_halfmodule_axial_sensor_volume" />
+          <positionref ref="module_L2b_halfmodule_axial_sensor_position" />
+          <rotationref ref="module_L2b_halfmodule_axial_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <visref ref="HalfModuleVis" />
+      </volume>
+      <volume name="module_L2b_halfmodule_stereo_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L2b_halfmodule_stereo_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L2b_halfmodule_stereo_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L2b_halfmodule_stereo_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L2b_halfmodule_stereo_sensor_active_volume" />
+          <positionref ref="module_L2b_halfmodule_stereo_sensor_active_position" />
+          <rotationref ref="module_L2b_halfmodule_stereo_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L2b_halfmodule_stereo_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L2b_halfmodule_stereoBox" />
+        <physvol>
+          <volumeref ref="module_L2b_halfmodule_stereo_sensor_volume" />
+          <positionref ref="module_L2b_halfmodule_stereo_sensor_position" />
+          <rotationref ref="module_L2b_halfmodule_stereo_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <visref ref="HalfModuleVis" />
+      </volume>
+      <volume name="module_L2t_halfmodule_axial_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L2t_halfmodule_axial_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L2t_halfmodule_axial_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L2t_halfmodule_axial_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L2t_halfmodule_axial_sensor_active_volume" />
+          <positionref ref="module_L2t_halfmodule_axial_sensor_active_position" />
+          <rotationref ref="module_L2t_halfmodule_axial_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L2t_halfmodule_axial_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L2t_halfmodule_axialBox" />
+        <physvol>
+          <volumeref ref="module_L2t_halfmodule_axial_sensor_volume" />
+          <positionref ref="module_L2t_halfmodule_axial_sensor_position" />
+          <rotationref ref="module_L2t_halfmodule_axial_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <visref ref="HalfModuleVis" />
+      </volume>
+      <volume name="module_L2t_halfmodule_stereo_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L2t_halfmodule_stereo_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L2t_halfmodule_stereo_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L2t_halfmodule_stereo_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L2t_halfmodule_stereo_sensor_active_volume" />
+          <positionref ref="module_L2t_halfmodule_stereo_sensor_active_position" />
+          <rotationref ref="module_L2t_halfmodule_stereo_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L2t_halfmodule_stereo_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L2t_halfmodule_stereoBox" />
+        <physvol>
+          <volumeref ref="module_L2t_halfmodule_stereo_sensor_volume" />
+          <positionref ref="module_L2t_halfmodule_stereo_sensor_position" />
+          <rotationref ref="module_L2t_halfmodule_stereo_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <visref ref="HalfModuleVis" />
+      </volume>
+      <volume name="module_L3b_halfmodule_axial_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L3b_halfmodule_axial_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L3b_halfmodule_axial_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L3b_halfmodule_axial_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L3b_halfmodule_axial_sensor_active_volume" />
+          <positionref ref="module_L3b_halfmodule_axial_sensor_active_position" />
+          <rotationref ref="module_L3b_halfmodule_axial_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L3b_halfmodule_axial_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L3b_halfmodule_axial_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L3b_halfmodule_axial_cf_volume">
+        <materialref ref="CarbonFiber" />
+        <solidref ref="module_L3b_halfmodule_axial_cfBox" />
+        <visref ref="CarbonFiberVis" />
+      </volume>
+      <volume name="module_L3b_halfmodule_axial_hybrid_volume">
+        <materialref ref="G10" />
+        <solidref ref="module_L3b_halfmodule_axial_hybridBox" />
+        <visref ref="HybridVis" />
+      </volume>
+      <volume name="module_L3b_halfmodule_axial_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L3b_halfmodule_axialBox" />
+        <physvol>
+          <volumeref ref="module_L3b_halfmodule_axial_sensor_volume" />
+          <positionref ref="module_L3b_halfmodule_axial_sensor_position" />
+          <rotationref ref="module_L3b_halfmodule_axial_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L3b_halfmodule_axial_lamination_volume" />
+          <positionref ref="module_L3b_halfmodule_axial_lamination_position" />
+          <rotationref ref="module_L3b_halfmodule_axial_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L3b_halfmodule_axial_cf_volume" />
+          <positionref ref="module_L3b_halfmodule_axial_cf_position" />
+          <rotationref ref="module_L3b_halfmodule_axial_cf_rotation" />
+          <physvolid field_name="component" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L3b_halfmodule_axial_hybrid_volume" />
+          <positionref ref="module_L3b_halfmodule_axial_hybrid_position" />
+          <rotationref ref="module_L3b_halfmodule_axial_hybrid_rotation" />
+          <physvolid field_name="component" value="3" />
+        </physvol>
+        <visref ref="HalfModuleVis" />
+      </volume>
+      <volume name="module_L3b_halfmodule_stereo_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L3b_halfmodule_stereo_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L3b_halfmodule_stereo_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L3b_halfmodule_stereo_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L3b_halfmodule_stereo_sensor_active_volume" />
+          <positionref ref="module_L3b_halfmodule_stereo_sensor_active_position" />
+          <rotationref ref="module_L3b_halfmodule_stereo_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L3b_halfmodule_stereo_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L3b_halfmodule_stereo_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L3b_halfmodule_stereo_cf_volume">
+        <materialref ref="CarbonFiber" />
+        <solidref ref="module_L3b_halfmodule_stereo_cfBox" />
+        <visref ref="CarbonFiberVis" />
+      </volume>
+      <volume name="module_L3b_halfmodule_stereo_hybrid_volume">
+        <materialref ref="G10" />
+        <solidref ref="module_L3b_halfmodule_stereo_hybridBox" />
+        <visref ref="HybridVis" />
+      </volume>
+      <volume name="module_L3b_halfmodule_stereo_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L3b_halfmodule_stereoBox" />
+        <physvol>
+          <volumeref ref="module_L3b_halfmodule_stereo_sensor_volume" />
+          <positionref ref="module_L3b_halfmodule_stereo_sensor_position" />
+          <rotationref ref="module_L3b_halfmodule_stereo_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L3b_halfmodule_stereo_lamination_volume" />
+          <positionref ref="module_L3b_halfmodule_stereo_lamination_position" />
+          <rotationref ref="module_L3b_halfmodule_stereo_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L3b_halfmodule_stereo_cf_volume" />
+          <positionref ref="module_L3b_halfmodule_stereo_cf_position" />
+          <rotationref ref="module_L3b_halfmodule_stereo_cf_rotation" />
+          <physvolid field_name="component" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L3b_halfmodule_stereo_hybrid_volume" />
+          <positionref ref="module_L3b_halfmodule_stereo_hybrid_position" />
+          <rotationref ref="module_L3b_halfmodule_stereo_hybrid_rotation" />
+          <physvolid field_name="component" value="3" />
+        </physvol>
+        <visref ref="HalfModuleVis" />
+      </volume>
+      <volume name="module_L3t_halfmodule_axial_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L3t_halfmodule_axial_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L3t_halfmodule_axial_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L3t_halfmodule_axial_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L3t_halfmodule_axial_sensor_active_volume" />
+          <positionref ref="module_L3t_halfmodule_axial_sensor_active_position" />
+          <rotationref ref="module_L3t_halfmodule_axial_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L3t_halfmodule_axial_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L3t_halfmodule_axial_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L3t_halfmodule_axial_cf_volume">
+        <materialref ref="CarbonFiber" />
+        <solidref ref="module_L3t_halfmodule_axial_cfBox" />
+        <visref ref="CarbonFiberVis" />
+      </volume>
+      <volume name="module_L3t_halfmodule_axial_hybrid_volume">
+        <materialref ref="G10" />
+        <solidref ref="module_L3t_halfmodule_axial_hybridBox" />
+        <visref ref="HybridVis" />
+      </volume>
+      <volume name="module_L3t_halfmodule_axial_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L3t_halfmodule_axialBox" />
+        <physvol>
+          <volumeref ref="module_L3t_halfmodule_axial_sensor_volume" />
+          <positionref ref="module_L3t_halfmodule_axial_sensor_position" />
+          <rotationref ref="module_L3t_halfmodule_axial_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L3t_halfmodule_axial_lamination_volume" />
+          <positionref ref="module_L3t_halfmodule_axial_lamination_position" />
+          <rotationref ref="module_L3t_halfmodule_axial_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L3t_halfmodule_axial_cf_volume" />
+          <positionref ref="module_L3t_halfmodule_axial_cf_position" />
+          <rotationref ref="module_L3t_halfmodule_axial_cf_rotation" />
+          <physvolid field_name="component" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L3t_halfmodule_axial_hybrid_volume" />
+          <positionref ref="module_L3t_halfmodule_axial_hybrid_position" />
+          <rotationref ref="module_L3t_halfmodule_axial_hybrid_rotation" />
+          <physvolid field_name="component" value="3" />
+        </physvol>
+        <visref ref="HalfModuleVis" />
+      </volume>
+      <volume name="module_L3t_halfmodule_stereo_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L3t_halfmodule_stereo_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L3t_halfmodule_stereo_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L3t_halfmodule_stereo_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L3t_halfmodule_stereo_sensor_active_volume" />
+          <positionref ref="module_L3t_halfmodule_stereo_sensor_active_position" />
+          <rotationref ref="module_L3t_halfmodule_stereo_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L3t_halfmodule_stereo_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L3t_halfmodule_stereo_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L3t_halfmodule_stereo_cf_volume">
+        <materialref ref="CarbonFiber" />
+        <solidref ref="module_L3t_halfmodule_stereo_cfBox" />
+        <visref ref="CarbonFiberVis" />
+      </volume>
+      <volume name="module_L3t_halfmodule_stereo_hybrid_volume">
+        <materialref ref="G10" />
+        <solidref ref="module_L3t_halfmodule_stereo_hybridBox" />
+        <visref ref="HybridVis" />
+      </volume>
+      <volume name="module_L3t_halfmodule_stereo_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L3t_halfmodule_stereoBox" />
+        <physvol>
+          <volumeref ref="module_L3t_halfmodule_stereo_sensor_volume" />
+          <positionref ref="module_L3t_halfmodule_stereo_sensor_position" />
+          <rotationref ref="module_L3t_halfmodule_stereo_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L3t_halfmodule_stereo_lamination_volume" />
+          <positionref ref="module_L3t_halfmodule_stereo_lamination_position" />
+          <rotationref ref="module_L3t_halfmodule_stereo_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L3t_halfmodule_stereo_cf_volume" />
+          <positionref ref="module_L3t_halfmodule_stereo_cf_position" />
+          <rotationref ref="module_L3t_halfmodule_stereo_cf_rotation" />
+          <physvolid field_name="component" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L3t_halfmodule_stereo_hybrid_volume" />
+          <positionref ref="module_L3t_halfmodule_stereo_hybrid_position" />
+          <rotationref ref="module_L3t_halfmodule_stereo_hybrid_rotation" />
+          <physvolid field_name="component" value="3" />
+        </physvol>
+        <visref ref="HalfModuleVis" />
+      </volume>
+      <volume name="module_L4b_halfmodule_axial_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L4b_halfmodule_axial_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L4b_halfmodule_axial_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L4b_halfmodule_axial_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L4b_halfmodule_axial_sensor_active_volume" />
+          <positionref ref="module_L4b_halfmodule_axial_sensor_active_position" />
+          <rotationref ref="module_L4b_halfmodule_axial_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L4b_halfmodule_axial_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L4b_halfmodule_axial_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L4b_halfmodule_axial_cf_volume">
+        <materialref ref="CarbonFiber" />
+        <solidref ref="module_L4b_halfmodule_axial_cfBox" />
+        <visref ref="CarbonFiberVis" />
+      </volume>
+      <volume name="module_L4b_halfmodule_axial_hybrid_volume">
+        <materialref ref="G10" />
+        <solidref ref="module_L4b_halfmodule_axial_hybridBox" />
+        <visref ref="HybridVis" />
+      </volume>
+      <volume name="module_L4b_halfmodule_axial_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L4b_halfmodule_axialBox" />
+        <physvol>
+          <volumeref ref="module_L4b_halfmodule_axial_sensor_volume" />
+          <positionref ref="module_L4b_halfmodule_axial_sensor_position" />
+          <rotationref ref="module_L4b_halfmodule_axial_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L4b_halfmodule_axial_lamination_volume" />
+          <positionref ref="module_L4b_halfmodule_axial_lamination_position" />
+          <rotationref ref="module_L4b_halfmodule_axial_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L4b_halfmodule_axial_cf_volume" />
+          <positionref ref="module_L4b_halfmodule_axial_cf_position" />
+          <rotationref ref="module_L4b_halfmodule_axial_cf_rotation" />
+          <physvolid field_name="component" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L4b_halfmodule_axial_hybrid_volume" />
+          <positionref ref="module_L4b_halfmodule_axial_hybrid_position" />
+          <rotationref ref="module_L4b_halfmodule_axial_hybrid_rotation" />
+          <physvolid field_name="component" value="3" />
+        </physvol>
+        <visref ref="HalfModuleVis" />
+      </volume>
+      <volume name="module_L4b_halfmodule_stereo_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L4b_halfmodule_stereo_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L4b_halfmodule_stereo_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L4b_halfmodule_stereo_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L4b_halfmodule_stereo_sensor_active_volume" />
+          <positionref ref="module_L4b_halfmodule_stereo_sensor_active_position" />
+          <rotationref ref="module_L4b_halfmodule_stereo_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L4b_halfmodule_stereo_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L4b_halfmodule_stereo_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L4b_halfmodule_stereo_cf_volume">
+        <materialref ref="CarbonFiber" />
+        <solidref ref="module_L4b_halfmodule_stereo_cfBox" />
+        <visref ref="CarbonFiberVis" />
+      </volume>
+      <volume name="module_L4b_halfmodule_stereo_hybrid_volume">
+        <materialref ref="G10" />
+        <solidref ref="module_L4b_halfmodule_stereo_hybridBox" />
+        <visref ref="HybridVis" />
+      </volume>
+      <volume name="module_L4b_halfmodule_stereo_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L4b_halfmodule_stereoBox" />
+        <physvol>
+          <volumeref ref="module_L4b_halfmodule_stereo_sensor_volume" />
+          <positionref ref="module_L4b_halfmodule_stereo_sensor_position" />
+          <rotationref ref="module_L4b_halfmodule_stereo_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L4b_halfmodule_stereo_lamination_volume" />
+          <positionref ref="module_L4b_halfmodule_stereo_lamination_position" />
+          <rotationref ref="module_L4b_halfmodule_stereo_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L4b_halfmodule_stereo_cf_volume" />
+          <positionref ref="module_L4b_halfmodule_stereo_cf_position" />
+          <rotationref ref="module_L4b_halfmodule_stereo_cf_rotation" />
+          <physvolid field_name="component" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L4b_halfmodule_stereo_hybrid_volume" />
+          <positionref ref="module_L4b_halfmodule_stereo_hybrid_position" />
+          <rotationref ref="module_L4b_halfmodule_stereo_hybrid_rotation" />
+          <physvolid field_name="component" value="3" />
+        </physvol>
+        <visref ref="HalfModuleVis" />
+      </volume>
+      <volume name="module_L4t_halfmodule_axial_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L4t_halfmodule_axial_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L4t_halfmodule_axial_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L4t_halfmodule_axial_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L4t_halfmodule_axial_sensor_active_volume" />
+          <positionref ref="module_L4t_halfmodule_axial_sensor_active_position" />
+          <rotationref ref="module_L4t_halfmodule_axial_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L4t_halfmodule_axial_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L4t_halfmodule_axial_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L4t_halfmodule_axial_cf_volume">
+        <materialref ref="CarbonFiber" />
+        <solidref ref="module_L4t_halfmodule_axial_cfBox" />
+        <visref ref="CarbonFiberVis" />
+      </volume>
+      <volume name="module_L4t_halfmodule_axial_hybrid_volume">
+        <materialref ref="G10" />
+        <solidref ref="module_L4t_halfmodule_axial_hybridBox" />
+        <visref ref="HybridVis" />
+      </volume>
+      <volume name="module_L4t_halfmodule_axial_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L4t_halfmodule_axialBox" />
+        <physvol>
+          <volumeref ref="module_L4t_halfmodule_axial_sensor_volume" />
+          <positionref ref="module_L4t_halfmodule_axial_sensor_position" />
+          <rotationref ref="module_L4t_halfmodule_axial_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L4t_halfmodule_axial_lamination_volume" />
+          <positionref ref="module_L4t_halfmodule_axial_lamination_position" />
+          <rotationref ref="module_L4t_halfmodule_axial_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L4t_halfmodule_axial_cf_volume" />
+          <positionref ref="module_L4t_halfmodule_axial_cf_position" />
+          <rotationref ref="module_L4t_halfmodule_axial_cf_rotation" />
+          <physvolid field_name="component" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L4t_halfmodule_axial_hybrid_volume" />
+          <positionref ref="module_L4t_halfmodule_axial_hybrid_position" />
+          <rotationref ref="module_L4t_halfmodule_axial_hybrid_rotation" />
+          <physvolid field_name="component" value="3" />
+        </physvol>
+        <visref ref="HalfModuleVis" />
+      </volume>
+      <volume name="module_L4t_halfmodule_stereo_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L4t_halfmodule_stereo_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L4t_halfmodule_stereo_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L4t_halfmodule_stereo_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L4t_halfmodule_stereo_sensor_active_volume" />
+          <positionref ref="module_L4t_halfmodule_stereo_sensor_active_position" />
+          <rotationref ref="module_L4t_halfmodule_stereo_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L4t_halfmodule_stereo_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L4t_halfmodule_stereo_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L4t_halfmodule_stereo_cf_volume">
+        <materialref ref="CarbonFiber" />
+        <solidref ref="module_L4t_halfmodule_stereo_cfBox" />
+        <visref ref="CarbonFiberVis" />
+      </volume>
+      <volume name="module_L4t_halfmodule_stereo_hybrid_volume">
+        <materialref ref="G10" />
+        <solidref ref="module_L4t_halfmodule_stereo_hybridBox" />
+        <visref ref="HybridVis" />
+      </volume>
+      <volume name="module_L4t_halfmodule_stereo_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L4t_halfmodule_stereoBox" />
+        <physvol>
+          <volumeref ref="module_L4t_halfmodule_stereo_sensor_volume" />
+          <positionref ref="module_L4t_halfmodule_stereo_sensor_position" />
+          <rotationref ref="module_L4t_halfmodule_stereo_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L4t_halfmodule_stereo_lamination_volume" />
+          <positionref ref="module_L4t_halfmodule_stereo_lamination_position" />
+          <rotationref ref="module_L4t_halfmodule_stereo_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L4t_halfmodule_stereo_cf_volume" />
+          <positionref ref="module_L4t_halfmodule_stereo_cf_position" />
+          <rotationref ref="module_L4t_halfmodule_stereo_cf_rotation" />
+          <physvolid field_name="component" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L4t_halfmodule_stereo_hybrid_volume" />
+          <positionref ref="module_L4t_halfmodule_stereo_hybrid_position" />
+          <rotationref ref="module_L4t_halfmodule_stereo_hybrid_rotation" />
+          <physvolid field_name="component" value="3" />
+        </physvol>
+        <visref ref="HalfModuleVis" />
+      </volume>
+      <volume name="module_L5b_halfmodule_axial_hole_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L5b_halfmodule_axial_hole_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L5b_halfmodule_axial_hole_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L5b_halfmodule_axial_hole_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L5b_halfmodule_axial_hole_sensor_active_volume" />
+          <positionref ref="module_L5b_halfmodule_axial_hole_sensor_active_position" />
+          <rotationref ref="module_L5b_halfmodule_axial_hole_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L5b_halfmodule_axial_hole_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L5b_halfmodule_axial_hole_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L5b_halfmodule_axial_hole_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L5b_halfmodule_axial_holeBox" />
+        <physvol>
+          <volumeref ref="module_L5b_halfmodule_axial_hole_sensor_volume" />
+          <positionref ref="module_L5b_halfmodule_axial_hole_sensor_position" />
+          <rotationref ref="module_L5b_halfmodule_axial_hole_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L5b_halfmodule_axial_hole_lamination_volume" />
+          <positionref ref="module_L5b_halfmodule_axial_hole_lamination_position" />
+          <rotationref ref="module_L5b_halfmodule_axial_hole_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L5b_halfmodule_axial_slot_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L5b_halfmodule_axial_slot_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L5b_halfmodule_axial_slot_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L5b_halfmodule_axial_slot_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L5b_halfmodule_axial_slot_sensor_active_volume" />
+          <positionref ref="module_L5b_halfmodule_axial_slot_sensor_active_position" />
+          <rotationref ref="module_L5b_halfmodule_axial_slot_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L5b_halfmodule_axial_slot_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L5b_halfmodule_axial_slot_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L5b_halfmodule_axial_slot_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L5b_halfmodule_axial_slotBox" />
+        <physvol>
+          <volumeref ref="module_L5b_halfmodule_axial_slot_sensor_volume" />
+          <positionref ref="module_L5b_halfmodule_axial_slot_sensor_position" />
+          <rotationref ref="module_L5b_halfmodule_axial_slot_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L5b_halfmodule_axial_slot_lamination_volume" />
+          <positionref ref="module_L5b_halfmodule_axial_slot_lamination_position" />
+          <rotationref ref="module_L5b_halfmodule_axial_slot_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L5b_halfmodule_stereo_hole_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L5b_halfmodule_stereo_hole_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L5b_halfmodule_stereo_hole_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L5b_halfmodule_stereo_hole_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L5b_halfmodule_stereo_hole_sensor_active_volume" />
+          <positionref ref="module_L5b_halfmodule_stereo_hole_sensor_active_position" />
+          <rotationref ref="module_L5b_halfmodule_stereo_hole_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L5b_halfmodule_stereo_hole_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L5b_halfmodule_stereo_hole_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L5b_halfmodule_stereo_hole_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L5b_halfmodule_stereo_holeBox" />
+        <physvol>
+          <volumeref ref="module_L5b_halfmodule_stereo_hole_sensor_volume" />
+          <positionref ref="module_L5b_halfmodule_stereo_hole_sensor_position" />
+          <rotationref ref="module_L5b_halfmodule_stereo_hole_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L5b_halfmodule_stereo_hole_lamination_volume" />
+          <positionref ref="module_L5b_halfmodule_stereo_hole_lamination_position" />
+          <rotationref ref="module_L5b_halfmodule_stereo_hole_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L5b_halfmodule_stereo_slot_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L5b_halfmodule_stereo_slot_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L5b_halfmodule_stereo_slot_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L5b_halfmodule_stereo_slot_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L5b_halfmodule_stereo_slot_sensor_active_volume" />
+          <positionref ref="module_L5b_halfmodule_stereo_slot_sensor_active_position" />
+          <rotationref ref="module_L5b_halfmodule_stereo_slot_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L5b_halfmodule_stereo_slot_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L5b_halfmodule_stereo_slot_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L5b_halfmodule_stereo_slot_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L5b_halfmodule_stereo_slotBox" />
+        <physvol>
+          <volumeref ref="module_L5b_halfmodule_stereo_slot_sensor_volume" />
+          <positionref ref="module_L5b_halfmodule_stereo_slot_sensor_position" />
+          <rotationref ref="module_L5b_halfmodule_stereo_slot_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L5b_halfmodule_stereo_slot_lamination_volume" />
+          <positionref ref="module_L5b_halfmodule_stereo_slot_lamination_position" />
+          <rotationref ref="module_L5b_halfmodule_stereo_slot_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L5t_halfmodule_axial_hole_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L5t_halfmodule_axial_hole_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L5t_halfmodule_axial_hole_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L5t_halfmodule_axial_hole_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L5t_halfmodule_axial_hole_sensor_active_volume" />
+          <positionref ref="module_L5t_halfmodule_axial_hole_sensor_active_position" />
+          <rotationref ref="module_L5t_halfmodule_axial_hole_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L5t_halfmodule_axial_hole_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L5t_halfmodule_axial_hole_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L5t_halfmodule_axial_hole_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L5t_halfmodule_axial_holeBox" />
+        <physvol>
+          <volumeref ref="module_L5t_halfmodule_axial_hole_sensor_volume" />
+          <positionref ref="module_L5t_halfmodule_axial_hole_sensor_position" />
+          <rotationref ref="module_L5t_halfmodule_axial_hole_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L5t_halfmodule_axial_hole_lamination_volume" />
+          <positionref ref="module_L5t_halfmodule_axial_hole_lamination_position" />
+          <rotationref ref="module_L5t_halfmodule_axial_hole_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L5t_halfmodule_axial_slot_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L5t_halfmodule_axial_slot_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L5t_halfmodule_axial_slot_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L5t_halfmodule_axial_slot_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L5t_halfmodule_axial_slot_sensor_active_volume" />
+          <positionref ref="module_L5t_halfmodule_axial_slot_sensor_active_position" />
+          <rotationref ref="module_L5t_halfmodule_axial_slot_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L5t_halfmodule_axial_slot_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L5t_halfmodule_axial_slot_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L5t_halfmodule_axial_slot_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L5t_halfmodule_axial_slotBox" />
+        <physvol>
+          <volumeref ref="module_L5t_halfmodule_axial_slot_sensor_volume" />
+          <positionref ref="module_L5t_halfmodule_axial_slot_sensor_position" />
+          <rotationref ref="module_L5t_halfmodule_axial_slot_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L5t_halfmodule_axial_slot_lamination_volume" />
+          <positionref ref="module_L5t_halfmodule_axial_slot_lamination_position" />
+          <rotationref ref="module_L5t_halfmodule_axial_slot_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L5t_halfmodule_stereo_hole_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L5t_halfmodule_stereo_hole_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L5t_halfmodule_stereo_hole_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L5t_halfmodule_stereo_hole_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L5t_halfmodule_stereo_hole_sensor_active_volume" />
+          <positionref ref="module_L5t_halfmodule_stereo_hole_sensor_active_position" />
+          <rotationref ref="module_L5t_halfmodule_stereo_hole_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L5t_halfmodule_stereo_hole_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L5t_halfmodule_stereo_hole_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L5t_halfmodule_stereo_hole_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L5t_halfmodule_stereo_holeBox" />
+        <physvol>
+          <volumeref ref="module_L5t_halfmodule_stereo_hole_sensor_volume" />
+          <positionref ref="module_L5t_halfmodule_stereo_hole_sensor_position" />
+          <rotationref ref="module_L5t_halfmodule_stereo_hole_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L5t_halfmodule_stereo_hole_lamination_volume" />
+          <positionref ref="module_L5t_halfmodule_stereo_hole_lamination_position" />
+          <rotationref ref="module_L5t_halfmodule_stereo_hole_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L5t_halfmodule_stereo_slot_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L5t_halfmodule_stereo_slot_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L5t_halfmodule_stereo_slot_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L5t_halfmodule_stereo_slot_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L5t_halfmodule_stereo_slot_sensor_active_volume" />
+          <positionref ref="module_L5t_halfmodule_stereo_slot_sensor_active_position" />
+          <rotationref ref="module_L5t_halfmodule_stereo_slot_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L5t_halfmodule_stereo_slot_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L5t_halfmodule_stereo_slot_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L5t_halfmodule_stereo_slot_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L5t_halfmodule_stereo_slotBox" />
+        <physvol>
+          <volumeref ref="module_L5t_halfmodule_stereo_slot_sensor_volume" />
+          <positionref ref="module_L5t_halfmodule_stereo_slot_sensor_position" />
+          <rotationref ref="module_L5t_halfmodule_stereo_slot_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L5t_halfmodule_stereo_slot_lamination_volume" />
+          <positionref ref="module_L5t_halfmodule_stereo_slot_lamination_position" />
+          <rotationref ref="module_L5t_halfmodule_stereo_slot_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L6b_halfmodule_axial_hole_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L6b_halfmodule_axial_hole_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L6b_halfmodule_axial_hole_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L6b_halfmodule_axial_hole_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L6b_halfmodule_axial_hole_sensor_active_volume" />
+          <positionref ref="module_L6b_halfmodule_axial_hole_sensor_active_position" />
+          <rotationref ref="module_L6b_halfmodule_axial_hole_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L6b_halfmodule_axial_hole_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L6b_halfmodule_axial_hole_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L6b_halfmodule_axial_hole_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L6b_halfmodule_axial_holeBox" />
+        <physvol>
+          <volumeref ref="module_L6b_halfmodule_axial_hole_sensor_volume" />
+          <positionref ref="module_L6b_halfmodule_axial_hole_sensor_position" />
+          <rotationref ref="module_L6b_halfmodule_axial_hole_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L6b_halfmodule_axial_hole_lamination_volume" />
+          <positionref ref="module_L6b_halfmodule_axial_hole_lamination_position" />
+          <rotationref ref="module_L6b_halfmodule_axial_hole_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L6b_halfmodule_axial_slot_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L6b_halfmodule_axial_slot_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L6b_halfmodule_axial_slot_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L6b_halfmodule_axial_slot_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L6b_halfmodule_axial_slot_sensor_active_volume" />
+          <positionref ref="module_L6b_halfmodule_axial_slot_sensor_active_position" />
+          <rotationref ref="module_L6b_halfmodule_axial_slot_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L6b_halfmodule_axial_slot_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L6b_halfmodule_axial_slot_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L6b_halfmodule_axial_slot_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L6b_halfmodule_axial_slotBox" />
+        <physvol>
+          <volumeref ref="module_L6b_halfmodule_axial_slot_sensor_volume" />
+          <positionref ref="module_L6b_halfmodule_axial_slot_sensor_position" />
+          <rotationref ref="module_L6b_halfmodule_axial_slot_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L6b_halfmodule_axial_slot_lamination_volume" />
+          <positionref ref="module_L6b_halfmodule_axial_slot_lamination_position" />
+          <rotationref ref="module_L6b_halfmodule_axial_slot_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L6b_halfmodule_stereo_hole_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L6b_halfmodule_stereo_hole_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L6b_halfmodule_stereo_hole_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L6b_halfmodule_stereo_hole_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L6b_halfmodule_stereo_hole_sensor_active_volume" />
+          <positionref ref="module_L6b_halfmodule_stereo_hole_sensor_active_position" />
+          <rotationref ref="module_L6b_halfmodule_stereo_hole_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L6b_halfmodule_stereo_hole_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L6b_halfmodule_stereo_hole_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L6b_halfmodule_stereo_hole_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L6b_halfmodule_stereo_holeBox" />
+        <physvol>
+          <volumeref ref="module_L6b_halfmodule_stereo_hole_sensor_volume" />
+          <positionref ref="module_L6b_halfmodule_stereo_hole_sensor_position" />
+          <rotationref ref="module_L6b_halfmodule_stereo_hole_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L6b_halfmodule_stereo_hole_lamination_volume" />
+          <positionref ref="module_L6b_halfmodule_stereo_hole_lamination_position" />
+          <rotationref ref="module_L6b_halfmodule_stereo_hole_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L6b_halfmodule_stereo_slot_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L6b_halfmodule_stereo_slot_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L6b_halfmodule_stereo_slot_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L6b_halfmodule_stereo_slot_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L6b_halfmodule_stereo_slot_sensor_active_volume" />
+          <positionref ref="module_L6b_halfmodule_stereo_slot_sensor_active_position" />
+          <rotationref ref="module_L6b_halfmodule_stereo_slot_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L6b_halfmodule_stereo_slot_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L6b_halfmodule_stereo_slot_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L6b_halfmodule_stereo_slot_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L6b_halfmodule_stereo_slotBox" />
+        <physvol>
+          <volumeref ref="module_L6b_halfmodule_stereo_slot_sensor_volume" />
+          <positionref ref="module_L6b_halfmodule_stereo_slot_sensor_position" />
+          <rotationref ref="module_L6b_halfmodule_stereo_slot_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L6b_halfmodule_stereo_slot_lamination_volume" />
+          <positionref ref="module_L6b_halfmodule_stereo_slot_lamination_position" />
+          <rotationref ref="module_L6b_halfmodule_stereo_slot_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L6t_halfmodule_axial_hole_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L6t_halfmodule_axial_hole_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L6t_halfmodule_axial_hole_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L6t_halfmodule_axial_hole_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L6t_halfmodule_axial_hole_sensor_active_volume" />
+          <positionref ref="module_L6t_halfmodule_axial_hole_sensor_active_position" />
+          <rotationref ref="module_L6t_halfmodule_axial_hole_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L6t_halfmodule_axial_hole_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L6t_halfmodule_axial_hole_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L6t_halfmodule_axial_hole_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L6t_halfmodule_axial_holeBox" />
+        <physvol>
+          <volumeref ref="module_L6t_halfmodule_axial_hole_sensor_volume" />
+          <positionref ref="module_L6t_halfmodule_axial_hole_sensor_position" />
+          <rotationref ref="module_L6t_halfmodule_axial_hole_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L6t_halfmodule_axial_hole_lamination_volume" />
+          <positionref ref="module_L6t_halfmodule_axial_hole_lamination_position" />
+          <rotationref ref="module_L6t_halfmodule_axial_hole_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L6t_halfmodule_axial_slot_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L6t_halfmodule_axial_slot_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L6t_halfmodule_axial_slot_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L6t_halfmodule_axial_slot_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L6t_halfmodule_axial_slot_sensor_active_volume" />
+          <positionref ref="module_L6t_halfmodule_axial_slot_sensor_active_position" />
+          <rotationref ref="module_L6t_halfmodule_axial_slot_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L6t_halfmodule_axial_slot_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L6t_halfmodule_axial_slot_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L6t_halfmodule_axial_slot_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L6t_halfmodule_axial_slotBox" />
+        <physvol>
+          <volumeref ref="module_L6t_halfmodule_axial_slot_sensor_volume" />
+          <positionref ref="module_L6t_halfmodule_axial_slot_sensor_position" />
+          <rotationref ref="module_L6t_halfmodule_axial_slot_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L6t_halfmodule_axial_slot_lamination_volume" />
+          <positionref ref="module_L6t_halfmodule_axial_slot_lamination_position" />
+          <rotationref ref="module_L6t_halfmodule_axial_slot_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L6t_halfmodule_stereo_hole_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L6t_halfmodule_stereo_hole_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L6t_halfmodule_stereo_hole_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L6t_halfmodule_stereo_hole_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L6t_halfmodule_stereo_hole_sensor_active_volume" />
+          <positionref ref="module_L6t_halfmodule_stereo_hole_sensor_active_position" />
+          <rotationref ref="module_L6t_halfmodule_stereo_hole_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L6t_halfmodule_stereo_hole_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L6t_halfmodule_stereo_hole_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L6t_halfmodule_stereo_hole_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L6t_halfmodule_stereo_holeBox" />
+        <physvol>
+          <volumeref ref="module_L6t_halfmodule_stereo_hole_sensor_volume" />
+          <positionref ref="module_L6t_halfmodule_stereo_hole_sensor_position" />
+          <rotationref ref="module_L6t_halfmodule_stereo_hole_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L6t_halfmodule_stereo_hole_lamination_volume" />
+          <positionref ref="module_L6t_halfmodule_stereo_hole_lamination_position" />
+          <rotationref ref="module_L6t_halfmodule_stereo_hole_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L6t_halfmodule_stereo_slot_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L6t_halfmodule_stereo_slot_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L6t_halfmodule_stereo_slot_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L6t_halfmodule_stereo_slot_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L6t_halfmodule_stereo_slot_sensor_active_volume" />
+          <positionref ref="module_L6t_halfmodule_stereo_slot_sensor_active_position" />
+          <rotationref ref="module_L6t_halfmodule_stereo_slot_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L6t_halfmodule_stereo_slot_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L6t_halfmodule_stereo_slot_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L6t_halfmodule_stereo_slot_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L6t_halfmodule_stereo_slotBox" />
+        <physvol>
+          <volumeref ref="module_L6t_halfmodule_stereo_slot_sensor_volume" />
+          <positionref ref="module_L6t_halfmodule_stereo_slot_sensor_position" />
+          <rotationref ref="module_L6t_halfmodule_stereo_slot_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L6t_halfmodule_stereo_slot_lamination_volume" />
+          <positionref ref="module_L6t_halfmodule_stereo_slot_lamination_position" />
+          <rotationref ref="module_L6t_halfmodule_stereo_slot_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L7b_halfmodule_axial_hole_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L7b_halfmodule_axial_hole_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L7b_halfmodule_axial_hole_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L7b_halfmodule_axial_hole_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L7b_halfmodule_axial_hole_sensor_active_volume" />
+          <positionref ref="module_L7b_halfmodule_axial_hole_sensor_active_position" />
+          <rotationref ref="module_L7b_halfmodule_axial_hole_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L7b_halfmodule_axial_hole_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L7b_halfmodule_axial_hole_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L7b_halfmodule_axial_hole_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L7b_halfmodule_axial_holeBox" />
+        <physvol>
+          <volumeref ref="module_L7b_halfmodule_axial_hole_sensor_volume" />
+          <positionref ref="module_L7b_halfmodule_axial_hole_sensor_position" />
+          <rotationref ref="module_L7b_halfmodule_axial_hole_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L7b_halfmodule_axial_hole_lamination_volume" />
+          <positionref ref="module_L7b_halfmodule_axial_hole_lamination_position" />
+          <rotationref ref="module_L7b_halfmodule_axial_hole_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L7b_halfmodule_axial_slot_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L7b_halfmodule_axial_slot_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L7b_halfmodule_axial_slot_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L7b_halfmodule_axial_slot_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L7b_halfmodule_axial_slot_sensor_active_volume" />
+          <positionref ref="module_L7b_halfmodule_axial_slot_sensor_active_position" />
+          <rotationref ref="module_L7b_halfmodule_axial_slot_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L7b_halfmodule_axial_slot_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L7b_halfmodule_axial_slot_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L7b_halfmodule_axial_slot_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L7b_halfmodule_axial_slotBox" />
+        <physvol>
+          <volumeref ref="module_L7b_halfmodule_axial_slot_sensor_volume" />
+          <positionref ref="module_L7b_halfmodule_axial_slot_sensor_position" />
+          <rotationref ref="module_L7b_halfmodule_axial_slot_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L7b_halfmodule_axial_slot_lamination_volume" />
+          <positionref ref="module_L7b_halfmodule_axial_slot_lamination_position" />
+          <rotationref ref="module_L7b_halfmodule_axial_slot_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L7b_halfmodule_stereo_hole_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L7b_halfmodule_stereo_hole_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L7b_halfmodule_stereo_hole_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L7b_halfmodule_stereo_hole_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L7b_halfmodule_stereo_hole_sensor_active_volume" />
+          <positionref ref="module_L7b_halfmodule_stereo_hole_sensor_active_position" />
+          <rotationref ref="module_L7b_halfmodule_stereo_hole_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L7b_halfmodule_stereo_hole_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L7b_halfmodule_stereo_hole_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L7b_halfmodule_stereo_hole_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L7b_halfmodule_stereo_holeBox" />
+        <physvol>
+          <volumeref ref="module_L7b_halfmodule_stereo_hole_sensor_volume" />
+          <positionref ref="module_L7b_halfmodule_stereo_hole_sensor_position" />
+          <rotationref ref="module_L7b_halfmodule_stereo_hole_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L7b_halfmodule_stereo_hole_lamination_volume" />
+          <positionref ref="module_L7b_halfmodule_stereo_hole_lamination_position" />
+          <rotationref ref="module_L7b_halfmodule_stereo_hole_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L7b_halfmodule_stereo_slot_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L7b_halfmodule_stereo_slot_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L7b_halfmodule_stereo_slot_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L7b_halfmodule_stereo_slot_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L7b_halfmodule_stereo_slot_sensor_active_volume" />
+          <positionref ref="module_L7b_halfmodule_stereo_slot_sensor_active_position" />
+          <rotationref ref="module_L7b_halfmodule_stereo_slot_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L7b_halfmodule_stereo_slot_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L7b_halfmodule_stereo_slot_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L7b_halfmodule_stereo_slot_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L7b_halfmodule_stereo_slotBox" />
+        <physvol>
+          <volumeref ref="module_L7b_halfmodule_stereo_slot_sensor_volume" />
+          <positionref ref="module_L7b_halfmodule_stereo_slot_sensor_position" />
+          <rotationref ref="module_L7b_halfmodule_stereo_slot_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L7b_halfmodule_stereo_slot_lamination_volume" />
+          <positionref ref="module_L7b_halfmodule_stereo_slot_lamination_position" />
+          <rotationref ref="module_L7b_halfmodule_stereo_slot_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L7t_halfmodule_axial_hole_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L7t_halfmodule_axial_hole_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L7t_halfmodule_axial_hole_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L7t_halfmodule_axial_hole_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L7t_halfmodule_axial_hole_sensor_active_volume" />
+          <positionref ref="module_L7t_halfmodule_axial_hole_sensor_active_position" />
+          <rotationref ref="module_L7t_halfmodule_axial_hole_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L7t_halfmodule_axial_hole_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L7t_halfmodule_axial_hole_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L7t_halfmodule_axial_hole_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L7t_halfmodule_axial_holeBox" />
+        <physvol>
+          <volumeref ref="module_L7t_halfmodule_axial_hole_sensor_volume" />
+          <positionref ref="module_L7t_halfmodule_axial_hole_sensor_position" />
+          <rotationref ref="module_L7t_halfmodule_axial_hole_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L7t_halfmodule_axial_hole_lamination_volume" />
+          <positionref ref="module_L7t_halfmodule_axial_hole_lamination_position" />
+          <rotationref ref="module_L7t_halfmodule_axial_hole_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L7t_halfmodule_axial_slot_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L7t_halfmodule_axial_slot_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L7t_halfmodule_axial_slot_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L7t_halfmodule_axial_slot_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L7t_halfmodule_axial_slot_sensor_active_volume" />
+          <positionref ref="module_L7t_halfmodule_axial_slot_sensor_active_position" />
+          <rotationref ref="module_L7t_halfmodule_axial_slot_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L7t_halfmodule_axial_slot_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L7t_halfmodule_axial_slot_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L7t_halfmodule_axial_slot_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L7t_halfmodule_axial_slotBox" />
+        <physvol>
+          <volumeref ref="module_L7t_halfmodule_axial_slot_sensor_volume" />
+          <positionref ref="module_L7t_halfmodule_axial_slot_sensor_position" />
+          <rotationref ref="module_L7t_halfmodule_axial_slot_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L7t_halfmodule_axial_slot_lamination_volume" />
+          <positionref ref="module_L7t_halfmodule_axial_slot_lamination_position" />
+          <rotationref ref="module_L7t_halfmodule_axial_slot_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L7t_halfmodule_stereo_hole_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L7t_halfmodule_stereo_hole_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L7t_halfmodule_stereo_hole_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L7t_halfmodule_stereo_hole_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L7t_halfmodule_stereo_hole_sensor_active_volume" />
+          <positionref ref="module_L7t_halfmodule_stereo_hole_sensor_active_position" />
+          <rotationref ref="module_L7t_halfmodule_stereo_hole_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L7t_halfmodule_stereo_hole_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L7t_halfmodule_stereo_hole_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L7t_halfmodule_stereo_hole_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L7t_halfmodule_stereo_holeBox" />
+        <physvol>
+          <volumeref ref="module_L7t_halfmodule_stereo_hole_sensor_volume" />
+          <positionref ref="module_L7t_halfmodule_stereo_hole_sensor_position" />
+          <rotationref ref="module_L7t_halfmodule_stereo_hole_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L7t_halfmodule_stereo_hole_lamination_volume" />
+          <positionref ref="module_L7t_halfmodule_stereo_hole_lamination_position" />
+          <rotationref ref="module_L7t_halfmodule_stereo_hole_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L7t_halfmodule_stereo_slot_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L7t_halfmodule_stereo_slot_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L7t_halfmodule_stereo_slot_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L7t_halfmodule_stereo_slot_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L7t_halfmodule_stereo_slot_sensor_active_volume" />
+          <positionref ref="module_L7t_halfmodule_stereo_slot_sensor_active_position" />
+          <rotationref ref="module_L7t_halfmodule_stereo_slot_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L7t_halfmodule_stereo_slot_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L7t_halfmodule_stereo_slot_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L7t_halfmodule_stereo_slot_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L7t_halfmodule_stereo_slotBox" />
+        <physvol>
+          <volumeref ref="module_L7t_halfmodule_stereo_slot_sensor_volume" />
+          <positionref ref="module_L7t_halfmodule_stereo_slot_sensor_position" />
+          <rotationref ref="module_L7t_halfmodule_stereo_slot_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L7t_halfmodule_stereo_slot_lamination_volume" />
+          <positionref ref="module_L7t_halfmodule_stereo_slot_lamination_position" />
+          <rotationref ref="module_L7t_halfmodule_stereo_slot_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="base_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="baseBox" />
+        <physvol>
+          <volumeref ref="base_plate_volume" />
+          <positionref ref="base_plate_position" />
+          <rotationref ref="base_plate_rotation" />
+        </physvol>
+        <physvol>
+          <volumeref ref="support_plate_bottom_L14_volume" />
+          <positionref ref="support_plate_bottom_L14_position" />
+          <rotationref ref="support_plate_bottom_L14_rotation" />
+        </physvol>
+        <physvol>
+          <volumeref ref="support_plate_top_L14_volume" />
+          <positionref ref="support_plate_top_L14_position" />
+          <rotationref ref="support_plate_top_L14_rotation" />
+        </physvol>
+        <physvol>
+          <volumeref ref="support_plate_bottom_L46_volume" />
+          <positionref ref="support_plate_bottom_L46_position" />
+          <rotationref ref="support_plate_bottom_L46_rotation" />
+        </physvol>
+        <physvol>
+          <volumeref ref="support_plate_top_L46_volume" />
+          <positionref ref="support_plate_top_L46_position" />
+          <rotationref ref="support_plate_top_L46_rotation" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L1b_halfmodule_axial_volume" />
+          <positionref ref="module_L1b_halfmodule_axial_position" />
+          <rotationref ref="module_L1b_halfmodule_axial_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="2" />
+          <physvolid field_name="module" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L1b_halfmodule_stereo_volume" />
+          <positionref ref="module_L1b_halfmodule_stereo_position" />
+          <rotationref ref="module_L1b_halfmodule_stereo_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="1" />
+          <physvolid field_name="module" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L1t_halfmodule_axial_volume" />
+          <positionref ref="module_L1t_halfmodule_axial_position" />
+          <rotationref ref="module_L1t_halfmodule_axial_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="1" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L1t_halfmodule_stereo_volume" />
+          <positionref ref="module_L1t_halfmodule_stereo_position" />
+          <rotationref ref="module_L1t_halfmodule_stereo_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="2" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L2b_halfmodule_axial_volume" />
+          <positionref ref="module_L2b_halfmodule_axial_position" />
+          <rotationref ref="module_L2b_halfmodule_axial_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="4" />
+          <physvolid field_name="module" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L2b_halfmodule_stereo_volume" />
+          <positionref ref="module_L2b_halfmodule_stereo_position" />
+          <rotationref ref="module_L2b_halfmodule_stereo_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="3" />
+          <physvolid field_name="module" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L2t_halfmodule_axial_volume" />
+          <positionref ref="module_L2t_halfmodule_axial_position" />
+          <rotationref ref="module_L2t_halfmodule_axial_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="3" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L2t_halfmodule_stereo_volume" />
+          <positionref ref="module_L2t_halfmodule_stereo_position" />
+          <rotationref ref="module_L2t_halfmodule_stereo_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="4" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L3b_halfmodule_axial_volume" />
+          <positionref ref="module_L3b_halfmodule_axial_position" />
+          <rotationref ref="module_L3b_halfmodule_axial_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="6" />
+          <physvolid field_name="module" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L3b_halfmodule_stereo_volume" />
+          <positionref ref="module_L3b_halfmodule_stereo_position" />
+          <rotationref ref="module_L3b_halfmodule_stereo_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="5" />
+          <physvolid field_name="module" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L3t_halfmodule_axial_volume" />
+          <positionref ref="module_L3t_halfmodule_axial_position" />
+          <rotationref ref="module_L3t_halfmodule_axial_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="5" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L3t_halfmodule_stereo_volume" />
+          <positionref ref="module_L3t_halfmodule_stereo_position" />
+          <rotationref ref="module_L3t_halfmodule_stereo_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="6" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L4b_halfmodule_axial_volume" />
+          <positionref ref="module_L4b_halfmodule_axial_position" />
+          <rotationref ref="module_L4b_halfmodule_axial_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="8" />
+          <physvolid field_name="module" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L4b_halfmodule_stereo_volume" />
+          <positionref ref="module_L4b_halfmodule_stereo_position" />
+          <rotationref ref="module_L4b_halfmodule_stereo_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="7" />
+          <physvolid field_name="module" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L4t_halfmodule_axial_volume" />
+          <positionref ref="module_L4t_halfmodule_axial_position" />
+          <rotationref ref="module_L4t_halfmodule_axial_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="7" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L4t_halfmodule_stereo_volume" />
+          <positionref ref="module_L4t_halfmodule_stereo_position" />
+          <rotationref ref="module_L4t_halfmodule_stereo_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="8" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L5b_halfmodule_axial_hole_volume" />
+          <positionref ref="module_L5b_halfmodule_axial_hole_position" />
+          <rotationref ref="module_L5b_halfmodule_axial_hole_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="10" />
+          <physvolid field_name="module" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L5b_halfmodule_axial_slot_volume" />
+          <positionref ref="module_L5b_halfmodule_axial_slot_position" />
+          <rotationref ref="module_L5b_halfmodule_axial_slot_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="10" />
+          <physvolid field_name="module" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L5b_halfmodule_stereo_hole_volume" />
+          <positionref ref="module_L5b_halfmodule_stereo_hole_position" />
+          <rotationref ref="module_L5b_halfmodule_stereo_hole_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="9" />
+          <physvolid field_name="module" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L5b_halfmodule_stereo_slot_volume" />
+          <positionref ref="module_L5b_halfmodule_stereo_slot_position" />
+          <rotationref ref="module_L5b_halfmodule_stereo_slot_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="9" />
+          <physvolid field_name="module" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L5t_halfmodule_axial_hole_volume" />
+          <positionref ref="module_L5t_halfmodule_axial_hole_position" />
+          <rotationref ref="module_L5t_halfmodule_axial_hole_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="9" />
+          <physvolid field_name="module" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L5t_halfmodule_axial_slot_volume" />
+          <positionref ref="module_L5t_halfmodule_axial_slot_position" />
+          <rotationref ref="module_L5t_halfmodule_axial_slot_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="9" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L5t_halfmodule_stereo_hole_volume" />
+          <positionref ref="module_L5t_halfmodule_stereo_hole_position" />
+          <rotationref ref="module_L5t_halfmodule_stereo_hole_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="10" />
+          <physvolid field_name="module" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L5t_halfmodule_stereo_slot_volume" />
+          <positionref ref="module_L5t_halfmodule_stereo_slot_position" />
+          <rotationref ref="module_L5t_halfmodule_stereo_slot_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="10" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L6b_halfmodule_axial_hole_volume" />
+          <positionref ref="module_L6b_halfmodule_axial_hole_position" />
+          <rotationref ref="module_L6b_halfmodule_axial_hole_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="12" />
+          <physvolid field_name="module" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L6b_halfmodule_axial_slot_volume" />
+          <positionref ref="module_L6b_halfmodule_axial_slot_position" />
+          <rotationref ref="module_L6b_halfmodule_axial_slot_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="12" />
+          <physvolid field_name="module" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L6b_halfmodule_stereo_hole_volume" />
+          <positionref ref="module_L6b_halfmodule_stereo_hole_position" />
+          <rotationref ref="module_L6b_halfmodule_stereo_hole_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="11" />
+          <physvolid field_name="module" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L6b_halfmodule_stereo_slot_volume" />
+          <positionref ref="module_L6b_halfmodule_stereo_slot_position" />
+          <rotationref ref="module_L6b_halfmodule_stereo_slot_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="11" />
+          <physvolid field_name="module" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L6t_halfmodule_axial_hole_volume" />
+          <positionref ref="module_L6t_halfmodule_axial_hole_position" />
+          <rotationref ref="module_L6t_halfmodule_axial_hole_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="11" />
+          <physvolid field_name="module" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L6t_halfmodule_axial_slot_volume" />
+          <positionref ref="module_L6t_halfmodule_axial_slot_position" />
+          <rotationref ref="module_L6t_halfmodule_axial_slot_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="11" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L6t_halfmodule_stereo_hole_volume" />
+          <positionref ref="module_L6t_halfmodule_stereo_hole_position" />
+          <rotationref ref="module_L6t_halfmodule_stereo_hole_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="12" />
+          <physvolid field_name="module" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L6t_halfmodule_stereo_slot_volume" />
+          <positionref ref="module_L6t_halfmodule_stereo_slot_position" />
+          <rotationref ref="module_L6t_halfmodule_stereo_slot_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="12" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L7b_halfmodule_axial_hole_volume" />
+          <positionref ref="module_L7b_halfmodule_axial_hole_position" />
+          <rotationref ref="module_L7b_halfmodule_axial_hole_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="14" />
+          <physvolid field_name="module" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L7b_halfmodule_axial_slot_volume" />
+          <positionref ref="module_L7b_halfmodule_axial_slot_position" />
+          <rotationref ref="module_L7b_halfmodule_axial_slot_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="14" />
+          <physvolid field_name="module" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L7b_halfmodule_stereo_hole_volume" />
+          <positionref ref="module_L7b_halfmodule_stereo_hole_position" />
+          <rotationref ref="module_L7b_halfmodule_stereo_hole_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="13" />
+          <physvolid field_name="module" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L7b_halfmodule_stereo_slot_volume" />
+          <positionref ref="module_L7b_halfmodule_stereo_slot_position" />
+          <rotationref ref="module_L7b_halfmodule_stereo_slot_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="13" />
+          <physvolid field_name="module" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L7t_halfmodule_axial_hole_volume" />
+          <positionref ref="module_L7t_halfmodule_axial_hole_position" />
+          <rotationref ref="module_L7t_halfmodule_axial_hole_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="13" />
+          <physvolid field_name="module" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L7t_halfmodule_axial_slot_volume" />
+          <positionref ref="module_L7t_halfmodule_axial_slot_position" />
+          <rotationref ref="module_L7t_halfmodule_axial_slot_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="13" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L7t_halfmodule_stereo_hole_volume" />
+          <positionref ref="module_L7t_halfmodule_stereo_hole_position" />
+          <rotationref ref="module_L7t_halfmodule_stereo_hole_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="14" />
+          <physvolid field_name="module" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L7t_halfmodule_stereo_slot_volume" />
+          <positionref ref="module_L7t_halfmodule_stereo_slot_position" />
+          <rotationref ref="module_L7t_halfmodule_stereo_slot_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="14" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <visref ref="SvtBoxVis" />
+      </volume>
+      <volume name="BeamLeftVolume_component0Sensor0">
+        <materialref ref="Vacuum" />
+        <solidref ref="BeamLeftVolume_component0Sensor0Box" />
+        <sdref ref="ECalScoring" />
+      </volume>
+      <volume name="BeamLeftVolume_component0">
+        <materialref ref="Vacuum" />
+        <solidref ref="BeamLeftVolume_component0Box" />
+        <physvol>
+          <volumeref ref="BeamLeftVolume_component0Sensor0" />
+          <positionref ref="BeamLeftVolume_component0Sensor0Position" />
+          <rotationref ref="BeamLeftVolume_component0Sensor0Rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+      </volume>
+      <volume name="BeamLeftVolume">
+        <materialref ref="Vacuum" />
+        <solidref ref="BeamLeftBox" />
+        <physvol>
+          <volumeref ref="BeamLeftVolume_component0" />
+          <positionref ref="BeamLeftVolume_component0_position" />
+          <rotationref ref="BeamLeftVolume_component0_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+      </volume>
+      <volume name="ElectronGapVolume_component0Sensor0">
+        <materialref ref="Vacuum" />
+        <solidref ref="ElectronGapVolume_component0Sensor0Box" />
+        <sdref ref="ECalScoring" />
+      </volume>
+      <volume name="ElectronGapVolume_component0">
+        <materialref ref="Vacuum" />
+        <solidref ref="ElectronGapVolume_component0Box" />
+        <physvol>
+          <volumeref ref="ElectronGapVolume_component0Sensor0" />
+          <positionref ref="ElectronGapVolume_component0Sensor0Position" />
+          <rotationref ref="ElectronGapVolume_component0Sensor0Rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+      </volume>
+      <volume name="ElectronGapVolume">
+        <materialref ref="Vacuum" />
+        <solidref ref="ElectronGapBox" />
+        <physvol>
+          <volumeref ref="ElectronGapVolume_component0" />
+          <positionref ref="ElectronGapVolume_component0_position" />
+          <rotationref ref="ElectronGapVolume_component0_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+      </volume>
+      <volume name="BeamRightVolume_component0Sensor0">
+        <materialref ref="Vacuum" />
+        <solidref ref="BeamRightVolume_component0Sensor0Box" />
+        <sdref ref="ECalScoring" />
+      </volume>
+      <volume name="BeamRightVolume_component0">
+        <materialref ref="Vacuum" />
+        <solidref ref="BeamRightVolume_component0Box" />
+        <physvol>
+          <volumeref ref="BeamRightVolume_component0Sensor0" />
+          <positionref ref="BeamRightVolume_component0Sensor0Position" />
+          <rotationref ref="BeamRightVolume_component0Sensor0Rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+      </volume>
+      <volume name="BeamRightVolume">
+        <materialref ref="Vacuum" />
+        <solidref ref="BeamRightBox" />
+        <physvol>
+          <volumeref ref="BeamRightVolume_component0" />
+          <positionref ref="BeamRightVolume_component0_position" />
+          <rotationref ref="BeamRightVolume_component0_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+      </volume>
+      <volume name="crystal_volume">
+        <materialref ref="LeadTungstate" />
+        <solidref ref="crystal_trap" />
+        <sdref ref="Ecal" />
+        <visref ref="ECALVis" />
+      </volume>
+      <volume name="hodo_vol_L1TP0">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L1TP0" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L1TP0">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L1TP0" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L1TP0">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L1TP0" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L1TP0">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L1TP0" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_vol_L1BP0">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L1BP0" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L1BP0">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L1BP0" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L1BP0">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L1BP0" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L1BP0">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L1BP0" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_vol_L1TP1">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L1TP1" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L1TP1">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L1TP1" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L1TP1">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L1TP1" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L1TP1">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L1TP1" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_vol_L1BP1">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L1BP1" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L1BP1">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L1BP1" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L1BP1">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L1BP1" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L1BP1">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L1BP1" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_vol_L1TP2">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L1TP2" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L1TP2">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L1TP2" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L1TP2">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L1TP2" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L1TP2">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L1TP2" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_vol_L1BP2">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L1BP2" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L1BP2">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L1BP2" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L1BP2">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L1BP2" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L1BP2">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L1BP2" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_vol_L1TP3">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L1TP3" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L1TP3">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L1TP3" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L1TP3">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L1TP3" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L1TP3">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L1TP3" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_vol_L1BP3">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L1BP3" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L1BP3">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L1BP3" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L1BP3">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L1BP3" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L1BP3">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L1BP3" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_vol_L1TP4">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L1TP4" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L1TP4">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L1TP4" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L1TP4">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L1TP4" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L1TP4">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L1TP4" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_vol_L1BP4">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L1BP4" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L1BP4">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L1BP4" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L1BP4">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L1BP4" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L1BP4">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L1BP4" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_vol_L2TP0">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L2TP0" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L2TP0">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L2TP0" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L2TP0">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L2TP0" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L2TP0">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L2TP0" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_vol_L2BP0">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L2BP0" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L2BP0">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L2BP0" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L2BP0">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L2BP0" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L2BP0">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L2BP0" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_vol_L2TP1">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L2TP1" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L2TP1">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L2TP1" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L2TP1">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L2TP1" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L2TP1">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L2TP1" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_vol_L2BP1">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L2BP1" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L2BP1">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L2BP1" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L2BP1">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L2BP1" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L2BP1">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L2BP1" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_vol_L2TP2">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L2TP2" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L2TP2">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L2TP2" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L2TP2">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L2TP2" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L2TP2">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L2TP2" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_vol_L2BP2">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L2BP2" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L2BP2">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L2BP2" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L2BP2">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L2BP2" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L2BP2">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L2BP2" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_vol_L2TP3">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L2TP3" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L2TP3">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L2TP3" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L2TP3">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L2TP3" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L2TP3">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L2TP3" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_vol_L2BP3">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L2BP3" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L2BP3">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L2BP3" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L2BP3">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L2BP3" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L2BP3">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L2BP3" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_vol_L2TP4">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L2TP4" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L2TP4">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L2TP4" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L2TP4">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L2TP4" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L2TP4">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L2TP4" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_vol_L2BP4">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L2BP4" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L2BP4">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L2BP4" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L2BP4">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L2BP4" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L2BP4">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L2BP4" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_buffer_vol">
+        <materialref ref="Carbon" />
+        <solidref ref="hodo_buffer" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="front_flange">
+        <materialref ref="G4_Al" />
+        <solidref ref="front_flange_shape" />
+      </volume>
+      <volume name="back_flange">
+        <materialref ref="G4_Al" />
+        <solidref ref="back_flange_shape" />
+      </volume>
+      <volume name="ECAL_chamber">
+        <materialref ref="G4_Al" />
+        <solidref ref="ECAL_chamber_shape" />
+      </volume>
+      <volume name="al_honeycomb">
+        <materialref ref="AlHoneycomb" />
+        <solidref ref="al_honeycomb_shape" />
+      </volume>
+      <volume name="layer_1_top">
+        <materialref ref="G4_Al" />
+        <solidref ref="layer_1_top_shape" />
+      </volume>
+      <volume name="layer_2_top">
+        <materialref ref="G4_Al" />
+        <solidref ref="layer_2_top_shape" />
+      </volume>
+      <volume name="layer_3_top">
+        <materialref ref="G4_Al" />
+        <solidref ref="layer_3_top_shape" />
+      </volume>
+      <volume name="layer_4_top">
+        <materialref ref="G4_Al" />
+        <solidref ref="layer_4_top_shape" />
+      </volume>
+      <volume name="layer_1_bottom">
+        <materialref ref="G4_Al" />
+        <solidref ref="layer_1_bottom_shape" />
+      </volume>
+      <volume name="layer_2_bottom">
+        <materialref ref="G4_Al" />
+        <solidref ref="layer_2_bottom_shape" />
+      </volume>
+      <volume name="layer_3_bottom">
+        <materialref ref="G4_Al" />
+        <solidref ref="layer_3_bottom_shape" />
+      </volume>
+      <volume name="layer_4_bottom">
+        <materialref ref="G4_Al" />
+        <solidref ref="layer_4_bottom_shape" />
+      </volume>
+      <volume name="layer_5T_left">
+        <materialref ref="G4_Al" />
+        <solidref ref="layer_5T_left_shape" />
+      </volume>
+      <volume name="layer_5B_left">
+        <materialref ref="G4_Al" />
+        <solidref ref="layer_5B_left_shape" />
+      </volume>
+      <volume name="steel_bar">
+        <materialref ref="StainlessSteel" />
+        <solidref ref="steel_bar_shape" />
+      </volume>
+      <volume name="cu_Tpipe_inner_left">
+        <materialref ref="G4_Cu" />
+        <solidref ref="cu_Tpipe_inner_left_shape" />
+      </volume>
+      <volume name="cu_Tpipe_inner_right">
+        <materialref ref="G4_Cu" />
+        <solidref ref="cu_Tpipe_inner_right_shape" />
+      </volume>
+      <volume name="cu_Bpipe_inner_left">
+        <materialref ref="G4_Cu" />
+        <solidref ref="cu_Bpipe_inner_left_shape" />
+      </volume>
+      <volume name="cu_Bpipe_inner_right">
+        <materialref ref="G4_Cu" />
+        <solidref ref="cu_Bpipe_inner_right_shape" />
+      </volume>
+      <volume name="cu_Tpipe_outer_right1">
+        <materialref ref="G4_Cu" />
+        <solidref ref="cu_Tpipe_outer_right1_shape" />
+      </volume>
+      <volume name="cu_Tpipe_outer_right2">
+        <materialref ref="G4_Cu" />
+        <solidref ref="cu_Tpipe_outer_right2_shape" />
+      </volume>
+      <volume name="cu_Tpipe_outer_right3">
+        <materialref ref="G4_Cu" />
+        <solidref ref="cu_Tpipe_outer_right3_shape" />
+      </volume>
+      <volume name="cu_Bpipe_outer_right">
+        <materialref ref="G4_Cu" />
+        <solidref ref="cu_Bpipe_outer_right_shape" />
+      </volume>
+      <volume name="cu_Bpipe_outer_right1">
+        <materialref ref="G4_Cu" />
+        <solidref ref="cu_Bpipe_outer_right1_shape" />
+      </volume>
+      <volume name="cu_Bpipe_outer_right2">
+        <materialref ref="G4_Cu" />
+        <solidref ref="cu_Bpipe_outer_right2_shape" />
+      </volume>
+      <volume name="al_pipe_across_top1">
+        <materialref ref="G4_Al" />
+        <solidref ref="al_pipe_across_top1_shape" />
+      </volume>
+      <volume name="al_pipe_across_top2">
+        <materialref ref="G4_Al" />
+        <solidref ref="al_pipe_across_top2_shape" />
+      </volume>
+      <volume name="al_pipe_across_bottom1">
+        <materialref ref="G4_Al" />
+        <solidref ref="al_pipe_across_bottom1_shape" />
+      </volume>
+      <volume name="al_pipe_across_bottom2">
+        <materialref ref="G4_Al" />
+        <solidref ref="al_pipe_across_bottom2_shape" />
+      </volume>
+      <volume name="cu_plate_top_left">
+        <materialref ref="G4_Cu" />
+        <solidref ref="cu_plate_top_left_shape" />
+      </volume>
+      <volume name="cu_plate_bottom_left">
+        <materialref ref="G4_Cu" />
+        <solidref ref="cu_plate_bottom_left_shape" />
+      </volume>
+      <volume name="cu_plate_top_right">
+        <materialref ref="G4_Cu" />
+        <solidref ref="cu_plate_top_right_shape" />
+      </volume>
+      <volume name="cu_plate_bottom_right">
+        <materialref ref="G4_Cu" />
+        <solidref ref="cu_plate_bottom_right_shape" />
+      </volume>
+      <volume name="cu_plate_top_middle">
+        <materialref ref="G4_Cu" />
+        <solidref ref="cu_plate_top_middle_shape" />
+      </volume>
+      <volume name="cu_plate_bottom_middle">
+        <materialref ref="G4_Cu" />
+        <solidref ref="cu_plate_bottom_middle_shape" />
+      </volume>
+      <volume name="hodo_flange">
+        <materialref ref="Aluminum" />
+        <solidref ref="hodo_flange_shape" />
+      </volume>
+      <volume name="arms1_block1">
+        <materialref ref="G10_FR4" />
+        <solidref ref="arms1_block1_shape" />
+      </volume>
+      <volume name="arms1_block2">
+        <materialref ref="G10_FR4" />
+        <solidref ref="arms1_block2_shape" />
+      </volume>
+      <volume name="arms1_block3">
+        <materialref ref="G10_FR4" />
+        <solidref ref="arms1_block3_shape" />
+      </volume>
+      <volume name="arms1_block4">
+        <materialref ref="G10_FR4" />
+        <solidref ref="arms1_block4_shape" />
+      </volume>
+      <volume name="cross_bar_top">
+        <materialref ref="G10_FR4" />
+        <solidref ref="cross_bar_top_shape" />
+      </volume>
+      <volume name="cross_bar_bottom">
+        <materialref ref="G10_FR4" />
+        <solidref ref="cross_bar_bottom_shape" />
+      </volume>
+      <volume name="support_arm_bottom_left_plus_block">
+        <materialref ref="G10_FR4" />
+        <solidref ref="support_arm_bottom_left_plus_block_shape" />
+      </volume>
+      <volume name="support_arm_bottom_right">
+        <materialref ref="G10_FR4" />
+        <solidref ref="support_arm_bottom_right_shape" />
+      </volume>
+      <volume name="support_arm_top_left">
+        <materialref ref="G10_FR4" />
+        <solidref ref="support_arm_top_left_shape" />
+      </volume>
+      <volume name="support_arm_top_right">
+        <materialref ref="G10_FR4" />
+        <solidref ref="support_arm_top_right_shape" />
+      </volume>
+      <volume name="u_support_bar_bottom">
+        <materialref ref="G10_FR4" />
+        <solidref ref="u_support_bar_bottom_shape" />
+      </volume>
+      <volume name="u_support_bar_upper1">
+        <materialref ref="G10_FR4" />
+        <solidref ref="u_support_bar_upper1_shape" />
+      </volume>
+      <volume name="u_support_bar_upper2">
+        <materialref ref="G10_FR4" />
+        <solidref ref="u_support_bar_upper2_shape" />
+      </volume>
+      <volume name="u_support_bar_top">
+        <materialref ref="G10_FR4" />
+        <solidref ref="u_support_bar_top_shape" />
+      </volume>
+      <volume name="u_support_bar_upper3">
+        <materialref ref="G10_FR4" />
+        <solidref ref="u_support_bar_upper3_shape" />
+      </volume>
+      <volume name="u_support_bar_upper4">
+        <materialref ref="G10_FR4" />
+        <solidref ref="u_support_bar_upper4_shape" />
+      </volume>
+      <volume name="svt_chamber_box_vol">
+        <materialref ref="Stainless_304" />
+        <solidref ref="svt_chamber_box" />
+      </volume>
+      <volume name="svt_chamber_flare1_vol">
+        <materialref ref="Stainless_304" />
+        <solidref ref="svt_chamber_flare1" />
+      </volume>
+      <volume name="svt_chamber_flare2_vol">
+        <materialref ref="Stainless_304" />
+        <solidref ref="svt_chamber_flare2" />
+      </volume>
+      <volume name="svt_chamber_flange_vol">
+        <materialref ref="Stainless_304" />
+        <solidref ref="svt_chamber_flange" />
+      </volume>
+      <volume name="tracking_volume">
+        <materialref ref="TrackingMaterial" />
+        <solidref ref="tracking_cylinder" />
+        <physvol>
+          <volumeref ref="base_volume" />
+          <positionref ref="base_position" />
+          <rotationref ref="base_rotation" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L1TP0" />
+          <positionref ref="hodo_pos_L1TP0" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="0" />
+          <physvolid field_name="ix" value="0" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1TP0" />
+          <positionref ref="hodo_forecover_pos_L1TP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1TP0" />
+          <positionref ref="hodo_postcover_pos_L1TP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1TP0" />
+          <positionref ref="hodo_sidereflR_pos_L1TP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1TP0" />
+          <positionref ref="hodo_siderefl2L_pos_L1TP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1TP0" />
+          <positionref ref="hodo_topreflT_pos_L1TP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1TP0" />
+          <positionref ref="hodo_toprefl2B_pos_L1TP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L1BP0" />
+          <positionref ref="hodo_pos_L1BP0" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="0" />
+          <physvolid field_name="ix" value="0" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1BP0" />
+          <positionref ref="hodo_forecover_pos_L1BP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1BP0" />
+          <positionref ref="hodo_postcover_pos_L1BP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1BP0" />
+          <positionref ref="hodo_sidereflR_pos_L1BP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1BP0" />
+          <positionref ref="hodo_siderefl2L_pos_L1BP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1BP0" />
+          <positionref ref="hodo_topreflT_pos_L1BP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1BP0" />
+          <positionref ref="hodo_toprefl2B_pos_L1BP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L1TP1" />
+          <positionref ref="hodo_pos_L1TP1" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="0" />
+          <physvolid field_name="ix" value="1" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1TP1" />
+          <positionref ref="hodo_forecover_pos_L1TP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1TP1" />
+          <positionref ref="hodo_postcover_pos_L1TP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1TP1" />
+          <positionref ref="hodo_sidereflR_pos_L1TP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1TP1" />
+          <positionref ref="hodo_siderefl2L_pos_L1TP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1TP1" />
+          <positionref ref="hodo_topreflT_pos_L1TP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1TP1" />
+          <positionref ref="hodo_toprefl2B_pos_L1TP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L1BP1" />
+          <positionref ref="hodo_pos_L1BP1" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="0" />
+          <physvolid field_name="ix" value="1" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1BP1" />
+          <positionref ref="hodo_forecover_pos_L1BP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1BP1" />
+          <positionref ref="hodo_postcover_pos_L1BP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1BP1" />
+          <positionref ref="hodo_sidereflR_pos_L1BP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1BP1" />
+          <positionref ref="hodo_siderefl2L_pos_L1BP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1BP1" />
+          <positionref ref="hodo_topreflT_pos_L1BP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1BP1" />
+          <positionref ref="hodo_toprefl2B_pos_L1BP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L1TP2" />
+          <positionref ref="hodo_pos_L1TP2" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="0" />
+          <physvolid field_name="ix" value="2" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1TP2" />
+          <positionref ref="hodo_forecover_pos_L1TP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1TP2" />
+          <positionref ref="hodo_postcover_pos_L1TP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1TP2" />
+          <positionref ref="hodo_sidereflR_pos_L1TP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1TP2" />
+          <positionref ref="hodo_siderefl2L_pos_L1TP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1TP2" />
+          <positionref ref="hodo_topreflT_pos_L1TP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1TP2" />
+          <positionref ref="hodo_toprefl2B_pos_L1TP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L1BP2" />
+          <positionref ref="hodo_pos_L1BP2" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="0" />
+          <physvolid field_name="ix" value="2" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1BP2" />
+          <positionref ref="hodo_forecover_pos_L1BP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1BP2" />
+          <positionref ref="hodo_postcover_pos_L1BP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1BP2" />
+          <positionref ref="hodo_sidereflR_pos_L1BP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1BP2" />
+          <positionref ref="hodo_siderefl2L_pos_L1BP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1BP2" />
+          <positionref ref="hodo_topreflT_pos_L1BP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1BP2" />
+          <positionref ref="hodo_toprefl2B_pos_L1BP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L1TP3" />
+          <positionref ref="hodo_pos_L1TP3" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="0" />
+          <physvolid field_name="ix" value="3" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1TP3" />
+          <positionref ref="hodo_forecover_pos_L1TP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1TP3" />
+          <positionref ref="hodo_postcover_pos_L1TP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1TP3" />
+          <positionref ref="hodo_sidereflR_pos_L1TP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1TP3" />
+          <positionref ref="hodo_siderefl2L_pos_L1TP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1TP3" />
+          <positionref ref="hodo_topreflT_pos_L1TP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1TP3" />
+          <positionref ref="hodo_toprefl2B_pos_L1TP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L1BP3" />
+          <positionref ref="hodo_pos_L1BP3" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="0" />
+          <physvolid field_name="ix" value="3" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1BP3" />
+          <positionref ref="hodo_forecover_pos_L1BP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1BP3" />
+          <positionref ref="hodo_postcover_pos_L1BP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1BP3" />
+          <positionref ref="hodo_sidereflR_pos_L1BP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1BP3" />
+          <positionref ref="hodo_siderefl2L_pos_L1BP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1BP3" />
+          <positionref ref="hodo_topreflT_pos_L1BP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1BP3" />
+          <positionref ref="hodo_toprefl2B_pos_L1BP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L1TP4" />
+          <positionref ref="hodo_pos_L1TP4" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="0" />
+          <physvolid field_name="ix" value="4" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1TP4" />
+          <positionref ref="hodo_forecover_pos_L1TP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1TP4" />
+          <positionref ref="hodo_postcover_pos_L1TP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1TP4" />
+          <positionref ref="hodo_sidereflR_pos_L1TP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1TP4" />
+          <positionref ref="hodo_siderefl2L_pos_L1TP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1TP4" />
+          <positionref ref="hodo_topreflT_pos_L1TP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1TP4" />
+          <positionref ref="hodo_toprefl2B_pos_L1TP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L1BP4" />
+          <positionref ref="hodo_pos_L1BP4" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="0" />
+          <physvolid field_name="ix" value="4" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1BP4" />
+          <positionref ref="hodo_forecover_pos_L1BP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1BP4" />
+          <positionref ref="hodo_postcover_pos_L1BP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1BP4" />
+          <positionref ref="hodo_sidereflR_pos_L1BP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1BP4" />
+          <positionref ref="hodo_siderefl2L_pos_L1BP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1BP4" />
+          <positionref ref="hodo_topreflT_pos_L1BP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1BP4" />
+          <positionref ref="hodo_toprefl2B_pos_L1BP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L2TP0" />
+          <positionref ref="hodo_pos_L2TP0" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="1" />
+          <physvolid field_name="ix" value="0" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2TP0" />
+          <positionref ref="hodo_forecover_pos_L2TP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2TP0" />
+          <positionref ref="hodo_postcover_pos_L2TP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2TP0" />
+          <positionref ref="hodo_sidereflR_pos_L2TP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2TP0" />
+          <positionref ref="hodo_siderefl2L_pos_L2TP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2TP0" />
+          <positionref ref="hodo_topreflT_pos_L2TP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2TP0" />
+          <positionref ref="hodo_toprefl2B_pos_L2TP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L2BP0" />
+          <positionref ref="hodo_pos_L2BP0" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="1" />
+          <physvolid field_name="ix" value="0" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2BP0" />
+          <positionref ref="hodo_forecover_pos_L2BP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2BP0" />
+          <positionref ref="hodo_postcover_pos_L2BP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2BP0" />
+          <positionref ref="hodo_sidereflR_pos_L2BP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2BP0" />
+          <positionref ref="hodo_siderefl2L_pos_L2BP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2BP0" />
+          <positionref ref="hodo_topreflT_pos_L2BP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2BP0" />
+          <positionref ref="hodo_toprefl2B_pos_L2BP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L2TP1" />
+          <positionref ref="hodo_pos_L2TP1" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="1" />
+          <physvolid field_name="ix" value="1" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2TP1" />
+          <positionref ref="hodo_forecover_pos_L2TP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2TP1" />
+          <positionref ref="hodo_postcover_pos_L2TP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2TP1" />
+          <positionref ref="hodo_sidereflR_pos_L2TP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2TP1" />
+          <positionref ref="hodo_siderefl2L_pos_L2TP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2TP1" />
+          <positionref ref="hodo_topreflT_pos_L2TP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2TP1" />
+          <positionref ref="hodo_toprefl2B_pos_L2TP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L2BP1" />
+          <positionref ref="hodo_pos_L2BP1" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="1" />
+          <physvolid field_name="ix" value="1" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2BP1" />
+          <positionref ref="hodo_forecover_pos_L2BP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2BP1" />
+          <positionref ref="hodo_postcover_pos_L2BP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2BP1" />
+          <positionref ref="hodo_sidereflR_pos_L2BP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2BP1" />
+          <positionref ref="hodo_siderefl2L_pos_L2BP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2BP1" />
+          <positionref ref="hodo_topreflT_pos_L2BP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2BP1" />
+          <positionref ref="hodo_toprefl2B_pos_L2BP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L2TP2" />
+          <positionref ref="hodo_pos_L2TP2" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="1" />
+          <physvolid field_name="ix" value="2" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2TP2" />
+          <positionref ref="hodo_forecover_pos_L2TP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2TP2" />
+          <positionref ref="hodo_postcover_pos_L2TP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2TP2" />
+          <positionref ref="hodo_sidereflR_pos_L2TP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2TP2" />
+          <positionref ref="hodo_siderefl2L_pos_L2TP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2TP2" />
+          <positionref ref="hodo_topreflT_pos_L2TP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2TP2" />
+          <positionref ref="hodo_toprefl2B_pos_L2TP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L2BP2" />
+          <positionref ref="hodo_pos_L2BP2" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="1" />
+          <physvolid field_name="ix" value="2" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2BP2" />
+          <positionref ref="hodo_forecover_pos_L2BP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2BP2" />
+          <positionref ref="hodo_postcover_pos_L2BP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2BP2" />
+          <positionref ref="hodo_sidereflR_pos_L2BP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2BP2" />
+          <positionref ref="hodo_siderefl2L_pos_L2BP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2BP2" />
+          <positionref ref="hodo_topreflT_pos_L2BP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2BP2" />
+          <positionref ref="hodo_toprefl2B_pos_L2BP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L2TP3" />
+          <positionref ref="hodo_pos_L2TP3" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="1" />
+          <physvolid field_name="ix" value="3" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2TP3" />
+          <positionref ref="hodo_forecover_pos_L2TP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2TP3" />
+          <positionref ref="hodo_postcover_pos_L2TP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2TP3" />
+          <positionref ref="hodo_sidereflR_pos_L2TP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2TP3" />
+          <positionref ref="hodo_siderefl2L_pos_L2TP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2TP3" />
+          <positionref ref="hodo_topreflT_pos_L2TP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2TP3" />
+          <positionref ref="hodo_toprefl2B_pos_L2TP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L2BP3" />
+          <positionref ref="hodo_pos_L2BP3" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="1" />
+          <physvolid field_name="ix" value="3" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2BP3" />
+          <positionref ref="hodo_forecover_pos_L2BP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2BP3" />
+          <positionref ref="hodo_postcover_pos_L2BP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2BP3" />
+          <positionref ref="hodo_sidereflR_pos_L2BP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2BP3" />
+          <positionref ref="hodo_siderefl2L_pos_L2BP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2BP3" />
+          <positionref ref="hodo_topreflT_pos_L2BP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2BP3" />
+          <positionref ref="hodo_toprefl2B_pos_L2BP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L2TP4" />
+          <positionref ref="hodo_pos_L2TP4" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="1" />
+          <physvolid field_name="ix" value="4" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2TP4" />
+          <positionref ref="hodo_forecover_pos_L2TP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2TP4" />
+          <positionref ref="hodo_postcover_pos_L2TP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2TP4" />
+          <positionref ref="hodo_sidereflR_pos_L2TP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2TP4" />
+          <positionref ref="hodo_siderefl2L_pos_L2TP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2TP4" />
+          <positionref ref="hodo_topreflT_pos_L2TP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2TP4" />
+          <positionref ref="hodo_toprefl2B_pos_L2TP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L2BP4" />
+          <positionref ref="hodo_pos_L2BP4" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="1" />
+          <physvolid field_name="ix" value="4" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2BP4" />
+          <positionref ref="hodo_forecover_pos_L2BP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2BP4" />
+          <positionref ref="hodo_postcover_pos_L2BP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2BP4" />
+          <positionref ref="hodo_sidereflR_pos_L2BP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2BP4" />
+          <positionref ref="hodo_siderefl2L_pos_L2BP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2BP4" />
+          <positionref ref="hodo_topreflT_pos_L2BP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2BP4" />
+          <positionref ref="hodo_toprefl2B_pos_L2BP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_buffer_vol" />
+          <positionref ref="hodo_bufferT_pos" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_buffer_vol" />
+          <positionref ref="hodo_bufferB_pos" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol name="hodo_flange_1">
+          <volumeref ref="hodo_flange" />
+          <positionref ref="hodo_flange_1intracking_volumepos" />
+        </physvol>
+        <physvol name="arms1_block1_1">
+          <volumeref ref="arms1_block1" />
+          <positionref ref="arms1_block1_1intracking_volumepos" />
+        </physvol>
+        <physvol name="arms1_block2_1">
+          <volumeref ref="arms1_block2" />
+          <positionref ref="arms1_block2_1intracking_volumepos" />
+        </physvol>
+        <physvol name="arms1_block3_1">
+          <volumeref ref="arms1_block3" />
+          <positionref ref="arms1_block3_1intracking_volumepos" />
+        </physvol>
+        <physvol name="arms1_block4_1">
+          <volumeref ref="arms1_block4" />
+          <positionref ref="arms1_block4_1intracking_volumepos" />
+        </physvol>
+        <physvol name="cross_bar_top_1">
+          <volumeref ref="cross_bar_top" />
+          <positionref ref="cross_bar_top_1intracking_volumepos" />
+        </physvol>
+        <physvol name="cross_bar_bottom_1">
+          <volumeref ref="cross_bar_bottom" />
+          <positionref ref="cross_bar_bottom_1intracking_volumepos" />
+        </physvol>
+        <physvol name="support_arm_bottom_left_plus_block_1">
+          <volumeref ref="support_arm_bottom_left_plus_block" />
+          <positionref ref="support_arm_bottom_left_plus_block_1intracking_volumepos" />
+        </physvol>
+        <physvol name="support_arm_bottom_right_1">
+          <volumeref ref="support_arm_bottom_right" />
+          <positionref ref="support_arm_bottom_right_1intracking_volumepos" />
+        </physvol>
+        <physvol name="support_arm_top_left_1">
+          <volumeref ref="support_arm_top_left" />
+          <positionref ref="support_arm_top_left_1intracking_volumepos" />
+          <rotationref ref="support_arm_top_left_1intracking_volumerot" />
+        </physvol>
+        <physvol name="support_arm_top_right_1">
+          <volumeref ref="support_arm_top_right" />
+          <positionref ref="support_arm_top_right_1intracking_volumepos" />
+          <rotationref ref="support_arm_top_right_1intracking_volumerot" />
+        </physvol>
+        <physvol name="u_support_bar_bottom_1">
+          <volumeref ref="u_support_bar_bottom" />
+          <positionref ref="u_support_bar_bottom_1intracking_volumepos" />
+        </physvol>
+        <physvol name="u_support_bar_upper1_1">
+          <volumeref ref="u_support_bar_upper1" />
+          <positionref ref="u_support_bar_upper1_1intracking_volumepos" />
+        </physvol>
+        <physvol name="u_support_bar_upper2_1">
+          <volumeref ref="u_support_bar_upper2" />
+          <positionref ref="u_support_bar_upper2_1intracking_volumepos" />
+        </physvol>
+        <physvol name="u_support_bar_top_1">
+          <volumeref ref="u_support_bar_top" />
+          <positionref ref="u_support_bar_top_1intracking_volumepos" />
+        </physvol>
+        <physvol name="u_support_bar_upper3_1">
+          <volumeref ref="u_support_bar_upper3" />
+          <positionref ref="u_support_bar_upper3_1intracking_volumepos" />
+        </physvol>
+        <physvol name="u_support_bar_upper4_1">
+          <volumeref ref="u_support_bar_upper4" />
+          <positionref ref="u_support_bar_upper4_1intracking_volumepos" />
+        </physvol>
+        <physvol>
+          <volumeref ref="svt_chamber_box_vol" />
+          <position name="svt_chamber_box_position" x="svt_chamber_x" y="0" z="svt_chamber_z+svt_chamber_box_z" />
+        </physvol>
+        <physvol>
+          <volumeref ref="svt_chamber_flare1_vol" />
+          <position name="svt_chamber_flare1_position" x="svt_chamber_x" y="0" z="svt_chamber_z+svt_chamber_flare1_z" />
+        </physvol>
+        <physvol>
+          <volumeref ref="svt_chamber_flare2_vol" />
+          <position name="svt_chamber_flare2_position" x="svt_chamber_x" y="0" z="svt_chamber_z+svt_chamber_flare2_z" />
+        </physvol>
+        <physvol>
+          <volumeref ref="svt_chamber_flange_vol" />
+          <position name="svt_chamber_flange_position" x="svt_chamber_x" y="0" z="svt_chamber_z+svt_chamber_flange_z" />
+        </physvol>
+        <regionref ref="TrackingRegion" />
+        <visref ref="TrackingVis" />
+      </volume>
+      <volume name="world_volume">
+        <materialref ref="WorldMaterial" />
+        <solidref ref="world_box" />
+        <physvol>
+          <volumeref ref="tracking_volume" />
+          <positionref ref="tracking_region_pos" />
+          <rotationref ref="identity_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="BeamLeftVolume" />
+          <positionref ref="ECalScoring_BeamLeft_layer1_module0_position" />
+          <rotationref ref="ECalScoring_BeamLeft_layer1_module0_rotation" />
+          <physvolid field_name="system" value="29" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="1" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="ElectronGapVolume" />
+          <positionref ref="ECalScoring_ElectronGap_layer1_module0_position" />
+          <rotationref ref="ECalScoring_ElectronGap_layer1_module0_rotation" />
+          <physvolid field_name="system" value="29" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="1" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="BeamRightVolume" />
+          <positionref ref="ECalScoring_BeamRight_layer1_module0_position" />
+          <rotationref ref="ECalScoring_BeamRight_layer1_module0_rotation" />
+          <physvolid field_name="system" value="29" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="1" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="BeamLeftVolume" />
+          <positionref ref="ECalScoring_BeamLeft_layer2_module0_position" />
+          <rotationref ref="ECalScoring_BeamLeft_layer2_module0_rotation" />
+          <physvolid field_name="system" value="29" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="2" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="ElectronGapVolume" />
+          <positionref ref="ECalScoring_ElectronGap_layer2_module0_position" />
+          <rotationref ref="ECalScoring_ElectronGap_layer2_module0_rotation" />
+          <physvolid field_name="system" value="29" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="2" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="BeamRightVolume" />
+          <positionref ref="ECalScoring_BeamRight_layer2_module0_position" />
+          <rotationref ref="ECalScoring_BeamRight_layer2_module0_rotation" />
+          <physvolid field_name="system" value="29" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="2" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-1_pos_pos_bot" />
+          <rotationref ref="crystal1-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="1" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-1_pos_neg_bot" />
+          <rotationref ref="crystal1-1_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-1" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-1_pos_pos_top" />
+          <rotationref ref="crystal1-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="1" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-1_pos_neg_top" />
+          <rotationref ref="crystal1-1_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-1" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal2-1_pos_pos_bot" />
+          <rotationref ref="crystal2-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="2" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal2-1_pos_pos_top" />
+          <rotationref ref="crystal2-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="2" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal3-1_pos_pos_bot" />
+          <rotationref ref="crystal3-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="3" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal3-1_pos_pos_top" />
+          <rotationref ref="crystal3-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="3" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal4-1_pos_pos_bot" />
+          <rotationref ref="crystal4-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="4" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal4-1_pos_pos_top" />
+          <rotationref ref="crystal4-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="4" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal5-1_pos_pos_bot" />
+          <rotationref ref="crystal5-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="5" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal5-1_pos_pos_top" />
+          <rotationref ref="crystal5-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="5" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal6-1_pos_pos_bot" />
+          <rotationref ref="crystal6-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="6" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal6-1_pos_pos_top" />
+          <rotationref ref="crystal6-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="6" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal7-1_pos_pos_bot" />
+          <rotationref ref="crystal7-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="7" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal7-1_pos_pos_top" />
+          <rotationref ref="crystal7-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="7" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal8-1_pos_pos_bot" />
+          <rotationref ref="crystal8-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="8" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal8-1_pos_pos_top" />
+          <rotationref ref="crystal8-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="8" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal9-1_pos_pos_bot" />
+          <rotationref ref="crystal9-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="9" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal9-1_pos_pos_top" />
+          <rotationref ref="crystal9-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="9" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal10-1_pos_pos_bot" />
+          <rotationref ref="crystal10-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="10" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal10-1_pos_pos_top" />
+          <rotationref ref="crystal10-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="10" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-1_pos_pos_bot" />
+          <rotationref ref="crystal11-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="11" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-1_pos_neg_bot" />
+          <rotationref ref="crystal11-1_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-11" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-1_pos_pos_top" />
+          <rotationref ref="crystal11-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="11" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-1_pos_neg_top" />
+          <rotationref ref="crystal11-1_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-11" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-1_pos_pos_bot" />
+          <rotationref ref="crystal12-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="12" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-1_pos_neg_bot" />
+          <rotationref ref="crystal12-1_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-12" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-1_pos_pos_top" />
+          <rotationref ref="crystal12-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="12" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-1_pos_neg_top" />
+          <rotationref ref="crystal12-1_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-12" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-1_pos_pos_bot" />
+          <rotationref ref="crystal13-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="13" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-1_pos_neg_bot" />
+          <rotationref ref="crystal13-1_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-13" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-1_pos_pos_top" />
+          <rotationref ref="crystal13-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="13" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-1_pos_neg_top" />
+          <rotationref ref="crystal13-1_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-13" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-1_pos_pos_bot" />
+          <rotationref ref="crystal14-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="14" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-1_pos_neg_bot" />
+          <rotationref ref="crystal14-1_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-14" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-1_pos_pos_top" />
+          <rotationref ref="crystal14-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="14" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-1_pos_neg_top" />
+          <rotationref ref="crystal14-1_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-14" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-1_pos_pos_bot" />
+          <rotationref ref="crystal15-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="15" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-1_pos_neg_bot" />
+          <rotationref ref="crystal15-1_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-15" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-1_pos_pos_top" />
+          <rotationref ref="crystal15-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="15" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-1_pos_neg_top" />
+          <rotationref ref="crystal15-1_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-15" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-1_pos_pos_bot" />
+          <rotationref ref="crystal16-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="16" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-1_pos_neg_bot" />
+          <rotationref ref="crystal16-1_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-16" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-1_pos_pos_top" />
+          <rotationref ref="crystal16-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="16" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-1_pos_neg_top" />
+          <rotationref ref="crystal16-1_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-16" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-1_pos_pos_bot" />
+          <rotationref ref="crystal17-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="17" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-1_pos_neg_bot" />
+          <rotationref ref="crystal17-1_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-17" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-1_pos_pos_top" />
+          <rotationref ref="crystal17-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="17" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-1_pos_neg_top" />
+          <rotationref ref="crystal17-1_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-17" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-1_pos_pos_bot" />
+          <rotationref ref="crystal18-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="18" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-1_pos_neg_bot" />
+          <rotationref ref="crystal18-1_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-18" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-1_pos_pos_top" />
+          <rotationref ref="crystal18-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="18" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-1_pos_neg_top" />
+          <rotationref ref="crystal18-1_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-18" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-1_pos_pos_bot" />
+          <rotationref ref="crystal19-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="19" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-1_pos_neg_bot" />
+          <rotationref ref="crystal19-1_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-19" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-1_pos_pos_top" />
+          <rotationref ref="crystal19-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="19" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-1_pos_neg_top" />
+          <rotationref ref="crystal19-1_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-19" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-1_pos_pos_bot" />
+          <rotationref ref="crystal20-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="20" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-1_pos_neg_bot" />
+          <rotationref ref="crystal20-1_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-20" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-1_pos_pos_top" />
+          <rotationref ref="crystal20-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="20" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-1_pos_neg_top" />
+          <rotationref ref="crystal20-1_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-20" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-1_pos_pos_bot" />
+          <rotationref ref="crystal21-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="21" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-1_pos_neg_bot" />
+          <rotationref ref="crystal21-1_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-21" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-1_pos_pos_top" />
+          <rotationref ref="crystal21-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="21" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-1_pos_neg_top" />
+          <rotationref ref="crystal21-1_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-21" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-1_pos_pos_bot" />
+          <rotationref ref="crystal22-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="22" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-1_pos_neg_bot" />
+          <rotationref ref="crystal22-1_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-22" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-1_pos_pos_top" />
+          <rotationref ref="crystal22-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="22" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-1_pos_neg_top" />
+          <rotationref ref="crystal22-1_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-22" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-1_pos_pos_bot" />
+          <rotationref ref="crystal23-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="23" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-1_pos_neg_bot" />
+          <rotationref ref="crystal23-1_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-23" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-1_pos_pos_top" />
+          <rotationref ref="crystal23-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="23" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-1_pos_neg_top" />
+          <rotationref ref="crystal23-1_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-23" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-2_pos_pos_bot" />
+          <rotationref ref="crystal1-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="1" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-2_pos_neg_bot" />
+          <rotationref ref="crystal1-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-1" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-2_pos_pos_top" />
+          <rotationref ref="crystal1-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="1" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-2_pos_neg_top" />
+          <rotationref ref="crystal1-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-1" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal2-2_pos_pos_bot" />
+          <rotationref ref="crystal2-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="2" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal2-2_pos_neg_bot" />
+          <rotationref ref="crystal2-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-2" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal2-2_pos_pos_top" />
+          <rotationref ref="crystal2-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="2" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal2-2_pos_neg_top" />
+          <rotationref ref="crystal2-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-2" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal3-2_pos_pos_bot" />
+          <rotationref ref="crystal3-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="3" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal3-2_pos_neg_bot" />
+          <rotationref ref="crystal3-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-3" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal3-2_pos_pos_top" />
+          <rotationref ref="crystal3-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="3" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal3-2_pos_neg_top" />
+          <rotationref ref="crystal3-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-3" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal4-2_pos_pos_bot" />
+          <rotationref ref="crystal4-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="4" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal4-2_pos_neg_bot" />
+          <rotationref ref="crystal4-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-4" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal4-2_pos_pos_top" />
+          <rotationref ref="crystal4-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="4" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal4-2_pos_neg_top" />
+          <rotationref ref="crystal4-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-4" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal5-2_pos_pos_bot" />
+          <rotationref ref="crystal5-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="5" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal5-2_pos_neg_bot" />
+          <rotationref ref="crystal5-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-5" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal5-2_pos_pos_top" />
+          <rotationref ref="crystal5-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="5" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal5-2_pos_neg_top" />
+          <rotationref ref="crystal5-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-5" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal6-2_pos_pos_bot" />
+          <rotationref ref="crystal6-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="6" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal6-2_pos_neg_bot" />
+          <rotationref ref="crystal6-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-6" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal6-2_pos_pos_top" />
+          <rotationref ref="crystal6-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="6" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal6-2_pos_neg_top" />
+          <rotationref ref="crystal6-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-6" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal7-2_pos_pos_bot" />
+          <rotationref ref="crystal7-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="7" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal7-2_pos_neg_bot" />
+          <rotationref ref="crystal7-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-7" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal7-2_pos_pos_top" />
+          <rotationref ref="crystal7-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="7" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal7-2_pos_neg_top" />
+          <rotationref ref="crystal7-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-7" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal8-2_pos_pos_bot" />
+          <rotationref ref="crystal8-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="8" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal8-2_pos_neg_bot" />
+          <rotationref ref="crystal8-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-8" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal8-2_pos_pos_top" />
+          <rotationref ref="crystal8-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="8" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal8-2_pos_neg_top" />
+          <rotationref ref="crystal8-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-8" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal9-2_pos_pos_bot" />
+          <rotationref ref="crystal9-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="9" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal9-2_pos_neg_bot" />
+          <rotationref ref="crystal9-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-9" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal9-2_pos_pos_top" />
+          <rotationref ref="crystal9-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="9" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal9-2_pos_neg_top" />
+          <rotationref ref="crystal9-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-9" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal10-2_pos_pos_bot" />
+          <rotationref ref="crystal10-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="10" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal10-2_pos_neg_bot" />
+          <rotationref ref="crystal10-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-10" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal10-2_pos_pos_top" />
+          <rotationref ref="crystal10-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="10" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal10-2_pos_neg_top" />
+          <rotationref ref="crystal10-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-10" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-2_pos_pos_bot" />
+          <rotationref ref="crystal11-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="11" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-2_pos_neg_bot" />
+          <rotationref ref="crystal11-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-11" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-2_pos_pos_top" />
+          <rotationref ref="crystal11-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="11" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-2_pos_neg_top" />
+          <rotationref ref="crystal11-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-11" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-2_pos_pos_bot" />
+          <rotationref ref="crystal12-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="12" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-2_pos_neg_bot" />
+          <rotationref ref="crystal12-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-12" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-2_pos_pos_top" />
+          <rotationref ref="crystal12-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="12" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-2_pos_neg_top" />
+          <rotationref ref="crystal12-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-12" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-2_pos_pos_bot" />
+          <rotationref ref="crystal13-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="13" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-2_pos_neg_bot" />
+          <rotationref ref="crystal13-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-13" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-2_pos_pos_top" />
+          <rotationref ref="crystal13-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="13" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-2_pos_neg_top" />
+          <rotationref ref="crystal13-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-13" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-2_pos_pos_bot" />
+          <rotationref ref="crystal14-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="14" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-2_pos_neg_bot" />
+          <rotationref ref="crystal14-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-14" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-2_pos_pos_top" />
+          <rotationref ref="crystal14-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="14" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-2_pos_neg_top" />
+          <rotationref ref="crystal14-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-14" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-2_pos_pos_bot" />
+          <rotationref ref="crystal15-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="15" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-2_pos_neg_bot" />
+          <rotationref ref="crystal15-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-15" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-2_pos_pos_top" />
+          <rotationref ref="crystal15-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="15" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-2_pos_neg_top" />
+          <rotationref ref="crystal15-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-15" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-2_pos_pos_bot" />
+          <rotationref ref="crystal16-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="16" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-2_pos_neg_bot" />
+          <rotationref ref="crystal16-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-16" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-2_pos_pos_top" />
+          <rotationref ref="crystal16-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="16" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-2_pos_neg_top" />
+          <rotationref ref="crystal16-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-16" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-2_pos_pos_bot" />
+          <rotationref ref="crystal17-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="17" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-2_pos_neg_bot" />
+          <rotationref ref="crystal17-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-17" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-2_pos_pos_top" />
+          <rotationref ref="crystal17-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="17" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-2_pos_neg_top" />
+          <rotationref ref="crystal17-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-17" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-2_pos_pos_bot" />
+          <rotationref ref="crystal18-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="18" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-2_pos_neg_bot" />
+          <rotationref ref="crystal18-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-18" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-2_pos_pos_top" />
+          <rotationref ref="crystal18-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="18" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-2_pos_neg_top" />
+          <rotationref ref="crystal18-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-18" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-2_pos_pos_bot" />
+          <rotationref ref="crystal19-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="19" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-2_pos_neg_bot" />
+          <rotationref ref="crystal19-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-19" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-2_pos_pos_top" />
+          <rotationref ref="crystal19-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="19" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-2_pos_neg_top" />
+          <rotationref ref="crystal19-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-19" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-2_pos_pos_bot" />
+          <rotationref ref="crystal20-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="20" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-2_pos_neg_bot" />
+          <rotationref ref="crystal20-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-20" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-2_pos_pos_top" />
+          <rotationref ref="crystal20-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="20" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-2_pos_neg_top" />
+          <rotationref ref="crystal20-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-20" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-2_pos_pos_bot" />
+          <rotationref ref="crystal21-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="21" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-2_pos_neg_bot" />
+          <rotationref ref="crystal21-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-21" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-2_pos_pos_top" />
+          <rotationref ref="crystal21-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="21" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-2_pos_neg_top" />
+          <rotationref ref="crystal21-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-21" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-2_pos_pos_bot" />
+          <rotationref ref="crystal22-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="22" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-2_pos_neg_bot" />
+          <rotationref ref="crystal22-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-22" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-2_pos_pos_top" />
+          <rotationref ref="crystal22-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="22" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-2_pos_neg_top" />
+          <rotationref ref="crystal22-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-22" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-2_pos_pos_bot" />
+          <rotationref ref="crystal23-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="23" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-2_pos_neg_bot" />
+          <rotationref ref="crystal23-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-23" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-2_pos_pos_top" />
+          <rotationref ref="crystal23-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="23" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-2_pos_neg_top" />
+          <rotationref ref="crystal23-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-23" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-3_pos_pos_bot" />
+          <rotationref ref="crystal1-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="1" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-3_pos_neg_bot" />
+          <rotationref ref="crystal1-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-1" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-3_pos_pos_top" />
+          <rotationref ref="crystal1-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="1" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-3_pos_neg_top" />
+          <rotationref ref="crystal1-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-1" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal2-3_pos_pos_bot" />
+          <rotationref ref="crystal2-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="2" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal2-3_pos_neg_bot" />
+          <rotationref ref="crystal2-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-2" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal2-3_pos_pos_top" />
+          <rotationref ref="crystal2-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="2" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal2-3_pos_neg_top" />
+          <rotationref ref="crystal2-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-2" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal3-3_pos_pos_bot" />
+          <rotationref ref="crystal3-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="3" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal3-3_pos_neg_bot" />
+          <rotationref ref="crystal3-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-3" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal3-3_pos_pos_top" />
+          <rotationref ref="crystal3-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="3" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal3-3_pos_neg_top" />
+          <rotationref ref="crystal3-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-3" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal4-3_pos_pos_bot" />
+          <rotationref ref="crystal4-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="4" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal4-3_pos_neg_bot" />
+          <rotationref ref="crystal4-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-4" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal4-3_pos_pos_top" />
+          <rotationref ref="crystal4-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="4" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal4-3_pos_neg_top" />
+          <rotationref ref="crystal4-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-4" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal5-3_pos_pos_bot" />
+          <rotationref ref="crystal5-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="5" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal5-3_pos_neg_bot" />
+          <rotationref ref="crystal5-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-5" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal5-3_pos_pos_top" />
+          <rotationref ref="crystal5-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="5" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal5-3_pos_neg_top" />
+          <rotationref ref="crystal5-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-5" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal6-3_pos_pos_bot" />
+          <rotationref ref="crystal6-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="6" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal6-3_pos_neg_bot" />
+          <rotationref ref="crystal6-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-6" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal6-3_pos_pos_top" />
+          <rotationref ref="crystal6-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="6" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal6-3_pos_neg_top" />
+          <rotationref ref="crystal6-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-6" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal7-3_pos_pos_bot" />
+          <rotationref ref="crystal7-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="7" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal7-3_pos_neg_bot" />
+          <rotationref ref="crystal7-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-7" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal7-3_pos_pos_top" />
+          <rotationref ref="crystal7-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="7" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal7-3_pos_neg_top" />
+          <rotationref ref="crystal7-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-7" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal8-3_pos_pos_bot" />
+          <rotationref ref="crystal8-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="8" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal8-3_pos_neg_bot" />
+          <rotationref ref="crystal8-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-8" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal8-3_pos_pos_top" />
+          <rotationref ref="crystal8-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="8" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal8-3_pos_neg_top" />
+          <rotationref ref="crystal8-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-8" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal9-3_pos_pos_bot" />
+          <rotationref ref="crystal9-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="9" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal9-3_pos_neg_bot" />
+          <rotationref ref="crystal9-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-9" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal9-3_pos_pos_top" />
+          <rotationref ref="crystal9-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="9" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal9-3_pos_neg_top" />
+          <rotationref ref="crystal9-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-9" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal10-3_pos_pos_bot" />
+          <rotationref ref="crystal10-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="10" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal10-3_pos_neg_bot" />
+          <rotationref ref="crystal10-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-10" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal10-3_pos_pos_top" />
+          <rotationref ref="crystal10-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="10" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal10-3_pos_neg_top" />
+          <rotationref ref="crystal10-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-10" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-3_pos_pos_bot" />
+          <rotationref ref="crystal11-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="11" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-3_pos_neg_bot" />
+          <rotationref ref="crystal11-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-11" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-3_pos_pos_top" />
+          <rotationref ref="crystal11-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="11" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-3_pos_neg_top" />
+          <rotationref ref="crystal11-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-11" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-3_pos_pos_bot" />
+          <rotationref ref="crystal12-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="12" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-3_pos_neg_bot" />
+          <rotationref ref="crystal12-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-12" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-3_pos_pos_top" />
+          <rotationref ref="crystal12-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="12" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-3_pos_neg_top" />
+          <rotationref ref="crystal12-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-12" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-3_pos_pos_bot" />
+          <rotationref ref="crystal13-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="13" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-3_pos_neg_bot" />
+          <rotationref ref="crystal13-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-13" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-3_pos_pos_top" />
+          <rotationref ref="crystal13-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="13" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-3_pos_neg_top" />
+          <rotationref ref="crystal13-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-13" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-3_pos_pos_bot" />
+          <rotationref ref="crystal14-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="14" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-3_pos_neg_bot" />
+          <rotationref ref="crystal14-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-14" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-3_pos_pos_top" />
+          <rotationref ref="crystal14-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="14" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-3_pos_neg_top" />
+          <rotationref ref="crystal14-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-14" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-3_pos_pos_bot" />
+          <rotationref ref="crystal15-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="15" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-3_pos_neg_bot" />
+          <rotationref ref="crystal15-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-15" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-3_pos_pos_top" />
+          <rotationref ref="crystal15-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="15" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-3_pos_neg_top" />
+          <rotationref ref="crystal15-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-15" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-3_pos_pos_bot" />
+          <rotationref ref="crystal16-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="16" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-3_pos_neg_bot" />
+          <rotationref ref="crystal16-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-16" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-3_pos_pos_top" />
+          <rotationref ref="crystal16-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="16" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-3_pos_neg_top" />
+          <rotationref ref="crystal16-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-16" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-3_pos_pos_bot" />
+          <rotationref ref="crystal17-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="17" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-3_pos_neg_bot" />
+          <rotationref ref="crystal17-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-17" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-3_pos_pos_top" />
+          <rotationref ref="crystal17-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="17" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-3_pos_neg_top" />
+          <rotationref ref="crystal17-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-17" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-3_pos_pos_bot" />
+          <rotationref ref="crystal18-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="18" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-3_pos_neg_bot" />
+          <rotationref ref="crystal18-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-18" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-3_pos_pos_top" />
+          <rotationref ref="crystal18-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="18" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-3_pos_neg_top" />
+          <rotationref ref="crystal18-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-18" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-3_pos_pos_bot" />
+          <rotationref ref="crystal19-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="19" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-3_pos_neg_bot" />
+          <rotationref ref="crystal19-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-19" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-3_pos_pos_top" />
+          <rotationref ref="crystal19-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="19" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-3_pos_neg_top" />
+          <rotationref ref="crystal19-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-19" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-3_pos_pos_bot" />
+          <rotationref ref="crystal20-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="20" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-3_pos_neg_bot" />
+          <rotationref ref="crystal20-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-20" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-3_pos_pos_top" />
+          <rotationref ref="crystal20-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="20" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-3_pos_neg_top" />
+          <rotationref ref="crystal20-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-20" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-3_pos_pos_bot" />
+          <rotationref ref="crystal21-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="21" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-3_pos_neg_bot" />
+          <rotationref ref="crystal21-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-21" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-3_pos_pos_top" />
+          <rotationref ref="crystal21-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="21" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-3_pos_neg_top" />
+          <rotationref ref="crystal21-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-21" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-3_pos_pos_bot" />
+          <rotationref ref="crystal22-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="22" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-3_pos_neg_bot" />
+          <rotationref ref="crystal22-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-22" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-3_pos_pos_top" />
+          <rotationref ref="crystal22-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="22" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-3_pos_neg_top" />
+          <rotationref ref="crystal22-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-22" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-3_pos_pos_bot" />
+          <rotationref ref="crystal23-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="23" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-3_pos_neg_bot" />
+          <rotationref ref="crystal23-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-23" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-3_pos_pos_top" />
+          <rotationref ref="crystal23-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="23" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-3_pos_neg_top" />
+          <rotationref ref="crystal23-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-23" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-4_pos_pos_bot" />
+          <rotationref ref="crystal1-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="1" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-4_pos_neg_bot" />
+          <rotationref ref="crystal1-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-1" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-4_pos_pos_top" />
+          <rotationref ref="crystal1-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="1" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-4_pos_neg_top" />
+          <rotationref ref="crystal1-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-1" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal2-4_pos_pos_bot" />
+          <rotationref ref="crystal2-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="2" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal2-4_pos_neg_bot" />
+          <rotationref ref="crystal2-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-2" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal2-4_pos_pos_top" />
+          <rotationref ref="crystal2-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="2" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal2-4_pos_neg_top" />
+          <rotationref ref="crystal2-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-2" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal3-4_pos_pos_bot" />
+          <rotationref ref="crystal3-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="3" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal3-4_pos_neg_bot" />
+          <rotationref ref="crystal3-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-3" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal3-4_pos_pos_top" />
+          <rotationref ref="crystal3-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="3" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal3-4_pos_neg_top" />
+          <rotationref ref="crystal3-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-3" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal4-4_pos_pos_bot" />
+          <rotationref ref="crystal4-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="4" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal4-4_pos_neg_bot" />
+          <rotationref ref="crystal4-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-4" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal4-4_pos_pos_top" />
+          <rotationref ref="crystal4-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="4" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal4-4_pos_neg_top" />
+          <rotationref ref="crystal4-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-4" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal5-4_pos_pos_bot" />
+          <rotationref ref="crystal5-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="5" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal5-4_pos_neg_bot" />
+          <rotationref ref="crystal5-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-5" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal5-4_pos_pos_top" />
+          <rotationref ref="crystal5-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="5" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal5-4_pos_neg_top" />
+          <rotationref ref="crystal5-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-5" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal6-4_pos_pos_bot" />
+          <rotationref ref="crystal6-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="6" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal6-4_pos_neg_bot" />
+          <rotationref ref="crystal6-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-6" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal6-4_pos_pos_top" />
+          <rotationref ref="crystal6-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="6" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal6-4_pos_neg_top" />
+          <rotationref ref="crystal6-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-6" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal7-4_pos_pos_bot" />
+          <rotationref ref="crystal7-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="7" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal7-4_pos_neg_bot" />
+          <rotationref ref="crystal7-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-7" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal7-4_pos_pos_top" />
+          <rotationref ref="crystal7-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="7" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal7-4_pos_neg_top" />
+          <rotationref ref="crystal7-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-7" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal8-4_pos_pos_bot" />
+          <rotationref ref="crystal8-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="8" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal8-4_pos_neg_bot" />
+          <rotationref ref="crystal8-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-8" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal8-4_pos_pos_top" />
+          <rotationref ref="crystal8-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="8" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal8-4_pos_neg_top" />
+          <rotationref ref="crystal8-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-8" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal9-4_pos_pos_bot" />
+          <rotationref ref="crystal9-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="9" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal9-4_pos_neg_bot" />
+          <rotationref ref="crystal9-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-9" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal9-4_pos_pos_top" />
+          <rotationref ref="crystal9-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="9" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal9-4_pos_neg_top" />
+          <rotationref ref="crystal9-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-9" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal10-4_pos_pos_bot" />
+          <rotationref ref="crystal10-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="10" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal10-4_pos_neg_bot" />
+          <rotationref ref="crystal10-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-10" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal10-4_pos_pos_top" />
+          <rotationref ref="crystal10-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="10" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal10-4_pos_neg_top" />
+          <rotationref ref="crystal10-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-10" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-4_pos_pos_bot" />
+          <rotationref ref="crystal11-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="11" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-4_pos_neg_bot" />
+          <rotationref ref="crystal11-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-11" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-4_pos_pos_top" />
+          <rotationref ref="crystal11-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="11" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-4_pos_neg_top" />
+          <rotationref ref="crystal11-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-11" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-4_pos_pos_bot" />
+          <rotationref ref="crystal12-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="12" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-4_pos_neg_bot" />
+          <rotationref ref="crystal12-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-12" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-4_pos_pos_top" />
+          <rotationref ref="crystal12-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="12" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-4_pos_neg_top" />
+          <rotationref ref="crystal12-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-12" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-4_pos_pos_bot" />
+          <rotationref ref="crystal13-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="13" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-4_pos_neg_bot" />
+          <rotationref ref="crystal13-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-13" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-4_pos_pos_top" />
+          <rotationref ref="crystal13-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="13" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-4_pos_neg_top" />
+          <rotationref ref="crystal13-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-13" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-4_pos_pos_bot" />
+          <rotationref ref="crystal14-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="14" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-4_pos_neg_bot" />
+          <rotationref ref="crystal14-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-14" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-4_pos_pos_top" />
+          <rotationref ref="crystal14-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="14" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-4_pos_neg_top" />
+          <rotationref ref="crystal14-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-14" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-4_pos_pos_bot" />
+          <rotationref ref="crystal15-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="15" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-4_pos_neg_bot" />
+          <rotationref ref="crystal15-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-15" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-4_pos_pos_top" />
+          <rotationref ref="crystal15-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="15" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-4_pos_neg_top" />
+          <rotationref ref="crystal15-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-15" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-4_pos_pos_bot" />
+          <rotationref ref="crystal16-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="16" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-4_pos_neg_bot" />
+          <rotationref ref="crystal16-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-16" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-4_pos_pos_top" />
+          <rotationref ref="crystal16-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="16" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-4_pos_neg_top" />
+          <rotationref ref="crystal16-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-16" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-4_pos_pos_bot" />
+          <rotationref ref="crystal17-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="17" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-4_pos_neg_bot" />
+          <rotationref ref="crystal17-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-17" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-4_pos_pos_top" />
+          <rotationref ref="crystal17-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="17" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-4_pos_neg_top" />
+          <rotationref ref="crystal17-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-17" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-4_pos_pos_bot" />
+          <rotationref ref="crystal18-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="18" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-4_pos_neg_bot" />
+          <rotationref ref="crystal18-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-18" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-4_pos_pos_top" />
+          <rotationref ref="crystal18-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="18" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-4_pos_neg_top" />
+          <rotationref ref="crystal18-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-18" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-4_pos_pos_bot" />
+          <rotationref ref="crystal19-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="19" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-4_pos_neg_bot" />
+          <rotationref ref="crystal19-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-19" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-4_pos_pos_top" />
+          <rotationref ref="crystal19-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="19" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-4_pos_neg_top" />
+          <rotationref ref="crystal19-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-19" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-4_pos_pos_bot" />
+          <rotationref ref="crystal20-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="20" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-4_pos_neg_bot" />
+          <rotationref ref="crystal20-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-20" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-4_pos_pos_top" />
+          <rotationref ref="crystal20-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="20" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-4_pos_neg_top" />
+          <rotationref ref="crystal20-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-20" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-4_pos_pos_bot" />
+          <rotationref ref="crystal21-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="21" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-4_pos_neg_bot" />
+          <rotationref ref="crystal21-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-21" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-4_pos_pos_top" />
+          <rotationref ref="crystal21-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="21" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-4_pos_neg_top" />
+          <rotationref ref="crystal21-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-21" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-4_pos_pos_bot" />
+          <rotationref ref="crystal22-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="22" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-4_pos_neg_bot" />
+          <rotationref ref="crystal22-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-22" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-4_pos_pos_top" />
+          <rotationref ref="crystal22-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="22" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-4_pos_neg_top" />
+          <rotationref ref="crystal22-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-22" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-4_pos_pos_bot" />
+          <rotationref ref="crystal23-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="23" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-4_pos_neg_bot" />
+          <rotationref ref="crystal23-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-23" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-4_pos_pos_top" />
+          <rotationref ref="crystal23-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="23" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-4_pos_neg_top" />
+          <rotationref ref="crystal23-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-23" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-5_pos_pos_bot" />
+          <rotationref ref="crystal1-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="1" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-5_pos_neg_bot" />
+          <rotationref ref="crystal1-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-1" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-5_pos_pos_top" />
+          <rotationref ref="crystal1-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="1" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-5_pos_neg_top" />
+          <rotationref ref="crystal1-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-1" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal2-5_pos_pos_bot" />
+          <rotationref ref="crystal2-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="2" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal2-5_pos_neg_bot" />
+          <rotationref ref="crystal2-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-2" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal2-5_pos_pos_top" />
+          <rotationref ref="crystal2-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="2" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal2-5_pos_neg_top" />
+          <rotationref ref="crystal2-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-2" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal3-5_pos_pos_bot" />
+          <rotationref ref="crystal3-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="3" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal3-5_pos_neg_bot" />
+          <rotationref ref="crystal3-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-3" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal3-5_pos_pos_top" />
+          <rotationref ref="crystal3-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="3" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal3-5_pos_neg_top" />
+          <rotationref ref="crystal3-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-3" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal4-5_pos_pos_bot" />
+          <rotationref ref="crystal4-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="4" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal4-5_pos_neg_bot" />
+          <rotationref ref="crystal4-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-4" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal4-5_pos_pos_top" />
+          <rotationref ref="crystal4-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="4" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal4-5_pos_neg_top" />
+          <rotationref ref="crystal4-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-4" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal5-5_pos_pos_bot" />
+          <rotationref ref="crystal5-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="5" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal5-5_pos_neg_bot" />
+          <rotationref ref="crystal5-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-5" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal5-5_pos_pos_top" />
+          <rotationref ref="crystal5-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="5" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal5-5_pos_neg_top" />
+          <rotationref ref="crystal5-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-5" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal6-5_pos_pos_bot" />
+          <rotationref ref="crystal6-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="6" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal6-5_pos_neg_bot" />
+          <rotationref ref="crystal6-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-6" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal6-5_pos_pos_top" />
+          <rotationref ref="crystal6-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="6" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal6-5_pos_neg_top" />
+          <rotationref ref="crystal6-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-6" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal7-5_pos_pos_bot" />
+          <rotationref ref="crystal7-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="7" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal7-5_pos_neg_bot" />
+          <rotationref ref="crystal7-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-7" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal7-5_pos_pos_top" />
+          <rotationref ref="crystal7-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="7" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal7-5_pos_neg_top" />
+          <rotationref ref="crystal7-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-7" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal8-5_pos_pos_bot" />
+          <rotationref ref="crystal8-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="8" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal8-5_pos_neg_bot" />
+          <rotationref ref="crystal8-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-8" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal8-5_pos_pos_top" />
+          <rotationref ref="crystal8-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="8" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal8-5_pos_neg_top" />
+          <rotationref ref="crystal8-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-8" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal9-5_pos_pos_bot" />
+          <rotationref ref="crystal9-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="9" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal9-5_pos_neg_bot" />
+          <rotationref ref="crystal9-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-9" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal9-5_pos_pos_top" />
+          <rotationref ref="crystal9-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="9" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal9-5_pos_neg_top" />
+          <rotationref ref="crystal9-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-9" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal10-5_pos_pos_bot" />
+          <rotationref ref="crystal10-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="10" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal10-5_pos_neg_bot" />
+          <rotationref ref="crystal10-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-10" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal10-5_pos_pos_top" />
+          <rotationref ref="crystal10-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="10" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal10-5_pos_neg_top" />
+          <rotationref ref="crystal10-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-10" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-5_pos_pos_bot" />
+          <rotationref ref="crystal11-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="11" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-5_pos_neg_bot" />
+          <rotationref ref="crystal11-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-11" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-5_pos_pos_top" />
+          <rotationref ref="crystal11-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="11" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-5_pos_neg_top" />
+          <rotationref ref="crystal11-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-11" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-5_pos_pos_bot" />
+          <rotationref ref="crystal12-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="12" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-5_pos_neg_bot" />
+          <rotationref ref="crystal12-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-12" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-5_pos_pos_top" />
+          <rotationref ref="crystal12-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="12" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-5_pos_neg_top" />
+          <rotationref ref="crystal12-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-12" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-5_pos_pos_bot" />
+          <rotationref ref="crystal13-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="13" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-5_pos_neg_bot" />
+          <rotationref ref="crystal13-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-13" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-5_pos_pos_top" />
+          <rotationref ref="crystal13-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="13" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-5_pos_neg_top" />
+          <rotationref ref="crystal13-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-13" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-5_pos_pos_bot" />
+          <rotationref ref="crystal14-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="14" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-5_pos_neg_bot" />
+          <rotationref ref="crystal14-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-14" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-5_pos_pos_top" />
+          <rotationref ref="crystal14-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="14" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-5_pos_neg_top" />
+          <rotationref ref="crystal14-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-14" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-5_pos_pos_bot" />
+          <rotationref ref="crystal15-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="15" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-5_pos_neg_bot" />
+          <rotationref ref="crystal15-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-15" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-5_pos_pos_top" />
+          <rotationref ref="crystal15-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="15" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-5_pos_neg_top" />
+          <rotationref ref="crystal15-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-15" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-5_pos_pos_bot" />
+          <rotationref ref="crystal16-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="16" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-5_pos_neg_bot" />
+          <rotationref ref="crystal16-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-16" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-5_pos_pos_top" />
+          <rotationref ref="crystal16-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="16" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-5_pos_neg_top" />
+          <rotationref ref="crystal16-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-16" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-5_pos_pos_bot" />
+          <rotationref ref="crystal17-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="17" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-5_pos_neg_bot" />
+          <rotationref ref="crystal17-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-17" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-5_pos_pos_top" />
+          <rotationref ref="crystal17-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="17" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-5_pos_neg_top" />
+          <rotationref ref="crystal17-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-17" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-5_pos_pos_bot" />
+          <rotationref ref="crystal18-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="18" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-5_pos_neg_bot" />
+          <rotationref ref="crystal18-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-18" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-5_pos_pos_top" />
+          <rotationref ref="crystal18-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="18" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-5_pos_neg_top" />
+          <rotationref ref="crystal18-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-18" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-5_pos_pos_bot" />
+          <rotationref ref="crystal19-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="19" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-5_pos_neg_bot" />
+          <rotationref ref="crystal19-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-19" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-5_pos_pos_top" />
+          <rotationref ref="crystal19-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="19" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-5_pos_neg_top" />
+          <rotationref ref="crystal19-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-19" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-5_pos_pos_bot" />
+          <rotationref ref="crystal20-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="20" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-5_pos_neg_bot" />
+          <rotationref ref="crystal20-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-20" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-5_pos_pos_top" />
+          <rotationref ref="crystal20-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="20" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-5_pos_neg_top" />
+          <rotationref ref="crystal20-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-20" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-5_pos_pos_bot" />
+          <rotationref ref="crystal21-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="21" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-5_pos_neg_bot" />
+          <rotationref ref="crystal21-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-21" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-5_pos_pos_top" />
+          <rotationref ref="crystal21-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="21" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-5_pos_neg_top" />
+          <rotationref ref="crystal21-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-21" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-5_pos_pos_bot" />
+          <rotationref ref="crystal22-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="22" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-5_pos_neg_bot" />
+          <rotationref ref="crystal22-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-22" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-5_pos_pos_top" />
+          <rotationref ref="crystal22-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="22" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-5_pos_neg_top" />
+          <rotationref ref="crystal22-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-22" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-5_pos_pos_bot" />
+          <rotationref ref="crystal23-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="23" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-5_pos_neg_bot" />
+          <rotationref ref="crystal23-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-23" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-5_pos_pos_top" />
+          <rotationref ref="crystal23-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="23" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-5_pos_neg_top" />
+          <rotationref ref="crystal23-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-23" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol name="front_flange_1">
+          <volumeref ref="front_flange" />
+          <positionref ref="front_flange_1inworld_volumepos" />
+        </physvol>
+        <physvol name="back_flange_1">
+          <volumeref ref="back_flange" />
+          <positionref ref="back_flange_1inworld_volumepos" />
+        </physvol>
+        <physvol name="ECAL_chamber_1">
+          <volumeref ref="ECAL_chamber" />
+          <positionref ref="ECAL_chamber_1inworld_volumepos" />
+        </physvol>
+        <physvol name="al_honeycomb_1">
+          <volumeref ref="al_honeycomb" />
+          <positionref ref="al_honeycomb_1inworld_volumepos" />
+        </physvol>
+        <physvol name="layer_1_top_1">
+          <volumeref ref="layer_1_top" />
+          <positionref ref="layer_1_top_1inworld_volumepos" />
+        </physvol>
+        <physvol name="layer_2_top_1">
+          <volumeref ref="layer_2_top" />
+          <positionref ref="layer_2_top_1inworld_volumepos" />
+        </physvol>
+        <physvol name="layer_3_top_1">
+          <volumeref ref="layer_3_top" />
+          <positionref ref="layer_3_top_1inworld_volumepos" />
+        </physvol>
+        <physvol name="layer_4_top_1">
+          <volumeref ref="layer_4_top" />
+          <positionref ref="layer_4_top_1inworld_volumepos" />
+        </physvol>
+        <physvol name="layer_1_bottom_1">
+          <volumeref ref="layer_1_bottom" />
+          <positionref ref="layer_1_bottom_1inworld_volumepos" />
+        </physvol>
+        <physvol name="layer_2_bottom_1">
+          <volumeref ref="layer_2_bottom" />
+          <positionref ref="layer_2_bottom_1inworld_volumepos" />
+        </physvol>
+        <physvol name="layer_3_bottom_1">
+          <volumeref ref="layer_3_bottom" />
+          <positionref ref="layer_3_bottom_1inworld_volumepos" />
+        </physvol>
+        <physvol name="layer_4_bottom_1">
+          <volumeref ref="layer_4_bottom" />
+          <positionref ref="layer_4_bottom_1inworld_volumepos" />
+        </physvol>
+        <physvol name="layer_5T_left_1">
+          <volumeref ref="layer_5T_left" />
+          <positionref ref="layer_5T_left_1inworld_volumepos" />
+        </physvol>
+        <physvol name="layer_5B_left_1">
+          <volumeref ref="layer_5B_left" />
+          <positionref ref="layer_5B_left_1inworld_volumepos" />
+        </physvol>
+        <physvol name="steel_bar_1">
+          <volumeref ref="steel_bar" />
+          <positionref ref="steel_bar_1inworld_volumepos" />
+        </physvol>
+        <physvol name="cu_Tpipe_inner_left_1">
+          <volumeref ref="cu_Tpipe_inner_left" />
+          <positionref ref="cu_Tpipe_inner_left_1inworld_volumepos" />
+          <rotationref ref="cu_Tpipe_inner_left_1inworld_volumerot" />
+        </physvol>
+        <physvol name="cu_Tpipe_inner_right_1">
+          <volumeref ref="cu_Tpipe_inner_right" />
+          <positionref ref="cu_Tpipe_inner_right_1inworld_volumepos" />
+          <rotationref ref="cu_Tpipe_inner_right_1inworld_volumerot" />
+        </physvol>
+        <physvol name="cu_Bpipe_inner_left_1">
+          <volumeref ref="cu_Bpipe_inner_left" />
+          <positionref ref="cu_Bpipe_inner_left_1inworld_volumepos" />
+          <rotationref ref="cu_Bpipe_inner_left_1inworld_volumerot" />
+        </physvol>
+        <physvol name="cu_Bpipe_inner_right_1">
+          <volumeref ref="cu_Bpipe_inner_right" />
+          <positionref ref="cu_Bpipe_inner_right_1inworld_volumepos" />
+          <rotationref ref="cu_Bpipe_inner_right_1inworld_volumerot" />
+        </physvol>
+        <physvol name="cu_Tpipe_outer_right1_1">
+          <volumeref ref="cu_Tpipe_outer_right1" />
+          <positionref ref="cu_Tpipe_outer_right1_1inworld_volumepos" />
+          <rotationref ref="cu_Tpipe_outer_right1_1inworld_volumerot" />
+        </physvol>
+        <physvol name="cu_Tpipe_outer_right2_1">
+          <volumeref ref="cu_Tpipe_outer_right2" />
+          <positionref ref="cu_Tpipe_outer_right2_1inworld_volumepos" />
+        </physvol>
+        <physvol name="cu_Tpipe_outer_right3_1">
+          <volumeref ref="cu_Tpipe_outer_right3" />
+          <positionref ref="cu_Tpipe_outer_right3_1inworld_volumepos" />
+          <rotationref ref="cu_Tpipe_outer_right3_1inworld_volumerot" />
+        </physvol>
+        <physvol name="cu_Bpipe_outer_right_1">
+          <volumeref ref="cu_Bpipe_outer_right" />
+          <positionref ref="cu_Bpipe_outer_right_1inworld_volumepos" />
+          <rotationref ref="cu_Bpipe_outer_right_1inworld_volumerot" />
+        </physvol>
+        <physvol name="cu_Bpipe_outer_right1_1">
+          <volumeref ref="cu_Bpipe_outer_right1" />
+          <positionref ref="cu_Bpipe_outer_right1_1inworld_volumepos" />
+          <rotationref ref="cu_Bpipe_outer_right1_1inworld_volumerot" />
+        </physvol>
+        <physvol name="cu_Bpipe_outer_right2_1">
+          <volumeref ref="cu_Bpipe_outer_right2" />
+          <positionref ref="cu_Bpipe_outer_right2_1inworld_volumepos" />
+        </physvol>
+        <physvol name="al_pipe_across_top1_1">
+          <volumeref ref="al_pipe_across_top1" />
+          <positionref ref="al_pipe_across_top1_1inworld_volumepos" />
+          <rotationref ref="al_pipe_across_top1_1inworld_volumerot" />
+        </physvol>
+        <physvol name="al_pipe_across_top2_1">
+          <volumeref ref="al_pipe_across_top2" />
+          <positionref ref="al_pipe_across_top2_1inworld_volumepos" />
+          <rotationref ref="al_pipe_across_top2_1inworld_volumerot" />
+        </physvol>
+        <physvol name="al_pipe_across_bottom1_1">
+          <volumeref ref="al_pipe_across_bottom1" />
+          <positionref ref="al_pipe_across_bottom1_1inworld_volumepos" />
+          <rotationref ref="al_pipe_across_bottom1_1inworld_volumerot" />
+        </physvol>
+        <physvol name="al_pipe_across_bottom2_1">
+          <volumeref ref="al_pipe_across_bottom2" />
+          <positionref ref="al_pipe_across_bottom2_1inworld_volumepos" />
+          <rotationref ref="al_pipe_across_bottom2_1inworld_volumerot" />
+        </physvol>
+        <physvol name="cu_plate_top_left_1">
+          <volumeref ref="cu_plate_top_left" />
+          <positionref ref="cu_plate_top_left_1inworld_volumepos" />
+        </physvol>
+        <physvol name="cu_plate_bottom_left_1">
+          <volumeref ref="cu_plate_bottom_left" />
+          <positionref ref="cu_plate_bottom_left_1inworld_volumepos" />
+        </physvol>
+        <physvol name="cu_plate_top_right_1">
+          <volumeref ref="cu_plate_top_right" />
+          <positionref ref="cu_plate_top_right_1inworld_volumepos" />
+        </physvol>
+        <physvol name="cu_plate_bottom_right_1">
+          <volumeref ref="cu_plate_bottom_right" />
+          <positionref ref="cu_plate_bottom_right_1inworld_volumepos" />
+        </physvol>
+        <physvol name="cu_plate_top_middle_1">
+          <volumeref ref="cu_plate_top_middle" />
+          <positionref ref="cu_plate_top_middle_1inworld_volumepos" />
+        </physvol>
+        <physvol name="cu_plate_bottom_middle_1">
+          <volumeref ref="cu_plate_bottom_middle" />
+          <positionref ref="cu_plate_bottom_middle_1inworld_volumepos" />
+        </physvol>
+        <visref ref="WorldVis" />
+      </volume>
+    </structure>
+    <setup name="Default" version="1.0">
+      <world ref="world_volume" />
+    </setup>
+  </gdml>
+  <fields>
+    <field_map_3d name="HPSDipoleFieldMap3D" lunit="mm" funit="tesla" filename="fieldmap/166acm2_4kg_corrected_unfolded_scaled_1.090896.dat" xoffset="21.17" yoffset="0.0" zoffset="457.2" />
+  </fields>
+</lcdd>
+

--- a/detector-data/detectors/HPS_Run2021Pass2FEE_1pt92_fixed/SamplingFractions/Ecal.properties
+++ b/detector-data/detectors/HPS_Run2021Pass2FEE_1pt92_fixed/SamplingFractions/Ecal.properties
@@ -1,0 +1,1 @@
+samplingFraction: 1.0

--- a/detector-data/detectors/HPS_Run2021Pass2FEE_1pt92_fixed/SamplingFractions/Hodoscope.properties
+++ b/detector-data/detectors/HPS_Run2021Pass2FEE_1pt92_fixed/SamplingFractions/Hodoscope.properties
@@ -1,0 +1,1 @@
+samplingFraction: 1.0

--- a/detector-data/detectors/HPS_Run2021Pass2FEE_1pt92_fixed/compact.xml
+++ b/detector-data/detectors/HPS_Run2021Pass2FEE_1pt92_fixed/compact.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <lccdd xmlns:compact="http://www.lcsim.org/schemas/compact/1.0" xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/compact/1.0/compact.xsd">
 
-<info name="HPS_Run2021Pass0_v1_1pt92GeV">
-    <comment>HPS detector for 2021 run with fieldmap,
+<info name="HPS_Run2021Pass2FEE_1pt92_fixed">
+    <comment>HPS detector for 2021 run with fieldmap for 1.92GeV running,
     Tracker at nominal opening angle, no SVT survey,
-    this detector uses the corrected fieldmap scaled for 3.74 GeV beam.
+    this detector uses the corrected fieldmap scaled to -1.022T for 3.7 GeV.
     Includes L0 and Hodoscope.
     ECAL with survey alignment for HPSEcal3 (global y/z translations).
     This detector has the full hierarchical alignment structure
@@ -33,7 +33,7 @@
     <constant name="dipoleMagnetHeight" value="100*cm" />
     <constant name="dipoleMagnetWidth" value="100*cm" />
     <constant name="dipoleMagnetLength" value="108*cm" />
-    <constant name="constBFieldY" value="-0.437" /><!-- set for 1.92 GeV running -->
+    <constant name="constBFieldY" value="-1.08" /><!-- set for 4.5GeV running -->
 
 
     <!-- ECAL crystal dimensions -->
@@ -197,26 +197,26 @@
       <millepede_constants>
 
         <!-- top half-module translations -->
-        <millepede_constant name="11101" value="0.0 + 0.014799 + 0.008569 - -0.065199 - -0.037883 - 0.01 - 0.003" />
-        <millepede_constant name="11102" value="0.0 + 0.036097 + 0.008870 - -0.054012 - -0.027420 - -0.008920 - 0.007 - 0.003" />
-        <millepede_constant name="11103" value="0.0 + -0.020397 + 0.006024 - -0.036267 - -0.028236 - 0.01 + 0.005" />
+        <millepede_constant name="11101" value="0.0 + 0.014799 + 0.008569 - -0.065199 - -0.037883" />
+        <millepede_constant name="11102" value="0.0 + 0.036097 + 0.008870 - -0.054012 - -0.027420 - -0.008920" />
+        <millepede_constant name="11103" value="0.0 + -0.020397 + 0.006024 - -0.036267 - -0.028236" />
         <millepede_constant name="11104" value="0.0 + 0.045729 + 0.006918 - -0.036733 - -0.019597 - -0.002183" />
         <millepede_constant name="11105" value="0.0 + 0.007688 + 0.005676 - -0.012362" />
-        <millepede_constant name="11106" value="0.0 + -0.010664 + -0.001609 - 0.006721 - 0.005305 - -0.001660 - 0.001480 - 0.020 - 0.015" /> <!-- HERE -->
-        <millepede_constant name="11107" value="0.0 + 0.004072 + 0.003523 - 0.007062 - -0.003817 - 0.001975 - 0.003762 - 0.030 - 0.02 + 0.005 + 0.005 - 0.01" /> 
+        <millepede_constant name="11106" value="0.0 + -0.010664 + -0.001609 - 0.006721 - 0.005305 - -0.001660 - 0.001480" />
+        <millepede_constant name="11107" value="0.0 + 0.004072 + 0.003523 - 0.007062 - -0.003817 - 0.001975 - 0.003762" />
         <millepede_constant name="11108" value="0.0 + -0.000794 + 0.000946 - -0.003989" />
-        <millepede_constant name="11109" value="0.0 - 0.018517 - 0.003440 - -0.005945 - 0.038002 - -0.031681" />
-        <millepede_constant name="11110" value="0.0 - -0.002565 - -0.005478 - 0.035065 - 0.016357 - 0.006881 - -0.006770 - -0.000414 - 0.007 + 0.007 + 0.005 + 0.01 - 0.016272 - 0.003394 - 0.035070 - 0.014843 - 0.003355 + 0.01 + 0.005 - 0.013350 - -0.038048 - 0.013055 - 0.000808 - 0.000077 - -0.019605 - 0.018048" />
-        <millepede_constant name="11111" value="0.0 - -0.027900 - -0.007513 - 0.012648 - -0.043451 - -0.065284" />
-        <millepede_constant name="11112" value="0.035655 - -0.014005 - -0.039993 - -0.011733 - -0.007860 - 0.035467 + 0.100 - 0.024782 - 0.022333 - -0.044758 - 0.051211 - 0.006091 - 0.01 - 0.005 + 0.002 - 0.003 - 0.043504 - -0.078576 - -0.014604 - -0.002392 - 0.136530 - -0.028722" /> 
-        <millepede_constant name="11113" value="0.0 - 0.048022 - 0.008019 - 0.026847 - -0.087271" />
-        <millepede_constant name="11114" value="0.0 - -0.010339 - 0.024258 - 0.011054 - 0.007932 - -0.059523 - 0.05 + 0.03 + 0.02 + 0.005 + 0.01 + 0.01 + 0.01 + 0.025 - 0.008013 - 0.003514 - 0.123270 - 0.026882 - 0.004377 + 0.01 + 0.01 + 0.01 - 0.024533 - -0.026879 - 0.019210 - 0.000367 - 0.000016 - 0.028655 - 0.048132" />
-        <millepede_constant name="11115" value="0.0 - -0.037736 - 0.001172 - -0.124470 - 0.083991" />
-        <millepede_constant name="11116" value="0.0 - -0.010376 - -0.045688 - -0.004289 - -0.008223 - 0.000515 - 0.023764 - -0.170300 - 0.165900 - 0.026027 + 0.03 + 0.003 - 0.124620 - -0.096263 - 0.005989 - 0.001142 - -0.041266 - -0.054556" />
-        <millepede_constant name="11117" value="0.0 - 0.089312 - 0.015816 + 0.003 - 0.018062 - -0.185950" />
-        <millepede_constant name="11118" value="0.008210 - -0.015812 - -0.066323 - -0.027323 - 0.006333 - -0.080147 + 0.03 + 0.01 + 0.01 + 0.02 + 0.045 - -0.008958 - 0.001975 - 0.246890 - 0.002482 - 0.001309 - -0.010665 - -0.018083 - 0.027693 - -0.000635 - -0.000105 - 0.108960 - 0.095626" />
-        <millepede_constant name="11119" value="0.0 - -0.079247 - 0.008245 - -0.238820 - 0.289240" />
-        <millepede_constant name="11120" value="-0.065534 - -0.043456 - -0.023106 - 0.036114 - 0.039496 - -0.005295 - 0.037244 - 0.054889 - -0.330230 - 0.312240 - 0.053709 + 0.02 + 0.01 + 0.005 + 0.005 - 0.239110 - -0.196730 - 0.004699 - 0.001197 - -0.164800 - -0.103970" />
+        <millepede_constant name="11109" value="0.0 - 0.018517 - 0.003440" />
+        <millepede_constant name="11110" value="0.0 - -0.002565 - -0.005478 - 0.035065 - 0.016357 - 0.006881" />
+        <millepede_constant name="11111" value="0.0 - -0.027900 - -0.007513" />
+        <millepede_constant name="11112" value="0.035655 - -0.014005 - -0.039993 - -0.011733 - -0.007860" />
+        <millepede_constant name="11113" value="0.0 - 0.048022 - 0.008019" />
+        <millepede_constant name="11114" value="0.0 - -0.010339 - 0.024258 - 0.011054 - 0.007932" />
+        <millepede_constant name="11115" value="0.0 - -0.037736 - 0.001172" />
+        <millepede_constant name="11116" value="0.0 - -0.010376 - -0.045688 - -0.004289 - -0.008223" />
+        <millepede_constant name="11117" value="0.0 - 0.089312 - 0.015816" />
+        <millepede_constant name="11118" value="0.008210 - -0.015812 - -0.066323 - -0.027323 - 0.006333" />
+        <millepede_constant name="11119" value="0.0 - -0.079247 - 0.008245" />
+        <millepede_constant name="11120" value="-0.065534 - -0.043456 - -0.023106 - 0.036114 - 0.039496 - -0.005295" />
         <millepede_constant name="11121" value="0.0" />
         <millepede_constant name="11122" value="0.0" />
 
@@ -322,43 +322,43 @@
         <millepede_constant name="12306" value="0.0" />
         <millepede_constant name="12307" value="0.0" />
         <millepede_constant name="12308" value="0.0" />
-        <millepede_constant name="12309" value="0.0 - 0.000205 + 0.000202" />
-        <millepede_constant name="12310" value="0.0 - 0.000113 + 0.000793" />
-        <millepede_constant name="12311" value="0.0 - -0.000219 + 0.002355" />
-        <millepede_constant name="12312" value="0.0 - -0.000665 + -0.003668" />
-        <millepede_constant name="12313" value="0.0 + -0.001213" />
-        <millepede_constant name="12314" value="0.0 + 0.001614" />
-        <millepede_constant name="12315" value="0.0 + 0.003976" />
-        <millepede_constant name="12316" value="0.0 + -0.003284" />
-        <millepede_constant name="12317" value="0.0 + -0.001738" />
-        <millepede_constant name="12318" value="0.0 + 0.000933" />
-        <millepede_constant name="12319" value="0.0 + 0.004628" />
-        <millepede_constant name="12320" value="0.0 + -0.004674" />
+        <millepede_constant name="12309" value="0.0" />
+        <millepede_constant name="12310" value="0.0" />
+        <millepede_constant name="12311" value="0.0" />
+        <millepede_constant name="12312" value="0.0" />
+        <millepede_constant name="12313" value="0.0" />
+        <millepede_constant name="12314" value="0.0" />
+        <millepede_constant name="12315" value="0.0" />
+        <millepede_constant name="12316" value="0.0" />
+        <millepede_constant name="12317" value="0.0" />
+        <millepede_constant name="12318" value="0.0" />
+        <millepede_constant name="12319" value="0.0" />
+        <millepede_constant name="12320" value="0.0" />
         <millepede_constant name="12321" value="0.0" />
         <millepede_constant name="12322" value="0.0" />
 
         <!-- bottom half-module translations -->
 
-        <millepede_constant name="21101" value="0.0 - 0.107190 - 0.005866 - 0.060341 - 0.003872" />
-        <millepede_constant name="21102" value="0.0 - 0.059475 - 0.027066 - 0.000800" />
-        <millepede_constant name="21103" value="0.0 - 0.079522 - -0.001877 - 0.042242 - 0.003328" />
-        <millepede_constant name="21104" value="0.0 - 0.047102 - -0.004770 - -0.002447" />
-        <millepede_constant name="21105" value="0.0 - -0.014915 - 0.013450 - -0.026219 - -0.009611 + 0.005" />
+        <millepede_constant name="21101" value="0.0 - 0.107190 - 0.005866 - 0.060341" />
+        <millepede_constant name="21102" value="0.0 - 0.059475 - 0.027066" />
+        <millepede_constant name="21103" value="0.0 - 0.079522 - -0.001877 - 0.042242" />
+        <millepede_constant name="21104" value="0.0 - 0.047102 - -0.004770" />
+        <millepede_constant name="21105" value="0.0 - -0.014915 - 0.013450 - -0.026219 - -0.009611" />
         <millepede_constant name="21106" value="0.0 - 0.031471 - -0.000722" />
-        <millepede_constant name="21107" value="0.0 - -0.029044 - 0.008449 - -0.018252 - -0.012929 + 0.010" />
+        <millepede_constant name="21107" value="0.0 - -0.029044 - 0.008449 - -0.018252 - -0.012929" />
         <millepede_constant name="21108" value="0.0 - 0.006131" />
         <millepede_constant name="21109" value="0.0" />
         <millepede_constant name="21110" value="0.0" />
-        <millepede_constant name="21111" value="-0.0203 - -0.042235 - 0.034795 - -0.044844 - -0.000811 - 0.001150 - 0.007410 - -0.037481 - 0.046508 - 0.006683 + 0.007 - 0.035346 - -0.025149 - -0.020406" />
-        <millepede_constant name="21112" value="-0.082 - 0.050569 - 0.004122 - -0.035304 - 0.036576" />
-        <millepede_constant name="21113" value="0.0 - -0.104520 - 0.106240 - 0.001598 - 0.002801 - -0.000999 - -0.042308 - 0.134950 - 0.025829" />
-        <millepede_constant name="21114" value="0.0 - -0.113090 - -0.003659 - 0.042258 - -0.142120" />
-        <millepede_constant name="21115" value="0.0 - 0.101260 - -0.113530 - -0.000371 - -0.003598 - -0.005391 - -0.092678 - 0.097442 - 0.016330 + 0.010 - 0.007 - 0.094864 - -0.152070 - -0.036997" />
-        <millepede_constant name="21116" value="0.0 - 0.119860 - 0.008016 - -0.094750 - 0.177580" />
-        <millepede_constant name="21117" value="0.0 - -0.070300 - -0.183510 - 0.210600 - 0.003086 - 0.007767 - 0.002723 + 0.002 - -0.067666 - 0.249320 - 0.049407" />
-        <millepede_constant name="21118" value="0.0 - -0.221920 - -0.013386 - 0.067585 - -0.290160" />
-        <millepede_constant name="21119" value="0.0 - 0.032623 - 0.172330 - -0.215950 - -0.002618 - -0.005793 - -0.008341 - -0.185020 - 0.187560 - 0.032886 - 0.01 - 0.218070 - -0.329270 - -0.081435" />
-        <millepede_constant name="21120" value="0.0 - 0.230800 - 0.012574 - 0.01 - -0.217800 - 0.365860" />
+        <millepede_constant name="21111" value="-0.0203 - -0.042235 - 0.034795 - -0.044844 - -0.000811 - 0.001150" />
+        <millepede_constant name="21112" value="-0.082 - 0.050569 - 0.004122" />
+        <millepede_constant name="21113" value="0.0 - -0.104520 - 0.106240 - 0.001598 - 0.002801" />
+        <millepede_constant name="21114" value="0.0 - -0.113090 - -0.003659" />
+        <millepede_constant name="21115" value="0.0 - 0.101260 - -0.113530 - -0.000371 - -0.003598" />
+        <millepede_constant name="21116" value="0.0 - 0.119860 - 0.008016" />
+        <millepede_constant name="21117" value="0.0 - -0.070300 - -0.183510 - 0.210600 - 0.003086 - 0.007767" />
+        <millepede_constant name="21118" value="0.0 - -0.221920 - -0.013386" />
+        <millepede_constant name="21119" value="0.0 - 0.032623 - 0.172330 - -0.215950 - -0.002618 - -0.005793" />
+        <millepede_constant name="21120" value="0.0 - 0.230800 - 0.012574" />
         <millepede_constant name="21121" value="0.0" />
         <millepede_constant name="21122" value="0.0" />
 
@@ -456,26 +456,26 @@
         <millepede_constant name="22221" value="0.0" />
         <millepede_constant name="22222" value="0.0" />
 
-        <millepede_constant name="22301" value="0.0 + -0.011634" />
-        <millepede_constant name="22302" value="0.0 + 0.008585" />
-        <millepede_constant name="22303" value="0.0 + -0.005113" />
-        <millepede_constant name="22304" value="0.0 + 0.001496" />
+        <millepede_constant name="22301" value="0.0" />
+        <millepede_constant name="22302" value="0.0" />
+        <millepede_constant name="22303" value="0.0" />
+        <millepede_constant name="22304" value="0.0" />
         <millepede_constant name="22305" value="0.0" />
         <millepede_constant name="22306" value="0.0" />
         <millepede_constant name="22307" value="0.0" />
         <millepede_constant name="22308" value="0.0" />
         <millepede_constant name="22309" value="0.0" />
         <millepede_constant name="22310" value="0.0" />
-        <millepede_constant name="22311" value="0.0 + -0.000782" />
-        <millepede_constant name="22312" value="0.0 + 0.001015" />
-        <millepede_constant name="22313" value="0.0 + 0.000359" />
-        <millepede_constant name="22314" value="0.0 + -0.001675" />
-        <millepede_constant name="22315" value="0.0 + -0.001699" />
-        <millepede_constant name="22316" value="0.0 + 0.002011" />
-        <millepede_constant name="22317" value="0.0 + 0.001003" />
-        <millepede_constant name="22318" value="0.0 + -0.002004" />
-        <millepede_constant name="22319" value="0.0 + -0.002691" />
-        <millepede_constant name="22320" value="0.0 + 0.002836" />
+        <millepede_constant name="22311" value="0.0" />
+        <millepede_constant name="22312" value="0.0" />
+        <millepede_constant name="22313" value="0.0" />
+        <millepede_constant name="22314" value="0.0" />
+        <millepede_constant name="22315" value="0.0" />
+        <millepede_constant name="22316" value="0.0" />
+        <millepede_constant name="22317" value="0.0" />
+        <millepede_constant name="22318" value="0.0" />
+        <millepede_constant name="22319" value="0.0" />
+        <millepede_constant name="22320" value="0.0" />
         <millepede_constant name="22321" value="0.0" />
         <millepede_constant name="22322" value="0.0" />
 
@@ -504,14 +504,14 @@
 
 
         <!-- L1Top Module translations and angles -->
-        <millepede_constant name="11161" value="0.0 + 0.029119 - -0.051153 - 0.038288" /> <!-- u  -> global Y   -->
+        <millepede_constant name="11161" value="0.0 + 0.029119 - -0.051153" /> <!-- u  -> global Y   -->
         <millepede_constant name="11261" value="0.0" /> <!-- v  -> X+svtAngle -->
         <millepede_constant name="11361" value="0.0" /> <!-- w  -> Z+svtAngle -->
         <millepede_constant name="12161" value="0.0" /> <!-- ru -->
         <millepede_constant name="12261" value="0.0" /> <!-- rv -->
         <millepede_constant name="12361" value="0.0" /> <!-- rw -->
 
-        <millepede_constant name="21161" value="0.0 + -0.142600 + -0.071162 - 0.086198 - 0.023561" /> <!-- u -->
+        <millepede_constant name="21161" value="0.0 + -0.142600 + -0.071162 - 0.086198" /> <!-- u -->
         <millepede_constant name="21261" value="0.0" /> <!-- v -->
         <millepede_constant name="21361" value="0.0" /> <!-- w -->
         <millepede_constant name="22161" value="0.0" /> <!-- ru -->
@@ -519,14 +519,14 @@
         <millepede_constant name="22361" value="0.0" /> <!-- rw -->
 
         <!-- L2 Top/Bottom translations and angles -->
-        <millepede_constant name="11162" value="0.0 + -0.022437 - -0.057777 - 0.027096" /> <!-- u  -> global Y   -->
+        <millepede_constant name="11162" value="0.0 + -0.022437 - -0.057777" /> <!-- u  -> global Y   -->
         <millepede_constant name="11262" value="0.0" /> <!-- v  -> X+svtAngle -->
         <millepede_constant name="11362" value="0.0" /> <!-- w  -> Z+svtAngle -->
         <millepede_constant name="12162" value="0.0" /> <!-- ru -->
         <millepede_constant name="12262" value="0.0" /> <!-- rv -->
         <millepede_constant name="12362" value="0.0" /> <!-- rw -->
 
-        <millepede_constant name="21162" value="0.0 + -0.055978 + -0.025022 - 0.087956 - 0.031777" /> <!-- u -->
+        <millepede_constant name="21162" value="0.0 + -0.055978 + -0.025022 - 0.087956" /> <!-- u -->
         <millepede_constant name="21262" value="0.0" /> <!-- v -->
         <millepede_constant name="21362" value="0.0" /> <!-- w -->
         <millepede_constant name="22162" value="0.0" /> <!-- ru -->
@@ -534,14 +534,14 @@
         <millepede_constant name="22362" value="0.0" /> <!-- rw -->
 
         <!-- L3 Top/Bottom translations and angles -->
-        <millepede_constant name="11163" value="0.0 + 0.000678 - -0.059459 - 0.012216 - 0.006668 - 0.002504 + -0.7" /> <!-- u  -> global Y   -->
+        <millepede_constant name="11163" value="0.0 + 0.000678 - -0.059459" /> <!-- u  -> global Y   -->
         <millepede_constant name="11263" value="0.0" /> <!-- v  -> X+svtAngle -->
         <millepede_constant name="11363" value="0.0" /> <!-- w  -> Z+svtAngle -->
         <millepede_constant name="12163" value="0.0" /> <!-- ru -->
         <millepede_constant name="12263" value="0.0" /> <!-- rv -->
         <millepede_constant name="12363" value="0.0" /> <!-- rw -->
 
-        <millepede_constant name="21163" value="0.0 + -0.046884 + -0.010228 - 0.075913 - 0.001767 - 0.023862 + -0.7" /> <!-- u -->
+        <millepede_constant name="21163" value="0.0 + -0.046884 + -0.010228 - 0.075913" /> <!-- u -->
         <millepede_constant name="21263" value="0.0" /> <!-- v -->
         <millepede_constant name="21363" value="0.0" /> <!-- w -->
         <millepede_constant name="22163" value="0.0" /> <!-- ru -->
@@ -549,14 +549,14 @@
         <millepede_constant name="22363" value="0.0" /> <!-- rw -->
 
         <!-- L4 Top/Bottom translations and angles -->
-        <millepede_constant name="11164" value="0.0 + -0.007361 - -0.033468 - -0.017968 - -0.013564 - 0.001690 + -0.7" /> <!-- u  -> global Y   -->
+        <millepede_constant name="11164" value="0.0 + -0.007361 - -0.033468" /> <!-- u  -> global Y   -->
         <millepede_constant name="11264" value="0.0" /> <!-- v  -> X+svtAngle -->
         <millepede_constant name="11364" value="0.0" /> <!-- w  -> Z+svtAngle -->
         <millepede_constant name="12164" value="0.0" /> <!-- ru -->
         <millepede_constant name="12264" value="0.0" /> <!-- rv -->
         <millepede_constant name="12364" value="0.0" /> <!-- rw -->
 
-        <millepede_constant name="21164" value="0.0 + -0.033974 + -0.006749 - 0.051528 - -0.004088 - 0.021074 - 0.001095 + -0.7" /> <!-- u -->
+        <millepede_constant name="21164" value="0.0 + -0.033974 + -0.006749 - 0.051528" /> <!-- u -->
         <millepede_constant name="21264" value="0.0" /> <!-- v -->
         <millepede_constant name="21364" value="0.0" /> <!-- w -->
         <millepede_constant name="22164" value="0.0" /> <!-- ru -->
@@ -771,9 +771,12 @@
 
   </readouts>
 
-  <fields>
-      <field type="FieldMap3D" name="HPSDipoleFieldMap3D" filename="fieldmap/166acm2_4kg_corrected_unfolded_scaled_1.090896.dat" url="https://github.com/JeffersonLab/hps-fieldmaps/raw/master/166acm2_4kg_corrected_unfolded_scaled_1.090896.tar.gz" xoffset="2.117*cm" yoffset="0.0*cm" zoffset="45.72*cm" />
-  </fields>
+    <fields>
+            <field type="FieldMap3D" name="HPSDipoleFieldMap3D"
+                    filename="fieldmap/166acm2_4kg_corrected_unfolded_scaled_1.090896.dat"
+                    url="https://github.com/JeffersonLab/hps-fieldmaps/raw/master/166acm2_4kg_corrected_unfolded_scaled_1.090896.tar.gz"
+                    xoffset="2.117*cm" yoffset="0.0*cm" zoffset="45.72*cm" />
+    </fields>
 
   <!--
        <fields>

--- a/detector-data/detectors/HPS_Run2021Pass2FEE_1pt92_fixed/detector.properties
+++ b/detector-data/detectors/HPS_Run2021Pass2FEE_1pt92_fixed/detector.properties
@@ -1,0 +1,1 @@
+name: HPS_Run2021Pass2FEE_1pt92_fixed

--- a/detector-data/detectors/HPS_Run2021Pass2FEE_fixed/HPS_Run2021Pass2FEE_fixed.lcdd
+++ b/detector-data/detectors/HPS_Run2021Pass2FEE_fixed/HPS_Run2021Pass2FEE_fixed.lcdd
@@ -1,0 +1,10070 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lcdd xmlns:lcdd="http://www.lcsim.org/schemas/lcdd/1.0" xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/lcdd/1.0/lcdd.xsd">
+  <header>
+    <detector name="HPS_Run2021Pass2FEE_fixed" />
+    <generator name="lcsim" version="1.0" file="/sdf/group/hps/users/sgaiser/src/hps-java/detector-data/detectors/HPS_Run2021Pass2FEE/compact.xml" checksum="1727512758" />
+    <author name="NONE" />
+    <comment>HPS detector for 2021 run with fieldmap, Tracker at nominal opening angle, no SVT survey, this detector uses the corrected fieldmap scaled to -1.022T for 3.7 GeV. Includes L0 and Hodoscope. ECAL with survey alignment for HPSEcal3 (global y/z translations). This detector has the full hierarchical alignment structure</comment>
+  </header>
+  <iddict>
+    <idspec name="HodoscopeForeHits" length="46">
+      <idfield signed="false" label="system" length="6" start="0" />
+      <idfield signed="false" label="barrel" length="3" start="6" />
+      <idfield signed="false" label="layer" length="4" start="9" />
+      <idfield signed="false" label="module" length="12" start="13" />
+      <idfield signed="false" label="sensor" length="1" start="25" />
+      <idfield signed="true" label="side" length="2" start="32" />
+      <idfield signed="false" label="strip" length="12" start="34" />
+    </idspec>
+    <idspec name="TrackerHitsFieldDef" length="46">
+      <idfield signed="false" label="system" length="6" start="0" />
+      <idfield signed="false" label="barrel" length="3" start="6" />
+      <idfield signed="false" label="layer" length="4" start="9" />
+      <idfield signed="false" label="module" length="12" start="13" />
+      <idfield signed="false" label="sensor" length="1" start="25" />
+      <idfield signed="true" label="side" length="2" start="32" />
+      <idfield signed="false" label="strip" length="12" start="34" />
+    </idspec>
+    <idspec name="TrackerHits" length="46">
+      <idfield signed="false" label="system" length="6" start="0" />
+      <idfield signed="false" label="barrel" length="3" start="6" />
+      <idfield signed="false" label="layer" length="4" start="9" />
+      <idfield signed="false" label="module" length="12" start="13" />
+      <idfield signed="false" label="sensor" length="1" start="25" />
+      <idfield signed="true" label="side" length="2" start="32" />
+      <idfield signed="false" label="strip" length="12" start="34" />
+    </idspec>
+    <idspec name="HodoscopeHits" length="23">
+      <idfield signed="false" label="system" length="6" start="0" />
+      <idfield signed="false" label="barrel" length="3" start="6" />
+      <idfield signed="false" label="layer" length="4" start="9" />
+      <idfield signed="false" label="ix" length="4" start="13" />
+      <idfield signed="true" label="iy" length="3" start="17" />
+      <idfield signed="true" label="hole" length="3" start="20" />
+    </idspec>
+    <idspec name="EcalHits" length="22">
+      <idfield signed="false" label="system" length="6" start="0" />
+      <idfield signed="false" label="layer" length="2" start="6" />
+      <idfield signed="true" label="ix" length="8" start="8" />
+      <idfield signed="true" label="iy" length="6" start="16" />
+    </idspec>
+    <idspec name="TrackerHitsECal" length="46">
+      <idfield signed="false" label="system" length="6" start="0" />
+      <idfield signed="false" label="barrel" length="3" start="6" />
+      <idfield signed="false" label="layer" length="4" start="9" />
+      <idfield signed="false" label="module" length="12" start="13" />
+      <idfield signed="false" label="sensor" length="1" start="25" />
+      <idfield signed="true" label="side" length="2" start="32" />
+      <idfield signed="false" label="strip" length="12" start="34" />
+    </idspec>
+  </iddict>
+  <sensitive_detectors>
+    <tracker name="Tracker" ecut="0.0" eunit="MeV" verbose="0" hits_collection="TrackerHits">
+      <idspecref ref="TrackerHits" />
+    </tracker>
+    <tracker name="ECalScoring" ecut="0.0" eunit="MeV" verbose="0" hits_collection="TrackerHitsECal">
+      <idspecref ref="TrackerHitsECal" />
+      <hit_processor type="ScoringTrackerHitProcessor" />
+    </tracker>
+    <calorimeter name="Ecal" ecut="0.0" eunit="MeV" verbose="0" hits_collection="EcalHits">
+      <idspecref ref="EcalHits" />
+      <grid_xyz grid_size_x="0.0" grid_size_y="0.0" grid_size_z="0.0" />
+    </calorimeter>
+    <tracker name="Hodoscope" ecut="0.0" eunit="MeV" verbose="0" hits_collection="HodoscopeHits">
+      <idspecref ref="HodoscopeHits" />
+    </tracker>
+  </sensitive_detectors>
+  <limits />
+  <regions>
+    <region name="TrackingRegion" store_secondaries="true" kill_tracks="false" cut="10.0" lunit="mm" threshold="1.0" eunit="MeV" />
+  </regions>
+  <display>
+    <vis name="InvisibleWithDaughters" line_style="unbroken" drawing_style="wireframe" show_daughters="true" visible="false">
+      <color R="0.0" G="0.0" B="0.0" alpha="0.0" />
+    </vis>
+    <vis name="SensorVis" line_style="unbroken" drawing_style="wireframe" show_daughters="true" visible="true">
+      <color R="1.0" G="0.0" B="0.0" alpha="1.0" />
+    </vis>
+    <vis name="SvtBoxVis" line_style="unbroken" drawing_style="wireframe" show_daughters="true" visible="true">
+      <color R="1.0" G="1.0" B="0.0" alpha="1.0" />
+    </vis>
+    <vis name="ComponentVis" line_style="unbroken" drawing_style="solid" show_daughters="false" visible="false">
+      <color R="0.0" G="0.2" B="0.4" alpha="0.0" />
+    </vis>
+    <vis name="HybridVis" line_style="unbroken" drawing_style="solid" show_daughters="true" visible="true">
+      <color R="0.0" G="1.0" B="0.0" alpha="1.0" />
+    </vis>
+    <vis name="ColdBlockVis" line_style="dashed" drawing_style="solid" show_daughters="true" visible="true">
+      <color R="0.75" G="0.73" B="0.75" alpha="1.0" />
+    </vis>
+    <vis name="ECALVis" line_style="unbroken" drawing_style="wireframe" show_daughters="true" visible="true">
+      <color R="0.8" G="0.5" B="0.1" alpha="1.0" />
+    </vis>
+    <vis name="HodoscopeVis" line_style="unbroken" drawing_style="solid" show_daughters="true" visible="true">
+      <color R="0.0" G="0.3372549" B="0.50980395" alpha="1.0" />
+    </vis>
+    <vis name="BasePlateVis" line_style="dashed" drawing_style="solid" show_daughters="true" visible="true">
+      <color R="0.35" G="0.35" B="0.35" alpha="1.0" />
+    </vis>
+    <vis name="BeamPlaneVis" line_style="unbroken" drawing_style="solid" show_daughters="false" visible="true">
+      <color R="1.0" G="1.0" B="1.0" alpha="1.0" />
+    </vis>
+    <vis name="HalfModuleVis" line_style="dashed" drawing_style="wireframe" show_daughters="true" visible="true">
+      <color R="1.0" G="1.0" B="1.0" alpha="1.0" />
+    </vis>
+    <vis name="CarbonFiberVis" line_style="unbroken" drawing_style="solid" show_daughters="true" visible="true">
+      <color R="0.88" G="0.88" B="0.88" alpha="1.0" />
+    </vis>
+    <vis name="ModuleVis" line_style="dotted" drawing_style="wireframe" show_daughters="true" visible="true">
+      <color R="1.0" G="1.0" B="1.0" alpha="1.0" />
+    </vis>
+    <vis name="SupportPlateVis" line_style="dashed" drawing_style="solid" show_daughters="true" visible="true">
+      <color R="0.45" G="0.45" B="0.45" alpha="1.0" />
+    </vis>
+    <vis name="LayerVis" line_style="unbroken" drawing_style="wireframe" show_daughters="true" visible="false">
+      <color R="0.0" G="0.0" B="1.0" alpha="0.0" />
+    </vis>
+    <vis name="ChamberVis" line_style="unbroken" drawing_style="wireframe" show_daughters="true" visible="true">
+      <color R="1.0" G="0.0" B="1.0" alpha="1.0" />
+    </vis>
+    <vis name="InvisibleNoDaughters" line_style="unbroken" drawing_style="wireframe" show_daughters="false" visible="false">
+      <color R="0.0" G="0.0" B="0.0" alpha="0.0" />
+    </vis>
+    <vis name="ActiveSensorVis" line_style="unbroken" drawing_style="solid" show_daughters="true" visible="true">
+      <color R="1.0" G="0.0" B="0.0" alpha="1.0" />
+    </vis>
+    <vis name="KaptonVis" line_style="unbroken" drawing_style="solid" show_daughters="true" visible="true">
+      <color R="0.91" G="0.77" B="0.06" alpha="1.0" />
+    </vis>
+    <vis name="SupportVolumeVis" line_style="dashed" drawing_style="wireframe" show_daughters="true" visible="true">
+      <color R="0.75" G="0.73" B="0.75" alpha="1.0" />
+    </vis>
+    <vis name="WorldVis" line_style="unbroken" drawing_style="wireframe" show_daughters="true" visible="false">
+      <color R="1.0" G="1.0" B="1.0" alpha="1.0" />
+    </vis>
+    <vis name="TrackingVis" line_style="unbroken" drawing_style="wireframe" show_daughters="true" visible="false">
+      <color R="1.0" G="1.0" B="1.0" alpha="1.0" />
+    </vis>
+  </display>
+  <gdml>
+    <define>
+      <rotation name="identity_rot" x="0.0" y="0.0" z="0.0" unit="radian" />
+      <rotation name="reflect_rot" x="3.141592653589793" y="0.0" z="0.0" unit="radian" />
+      <position name="identity_pos" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <constant name="bot_tr_x" value="-0.405" />
+      <constant name="x_rot_top" value="0.0" />
+      <constant name="hodoscopeXMin2" value="48.0" />
+      <constant name="hodoscopeXMin1" value="43.548" />
+      <constant name="scoringThickness" value="0.001" />
+      <constant name="ecal_back" value="8.0" />
+      <constant name="pivot" value="791.0" />
+      <constant name="bot_tr_y" value="-0.9125" />
+      <constant name="hodoscopeThickness" value="10.0" />
+      <constant name="bot_tr_z" value="2.6225" />
+      <constant name="bot_rot_beta" value="0.0" />
+      <constant name="dipoleMagnetWidth" value="1000.0" />
+      <constant name="top_rot_beta" value="0.0" />
+      <constant name="SA1" value="0.1" />
+      <constant name="x_rot_top_add" value="0.0" />
+      <constant name="SA2" value="0.05" />
+      <constant name="tracking_region_min" value="50.0" />
+      <constant name="y02t" value="21.419865625949214" />
+      <constant name="world_side" value="5000.0" />
+      <constant name="sensorLength" value="98.33" />
+      <constant name="sensorWidth" value="38.3399" />
+      <constant name="y02b" value="-21.419865625949214" />
+      <constant name="bot_rot_gamma" value="0.0013469727279283583" />
+      <constant name="x_rot_bot" value="0.0" />
+      <constant name="dipoleMagnetHeight" value="1000.0" />
+      <constant name="z02t" value="146.185" />
+      <constant name="top_rot_alpha" value="6.4964212772E-4" />
+      <constant name="y_rot" value="0.03052" />
+      <constant name="tracking_region_zmax" value="1368.0" />
+      <constant name="constBFieldY" value="-1.08" />
+      <constant name="top_tr_z" value="4.9375" />
+      <constant name="top_tr_y" value="2.725" />
+      <constant name="top_tr_x" value="-0.71" />
+      <constant name="dipoleMagnetLength" value="1080.0" />
+      <constant name="top_rot_gamma" value="-4.6882347412E-4" />
+      <constant name="y01t" value="21.419865625949214" />
+      <constant name="x_rot_bot_add" value="0.0" />
+      <constant name="zst" value="1.0" />
+      <constant name="bot_rot_alpha" value="5.150274940439E-4" />
+      <constant name="hodoscopePixelHeight" value="59.225" />
+      <constant name="beam_angle" value="0.03052" />
+      <constant name="z02b" value="161.185" />
+      <constant name="y01b" value="-21.419865625949214" />
+      <constant name="electronGapLeftEdge" value="382.492" />
+      <constant name="ecal_front" value="6.65" />
+      <constant name="z01t" value="138.815" />
+      <constant name="world_x" value="5000.0" />
+      <constant name="hodoscopeScoreDisplacement" value="1.0" />
+      <constant name="world_y" value="5000.0" />
+      <constant name="dipoleMagnetPositionX" value="21.17" />
+      <constant name="world_z" value="5000.0" />
+      <constant name="dipoleMagnetPositionZ" value="457.2" />
+      <constant name="tracking_region_radius" value="2000.0" />
+      <constant name="moduleWidth" value="40.34" />
+      <constant name="x_off" value="0.0" />
+      <constant name="electronGapRightEdge" value="474.962" />
+      <constant name="hodoscopeZ" value="1098.5" />
+      <constant name="moduleLength" value="100.0" />
+      <constant name="PI" value="3.14159265359" />
+      <constant name="ecal_dface" value="1448.0" />
+      <constant name="ecal_z" value="80.0" />
+      <constant name="z01b" value="153.815" />
+      <position name="tracking_region_pos" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <position name="base_position" x="21.336" y="0.0" z="349.9358" unit="mm" />
+      <rotation name="base_rotation" x="1.5707963267948963" y="-0.0" z="0.0" unit="radian" />
+      <position name="base_plate_position" x="0.0" y="0.0" z="-82.423" unit="mm" />
+      <rotation name="base_plate_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="support_plate_bottom_L14_position" x="-43.91306765955236" y="158.27805970493353" z="-64.29618504855034" unit="mm" />
+      <rotation name="support_plate_bottom_L14_rotation" x="0.0013959999999999999" y="3.3881317890172014E-21" z="3.111052254139705" unit="radian" />
+      <position name="support_plate_top_L14_position" x="-43.92289273297252" y="158.275538638572" z="63.9526433720102" unit="mm" />
+      <rotation name="support_plate_top_L14_rotation" x="-3.1412006535897934" y="4.235164736271502E-21" z="0.030433306424175563" unit="radian" />
+      <position name="support_plate_bottom_L46_position" x="0.14270823091617224" y="-354.5345474665431" z="-65.573" unit="mm" />
+      <rotation name="support_plate_bottom_L46_rotation" x="0.0" y="-0.0" z="3.1111093540316292" unit="radian" />
+      <position name="support_plate_top_L46_position" x="0.14255566889328364" y="-354.53517226223204" z="65.573" unit="mm" />
+      <rotation name="support_plate_top_L46_rotation" x="3.141592653589793" y="-0.0" z="0.030483299558163937" unit="radian" />
+      <position name="module_L1b_halfmodule_axial_position" x="-19.4763620296784" y="288.43080680314125" z="-7.868322240733008" unit="mm" />
+      <rotation name="module_L1b_halfmodule_axial_rotation" x="-1.5694003267948962" y="-0.030540399450088122" z="1.5707963267948963" unit="radian" />
+      <position name="module_L1b_halfmodule_axial_sensor_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L1b_halfmodule_axial_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L1b_halfmodule_axial_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L1b_halfmodule_axial_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L1b_halfmodule_stereo_position" x="-18.950975318076487" y="296.04516725251904" z="-7.754181868972481" unit="mm" />
+      <rotation name="module_L1b_halfmodule_stereo_rotation" x="1.5721923267948965" y="0.03054039945008829" z="-1.4707963267948965" unit="radian" />
+      <position name="module_L1b_halfmodule_stereo_sensor_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L1b_halfmodule_stereo_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L1b_halfmodule_stereo_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L1b_halfmodule_stereo_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L1t_halfmodule_axial_position" x="-20.1794485390661" y="311.555035823137" z="7.876275502193266" unit="mm" />
+      <rotation name="module_L1t_halfmodule_axial_rotation" x="1.5711883267948965" y="0.03043330642417559" z="1.5707963267948966" unit="radian" />
+      <position name="module_L1t_halfmodule_axial_sensor_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L1t_halfmodule_axial_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L1t_halfmodule_axial_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L1t_halfmodule_axial_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L1t_halfmodule_stereo_position" x="-19.160254276741043" y="303.9879330807766" z="7.848654605882075" unit="mm" />
+      <rotation name="module_L1t_halfmodule_stereo_rotation" x="-1.5704043267948966" y="-0.030433306424175424" z="-1.4707963267948967" unit="radian" />
+      <position name="module_L1t_halfmodule_stereo_sensor_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L1t_halfmodule_stereo_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L1t_halfmodule_stereo_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L1t_halfmodule_stereo_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L2b_halfmodule_axial_position" x="-18.19946284499224" y="238.4458742857045" z="-8.273756692661564" unit="mm" />
+      <rotation name="module_L2b_halfmodule_axial_rotation" x="-1.5694003267948962" y="-0.030540399450088122" z="1.5707963267948963" unit="radian" />
+      <position name="module_L2b_halfmodule_axial_sensor_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L2b_halfmodule_axial_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L2b_halfmodule_axial_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L2b_halfmodule_axial_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L2b_halfmodule_stereo_position" x="-17.668736538396516" y="246.06038524800337" z="-8.168650212703746" unit="mm" />
+      <rotation name="module_L2b_halfmodule_stereo_rotation" x="1.5721923267948965" y="0.03054039945008829" z="-1.4707963267948965" unit="radian" />
+      <position name="module_L2b_halfmodule_stereo_sensor_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L2b_halfmodule_stereo_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L2b_halfmodule_stereo_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L2b_halfmodule_stereo_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L2t_halfmodule_axial_position" x="-18.90790233353613" y="261.57065544697707" z="8.074617394037915" unit="mm" />
+      <rotation name="module_L2t_halfmodule_axial_rotation" x="1.5711883267948965" y="0.03043330642417559" z="1.5707963267948966" unit="radian" />
+      <position name="module_L2t_halfmodule_axial_sensor_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L2t_halfmodule_axial_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L2t_halfmodule_axial_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L2t_halfmodule_axial_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L2t_halfmodule_stereo_position" x="-17.891118829887205" y="254.00349980902942" z="8.099278216849733" unit="mm" />
+      <rotation name="module_L2t_halfmodule_stereo_rotation" x="-1.5704043267948966" y="-0.030433306424175424" z="-1.4707963267948967" unit="radian" />
+      <position name="module_L2t_halfmodule_stereo_sensor_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L2t_halfmodule_stereo_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L2t_halfmodule_stereo_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L2t_halfmodule_stereo_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3b_halfmodule_axial_position" x="-44.86653535485047" y="137.05263425928803" z="-25.698042753919832" unit="mm" />
+      <rotation name="module_L3b_halfmodule_axial_rotation" x="-1.5694003267948962" y="-0.030540399450088122" z="1.5707963267948963" unit="radian" />
+      <position name="module_L3b_halfmodule_axial_sensor_position" x="-3.414999999999999" y="30.0" z="-0.50725" unit="mm" />
+      <rotation name="module_L3b_halfmodule_axial_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3b_halfmodule_axial_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L3b_halfmodule_axial_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3b_halfmodule_axial_lamination_position" x="-3.414999999999999" y="30.0" z="-0.69225" unit="mm" />
+      <rotation name="module_L3b_halfmodule_axial_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3b_halfmodule_axial_cf_position" x="-3.414999999999999" y="30.0" z="-0.81875" unit="mm" />
+      <rotation name="module_L3b_halfmodule_axial_cf_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3b_halfmodule_axial_hybrid_position" x="-3.414999999999999" y="-55.0" z="0.12649999999999995" unit="mm" />
+      <rotation name="module_L3b_halfmodule_axial_hybrid_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3b_halfmodule_stereo_position" x="-45.31712792075798" y="145.4286090945948" z="-21.88543549059398" unit="mm" />
+      <rotation name="module_L3b_halfmodule_stereo_rotation" x="1.5721923267948963" y="0.03054039945008801" z="1.6707963267948964" unit="radian" />
+      <position name="module_L3b_halfmodule_stereo_sensor_position" x="-3.414999999999999" y="30.0" z="-0.50725" unit="mm" />
+      <rotation name="module_L3b_halfmodule_stereo_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3b_halfmodule_stereo_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L3b_halfmodule_stereo_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3b_halfmodule_stereo_lamination_position" x="-3.414999999999999" y="30.0" z="-0.69225" unit="mm" />
+      <rotation name="module_L3b_halfmodule_stereo_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3b_halfmodule_stereo_cf_position" x="-3.414999999999999" y="30.0" z="-0.81875" unit="mm" />
+      <rotation name="module_L3b_halfmodule_stereo_cf_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3b_halfmodule_stereo_hybrid_position" x="-3.414999999999999" y="-55.0" z="0.12649999999999995" unit="mm" />
+      <rotation name="module_L3b_halfmodule_stereo_hybrid_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3t_halfmodule_axial_position" x="-45.61670040744279" y="161.22560021920657" z="25.632647003698295" unit="mm" />
+      <rotation name="module_L3t_halfmodule_axial_rotation" x="1.5711883267948965" y="0.03043330642417559" z="1.5707963267948966" unit="radian" />
+      <position name="module_L3t_halfmodule_axial_sensor_position" x="-3.414999999999999" y="30.0" z="-0.50725" unit="mm" />
+      <rotation name="module_L3t_halfmodule_axial_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3t_halfmodule_axial_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L3t_halfmodule_axial_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3t_halfmodule_axial_lamination_position" x="-3.414999999999999" y="30.0" z="-0.69225" unit="mm" />
+      <rotation name="module_L3t_halfmodule_axial_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3t_halfmodule_axial_cf_position" x="-3.414999999999999" y="30.0" z="-0.81875" unit="mm" />
+      <rotation name="module_L3t_halfmodule_axial_cf_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3t_halfmodule_axial_hybrid_position" x="-3.414999999999999" y="-55.0" z="0.12649999999999995" unit="mm" />
+      <rotation name="module_L3t_halfmodule_axial_hybrid_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3t_halfmodule_stereo_position" x="-45.550254290278474" y="152.84174390474504" z="21.816268962512165" unit="mm" />
+      <rotation name="module_L3t_halfmodule_stereo_rotation" x="-1.5704043267948962" y="-0.030433306424175535" z="1.6707963267948964" unit="radian" />
+      <position name="module_L3t_halfmodule_stereo_sensor_position" x="-3.414999999999999" y="30.0" z="-0.50725" unit="mm" />
+      <rotation name="module_L3t_halfmodule_stereo_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3t_halfmodule_stereo_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L3t_halfmodule_stereo_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3t_halfmodule_stereo_lamination_position" x="-3.414999999999999" y="30.0" z="-0.69225" unit="mm" />
+      <rotation name="module_L3t_halfmodule_stereo_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3t_halfmodule_stereo_cf_position" x="-3.414999999999999" y="30.0" z="-0.81875" unit="mm" />
+      <rotation name="module_L3t_halfmodule_stereo_cf_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L3t_halfmodule_stereo_hybrid_position" x="-3.414999999999999" y="-55.0" z="0.12649999999999995" unit="mm" />
+      <rotation name="module_L3t_halfmodule_stereo_hybrid_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4b_halfmodule_axial_position" x="-41.81297014635422" y="37.09717854332278" z="-27.123898372427487" unit="mm" />
+      <rotation name="module_L4b_halfmodule_axial_rotation" x="-1.5694003267948962" y="-0.030540399450088122" z="1.5707963267948963" unit="radian" />
+      <position name="module_L4b_halfmodule_axial_sensor_position" x="-3.414999999999999" y="30.0" z="-0.50725" unit="mm" />
+      <rotation name="module_L4b_halfmodule_axial_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4b_halfmodule_axial_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L4b_halfmodule_axial_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4b_halfmodule_axial_lamination_position" x="-3.414999999999999" y="30.0" z="-0.69225" unit="mm" />
+      <rotation name="module_L4b_halfmodule_axial_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4b_halfmodule_axial_cf_position" x="-3.414999999999999" y="30.0" z="-0.81875" unit="mm" />
+      <rotation name="module_L4b_halfmodule_axial_cf_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4b_halfmodule_axial_hybrid_position" x="-3.414999999999999" y="-55.0" z="0.12649999999999995" unit="mm" />
+      <rotation name="module_L4b_halfmodule_axial_hybrid_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4b_halfmodule_stereo_position" x="-42.265007725812566" y="45.47316371484888" z="-23.272264430185697" unit="mm" />
+      <rotation name="module_L4b_halfmodule_stereo_rotation" x="1.5721923267948963" y="0.03054039945008801" z="1.6707963267948964" unit="radian" />
+      <position name="module_L4b_halfmodule_stereo_sensor_position" x="-3.414999999999999" y="30.0" z="-0.50725" unit="mm" />
+      <rotation name="module_L4b_halfmodule_stereo_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4b_halfmodule_stereo_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L4b_halfmodule_stereo_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4b_halfmodule_stereo_lamination_position" x="-3.414999999999999" y="30.0" z="-0.69225" unit="mm" />
+      <rotation name="module_L4b_halfmodule_stereo_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4b_halfmodule_stereo_cf_position" x="-3.414999999999999" y="30.0" z="-0.81875" unit="mm" />
+      <rotation name="module_L4b_halfmodule_stereo_cf_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4b_halfmodule_stereo_hybrid_position" x="-3.414999999999999" y="-55.0" z="0.12649999999999995" unit="mm" />
+      <rotation name="module_L4b_halfmodule_stereo_hybrid_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4t_halfmodule_axial_position" x="-42.57383952504715" y="61.27247766363083" z="27.110685740297292" unit="mm" />
+      <rotation name="module_L4t_halfmodule_axial_rotation" x="1.5711883267948965" y="0.03043330642417559" z="1.5707963267948966" unit="radian" />
+      <position name="module_L4t_halfmodule_axial_sensor_position" x="-3.414999999999999" y="30.0" z="-0.50725" unit="mm" />
+      <rotation name="module_L4t_halfmodule_axial_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4t_halfmodule_axial_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L4t_halfmodule_axial_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4t_halfmodule_axial_lamination_position" x="-3.414999999999999" y="30.0" z="-0.69225" unit="mm" />
+      <rotation name="module_L4t_halfmodule_axial_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4t_halfmodule_axial_cf_position" x="-3.414999999999999" y="30.0" z="-0.81875" unit="mm" />
+      <rotation name="module_L4t_halfmodule_axial_cf_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4t_halfmodule_axial_hybrid_position" x="-3.414999999999999" y="-55.0" z="0.12649999999999995" unit="mm" />
+      <rotation name="module_L4t_halfmodule_axial_hybrid_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4t_halfmodule_stereo_position" x="-42.51021339381717" y="52.88853510689392" z="23.293301915130098" unit="mm" />
+      <rotation name="module_L4t_halfmodule_stereo_rotation" x="-1.5704043267948962" y="-0.030433306424175535" z="1.6707963267948964" unit="radian" />
+      <position name="module_L4t_halfmodule_stereo_sensor_position" x="-3.414999999999999" y="30.0" z="-0.50725" unit="mm" />
+      <rotation name="module_L4t_halfmodule_stereo_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4t_halfmodule_stereo_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L4t_halfmodule_stereo_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4t_halfmodule_stereo_lamination_position" x="-3.414999999999999" y="30.0" z="-0.69225" unit="mm" />
+      <rotation name="module_L4t_halfmodule_stereo_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4t_halfmodule_stereo_cf_position" x="-3.414999999999999" y="30.0" z="-0.81875" unit="mm" />
+      <rotation name="module_L4t_halfmodule_stereo_cf_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L4t_halfmodule_stereo_hybrid_position" x="-3.414999999999999" y="-55.0" z="0.12649999999999995" unit="mm" />
+      <rotation name="module_L4t_halfmodule_stereo_hybrid_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5b_halfmodule_axial_hole_position" x="-56.217250308986" y="-162.97132249781242" z="-26.654184000000008" unit="mm" />
+      <rotation name="module_L5b_halfmodule_axial_hole_rotation" x="-1.5707963267948966" y="-0.030483299558163958" z="1.5707963267948963" unit="radian" />
+      <position name="module_L5b_halfmodule_axial_hole_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L5b_halfmodule_axial_hole_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5b_halfmodule_axial_hole_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L5b_halfmodule_axial_hole_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5b_halfmodule_axial_hole_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L5b_halfmodule_axial_hole_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5b_halfmodule_axial_slot_position" x="44.72623159126889" y="-159.89327863637723" z="-26.790875000000007" unit="mm" />
+      <rotation name="module_L5b_halfmodule_axial_slot_rotation" x="-1.5707963267948968" y="-0.030483299558164013" z="-1.5707963267948963" unit="radian" />
+      <position name="module_L5b_halfmodule_axial_slot_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L5b_halfmodule_axial_slot_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5b_halfmodule_axial_slot_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L5b_halfmodule_axial_slot_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5b_halfmodule_axial_slot_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L5b_halfmodule_axial_slot_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5b_halfmodule_stereo_hole_position" x="-56.38945519192267" y="-155.65717305182127" z="-29.194184000000007" unit="mm" />
+      <rotation name="module_L5b_halfmodule_stereo_hole_rotation" x="1.5707963267948963" y="0.030483299558163958" z="1.6207963267948968" unit="radian" />
+      <position name="module_L5b_halfmodule_stereo_hole_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L5b_halfmodule_stereo_hole_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5b_halfmodule_stereo_hole_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L5b_halfmodule_stereo_hole_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5b_halfmodule_stereo_hole_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L5b_halfmodule_stereo_hole_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5b_halfmodule_stereo_slot_position" x="44.454054765676254" y="-152.582177609349" z="-24.171189451990195" unit="mm" />
+      <rotation name="module_L5b_halfmodule_stereo_slot_rotation" x="1.5707963267948963" y="0.030483299558163958" z="-1.520796326794897" unit="radian" />
+      <position name="module_L5b_halfmodule_stereo_slot_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L5b_halfmodule_stereo_slot_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5b_halfmodule_stereo_slot_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L5b_halfmodule_stereo_slot_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5b_halfmodule_stereo_slot_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L5b_halfmodule_stereo_slot_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5t_halfmodule_axial_hole_position" x="-56.924231591268885" y="-139.79172136362277" z="26.541846000000007" unit="mm" />
+      <rotation name="module_L5t_halfmodule_axial_hole_rotation" x="1.5707963267948966" y="0.030483299558163958" z="1.5707963267948963" unit="radian" />
+      <position name="module_L5t_halfmodule_axial_hole_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L5t_halfmodule_axial_hole_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5t_halfmodule_axial_hole_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L5t_halfmodule_axial_hole_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5t_halfmodule_axial_hole_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L5t_halfmodule_axial_hole_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5t_halfmodule_axial_slot_position" x="44.01925030898598" y="-136.71367750218758" z="26.52839000000001" unit="mm" />
+      <rotation name="module_L5t_halfmodule_axial_slot_rotation" x="1.5707963267948968" y="0.030483299558164013" z="-1.5707963267948963" unit="radian" />
+      <position name="module_L5t_halfmodule_axial_slot_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L5t_halfmodule_axial_slot_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5t_halfmodule_axial_slot_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L5t_halfmodule_axial_slot_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5t_halfmodule_axial_slot_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L5t_halfmodule_axial_slot_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5t_halfmodule_stereo_hole_position" x="-56.6479631235949" y="-147.10269762525203" z="29.15400018808746" unit="mm" />
+      <rotation name="module_L5t_halfmodule_stereo_hole_rotation" x="-1.5707963267948963" y="-0.030483299558163958" z="1.6207963267948968" unit="radian" />
+      <position name="module_L5t_halfmodule_stereo_hole_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L5t_halfmodule_stereo_hole_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5t_halfmodule_stereo_hole_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L5t_halfmodule_stereo_hole_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5t_halfmodule_stereo_hole_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L5t_halfmodule_stereo_hole_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5t_halfmodule_stereo_slot_position" x="44.1969126796318" y="-144.02766053439723" z="24.15831247094711" unit="mm" />
+      <rotation name="module_L5t_halfmodule_stereo_slot_rotation" x="-1.5707963267948966" y="-0.030483299558163847" z="-1.520796326794897" unit="radian" />
+      <position name="module_L5t_halfmodule_stereo_slot_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L5t_halfmodule_stereo_slot_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5t_halfmodule_stereo_slot_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L5t_halfmodule_stereo_slot_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L5t_halfmodule_stereo_slot_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L5t_halfmodule_stereo_slot_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6b_halfmodule_axial_hole_position" x="-50.12153455494366" y="-362.8784065379883" z="-29.752676000000015" unit="mm" />
+      <rotation name="module_L6b_halfmodule_axial_hole_rotation" x="-1.5707963267948966" y="-0.030483299558163958" z="1.5707963267948963" unit="radian" />
+      <position name="module_L6b_halfmodule_axial_hole_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L6b_halfmodule_axial_hole_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6b_halfmodule_axial_hole_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L6b_halfmodule_axial_hole_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6b_halfmodule_axial_hole_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L6b_halfmodule_axial_hole_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6b_halfmodule_axial_slot_position" x="50.82194734531124" y="-359.8003626765531" z="-29.763803000000017" unit="mm" />
+      <rotation name="module_L6b_halfmodule_axial_slot_rotation" x="-1.5707963267948968" y="-0.030483299558164013" z="-1.5707963267948963" unit="radian" />
+      <position name="module_L6b_halfmodule_axial_slot_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L6b_halfmodule_axial_slot_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6b_halfmodule_axial_slot_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L6b_halfmodule_axial_slot_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6b_halfmodule_axial_slot_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L6b_halfmodule_axial_slot_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6b_halfmodule_stereo_hole_position" x="-50.29343375742253" y="-355.5642477709609" z="-32.18203835284337" unit="mm" />
+      <rotation name="module_L6b_halfmodule_stereo_hole_rotation" x="1.5707963267948963" y="0.030483299558163958" z="1.6207963267948968" unit="radian" />
+      <position name="module_L6b_halfmodule_stereo_hole_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L6b_halfmodule_stereo_hole_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6b_halfmodule_stereo_hole_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L6b_halfmodule_stereo_hole_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6b_halfmodule_stereo_hole_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L6b_halfmodule_stereo_hole_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6b_halfmodule_stereo_slot_position" x="50.549000898353505" y="-352.48928511739297" z="-27.13754570547856" unit="mm" />
+      <rotation name="module_L6b_halfmodule_stereo_slot_rotation" x="1.5707963267948963" y="0.030483299558163958" z="-1.520796326794897" unit="radian" />
+      <position name="module_L6b_halfmodule_stereo_slot_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L6b_halfmodule_stereo_slot_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6b_halfmodule_stereo_slot_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L6b_halfmodule_stereo_slot_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6b_halfmodule_stereo_slot_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L6b_halfmodule_stereo_slot_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6t_halfmodule_axial_hole_position" x="-50.82851583722654" y="-339.6988054037986" z="29.47463400000001" unit="mm" />
+      <rotation name="module_L6t_halfmodule_axial_hole_rotation" x="1.5707963267948966" y="0.030483299558163958" z="1.5707963267948963" unit="radian" />
+      <position name="module_L6t_halfmodule_axial_hole_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L6t_halfmodule_axial_hole_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6t_halfmodule_axial_hole_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L6t_halfmodule_axial_hole_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6t_halfmodule_axial_hole_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L6t_halfmodule_axial_hole_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6t_halfmodule_axial_slot_position" x="50.11496606302833" y="-336.6207615423634" z="29.49411100000001" unit="mm" />
+      <rotation name="module_L6t_halfmodule_axial_slot_rotation" x="1.5707963267948968" y="0.030483299558164013" z="-1.5707963267948963" unit="radian" />
+      <position name="module_L6t_halfmodule_axial_slot_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L6t_halfmodule_axial_slot_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6t_halfmodule_axial_slot_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L6t_halfmodule_axial_slot_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6t_halfmodule_axial_slot_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L6t_halfmodule_axial_slot_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6t_halfmodule_stereo_hole_position" x="-50.553114355064075" y="-347.0098081021961" z="32.10353887731831" unit="mm" />
+      <rotation name="module_L6t_halfmodule_stereo_hole_rotation" x="-1.5707963267948963" y="-0.030483299558163958" z="1.6207963267948968" unit="radian" />
+      <position name="module_L6t_halfmodule_stereo_hole_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L6t_halfmodule_stereo_hole_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6t_halfmodule_stereo_hole_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L6t_halfmodule_stereo_hole_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6t_halfmodule_stereo_hole_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L6t_halfmodule_stereo_hole_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6t_halfmodule_stereo_slot_position" x="50.29059672518935" y="-343.934806526942" z="27.084565297856848" unit="mm" />
+      <rotation name="module_L6t_halfmodule_stereo_slot_rotation" x="-1.5707963267948966" y="-0.030483299558163847" z="-1.520796326794897" unit="radian" />
+      <position name="module_L6t_halfmodule_stereo_slot_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L6t_halfmodule_stereo_slot_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6t_halfmodule_stereo_slot_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L6t_halfmodule_stereo_slot_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L6t_halfmodule_stereo_slot_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L6t_halfmodule_stereo_slot_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7b_halfmodule_axial_hole_position" x="-44.02581880090134" y="-562.7854905781641" z="-32.83617600000001" unit="mm" />
+      <rotation name="module_L7b_halfmodule_axial_hole_rotation" x="-1.5707963267948966" y="-0.030483299558163958" z="1.5707963267948963" unit="radian" />
+      <position name="module_L7b_halfmodule_axial_hole_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L7b_halfmodule_axial_hole_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7b_halfmodule_axial_hole_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L7b_halfmodule_axial_hole_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7b_halfmodule_axial_hole_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L7b_halfmodule_axial_hole_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7b_halfmodule_axial_slot_position" x="56.917663099353554" y="-559.7074467167289" z="-32.84424400000001" unit="mm" />
+      <rotation name="module_L7b_halfmodule_axial_slot_rotation" x="-1.5707963267948968" y="-0.030483299558164013" z="-1.5707963267948963" unit="radian" />
+      <position name="module_L7b_halfmodule_axial_slot_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L7b_halfmodule_axial_slot_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7b_halfmodule_axial_slot_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L7b_halfmodule_axial_slot_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7b_halfmodule_axial_slot_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L7b_halfmodule_axial_slot_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7b_halfmodule_stereo_hole_position" x="-44.1996401085108" y="-555.4713904213984" z="-35.108553437824405" unit="mm" />
+      <rotation name="module_L7b_halfmodule_stereo_hole_rotation" x="1.5707963267948963" y="0.030483299558163958" z="1.6207963267948968" unit="radian" />
+      <position name="module_L7b_halfmodule_stereo_hole_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L7b_halfmodule_stereo_hole_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7b_halfmodule_stereo_hole_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L7b_halfmodule_stereo_hole_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7b_halfmodule_stereo_hole_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L7b_halfmodule_stereo_hole_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7b_halfmodule_stereo_slot_position" x="56.644874962801275" y="-552.3963643302499" z="-30.105653745053743" unit="mm" />
+      <rotation name="module_L7b_halfmodule_stereo_slot_rotation" x="1.5707963267948963" y="0.030483299558163958" z="-1.520796326794897" unit="radian" />
+      <position name="module_L7b_halfmodule_stereo_slot_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L7b_halfmodule_stereo_slot_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7b_halfmodule_stereo_slot_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L7b_halfmodule_stereo_slot_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7b_halfmodule_stereo_slot_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L7b_halfmodule_stereo_slot_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7t_halfmodule_axial_hole_position" x="-44.732800083184195" y="-539.6058894439745" z="32.40270000000001" unit="mm" />
+      <rotation name="module_L7t_halfmodule_axial_hole_rotation" x="1.5707963267948966" y="0.030483299558163958" z="1.5707963267948963" unit="radian" />
+      <position name="module_L7t_halfmodule_axial_hole_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L7t_halfmodule_axial_hole_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7t_halfmodule_axial_hole_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L7t_halfmodule_axial_hole_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7t_halfmodule_axial_hole_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L7t_halfmodule_axial_hole_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7t_halfmodule_axial_slot_position" x="56.21068181707067" y="-536.5278455825394" z="32.43682600000001" unit="mm" />
+      <rotation name="module_L7t_halfmodule_axial_slot_rotation" x="1.5707963267948968" y="0.030483299558164013" z="-1.5707963267948963" unit="radian" />
+      <position name="module_L7t_halfmodule_axial_slot_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L7t_halfmodule_axial_slot_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7t_halfmodule_axial_slot_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L7t_halfmodule_axial_slot_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7t_halfmodule_axial_slot_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L7t_halfmodule_axial_slot_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7t_halfmodule_stereo_hole_position" x="-44.46460424724372" y="-546.9171118623054" z="34.936632139758935" unit="mm" />
+      <rotation name="module_L7t_halfmodule_stereo_hole_rotation" x="-1.5707963267948963" y="-0.030483299558163958" z="1.6207963267948968" unit="radian" />
+      <position name="module_L7t_halfmodule_stereo_hole_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L7t_halfmodule_stereo_hole_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7t_halfmodule_stereo_hole_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L7t_halfmodule_stereo_hole_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7t_halfmodule_stereo_hole_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L7t_halfmodule_stereo_hole_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7t_halfmodule_stereo_slot_position" x="56.37942540210259" y="-543.8421005730052" z="29.924027590708015" unit="mm" />
+      <rotation name="module_L7t_halfmodule_stereo_slot_rotation" x="-1.5707963267948966" y="-0.030483299558163847" z="-1.520796326794897" unit="radian" />
+      <position name="module_L7t_halfmodule_stereo_slot_sensor_position" x="0.0" y="0.0" z="0.024999999999999994" unit="mm" />
+      <rotation name="module_L7t_halfmodule_stereo_slot_sensor_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7t_halfmodule_stereo_slot_sensor_active_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="module_L7t_halfmodule_stereo_slot_sensor_active_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="module_L7t_halfmodule_stereo_slot_lamination_position" x="0.0" y="0.0" z="-0.16" unit="mm" />
+      <rotation name="module_L7t_halfmodule_stereo_slot_lamination_rotation" x="0.0" y="-0.0" z="0.0" unit="radian" />
+      <position name="BeamLeftVolume_component0_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="BeamLeftVolume_component0_rotation" x="0.0" y="0.0" z="0.0" unit="radian" />
+      <position name="BeamLeftVolume_component0Sensor0Position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="BeamLeftVolume_component0Sensor0Rotation" x="0.0" y="0.0" z="0.0" unit="radian" />
+      <position name="ElectronGapVolume_component0_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="ElectronGapVolume_component0_rotation" x="0.0" y="0.0" z="0.0" unit="radian" />
+      <position name="ElectronGapVolume_component0Sensor0Position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="ElectronGapVolume_component0Sensor0Rotation" x="0.0" y="0.0" z="0.0" unit="radian" />
+      <position name="BeamRightVolume_component0_position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="BeamRightVolume_component0_rotation" x="0.0" y="0.0" z="0.0" unit="radian" />
+      <position name="BeamRightVolume_component0Sensor0Position" x="0.0" y="0.0" z="0.0" unit="mm" />
+      <rotation name="BeamRightVolume_component0Sensor0Rotation" x="0.0" y="0.0" z="0.0" unit="radian" />
+      <position name="ECalScoring_BeamLeft_layer1_module0_position" x="214.099" y="122.8" z="1443.001" unit="mm" />
+      <rotation name="ECalScoring_BeamLeft_layer1_module0_rotation" x="0.0" y="0.0" z="-1.570796326795" unit="radian" />
+      <position name="ECalScoring_ElectronGap_layer1_module0_position" x="-23.38199999999999" y="130.465" z="1443.001" unit="mm" />
+      <rotation name="ECalScoring_ElectronGap_layer1_module0_rotation" x="0.0" y="0.0" z="-1.570796326795" unit="radian" />
+      <position name="ECalScoring_BeamRight_layer1_module0_position" x="-216.31099999999998" y="121.3" z="1443.001" unit="mm" />
+      <rotation name="ECalScoring_BeamRight_layer1_module0_rotation" x="0.0" y="0.0" z="-1.570796326795" unit="radian" />
+      <position name="ECalScoring_BeamLeft_layer2_module0_position" x="214.099" y="-122.8" z="1443.001" unit="mm" />
+      <rotation name="ECalScoring_BeamLeft_layer2_module0_rotation" x="0.0" y="0.0" z="-4.7123889803850005" unit="radian" />
+      <position name="ECalScoring_ElectronGap_layer2_module0_position" x="-23.38199999999999" y="-130.465" z="1443.001" unit="mm" />
+      <rotation name="ECalScoring_ElectronGap_layer2_module0_rotation" x="0.0" y="0.0" z="-4.7123889803850005" unit="radian" />
+      <position name="ECalScoring_BeamRight_layer2_module0_position" x="-216.31099999999998" y="-121.3" z="1443.001" unit="mm" />
+      <rotation name="ECalScoring_BeamRight_layer2_module0_rotation" x="0.0" y="0.0" z="-4.7123889803850005" unit="radian" />
+      <position name="crystal1-1_pos_pos_bot" x="50.20495188328156" y="-29.07473927539554" z="1528.1626281236922" unit="mm" />
+      <rotation name="crystal1-1_rot_pos_bot" x="-0.0084372997827221" y="-0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal1-1_pos_neg_bot" x="35.15547333249048" y="-29.07473927539554" z="1528.1626281236922" unit="mm" />
+      <rotation name="crystal1-1_rot_neg_bot" x="-0.0084372997827221" y="0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal1-1_pos_pos_top" x="50.20495188328156" y="29.974739275395542" z="1528.1626281236922" unit="mm" />
+      <rotation name="crystal1-1_rot_pos_top" x="0.0084372997827221" y="-0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal1-1_pos_neg_top" x="35.15547333249048" y="29.974739275395542" z="1528.1626281236922" unit="mm" />
+      <rotation name="crystal1-1_rot_neg_top" x="0.0084372997827221" y="0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal2-1_pos_pos_bot" x="65.05802548582456" y="-29.07473927539554" z="1528.2520480856124" unit="mm" />
+      <rotation name="crystal2-1_rot_pos_bot" x="-0.0084372997827221" y="-0.0253118993481663" z="0.0" unit="radian" />
+      <position name="crystal2-1_pos_pos_top" x="65.05802548582456" y="29.974739275395542" z="1528.2520480856124" unit="mm" />
+      <rotation name="crystal2-1_rot_pos_top" x="0.0084372997827221" y="-0.0253118993481663" z="0.0" unit="radian" />
+      <position name="crystal3-1_pos_pos_bot" x="79.9180994782841" y="-29.07473927539554" z="1528.3186477918262" unit="mm" />
+      <rotation name="crystal3-1_rot_pos_bot" x="-0.0084372997827221" y="-0.042186498913610496" z="0.0" unit="radian" />
+      <position name="crystal3-1_pos_pos_top" x="79.9180994782841" y="29.974739275395542" z="1528.3186477918262" unit="mm" />
+      <rotation name="crystal3-1_rot_pos_top" x="0.0084372997827221" y="-0.042186498913610496" z="0.0" unit="radian" />
+      <position name="crystal4-1_pos_pos_bot" x="94.78858692586502" y="-29.07473927539554" z="1528.3624082783765" unit="mm" />
+      <rotation name="crystal4-1_rot_pos_bot" x="-0.0084372997827221" y="-0.0590610984790547" z="0.0" unit="radian" />
+      <position name="crystal4-1_pos_pos_top" x="94.78858692586502" y="29.974739275395542" z="1528.3624082783765" unit="mm" />
+      <rotation name="crystal4-1_rot_pos_top" x="0.0084372997827221" y="-0.0590610984790547" z="0.0" unit="radian" />
+      <position name="crystal5-1_pos_pos_bot" x="109.67291416309662" y="-29.07473927539554" z="1528.3833170846683" unit="mm" />
+      <rotation name="crystal5-1_rot_pos_bot" x="-0.0084372997827221" y="-0.0759356980444989" z="0.0" unit="radian" />
+      <position name="crystal5-1_pos_pos_top" x="109.67291416309662" y="29.974739275395542" z="1528.3833170846683" unit="mm" />
+      <rotation name="crystal5-1_rot_pos_top" x="0.0084372997827221" y="-0.0759356980444989" z="0.0" unit="radian" />
+      <position name="crystal6-1_pos_pos_bot" x="124.57452638340096" y="-29.07473927539554" z="1528.381368257016" unit="mm" />
+      <rotation name="crystal6-1_rot_pos_bot" x="-0.0084372997827221" y="-0.0928102976099431" z="0.0" unit="radian" />
+      <position name="crystal6-1_pos_pos_top" x="124.57452638340096" y="29.974739275395542" z="1528.381368257016" unit="mm" />
+      <rotation name="crystal6-1_rot_pos_top" x="0.0084372997827221" y="-0.0928102976099431" z="0.0" unit="radian" />
+      <position name="crystal7-1_pos_pos_bot" x="139.4968932952259" y="-29.07473927539554" z="1528.3565623503396" unit="mm" />
+      <rotation name="crystal7-1_rot_pos_bot" x="-0.0084372997827221" y="-0.10968489717538729" z="0.0" unit="radian" />
+      <position name="crystal7-1_pos_pos_top" x="139.4968932952259" y="29.974739275395542" z="1528.3565623503396" unit="mm" />
+      <rotation name="crystal7-1_rot_pos_top" x="0.0084372997827221" y="-0.10968489717538729" z="0.0" unit="radian" />
+      <position name="crystal8-1_pos_pos_bot" x="154.44351486445828" y="-29.07473927539554" z="1528.3089064280052" unit="mm" />
+      <rotation name="crystal8-1_rot_pos_bot" x="-0.0084372997827221" y="-0.1265594967408315" z="0.0" unit="radian" />
+      <position name="crystal8-1_pos_pos_top" x="154.44351486445828" y="29.974739275395542" z="1528.3089064280052" unit="mm" />
+      <rotation name="crystal8-1_rot_pos_top" x="0.0084372997827221" y="-0.1265594967408315" z="0.0" unit="radian" />
+      <position name="crystal9-1_pos_pos_bot" x="169.41792716339802" y="-29.07473927539554" z="1528.2384140598156" unit="mm" />
+      <rotation name="crystal9-1_rot_pos_bot" x="-0.0084372997827221" y="-0.14343409630627568" z="0.0" unit="radian" />
+      <position name="crystal9-1_pos_pos_top" x="169.41792716339802" y="29.974739275395542" z="1528.2384140598156" unit="mm" />
+      <rotation name="crystal9-1_rot_pos_top" x="0.0084372997827221" y="-0.14343409630627568" z="0.0" unit="radian" />
+      <position name="crystal10-1_pos_pos_bot" x="184.42370834727978" y="-29.07473927539554" z="1528.1451053181452" unit="mm" />
+      <rotation name="crystal10-1_rot_pos_bot" x="-0.0084372997827221" y="-0.1603086958717199" z="0.0" unit="radian" />
+      <position name="crystal10-1_pos_pos_top" x="184.42370834727978" y="29.974739275395542" z="1528.1451053181452" unit="mm" />
+      <rotation name="crystal10-1_rot_pos_top" x="0.0084372997827221" y="-0.1603086958717199" z="0.0" unit="radian" />
+      <position name="crystal11-1_pos_pos_bot" x="199.46448478017476" y="-29.07473927539554" z="1528.0290067722244" unit="mm" />
+      <rotation name="crystal11-1_rot_pos_bot" x="-0.0084372997827221" y="-0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal11-1_pos_neg_bot" x="-114.1040595644027" y="-29.07473927539554" z="1528.0290067722244" unit="mm" />
+      <rotation name="crystal11-1_rot_neg_bot" x="-0.0084372997827221" y="0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal11-1_pos_pos_top" x="199.46448478017476" y="29.974739275395542" z="1528.0290067722244" unit="mm" />
+      <rotation name="crystal11-1_rot_pos_top" x="0.0084372997827221" y="-0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal11-1_pos_neg_top" x="-114.1040595644027" y="29.974739275395542" z="1528.0290067722244" unit="mm" />
+      <rotation name="crystal11-1_rot_neg_top" x="0.0084372997827221" y="0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal12-1_pos_pos_bot" x="214.5439373331128" y="-29.07473927539554" z="1527.8901514805746" unit="mm" />
+      <rotation name="crystal12-1_rot_pos_bot" x="-0.0084372997827221" y="-0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal12-1_pos_neg_bot" x="-129.1835121173408" y="-29.07473927539554" z="1527.8901514805746" unit="mm" />
+      <rotation name="crystal12-1_rot_neg_bot" x="-0.0084372997827221" y="0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal12-1_pos_pos_top" x="214.5439373331128" y="29.974739275395542" z="1527.8901514805746" unit="mm" />
+      <rotation name="crystal12-1_rot_pos_top" x="0.0084372997827221" y="-0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal12-1_pos_neg_top" x="-129.1835121173408" y="29.974739275395542" z="1527.8901514805746" unit="mm" />
+      <rotation name="crystal12-1_rot_neg_top" x="0.0084372997827221" y="0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal13-1_pos_pos_bot" x="229.66580787843168" y="-29.07473927539554" z="1527.7285789815953" unit="mm" />
+      <rotation name="crystal13-1_rot_pos_bot" x="-0.0084372997827221" y="-0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal13-1_pos_neg_bot" x="-144.30538266265967" y="-29.07473927539554" z="1527.7285789815953" unit="mm" />
+      <rotation name="crystal13-1_rot_neg_bot" x="-0.0084372997827221" y="0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal13-1_pos_pos_top" x="229.66580787843168" y="29.974739275395542" z="1527.7285789815953" unit="mm" />
+      <rotation name="crystal13-1_rot_pos_top" x="0.0084372997827221" y="-0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal13-1_pos_neg_top" x="-144.30538266265967" y="29.974739275395542" z="1527.7285789815953" unit="mm" />
+      <rotation name="crystal13-1_rot_neg_top" x="0.0084372997827221" y="0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal14-1_pos_pos_bot" x="244.83390600570817" y="-29.07473927539554" z="1527.5443352823047" unit="mm" />
+      <rotation name="crystal14-1_rot_pos_bot" x="-0.0084372997827221" y="-0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal14-1_pos_neg_bot" x="-159.47348078993616" y="-29.07473927539554" z="1527.5443352823047" unit="mm" />
+      <rotation name="crystal14-1_rot_neg_bot" x="-0.0084372997827221" y="0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal14-1_pos_pos_top" x="244.83390600570817" y="29.974739275395542" z="1527.5443352823047" unit="mm" />
+      <rotation name="crystal14-1_rot_pos_top" x="0.0084372997827221" y="-0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal14-1_pos_neg_top" x="-159.47348078993616" y="29.974739275395542" z="1527.5443352823047" unit="mm" />
+      <rotation name="crystal14-1_rot_neg_top" x="0.0084372997827221" y="0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal15-1_pos_pos_bot" x="260.0521159861688" y="-29.07473927539554" z="1527.3374728452397" unit="mm" />
+      <rotation name="crystal15-1_rot_pos_bot" x="-0.0084372997827221" y="-0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal15-1_pos_neg_bot" x="-174.6916907703968" y="-29.07473927539554" z="1527.3374728452397" unit="mm" />
+      <rotation name="crystal15-1_rot_neg_bot" x="-0.0084372997827221" y="0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal15-1_pos_pos_top" x="260.0521159861688" y="29.974739275395542" z="1527.3374728452397" unit="mm" />
+      <rotation name="crystal15-1_rot_pos_top" x="0.0084372997827221" y="-0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal15-1_pos_neg_top" x="-174.6916907703968" y="29.974739275395542" z="1527.3374728452397" unit="mm" />
+      <rotation name="crystal15-1_rot_neg_top" x="0.0084372997827221" y="0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal16-1_pos_pos_bot" x="275.32440401422616" y="-29.07473927539554" z="1527.108050573519" unit="mm" />
+      <rotation name="crystal16-1_rot_pos_bot" x="-0.0084372997827221" y="-0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal16-1_pos_neg_bot" x="-189.96397879845415" y="-29.07473927539554" z="1527.108050573519" unit="mm" />
+      <rotation name="crystal16-1_rot_neg_bot" x="-0.0084372997827221" y="0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal16-1_pos_pos_top" x="275.32440401422616" y="29.974739275395542" z="1527.108050573519" unit="mm" />
+      <rotation name="crystal16-1_rot_pos_top" x="0.0084372997827221" y="-0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal16-1_pos_neg_top" x="-189.96397879845415" y="29.974739275395542" z="1527.108050573519" unit="mm" />
+      <rotation name="crystal16-1_rot_neg_top" x="0.0084372997827221" y="0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal17-1_pos_pos_bot" x="290.6548257567732" y="-29.07473927539554" z="1526.8561337940675" unit="mm" />
+      <rotation name="crystal17-1_rot_pos_bot" x="-0.0084372997827221" y="-0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal17-1_pos_neg_bot" x="-205.2944005410012" y="-29.07473927539554" z="1526.8561337940675" unit="mm" />
+      <rotation name="crystal17-1_rot_neg_bot" x="-0.0084372997827221" y="0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal17-1_pos_pos_top" x="290.6548257567732" y="29.974739275395542" z="1526.8561337940675" unit="mm" />
+      <rotation name="crystal17-1_rot_pos_top" x="0.0084372997827221" y="-0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal17-1_pos_neg_top" x="-205.2944005410012" y="29.974739275395542" z="1526.8561337940675" unit="mm" />
+      <rotation name="crystal17-1_rot_neg_top" x="0.0084372997827221" y="0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal18-1_pos_pos_bot" x="306.0475342431027" y="-29.07473927539554" z="1526.581794239018" unit="mm" />
+      <rotation name="crystal18-1_rot_pos_bot" x="-0.0084372997827221" y="-0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal18-1_pos_neg_bot" x="-220.68710902733068" y="-29.07473927539554" z="1526.581794239018" unit="mm" />
+      <rotation name="crystal18-1_rot_neg_bot" x="-0.0084372997827221" y="0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal18-1_pos_pos_top" x="306.0475342431027" y="29.974739275395542" z="1526.581794239018" unit="mm" />
+      <rotation name="crystal18-1_rot_pos_top" x="0.0084372997827221" y="-0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal18-1_pos_neg_top" x="-220.68710902733068" y="29.974739275395542" z="1526.581794239018" unit="mm" />
+      <rotation name="crystal18-1_rot_neg_top" x="0.0084372997827221" y="0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal19-1_pos_pos_bot" x="321.5067881308382" y="-29.07473927539554" z="1526.2851100252847" unit="mm" />
+      <rotation name="crystal19-1_rot_pos_bot" x="-0.0084372997827221" y="-0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal19-1_pos_neg_bot" x="-236.14636291506616" y="-29.07473927539554" z="1526.2851100252847" unit="mm" />
+      <rotation name="crystal19-1_rot_neg_bot" x="-0.0084372997827221" y="0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal19-1_pos_pos_top" x="321.5067881308382" y="29.974739275395542" z="1526.2851100252847" unit="mm" />
+      <rotation name="crystal19-1_rot_pos_top" x="0.0084372997827221" y="-0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal19-1_pos_neg_top" x="-236.14636291506616" y="29.974739275395542" z="1526.2851100252847" unit="mm" />
+      <rotation name="crystal19-1_rot_neg_top" x="0.0084372997827221" y="0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal20-1_pos_pos_bot" x="337.03696038609246" y="-29.07473927539554" z="1525.9661656323178" unit="mm" />
+      <rotation name="crystal20-1_rot_pos_bot" x="-0.0084372997827221" y="-0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal20-1_pos_neg_bot" x="-251.67653517032045" y="-29.07473927539554" z="1525.9661656323178" unit="mm" />
+      <rotation name="crystal20-1_rot_neg_bot" x="-0.0084372997827221" y="0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal20-1_pos_pos_top" x="337.03696038609246" y="29.974739275395542" z="1525.9661656323178" unit="mm" />
+      <rotation name="crystal20-1_rot_pos_top" x="0.0084372997827221" y="-0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal20-1_pos_neg_top" x="-251.67653517032045" y="29.974739275395542" z="1525.9661656323178" unit="mm" />
+      <rotation name="crystal20-1_rot_neg_top" x="0.0084372997827221" y="0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal21-1_pos_pos_bot" x="352.64254741924634" y="-29.07473927539554" z="1525.625051878052" unit="mm" />
+      <rotation name="crystal21-1_rot_pos_bot" x="-0.0084372997827221" y="-0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal21-1_pos_neg_bot" x="-267.28212220347433" y="-29.07473927539554" z="1525.625051878052" unit="mm" />
+      <rotation name="crystal21-1_rot_neg_bot" x="-0.0084372997827221" y="0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal21-1_pos_pos_top" x="352.64254741924634" y="29.974739275395542" z="1525.625051878052" unit="mm" />
+      <rotation name="crystal21-1_rot_pos_top" x="0.0084372997827221" y="-0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal21-1_pos_neg_top" x="-267.28212220347433" y="29.974739275395542" z="1525.625051878052" unit="mm" />
+      <rotation name="crystal21-1_rot_neg_top" x="0.0084372997827221" y="0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal22-1_pos_pos_bot" x="368.32817872130425" y="-29.07473927539554" z="1525.2618658930442" unit="mm" />
+      <rotation name="crystal22-1_rot_pos_bot" x="-0.0084372997827221" y="-0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal22-1_pos_neg_bot" x="-282.96775350553224" y="-29.07473927539554" z="1525.2618658930442" unit="mm" />
+      <rotation name="crystal22-1_rot_neg_bot" x="-0.0084372997827221" y="0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal22-1_pos_pos_top" x="368.32817872130425" y="29.974739275395542" z="1525.2618658930442" unit="mm" />
+      <rotation name="crystal22-1_rot_pos_top" x="0.0084372997827221" y="-0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal22-1_pos_neg_top" x="-282.96775350553224" y="29.974739275395542" z="1525.2618658930442" unit="mm" />
+      <rotation name="crystal22-1_rot_neg_top" x="0.0084372997827221" y="0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal23-1_pos_pos_bot" x="384.09862704978" y="-29.07473927539554" z="1524.8767110928152" unit="mm" />
+      <rotation name="crystal23-1_rot_pos_bot" x="-0.0084372997827221" y="-0.3796784902224945" z="0.0" unit="radian" />
+      <position name="crystal23-1_pos_neg_bot" x="-298.738201834008" y="-29.07473927539554" z="1524.8767110928152" unit="mm" />
+      <rotation name="crystal23-1_rot_neg_bot" x="-0.0084372997827221" y="0.3796784902224945" z="0.0" unit="radian" />
+      <position name="crystal23-1_pos_pos_top" x="384.09862704978" y="29.974739275395542" z="1524.8767110928152" unit="mm" />
+      <rotation name="crystal23-1_rot_pos_top" x="0.0084372997827221" y="-0.3796784902224945" z="0.0" unit="radian" />
+      <position name="crystal23-1_pos_neg_top" x="-298.738201834008" y="29.974739275395542" z="1524.8767110928152" unit="mm" />
+      <rotation name="crystal23-1_rot_neg_top" x="0.0084372997827221" y="0.3796784902224945" z="0.0" unit="radian" />
+      <position name="crystal1-2_pos_pos_bot" x="50.20495188328156" y="-44.077812877938534" z="1528.2520480856124" unit="mm" />
+      <rotation name="crystal1-2_rot_pos_bot" x="-0.0253118993481663" y="-0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal1-2_pos_neg_bot" x="35.15547333249048" y="-44.077812877938534" z="1528.2520480856124" unit="mm" />
+      <rotation name="crystal1-2_rot_neg_bot" x="-0.0253118993481663" y="0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal1-2_pos_pos_top" x="50.20495188328156" y="44.97781287793853" z="1528.2520480856124" unit="mm" />
+      <rotation name="crystal1-2_rot_pos_top" x="0.0253118993481663" y="-0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal1-2_pos_neg_top" x="35.15547333249048" y="44.97781287793853" z="1528.2520480856124" unit="mm" />
+      <rotation name="crystal1-2_rot_neg_top" x="0.0253118993481663" y="0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal2-2_pos_pos_bot" x="65.05802548582456" y="-44.077812877938534" z="1528.3414680475323" unit="mm" />
+      <rotation name="crystal2-2_rot_pos_bot" x="-0.0253118993481663" y="-0.0253118993481663" z="0.0" unit="radian" />
+      <position name="crystal2-2_pos_neg_bot" x="20.302399729947485" y="-44.077812877938534" z="1528.3414680475323" unit="mm" />
+      <rotation name="crystal2-2_rot_neg_bot" x="-0.0253118993481663" y="0.0253118993481663" z="0.0" unit="radian" />
+      <position name="crystal2-2_pos_pos_top" x="65.05802548582456" y="44.97781287793853" z="1528.3414680475323" unit="mm" />
+      <rotation name="crystal2-2_rot_pos_top" x="0.0253118993481663" y="-0.0253118993481663" z="0.0" unit="radian" />
+      <position name="crystal2-2_pos_neg_top" x="20.302399729947485" y="44.97781287793853" z="1528.3414680475323" unit="mm" />
+      <rotation name="crystal2-2_rot_neg_top" x="0.0253118993481663" y="0.0253118993481663" z="0.0" unit="radian" />
+      <position name="crystal3-2_pos_pos_bot" x="79.9180994782841" y="-44.077812877938534" z="1528.4080677537463" unit="mm" />
+      <rotation name="crystal3-2_rot_pos_bot" x="-0.0253118993481663" y="-0.042186498913610496" z="0.0" unit="radian" />
+      <position name="crystal3-2_pos_neg_bot" x="5.442325737487934" y="-44.077812877938534" z="1528.4080677537463" unit="mm" />
+      <rotation name="crystal3-2_rot_neg_bot" x="-0.0253118993481663" y="0.042186498913610496" z="0.0" unit="radian" />
+      <position name="crystal3-2_pos_pos_top" x="79.9180994782841" y="44.97781287793853" z="1528.4080677537463" unit="mm" />
+      <rotation name="crystal3-2_rot_pos_top" x="0.0253118993481663" y="-0.042186498913610496" z="0.0" unit="radian" />
+      <position name="crystal3-2_pos_neg_top" x="5.442325737487934" y="44.97781287793853" z="1528.4080677537463" unit="mm" />
+      <rotation name="crystal3-2_rot_neg_top" x="0.0253118993481663" y="0.042186498913610496" z="0.0" unit="radian" />
+      <position name="crystal4-2_pos_pos_bot" x="94.78858692586502" y="-44.077812877938534" z="1528.4518282402964" unit="mm" />
+      <rotation name="crystal4-2_rot_pos_bot" x="-0.0253118993481663" y="-0.0590610984790547" z="0.0" unit="radian" />
+      <position name="crystal4-2_pos_neg_bot" x="-9.42816171009298" y="-44.077812877938534" z="1528.4518282402964" unit="mm" />
+      <rotation name="crystal4-2_rot_neg_bot" x="-0.0253118993481663" y="0.0590610984790547" z="0.0" unit="radian" />
+      <position name="crystal4-2_pos_pos_top" x="94.78858692586502" y="44.97781287793853" z="1528.4518282402964" unit="mm" />
+      <rotation name="crystal4-2_rot_pos_top" x="0.0253118993481663" y="-0.0590610984790547" z="0.0" unit="radian" />
+      <position name="crystal4-2_pos_neg_top" x="-9.42816171009298" y="44.97781287793853" z="1528.4518282402964" unit="mm" />
+      <rotation name="crystal4-2_rot_neg_top" x="0.0253118993481663" y="0.0590610984790547" z="0.0" unit="radian" />
+      <position name="crystal5-2_pos_pos_bot" x="109.67291416309662" y="-44.077812877938534" z="1528.4727370465882" unit="mm" />
+      <rotation name="crystal5-2_rot_pos_bot" x="-0.0253118993481663" y="-0.0759356980444989" z="0.0" unit="radian" />
+      <position name="crystal5-2_pos_neg_bot" x="-24.31248894732458" y="-44.077812877938534" z="1528.4727370465882" unit="mm" />
+      <rotation name="crystal5-2_rot_neg_bot" x="-0.0253118993481663" y="0.0759356980444989" z="0.0" unit="radian" />
+      <position name="crystal5-2_pos_pos_top" x="109.67291416309662" y="44.97781287793853" z="1528.4727370465882" unit="mm" />
+      <rotation name="crystal5-2_rot_pos_top" x="0.0253118993481663" y="-0.0759356980444989" z="0.0" unit="radian" />
+      <position name="crystal5-2_pos_neg_top" x="-24.31248894732458" y="44.97781287793853" z="1528.4727370465882" unit="mm" />
+      <rotation name="crystal5-2_rot_neg_top" x="0.0253118993481663" y="0.0759356980444989" z="0.0" unit="radian" />
+      <position name="crystal6-2_pos_pos_bot" x="124.57452638340096" y="-44.077812877938534" z="1528.4707882189361" unit="mm" />
+      <rotation name="crystal6-2_rot_pos_bot" x="-0.0253118993481663" y="-0.0928102976099431" z="0.0" unit="radian" />
+      <position name="crystal6-2_pos_neg_bot" x="-39.214101167628925" y="-44.077812877938534" z="1528.4707882189361" unit="mm" />
+      <rotation name="crystal6-2_rot_neg_bot" x="-0.0253118993481663" y="0.0928102976099431" z="0.0" unit="radian" />
+      <position name="crystal6-2_pos_pos_top" x="124.57452638340096" y="44.97781287793853" z="1528.4707882189361" unit="mm" />
+      <rotation name="crystal6-2_rot_pos_top" x="0.0253118993481663" y="-0.0928102976099431" z="0.0" unit="radian" />
+      <position name="crystal6-2_pos_neg_top" x="-39.214101167628925" y="44.97781287793853" z="1528.4707882189361" unit="mm" />
+      <rotation name="crystal6-2_rot_neg_top" x="0.0253118993481663" y="0.0928102976099431" z="0.0" unit="radian" />
+      <position name="crystal7-2_pos_pos_bot" x="139.4968932952259" y="-44.077812877938534" z="1528.4459823122595" unit="mm" />
+      <rotation name="crystal7-2_rot_pos_bot" x="-0.0253118993481663" y="-0.10968489717538729" z="0.0" unit="radian" />
+      <position name="crystal7-2_pos_neg_bot" x="-54.13646807945388" y="-44.077812877938534" z="1528.4459823122595" unit="mm" />
+      <rotation name="crystal7-2_rot_neg_bot" x="-0.0253118993481663" y="0.10968489717538729" z="0.0" unit="radian" />
+      <position name="crystal7-2_pos_pos_top" x="139.4968932952259" y="44.97781287793853" z="1528.4459823122595" unit="mm" />
+      <rotation name="crystal7-2_rot_pos_top" x="0.0253118993481663" y="-0.10968489717538729" z="0.0" unit="radian" />
+      <position name="crystal7-2_pos_neg_top" x="-54.13646807945388" y="44.97781287793853" z="1528.4459823122595" unit="mm" />
+      <rotation name="crystal7-2_rot_neg_top" x="0.0253118993481663" y="0.10968489717538729" z="0.0" unit="radian" />
+      <position name="crystal8-2_pos_pos_bot" x="154.44351486445828" y="-44.077812877938534" z="1528.3983263899254" unit="mm" />
+      <rotation name="crystal8-2_rot_pos_bot" x="-0.0253118993481663" y="-0.1265594967408315" z="0.0" unit="radian" />
+      <position name="crystal8-2_pos_neg_bot" x="-69.08308964868624" y="-44.077812877938534" z="1528.3983263899254" unit="mm" />
+      <rotation name="crystal8-2_rot_neg_bot" x="-0.0253118993481663" y="0.1265594967408315" z="0.0" unit="radian" />
+      <position name="crystal8-2_pos_pos_top" x="154.44351486445828" y="44.97781287793853" z="1528.3983263899254" unit="mm" />
+      <rotation name="crystal8-2_rot_pos_top" x="0.0253118993481663" y="-0.1265594967408315" z="0.0" unit="radian" />
+      <position name="crystal8-2_pos_neg_top" x="-69.08308964868624" y="44.97781287793853" z="1528.3983263899254" unit="mm" />
+      <rotation name="crystal8-2_rot_neg_top" x="0.0253118993481663" y="0.1265594967408315" z="0.0" unit="radian" />
+      <position name="crystal9-2_pos_pos_bot" x="169.41792716339802" y="-44.077812877938534" z="1528.3278340217357" unit="mm" />
+      <rotation name="crystal9-2_rot_pos_bot" x="-0.0253118993481663" y="-0.14343409630627568" z="0.0" unit="radian" />
+      <position name="crystal9-2_pos_neg_bot" x="-84.057501947626" y="-44.077812877938534" z="1528.3278340217357" unit="mm" />
+      <rotation name="crystal9-2_rot_neg_bot" x="-0.0253118993481663" y="0.14343409630627568" z="0.0" unit="radian" />
+      <position name="crystal9-2_pos_pos_top" x="169.41792716339802" y="44.97781287793853" z="1528.3278340217357" unit="mm" />
+      <rotation name="crystal9-2_rot_pos_top" x="0.0253118993481663" y="-0.14343409630627568" z="0.0" unit="radian" />
+      <position name="crystal9-2_pos_neg_top" x="-84.057501947626" y="44.97781287793853" z="1528.3278340217357" unit="mm" />
+      <rotation name="crystal9-2_rot_neg_top" x="0.0253118993481663" y="0.14343409630627568" z="0.0" unit="radian" />
+      <position name="crystal10-2_pos_pos_bot" x="184.42370834727978" y="-44.077812877938534" z="1528.2345252800653" unit="mm" />
+      <rotation name="crystal10-2_rot_pos_bot" x="-0.0253118993481663" y="-0.1603086958717199" z="0.0" unit="radian" />
+      <position name="crystal10-2_pos_neg_bot" x="-99.06328313150773" y="-44.077812877938534" z="1528.2345252800653" unit="mm" />
+      <rotation name="crystal10-2_rot_neg_bot" x="-0.0253118993481663" y="0.1603086958717199" z="0.0" unit="radian" />
+      <position name="crystal10-2_pos_pos_top" x="184.42370834727978" y="44.97781287793853" z="1528.2345252800653" unit="mm" />
+      <rotation name="crystal10-2_rot_pos_top" x="0.0253118993481663" y="-0.1603086958717199" z="0.0" unit="radian" />
+      <position name="crystal10-2_pos_neg_top" x="-99.06328313150773" y="44.97781287793853" z="1528.2345252800653" unit="mm" />
+      <rotation name="crystal10-2_rot_neg_top" x="0.0253118993481663" y="0.1603086958717199" z="0.0" unit="radian" />
+      <position name="crystal11-2_pos_pos_bot" x="199.46448478017476" y="-44.077812877938534" z="1528.1184267341444" unit="mm" />
+      <rotation name="crystal11-2_rot_pos_bot" x="-0.0253118993481663" y="-0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal11-2_pos_neg_bot" x="-114.1040595644027" y="-44.077812877938534" z="1528.1184267341444" unit="mm" />
+      <rotation name="crystal11-2_rot_neg_bot" x="-0.0253118993481663" y="0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal11-2_pos_pos_top" x="199.46448478017476" y="44.97781287793853" z="1528.1184267341444" unit="mm" />
+      <rotation name="crystal11-2_rot_pos_top" x="0.0253118993481663" y="-0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal11-2_pos_neg_top" x="-114.1040595644027" y="44.97781287793853" z="1528.1184267341444" unit="mm" />
+      <rotation name="crystal11-2_rot_neg_top" x="0.0253118993481663" y="0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal12-2_pos_pos_bot" x="214.5439373331128" y="-44.077812877938534" z="1527.9795714424947" unit="mm" />
+      <rotation name="crystal12-2_rot_pos_bot" x="-0.0253118993481663" y="-0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal12-2_pos_neg_bot" x="-129.1835121173408" y="-44.077812877938534" z="1527.9795714424947" unit="mm" />
+      <rotation name="crystal12-2_rot_neg_bot" x="-0.0253118993481663" y="0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal12-2_pos_pos_top" x="214.5439373331128" y="44.97781287793853" z="1527.9795714424947" unit="mm" />
+      <rotation name="crystal12-2_rot_pos_top" x="0.0253118993481663" y="-0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal12-2_pos_neg_top" x="-129.1835121173408" y="44.97781287793853" z="1527.9795714424947" unit="mm" />
+      <rotation name="crystal12-2_rot_neg_top" x="0.0253118993481663" y="0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal13-2_pos_pos_bot" x="229.66580787843168" y="-44.077812877938534" z="1527.8179989435152" unit="mm" />
+      <rotation name="crystal13-2_rot_pos_bot" x="-0.0253118993481663" y="-0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal13-2_pos_neg_bot" x="-144.30538266265967" y="-44.077812877938534" z="1527.8179989435152" unit="mm" />
+      <rotation name="crystal13-2_rot_neg_bot" x="-0.0253118993481663" y="0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal13-2_pos_pos_top" x="229.66580787843168" y="44.97781287793853" z="1527.8179989435152" unit="mm" />
+      <rotation name="crystal13-2_rot_pos_top" x="0.0253118993481663" y="-0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal13-2_pos_neg_top" x="-144.30538266265967" y="44.97781287793853" z="1527.8179989435152" unit="mm" />
+      <rotation name="crystal13-2_rot_neg_top" x="0.0253118993481663" y="0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal14-2_pos_pos_bot" x="244.83390600570817" y="-44.077812877938534" z="1527.6337552442246" unit="mm" />
+      <rotation name="crystal14-2_rot_pos_bot" x="-0.0253118993481663" y="-0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal14-2_pos_neg_bot" x="-159.47348078993616" y="-44.077812877938534" z="1527.6337552442246" unit="mm" />
+      <rotation name="crystal14-2_rot_neg_bot" x="-0.0253118993481663" y="0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal14-2_pos_pos_top" x="244.83390600570817" y="44.97781287793853" z="1527.6337552442246" unit="mm" />
+      <rotation name="crystal14-2_rot_pos_top" x="0.0253118993481663" y="-0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal14-2_pos_neg_top" x="-159.47348078993616" y="44.97781287793853" z="1527.6337552442246" unit="mm" />
+      <rotation name="crystal14-2_rot_neg_top" x="0.0253118993481663" y="0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal15-2_pos_pos_bot" x="260.0521159861688" y="-44.077812877938534" z="1527.42689280716" unit="mm" />
+      <rotation name="crystal15-2_rot_pos_bot" x="-0.0253118993481663" y="-0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal15-2_pos_neg_bot" x="-174.6916907703968" y="-44.077812877938534" z="1527.42689280716" unit="mm" />
+      <rotation name="crystal15-2_rot_neg_bot" x="-0.0253118993481663" y="0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal15-2_pos_pos_top" x="260.0521159861688" y="44.97781287793853" z="1527.42689280716" unit="mm" />
+      <rotation name="crystal15-2_rot_pos_top" x="0.0253118993481663" y="-0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal15-2_pos_neg_top" x="-174.6916907703968" y="44.97781287793853" z="1527.42689280716" unit="mm" />
+      <rotation name="crystal15-2_rot_neg_top" x="0.0253118993481663" y="0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal16-2_pos_pos_bot" x="275.32440401422616" y="-44.077812877938534" z="1527.1974705354392" unit="mm" />
+      <rotation name="crystal16-2_rot_pos_bot" x="-0.0253118993481663" y="-0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal16-2_pos_neg_bot" x="-189.96397879845415" y="-44.077812877938534" z="1527.1974705354392" unit="mm" />
+      <rotation name="crystal16-2_rot_neg_bot" x="-0.0253118993481663" y="0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal16-2_pos_pos_top" x="275.32440401422616" y="44.97781287793853" z="1527.1974705354392" unit="mm" />
+      <rotation name="crystal16-2_rot_pos_top" x="0.0253118993481663" y="-0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal16-2_pos_neg_top" x="-189.96397879845415" y="44.97781287793853" z="1527.1974705354392" unit="mm" />
+      <rotation name="crystal16-2_rot_neg_top" x="0.0253118993481663" y="0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal17-2_pos_pos_bot" x="290.6548257567732" y="-44.077812877938534" z="1526.9455537559877" unit="mm" />
+      <rotation name="crystal17-2_rot_pos_bot" x="-0.0253118993481663" y="-0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal17-2_pos_neg_bot" x="-205.2944005410012" y="-44.077812877938534" z="1526.9455537559877" unit="mm" />
+      <rotation name="crystal17-2_rot_neg_bot" x="-0.0253118993481663" y="0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal17-2_pos_pos_top" x="290.6548257567732" y="44.97781287793853" z="1526.9455537559877" unit="mm" />
+      <rotation name="crystal17-2_rot_pos_top" x="0.0253118993481663" y="-0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal17-2_pos_neg_top" x="-205.2944005410012" y="44.97781287793853" z="1526.9455537559877" unit="mm" />
+      <rotation name="crystal17-2_rot_neg_top" x="0.0253118993481663" y="0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal18-2_pos_pos_bot" x="306.0475342431027" y="-44.077812877938534" z="1526.6712142009383" unit="mm" />
+      <rotation name="crystal18-2_rot_pos_bot" x="-0.0253118993481663" y="-0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal18-2_pos_neg_bot" x="-220.68710902733068" y="-44.077812877938534" z="1526.6712142009383" unit="mm" />
+      <rotation name="crystal18-2_rot_neg_bot" x="-0.0253118993481663" y="0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal18-2_pos_pos_top" x="306.0475342431027" y="44.97781287793853" z="1526.6712142009383" unit="mm" />
+      <rotation name="crystal18-2_rot_pos_top" x="0.0253118993481663" y="-0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal18-2_pos_neg_top" x="-220.68710902733068" y="44.97781287793853" z="1526.6712142009383" unit="mm" />
+      <rotation name="crystal18-2_rot_neg_top" x="0.0253118993481663" y="0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal19-2_pos_pos_bot" x="321.5067881308382" y="-44.077812877938534" z="1526.3745299872046" unit="mm" />
+      <rotation name="crystal19-2_rot_pos_bot" x="-0.0253118993481663" y="-0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal19-2_pos_neg_bot" x="-236.14636291506616" y="-44.077812877938534" z="1526.3745299872046" unit="mm" />
+      <rotation name="crystal19-2_rot_neg_bot" x="-0.0253118993481663" y="0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal19-2_pos_pos_top" x="321.5067881308382" y="44.97781287793853" z="1526.3745299872046" unit="mm" />
+      <rotation name="crystal19-2_rot_pos_top" x="0.0253118993481663" y="-0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal19-2_pos_neg_top" x="-236.14636291506616" y="44.97781287793853" z="1526.3745299872046" unit="mm" />
+      <rotation name="crystal19-2_rot_neg_top" x="0.0253118993481663" y="0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal20-2_pos_pos_bot" x="337.03696038609246" y="-44.077812877938534" z="1526.055585594238" unit="mm" />
+      <rotation name="crystal20-2_rot_pos_bot" x="-0.0253118993481663" y="-0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal20-2_pos_neg_bot" x="-251.67653517032045" y="-44.077812877938534" z="1526.055585594238" unit="mm" />
+      <rotation name="crystal20-2_rot_neg_bot" x="-0.0253118993481663" y="0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal20-2_pos_pos_top" x="337.03696038609246" y="44.97781287793853" z="1526.055585594238" unit="mm" />
+      <rotation name="crystal20-2_rot_pos_top" x="0.0253118993481663" y="-0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal20-2_pos_neg_top" x="-251.67653517032045" y="44.97781287793853" z="1526.055585594238" unit="mm" />
+      <rotation name="crystal20-2_rot_neg_top" x="0.0253118993481663" y="0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal21-2_pos_pos_bot" x="352.64254741924634" y="-44.077812877938534" z="1525.7144718399722" unit="mm" />
+      <rotation name="crystal21-2_rot_pos_bot" x="-0.0253118993481663" y="-0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal21-2_pos_neg_bot" x="-267.28212220347433" y="-44.077812877938534" z="1525.7144718399722" unit="mm" />
+      <rotation name="crystal21-2_rot_neg_bot" x="-0.0253118993481663" y="0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal21-2_pos_pos_top" x="352.64254741924634" y="44.97781287793853" z="1525.7144718399722" unit="mm" />
+      <rotation name="crystal21-2_rot_pos_top" x="0.0253118993481663" y="-0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal21-2_pos_neg_top" x="-267.28212220347433" y="44.97781287793853" z="1525.7144718399722" unit="mm" />
+      <rotation name="crystal21-2_rot_neg_top" x="0.0253118993481663" y="0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal22-2_pos_pos_bot" x="368.32817872130425" y="-44.077812877938534" z="1525.351285854964" unit="mm" />
+      <rotation name="crystal22-2_rot_pos_bot" x="-0.0253118993481663" y="-0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal22-2_pos_neg_bot" x="-282.96775350553224" y="-44.077812877938534" z="1525.351285854964" unit="mm" />
+      <rotation name="crystal22-2_rot_neg_bot" x="-0.0253118993481663" y="0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal22-2_pos_pos_top" x="368.32817872130425" y="44.97781287793853" z="1525.351285854964" unit="mm" />
+      <rotation name="crystal22-2_rot_pos_top" x="0.0253118993481663" y="-0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal22-2_pos_neg_top" x="-282.96775350553224" y="44.97781287793853" z="1525.351285854964" unit="mm" />
+      <rotation name="crystal22-2_rot_neg_top" x="0.0253118993481663" y="0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal23-2_pos_pos_bot" x="384.09862704978" y="-44.077812877938534" z="1524.9661310547353" unit="mm" />
+      <rotation name="crystal23-2_rot_pos_bot" x="-0.0253118993481663" y="-0.3796784902224945" z="0.0" unit="radian" />
+      <position name="crystal23-2_pos_neg_bot" x="-298.738201834008" y="-44.077812877938534" z="1524.9661310547353" unit="mm" />
+      <rotation name="crystal23-2_rot_neg_bot" x="-0.0253118993481663" y="0.3796784902224945" z="0.0" unit="radian" />
+      <position name="crystal23-2_pos_pos_top" x="384.09862704978" y="44.97781287793853" z="1524.9661310547353" unit="mm" />
+      <rotation name="crystal23-2_rot_pos_top" x="0.0253118993481663" y="-0.3796784902224945" z="0.0" unit="radian" />
+      <position name="crystal23-2_pos_neg_top" x="-298.738201834008" y="44.97781287793853" z="1524.9661310547353" unit="mm" />
+      <rotation name="crystal23-2_rot_neg_top" x="0.0253118993481663" y="0.3796784902224945" z="0.0" unit="radian" />
+      <position name="crystal1-3_pos_pos_bot" x="50.20495188328156" y="-59.08788687039808" z="1528.3186477918262" unit="mm" />
+      <rotation name="crystal1-3_rot_pos_bot" x="-0.042186498913610496" y="-0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal1-3_pos_neg_bot" x="35.15547333249048" y="-59.08788687039808" z="1528.3186477918262" unit="mm" />
+      <rotation name="crystal1-3_rot_neg_bot" x="-0.042186498913610496" y="0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal1-3_pos_pos_top" x="50.20495188328156" y="59.987886870398086" z="1528.3186477918262" unit="mm" />
+      <rotation name="crystal1-3_rot_pos_top" x="0.042186498913610496" y="-0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal1-3_pos_neg_top" x="35.15547333249048" y="59.987886870398086" z="1528.3186477918262" unit="mm" />
+      <rotation name="crystal1-3_rot_neg_top" x="0.042186498913610496" y="0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal2-3_pos_pos_bot" x="65.05802548582456" y="-59.08788687039808" z="1528.4080677537463" unit="mm" />
+      <rotation name="crystal2-3_rot_pos_bot" x="-0.042186498913610496" y="-0.0253118993481663" z="0.0" unit="radian" />
+      <position name="crystal2-3_pos_neg_bot" x="20.302399729947485" y="-59.08788687039808" z="1528.4080677537463" unit="mm" />
+      <rotation name="crystal2-3_rot_neg_bot" x="-0.042186498913610496" y="0.0253118993481663" z="0.0" unit="radian" />
+      <position name="crystal2-3_pos_pos_top" x="65.05802548582456" y="59.987886870398086" z="1528.4080677537463" unit="mm" />
+      <rotation name="crystal2-3_rot_pos_top" x="0.042186498913610496" y="-0.0253118993481663" z="0.0" unit="radian" />
+      <position name="crystal2-3_pos_neg_top" x="20.302399729947485" y="59.987886870398086" z="1528.4080677537463" unit="mm" />
+      <rotation name="crystal2-3_rot_neg_top" x="0.042186498913610496" y="0.0253118993481663" z="0.0" unit="radian" />
+      <position name="crystal3-3_pos_pos_bot" x="79.9180994782841" y="-59.08788687039808" z="1528.47466745996" unit="mm" />
+      <rotation name="crystal3-3_rot_pos_bot" x="-0.042186498913610496" y="-0.042186498913610496" z="0.0" unit="radian" />
+      <position name="crystal3-3_pos_neg_bot" x="5.442325737487934" y="-59.08788687039808" z="1528.47466745996" unit="mm" />
+      <rotation name="crystal3-3_rot_neg_bot" x="-0.042186498913610496" y="0.042186498913610496" z="0.0" unit="radian" />
+      <position name="crystal3-3_pos_pos_top" x="79.9180994782841" y="59.987886870398086" z="1528.47466745996" unit="mm" />
+      <rotation name="crystal3-3_rot_pos_top" x="0.042186498913610496" y="-0.042186498913610496" z="0.0" unit="radian" />
+      <position name="crystal3-3_pos_neg_top" x="5.442325737487934" y="59.987886870398086" z="1528.47466745996" unit="mm" />
+      <rotation name="crystal3-3_rot_neg_top" x="0.042186498913610496" y="0.042186498913610496" z="0.0" unit="radian" />
+      <position name="crystal4-3_pos_pos_bot" x="94.78858692586502" y="-59.08788687039808" z="1528.5184279465104" unit="mm" />
+      <rotation name="crystal4-3_rot_pos_bot" x="-0.042186498913610496" y="-0.0590610984790547" z="0.0" unit="radian" />
+      <position name="crystal4-3_pos_neg_bot" x="-9.42816171009298" y="-59.08788687039808" z="1528.5184279465104" unit="mm" />
+      <rotation name="crystal4-3_rot_neg_bot" x="-0.042186498913610496" y="0.0590610984790547" z="0.0" unit="radian" />
+      <position name="crystal4-3_pos_pos_top" x="94.78858692586502" y="59.987886870398086" z="1528.5184279465104" unit="mm" />
+      <rotation name="crystal4-3_rot_pos_top" x="0.042186498913610496" y="-0.0590610984790547" z="0.0" unit="radian" />
+      <position name="crystal4-3_pos_neg_top" x="-9.42816171009298" y="59.987886870398086" z="1528.5184279465104" unit="mm" />
+      <rotation name="crystal4-3_rot_neg_top" x="0.042186498913610496" y="0.0590610984790547" z="0.0" unit="radian" />
+      <position name="crystal5-3_pos_pos_bot" x="109.67291416309662" y="-59.08788687039808" z="1528.5393367528022" unit="mm" />
+      <rotation name="crystal5-3_rot_pos_bot" x="-0.042186498913610496" y="-0.0759356980444989" z="0.0" unit="radian" />
+      <position name="crystal5-3_pos_neg_bot" x="-24.31248894732458" y="-59.08788687039808" z="1528.5393367528022" unit="mm" />
+      <rotation name="crystal5-3_rot_neg_bot" x="-0.042186498913610496" y="0.0759356980444989" z="0.0" unit="radian" />
+      <position name="crystal5-3_pos_pos_top" x="109.67291416309662" y="59.987886870398086" z="1528.5393367528022" unit="mm" />
+      <rotation name="crystal5-3_rot_pos_top" x="0.042186498913610496" y="-0.0759356980444989" z="0.0" unit="radian" />
+      <position name="crystal5-3_pos_neg_top" x="-24.31248894732458" y="59.987886870398086" z="1528.5393367528022" unit="mm" />
+      <rotation name="crystal5-3_rot_neg_top" x="0.042186498913610496" y="0.0759356980444989" z="0.0" unit="radian" />
+      <position name="crystal6-3_pos_pos_bot" x="124.57452638340096" y="-59.08788687039808" z="1528.53738792515" unit="mm" />
+      <rotation name="crystal6-3_rot_pos_bot" x="-0.042186498913610496" y="-0.0928102976099431" z="0.0" unit="radian" />
+      <position name="crystal6-3_pos_neg_bot" x="-39.214101167628925" y="-59.08788687039808" z="1528.53738792515" unit="mm" />
+      <rotation name="crystal6-3_rot_neg_bot" x="-0.042186498913610496" y="0.0928102976099431" z="0.0" unit="radian" />
+      <position name="crystal6-3_pos_pos_top" x="124.57452638340096" y="59.987886870398086" z="1528.53738792515" unit="mm" />
+      <rotation name="crystal6-3_rot_pos_top" x="0.042186498913610496" y="-0.0928102976099431" z="0.0" unit="radian" />
+      <position name="crystal6-3_pos_neg_top" x="-39.214101167628925" y="59.987886870398086" z="1528.53738792515" unit="mm" />
+      <rotation name="crystal6-3_rot_neg_top" x="0.042186498913610496" y="0.0928102976099431" z="0.0" unit="radian" />
+      <position name="crystal7-3_pos_pos_bot" x="139.4968932952259" y="-59.08788687039808" z="1528.5125820184735" unit="mm" />
+      <rotation name="crystal7-3_rot_pos_bot" x="-0.042186498913610496" y="-0.10968489717538729" z="0.0" unit="radian" />
+      <position name="crystal7-3_pos_neg_bot" x="-54.13646807945388" y="-59.08788687039808" z="1528.5125820184735" unit="mm" />
+      <rotation name="crystal7-3_rot_neg_bot" x="-0.042186498913610496" y="0.10968489717538729" z="0.0" unit="radian" />
+      <position name="crystal7-3_pos_pos_top" x="139.4968932952259" y="59.987886870398086" z="1528.5125820184735" unit="mm" />
+      <rotation name="crystal7-3_rot_pos_top" x="0.042186498913610496" y="-0.10968489717538729" z="0.0" unit="radian" />
+      <position name="crystal7-3_pos_neg_top" x="-54.13646807945388" y="59.987886870398086" z="1528.5125820184735" unit="mm" />
+      <rotation name="crystal7-3_rot_neg_top" x="0.042186498913610496" y="0.10968489717538729" z="0.0" unit="radian" />
+      <position name="crystal8-3_pos_pos_bot" x="154.44351486445828" y="-59.08788687039808" z="1528.4649260961392" unit="mm" />
+      <rotation name="crystal8-3_rot_pos_bot" x="-0.042186498913610496" y="-0.1265594967408315" z="0.0" unit="radian" />
+      <position name="crystal8-3_pos_neg_bot" x="-69.08308964868624" y="-59.08788687039808" z="1528.4649260961392" unit="mm" />
+      <rotation name="crystal8-3_rot_neg_bot" x="-0.042186498913610496" y="0.1265594967408315" z="0.0" unit="radian" />
+      <position name="crystal8-3_pos_pos_top" x="154.44351486445828" y="59.987886870398086" z="1528.4649260961392" unit="mm" />
+      <rotation name="crystal8-3_rot_pos_top" x="0.042186498913610496" y="-0.1265594967408315" z="0.0" unit="radian" />
+      <position name="crystal8-3_pos_neg_top" x="-69.08308964868624" y="59.987886870398086" z="1528.4649260961392" unit="mm" />
+      <rotation name="crystal8-3_rot_neg_top" x="0.042186498913610496" y="0.1265594967408315" z="0.0" unit="radian" />
+      <position name="crystal9-3_pos_pos_bot" x="169.41792716339802" y="-59.08788687039808" z="1528.3944337279495" unit="mm" />
+      <rotation name="crystal9-3_rot_pos_bot" x="-0.042186498913610496" y="-0.14343409630627568" z="0.0" unit="radian" />
+      <position name="crystal9-3_pos_neg_bot" x="-84.057501947626" y="-59.08788687039808" z="1528.3944337279495" unit="mm" />
+      <rotation name="crystal9-3_rot_neg_bot" x="-0.042186498913610496" y="0.14343409630627568" z="0.0" unit="radian" />
+      <position name="crystal9-3_pos_pos_top" x="169.41792716339802" y="59.987886870398086" z="1528.3944337279495" unit="mm" />
+      <rotation name="crystal9-3_rot_pos_top" x="0.042186498913610496" y="-0.14343409630627568" z="0.0" unit="radian" />
+      <position name="crystal9-3_pos_neg_top" x="-84.057501947626" y="59.987886870398086" z="1528.3944337279495" unit="mm" />
+      <rotation name="crystal9-3_rot_neg_top" x="0.042186498913610496" y="0.14343409630627568" z="0.0" unit="radian" />
+      <position name="crystal10-3_pos_pos_bot" x="184.42370834727978" y="-59.08788687039808" z="1528.301124986279" unit="mm" />
+      <rotation name="crystal10-3_rot_pos_bot" x="-0.042186498913610496" y="-0.1603086958717199" z="0.0" unit="radian" />
+      <position name="crystal10-3_pos_neg_bot" x="-99.06328313150773" y="-59.08788687039808" z="1528.301124986279" unit="mm" />
+      <rotation name="crystal10-3_rot_neg_bot" x="-0.042186498913610496" y="0.1603086958717199" z="0.0" unit="radian" />
+      <position name="crystal10-3_pos_pos_top" x="184.42370834727978" y="59.987886870398086" z="1528.301124986279" unit="mm" />
+      <rotation name="crystal10-3_rot_pos_top" x="0.042186498913610496" y="-0.1603086958717199" z="0.0" unit="radian" />
+      <position name="crystal10-3_pos_neg_top" x="-99.06328313150773" y="59.987886870398086" z="1528.301124986279" unit="mm" />
+      <rotation name="crystal10-3_rot_neg_top" x="0.042186498913610496" y="0.1603086958717199" z="0.0" unit="radian" />
+      <position name="crystal11-3_pos_pos_bot" x="199.46448478017476" y="-59.08788687039808" z="1528.1850264403583" unit="mm" />
+      <rotation name="crystal11-3_rot_pos_bot" x="-0.042186498913610496" y="-0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal11-3_pos_neg_bot" x="-114.1040595644027" y="-59.08788687039808" z="1528.1850264403583" unit="mm" />
+      <rotation name="crystal11-3_rot_neg_bot" x="-0.042186498913610496" y="0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal11-3_pos_pos_top" x="199.46448478017476" y="59.987886870398086" z="1528.1850264403583" unit="mm" />
+      <rotation name="crystal11-3_rot_pos_top" x="0.042186498913610496" y="-0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal11-3_pos_neg_top" x="-114.1040595644027" y="59.987886870398086" z="1528.1850264403583" unit="mm" />
+      <rotation name="crystal11-3_rot_neg_top" x="0.042186498913610496" y="0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal12-3_pos_pos_bot" x="214.5439373331128" y="-59.08788687039808" z="1528.0461711487085" unit="mm" />
+      <rotation name="crystal12-3_rot_pos_bot" x="-0.042186498913610496" y="-0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal12-3_pos_neg_bot" x="-129.1835121173408" y="-59.08788687039808" z="1528.0461711487085" unit="mm" />
+      <rotation name="crystal12-3_rot_neg_bot" x="-0.042186498913610496" y="0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal12-3_pos_pos_top" x="214.5439373331128" y="59.987886870398086" z="1528.0461711487085" unit="mm" />
+      <rotation name="crystal12-3_rot_pos_top" x="0.042186498913610496" y="-0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal12-3_pos_neg_top" x="-129.1835121173408" y="59.987886870398086" z="1528.0461711487085" unit="mm" />
+      <rotation name="crystal12-3_rot_neg_top" x="0.042186498913610496" y="0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal13-3_pos_pos_bot" x="229.66580787843168" y="-59.08788687039808" z="1527.8845986497292" unit="mm" />
+      <rotation name="crystal13-3_rot_pos_bot" x="-0.042186498913610496" y="-0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal13-3_pos_neg_bot" x="-144.30538266265967" y="-59.08788687039808" z="1527.8845986497292" unit="mm" />
+      <rotation name="crystal13-3_rot_neg_bot" x="-0.042186498913610496" y="0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal13-3_pos_pos_top" x="229.66580787843168" y="59.987886870398086" z="1527.8845986497292" unit="mm" />
+      <rotation name="crystal13-3_rot_pos_top" x="0.042186498913610496" y="-0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal13-3_pos_neg_top" x="-144.30538266265967" y="59.987886870398086" z="1527.8845986497292" unit="mm" />
+      <rotation name="crystal13-3_rot_neg_top" x="0.042186498913610496" y="0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal14-3_pos_pos_bot" x="244.83390600570817" y="-59.08788687039808" z="1527.7003549504386" unit="mm" />
+      <rotation name="crystal14-3_rot_pos_bot" x="-0.042186498913610496" y="-0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal14-3_pos_neg_bot" x="-159.47348078993616" y="-59.08788687039808" z="1527.7003549504386" unit="mm" />
+      <rotation name="crystal14-3_rot_neg_bot" x="-0.042186498913610496" y="0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal14-3_pos_pos_top" x="244.83390600570817" y="59.987886870398086" z="1527.7003549504386" unit="mm" />
+      <rotation name="crystal14-3_rot_pos_top" x="0.042186498913610496" y="-0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal14-3_pos_neg_top" x="-159.47348078993616" y="59.987886870398086" z="1527.7003549504386" unit="mm" />
+      <rotation name="crystal14-3_rot_neg_top" x="0.042186498913610496" y="0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal15-3_pos_pos_bot" x="260.0521159861688" y="-59.08788687039808" z="1527.4934925133737" unit="mm" />
+      <rotation name="crystal15-3_rot_pos_bot" x="-0.042186498913610496" y="-0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal15-3_pos_neg_bot" x="-174.6916907703968" y="-59.08788687039808" z="1527.4934925133737" unit="mm" />
+      <rotation name="crystal15-3_rot_neg_bot" x="-0.042186498913610496" y="0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal15-3_pos_pos_top" x="260.0521159861688" y="59.987886870398086" z="1527.4934925133737" unit="mm" />
+      <rotation name="crystal15-3_rot_pos_top" x="0.042186498913610496" y="-0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal15-3_pos_neg_top" x="-174.6916907703968" y="59.987886870398086" z="1527.4934925133737" unit="mm" />
+      <rotation name="crystal15-3_rot_neg_top" x="0.042186498913610496" y="0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal16-3_pos_pos_bot" x="275.32440401422616" y="-59.08788687039808" z="1527.264070241653" unit="mm" />
+      <rotation name="crystal16-3_rot_pos_bot" x="-0.042186498913610496" y="-0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal16-3_pos_neg_bot" x="-189.96397879845415" y="-59.08788687039808" z="1527.264070241653" unit="mm" />
+      <rotation name="crystal16-3_rot_neg_bot" x="-0.042186498913610496" y="0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal16-3_pos_pos_top" x="275.32440401422616" y="59.987886870398086" z="1527.264070241653" unit="mm" />
+      <rotation name="crystal16-3_rot_pos_top" x="0.042186498913610496" y="-0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal16-3_pos_neg_top" x="-189.96397879845415" y="59.987886870398086" z="1527.264070241653" unit="mm" />
+      <rotation name="crystal16-3_rot_neg_top" x="0.042186498913610496" y="0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal17-3_pos_pos_bot" x="290.6548257567732" y="-59.08788687039808" z="1527.0121534622015" unit="mm" />
+      <rotation name="crystal17-3_rot_pos_bot" x="-0.042186498913610496" y="-0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal17-3_pos_neg_bot" x="-205.2944005410012" y="-59.08788687039808" z="1527.0121534622015" unit="mm" />
+      <rotation name="crystal17-3_rot_neg_bot" x="-0.042186498913610496" y="0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal17-3_pos_pos_top" x="290.6548257567732" y="59.987886870398086" z="1527.0121534622015" unit="mm" />
+      <rotation name="crystal17-3_rot_pos_top" x="0.042186498913610496" y="-0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal17-3_pos_neg_top" x="-205.2944005410012" y="59.987886870398086" z="1527.0121534622015" unit="mm" />
+      <rotation name="crystal17-3_rot_neg_top" x="0.042186498913610496" y="0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal18-3_pos_pos_bot" x="306.0475342431027" y="-59.08788687039808" z="1526.737813907152" unit="mm" />
+      <rotation name="crystal18-3_rot_pos_bot" x="-0.042186498913610496" y="-0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal18-3_pos_neg_bot" x="-220.68710902733068" y="-59.08788687039808" z="1526.737813907152" unit="mm" />
+      <rotation name="crystal18-3_rot_neg_bot" x="-0.042186498913610496" y="0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal18-3_pos_pos_top" x="306.0475342431027" y="59.987886870398086" z="1526.737813907152" unit="mm" />
+      <rotation name="crystal18-3_rot_pos_top" x="0.042186498913610496" y="-0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal18-3_pos_neg_top" x="-220.68710902733068" y="59.987886870398086" z="1526.737813907152" unit="mm" />
+      <rotation name="crystal18-3_rot_neg_top" x="0.042186498913610496" y="0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal19-3_pos_pos_bot" x="321.5067881308382" y="-59.08788687039808" z="1526.4411296934186" unit="mm" />
+      <rotation name="crystal19-3_rot_pos_bot" x="-0.042186498913610496" y="-0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal19-3_pos_neg_bot" x="-236.14636291506616" y="-59.08788687039808" z="1526.4411296934186" unit="mm" />
+      <rotation name="crystal19-3_rot_neg_bot" x="-0.042186498913610496" y="0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal19-3_pos_pos_top" x="321.5067881308382" y="59.987886870398086" z="1526.4411296934186" unit="mm" />
+      <rotation name="crystal19-3_rot_pos_top" x="0.042186498913610496" y="-0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal19-3_pos_neg_top" x="-236.14636291506616" y="59.987886870398086" z="1526.4411296934186" unit="mm" />
+      <rotation name="crystal19-3_rot_neg_top" x="0.042186498913610496" y="0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal20-3_pos_pos_bot" x="337.03696038609246" y="-59.08788687039808" z="1526.1221853004517" unit="mm" />
+      <rotation name="crystal20-3_rot_pos_bot" x="-0.042186498913610496" y="-0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal20-3_pos_neg_bot" x="-251.67653517032045" y="-59.08788687039808" z="1526.1221853004517" unit="mm" />
+      <rotation name="crystal20-3_rot_neg_bot" x="-0.042186498913610496" y="0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal20-3_pos_pos_top" x="337.03696038609246" y="59.987886870398086" z="1526.1221853004517" unit="mm" />
+      <rotation name="crystal20-3_rot_pos_top" x="0.042186498913610496" y="-0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal20-3_pos_neg_top" x="-251.67653517032045" y="59.987886870398086" z="1526.1221853004517" unit="mm" />
+      <rotation name="crystal20-3_rot_neg_top" x="0.042186498913610496" y="0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal21-3_pos_pos_bot" x="352.64254741924634" y="-59.08788687039808" z="1525.781071546186" unit="mm" />
+      <rotation name="crystal21-3_rot_pos_bot" x="-0.042186498913610496" y="-0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal21-3_pos_neg_bot" x="-267.28212220347433" y="-59.08788687039808" z="1525.781071546186" unit="mm" />
+      <rotation name="crystal21-3_rot_neg_bot" x="-0.042186498913610496" y="0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal21-3_pos_pos_top" x="352.64254741924634" y="59.987886870398086" z="1525.781071546186" unit="mm" />
+      <rotation name="crystal21-3_rot_pos_top" x="0.042186498913610496" y="-0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal21-3_pos_neg_top" x="-267.28212220347433" y="59.987886870398086" z="1525.781071546186" unit="mm" />
+      <rotation name="crystal21-3_rot_neg_top" x="0.042186498913610496" y="0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal22-3_pos_pos_bot" x="368.32817872130425" y="-59.08788687039808" z="1525.417885561178" unit="mm" />
+      <rotation name="crystal22-3_rot_pos_bot" x="-0.042186498913610496" y="-0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal22-3_pos_neg_bot" x="-282.96775350553224" y="-59.08788687039808" z="1525.417885561178" unit="mm" />
+      <rotation name="crystal22-3_rot_neg_bot" x="-0.042186498913610496" y="0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal22-3_pos_pos_top" x="368.32817872130425" y="59.987886870398086" z="1525.417885561178" unit="mm" />
+      <rotation name="crystal22-3_rot_pos_top" x="0.042186498913610496" y="-0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal22-3_pos_neg_top" x="-282.96775350553224" y="59.987886870398086" z="1525.417885561178" unit="mm" />
+      <rotation name="crystal22-3_rot_neg_top" x="0.042186498913610496" y="0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal23-3_pos_pos_bot" x="384.09862704978" y="-59.08788687039808" z="1525.032730760949" unit="mm" />
+      <rotation name="crystal23-3_rot_pos_bot" x="-0.042186498913610496" y="-0.3796784902224945" z="0.0" unit="radian" />
+      <position name="crystal23-3_pos_neg_bot" x="-298.738201834008" y="-59.08788687039808" z="1525.032730760949" unit="mm" />
+      <rotation name="crystal23-3_rot_neg_bot" x="-0.042186498913610496" y="0.3796784902224945" z="0.0" unit="radian" />
+      <position name="crystal23-3_pos_pos_top" x="384.09862704978" y="59.987886870398086" z="1525.032730760949" unit="mm" />
+      <rotation name="crystal23-3_rot_pos_top" x="0.042186498913610496" y="-0.3796784902224945" z="0.0" unit="radian" />
+      <position name="crystal23-3_pos_neg_top" x="-298.738201834008" y="59.987886870398086" z="1525.032730760949" unit="mm" />
+      <rotation name="crystal23-3_rot_neg_top" x="0.042186498913610496" y="0.3796784902224945" z="0.0" unit="radian" />
+      <position name="crystal1-4_pos_pos_bot" x="50.20495188328156" y="-74.108374317979" z="1528.3624082783765" unit="mm" />
+      <rotation name="crystal1-4_rot_pos_bot" x="-0.0590610984790547" y="-0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal1-4_pos_neg_bot" x="35.15547333249048" y="-74.108374317979" z="1528.3624082783765" unit="mm" />
+      <rotation name="crystal1-4_rot_neg_bot" x="-0.0590610984790547" y="0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal1-4_pos_pos_top" x="50.20495188328156" y="75.008374317979" z="1528.3624082783765" unit="mm" />
+      <rotation name="crystal1-4_rot_pos_top" x="0.0590610984790547" y="-0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal1-4_pos_neg_top" x="35.15547333249048" y="75.008374317979" z="1528.3624082783765" unit="mm" />
+      <rotation name="crystal1-4_rot_neg_top" x="0.0590610984790547" y="0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal2-4_pos_pos_bot" x="65.05802548582456" y="-74.108374317979" z="1528.4518282402964" unit="mm" />
+      <rotation name="crystal2-4_rot_pos_bot" x="-0.0590610984790547" y="-0.0253118993481663" z="0.0" unit="radian" />
+      <position name="crystal2-4_pos_neg_bot" x="20.302399729947485" y="-74.108374317979" z="1528.4518282402964" unit="mm" />
+      <rotation name="crystal2-4_rot_neg_bot" x="-0.0590610984790547" y="0.0253118993481663" z="0.0" unit="radian" />
+      <position name="crystal2-4_pos_pos_top" x="65.05802548582456" y="75.008374317979" z="1528.4518282402964" unit="mm" />
+      <rotation name="crystal2-4_rot_pos_top" x="0.0590610984790547" y="-0.0253118993481663" z="0.0" unit="radian" />
+      <position name="crystal2-4_pos_neg_top" x="20.302399729947485" y="75.008374317979" z="1528.4518282402964" unit="mm" />
+      <rotation name="crystal2-4_rot_neg_top" x="0.0590610984790547" y="0.0253118993481663" z="0.0" unit="radian" />
+      <position name="crystal3-4_pos_pos_bot" x="79.9180994782841" y="-74.108374317979" z="1528.5184279465104" unit="mm" />
+      <rotation name="crystal3-4_rot_pos_bot" x="-0.0590610984790547" y="-0.042186498913610496" z="0.0" unit="radian" />
+      <position name="crystal3-4_pos_neg_bot" x="5.442325737487934" y="-74.108374317979" z="1528.5184279465104" unit="mm" />
+      <rotation name="crystal3-4_rot_neg_bot" x="-0.0590610984790547" y="0.042186498913610496" z="0.0" unit="radian" />
+      <position name="crystal3-4_pos_pos_top" x="79.9180994782841" y="75.008374317979" z="1528.5184279465104" unit="mm" />
+      <rotation name="crystal3-4_rot_pos_top" x="0.0590610984790547" y="-0.042186498913610496" z="0.0" unit="radian" />
+      <position name="crystal3-4_pos_neg_top" x="5.442325737487934" y="75.008374317979" z="1528.5184279465104" unit="mm" />
+      <rotation name="crystal3-4_rot_neg_top" x="0.0590610984790547" y="0.042186498913610496" z="0.0" unit="radian" />
+      <position name="crystal4-4_pos_pos_bot" x="94.78858692586502" y="-74.108374317979" z="1528.5621884330608" unit="mm" />
+      <rotation name="crystal4-4_rot_pos_bot" x="-0.0590610984790547" y="-0.0590610984790547" z="0.0" unit="radian" />
+      <position name="crystal4-4_pos_neg_bot" x="-9.42816171009298" y="-74.108374317979" z="1528.5621884330608" unit="mm" />
+      <rotation name="crystal4-4_rot_neg_bot" x="-0.0590610984790547" y="0.0590610984790547" z="0.0" unit="radian" />
+      <position name="crystal4-4_pos_pos_top" x="94.78858692586502" y="75.008374317979" z="1528.5621884330608" unit="mm" />
+      <rotation name="crystal4-4_rot_pos_top" x="0.0590610984790547" y="-0.0590610984790547" z="0.0" unit="radian" />
+      <position name="crystal4-4_pos_neg_top" x="-9.42816171009298" y="75.008374317979" z="1528.5621884330608" unit="mm" />
+      <rotation name="crystal4-4_rot_neg_top" x="0.0590610984790547" y="0.0590610984790547" z="0.0" unit="radian" />
+      <position name="crystal5-4_pos_pos_bot" x="109.67291416309662" y="-74.108374317979" z="1528.5830972393524" unit="mm" />
+      <rotation name="crystal5-4_rot_pos_bot" x="-0.0590610984790547" y="-0.0759356980444989" z="0.0" unit="radian" />
+      <position name="crystal5-4_pos_neg_bot" x="-24.31248894732458" y="-74.108374317979" z="1528.5830972393524" unit="mm" />
+      <rotation name="crystal5-4_rot_neg_bot" x="-0.0590610984790547" y="0.0759356980444989" z="0.0" unit="radian" />
+      <position name="crystal5-4_pos_pos_top" x="109.67291416309662" y="75.008374317979" z="1528.5830972393524" unit="mm" />
+      <rotation name="crystal5-4_rot_pos_top" x="0.0590610984790547" y="-0.0759356980444989" z="0.0" unit="radian" />
+      <position name="crystal5-4_pos_neg_top" x="-24.31248894732458" y="75.008374317979" z="1528.5830972393524" unit="mm" />
+      <rotation name="crystal5-4_rot_neg_top" x="0.0590610984790547" y="0.0759356980444989" z="0.0" unit="radian" />
+      <position name="crystal6-4_pos_pos_bot" x="124.57452638340096" y="-74.108374317979" z="1528.5811484117003" unit="mm" />
+      <rotation name="crystal6-4_rot_pos_bot" x="-0.0590610984790547" y="-0.0928102976099431" z="0.0" unit="radian" />
+      <position name="crystal6-4_pos_neg_bot" x="-39.214101167628925" y="-74.108374317979" z="1528.5811484117003" unit="mm" />
+      <rotation name="crystal6-4_rot_neg_bot" x="-0.0590610984790547" y="0.0928102976099431" z="0.0" unit="radian" />
+      <position name="crystal6-4_pos_pos_top" x="124.57452638340096" y="75.008374317979" z="1528.5811484117003" unit="mm" />
+      <rotation name="crystal6-4_rot_pos_top" x="0.0590610984790547" y="-0.0928102976099431" z="0.0" unit="radian" />
+      <position name="crystal6-4_pos_neg_top" x="-39.214101167628925" y="75.008374317979" z="1528.5811484117003" unit="mm" />
+      <rotation name="crystal6-4_rot_neg_top" x="0.0590610984790547" y="0.0928102976099431" z="0.0" unit="radian" />
+      <position name="crystal7-4_pos_pos_bot" x="139.4968932952259" y="-74.108374317979" z="1528.5563425050236" unit="mm" />
+      <rotation name="crystal7-4_rot_pos_bot" x="-0.0590610984790547" y="-0.10968489717538729" z="0.0" unit="radian" />
+      <position name="crystal7-4_pos_neg_bot" x="-54.13646807945388" y="-74.108374317979" z="1528.5563425050236" unit="mm" />
+      <rotation name="crystal7-4_rot_neg_bot" x="-0.0590610984790547" y="0.10968489717538729" z="0.0" unit="radian" />
+      <position name="crystal7-4_pos_pos_top" x="139.4968932952259" y="75.008374317979" z="1528.5563425050236" unit="mm" />
+      <rotation name="crystal7-4_rot_pos_top" x="0.0590610984790547" y="-0.10968489717538729" z="0.0" unit="radian" />
+      <position name="crystal7-4_pos_neg_top" x="-54.13646807945388" y="75.008374317979" z="1528.5563425050236" unit="mm" />
+      <rotation name="crystal7-4_rot_neg_top" x="0.0590610984790547" y="0.10968489717538729" z="0.0" unit="radian" />
+      <position name="crystal8-4_pos_pos_bot" x="154.44351486445828" y="-74.108374317979" z="1528.5086865826895" unit="mm" />
+      <rotation name="crystal8-4_rot_pos_bot" x="-0.0590610984790547" y="-0.1265594967408315" z="0.0" unit="radian" />
+      <position name="crystal8-4_pos_neg_bot" x="-69.08308964868624" y="-74.108374317979" z="1528.5086865826895" unit="mm" />
+      <rotation name="crystal8-4_rot_neg_bot" x="-0.0590610984790547" y="0.1265594967408315" z="0.0" unit="radian" />
+      <position name="crystal8-4_pos_pos_top" x="154.44351486445828" y="75.008374317979" z="1528.5086865826895" unit="mm" />
+      <rotation name="crystal8-4_rot_pos_top" x="0.0590610984790547" y="-0.1265594967408315" z="0.0" unit="radian" />
+      <position name="crystal8-4_pos_neg_top" x="-69.08308964868624" y="75.008374317979" z="1528.5086865826895" unit="mm" />
+      <rotation name="crystal8-4_rot_neg_top" x="0.0590610984790547" y="0.1265594967408315" z="0.0" unit="radian" />
+      <position name="crystal9-4_pos_pos_bot" x="169.41792716339802" y="-74.108374317979" z="1528.4381942144998" unit="mm" />
+      <rotation name="crystal9-4_rot_pos_bot" x="-0.0590610984790547" y="-0.14343409630627568" z="0.0" unit="radian" />
+      <position name="crystal9-4_pos_neg_bot" x="-84.057501947626" y="-74.108374317979" z="1528.4381942144998" unit="mm" />
+      <rotation name="crystal9-4_rot_neg_bot" x="-0.0590610984790547" y="0.14343409630627568" z="0.0" unit="radian" />
+      <position name="crystal9-4_pos_pos_top" x="169.41792716339802" y="75.008374317979" z="1528.4381942144998" unit="mm" />
+      <rotation name="crystal9-4_rot_pos_top" x="0.0590610984790547" y="-0.14343409630627568" z="0.0" unit="radian" />
+      <position name="crystal9-4_pos_neg_top" x="-84.057501947626" y="75.008374317979" z="1528.4381942144998" unit="mm" />
+      <rotation name="crystal9-4_rot_neg_top" x="0.0590610984790547" y="0.14343409630627568" z="0.0" unit="radian" />
+      <position name="crystal10-4_pos_pos_bot" x="184.42370834727978" y="-74.108374317979" z="1528.3448854728294" unit="mm" />
+      <rotation name="crystal10-4_rot_pos_bot" x="-0.0590610984790547" y="-0.1603086958717199" z="0.0" unit="radian" />
+      <position name="crystal10-4_pos_neg_bot" x="-99.06328313150773" y="-74.108374317979" z="1528.3448854728294" unit="mm" />
+      <rotation name="crystal10-4_rot_neg_bot" x="-0.0590610984790547" y="0.1603086958717199" z="0.0" unit="radian" />
+      <position name="crystal10-4_pos_pos_top" x="184.42370834727978" y="75.008374317979" z="1528.3448854728294" unit="mm" />
+      <rotation name="crystal10-4_rot_pos_top" x="0.0590610984790547" y="-0.1603086958717199" z="0.0" unit="radian" />
+      <position name="crystal10-4_pos_neg_top" x="-99.06328313150773" y="75.008374317979" z="1528.3448854728294" unit="mm" />
+      <rotation name="crystal10-4_rot_neg_top" x="0.0590610984790547" y="0.1603086958717199" z="0.0" unit="radian" />
+      <position name="crystal11-4_pos_pos_bot" x="199.46448478017476" y="-74.108374317979" z="1528.2287869269085" unit="mm" />
+      <rotation name="crystal11-4_rot_pos_bot" x="-0.0590610984790547" y="-0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal11-4_pos_neg_bot" x="-114.1040595644027" y="-74.108374317979" z="1528.2287869269085" unit="mm" />
+      <rotation name="crystal11-4_rot_neg_bot" x="-0.0590610984790547" y="0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal11-4_pos_pos_top" x="199.46448478017476" y="75.008374317979" z="1528.2287869269085" unit="mm" />
+      <rotation name="crystal11-4_rot_pos_top" x="0.0590610984790547" y="-0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal11-4_pos_neg_top" x="-114.1040595644027" y="75.008374317979" z="1528.2287869269085" unit="mm" />
+      <rotation name="crystal11-4_rot_neg_top" x="0.0590610984790547" y="0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal12-4_pos_pos_bot" x="214.5439373331128" y="-74.108374317979" z="1528.0899316352588" unit="mm" />
+      <rotation name="crystal12-4_rot_pos_bot" x="-0.0590610984790547" y="-0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal12-4_pos_neg_bot" x="-129.1835121173408" y="-74.108374317979" z="1528.0899316352588" unit="mm" />
+      <rotation name="crystal12-4_rot_neg_bot" x="-0.0590610984790547" y="0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal12-4_pos_pos_top" x="214.5439373331128" y="75.008374317979" z="1528.0899316352588" unit="mm" />
+      <rotation name="crystal12-4_rot_pos_top" x="0.0590610984790547" y="-0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal12-4_pos_neg_top" x="-129.1835121173408" y="75.008374317979" z="1528.0899316352588" unit="mm" />
+      <rotation name="crystal12-4_rot_neg_top" x="0.0590610984790547" y="0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal13-4_pos_pos_bot" x="229.66580787843168" y="-74.108374317979" z="1527.9283591362796" unit="mm" />
+      <rotation name="crystal13-4_rot_pos_bot" x="-0.0590610984790547" y="-0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal13-4_pos_neg_bot" x="-144.30538266265967" y="-74.108374317979" z="1527.9283591362796" unit="mm" />
+      <rotation name="crystal13-4_rot_neg_bot" x="-0.0590610984790547" y="0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal13-4_pos_pos_top" x="229.66580787843168" y="75.008374317979" z="1527.9283591362796" unit="mm" />
+      <rotation name="crystal13-4_rot_pos_top" x="0.0590610984790547" y="-0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal13-4_pos_neg_top" x="-144.30538266265967" y="75.008374317979" z="1527.9283591362796" unit="mm" />
+      <rotation name="crystal13-4_rot_neg_top" x="0.0590610984790547" y="0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal14-4_pos_pos_bot" x="244.83390600570817" y="-74.108374317979" z="1527.744115436989" unit="mm" />
+      <rotation name="crystal14-4_rot_pos_bot" x="-0.0590610984790547" y="-0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal14-4_pos_neg_bot" x="-159.47348078993616" y="-74.108374317979" z="1527.744115436989" unit="mm" />
+      <rotation name="crystal14-4_rot_neg_bot" x="-0.0590610984790547" y="0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal14-4_pos_pos_top" x="244.83390600570817" y="75.008374317979" z="1527.744115436989" unit="mm" />
+      <rotation name="crystal14-4_rot_pos_top" x="0.0590610984790547" y="-0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal14-4_pos_neg_top" x="-159.47348078993616" y="75.008374317979" z="1527.744115436989" unit="mm" />
+      <rotation name="crystal14-4_rot_neg_top" x="0.0590610984790547" y="0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal15-4_pos_pos_bot" x="260.0521159861688" y="-74.108374317979" z="1527.537252999924" unit="mm" />
+      <rotation name="crystal15-4_rot_pos_bot" x="-0.0590610984790547" y="-0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal15-4_pos_neg_bot" x="-174.6916907703968" y="-74.108374317979" z="1527.537252999924" unit="mm" />
+      <rotation name="crystal15-4_rot_neg_bot" x="-0.0590610984790547" y="0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal15-4_pos_pos_top" x="260.0521159861688" y="75.008374317979" z="1527.537252999924" unit="mm" />
+      <rotation name="crystal15-4_rot_pos_top" x="0.0590610984790547" y="-0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal15-4_pos_neg_top" x="-174.6916907703968" y="75.008374317979" z="1527.537252999924" unit="mm" />
+      <rotation name="crystal15-4_rot_neg_top" x="0.0590610984790547" y="0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal16-4_pos_pos_bot" x="275.32440401422616" y="-74.108374317979" z="1527.3078307282033" unit="mm" />
+      <rotation name="crystal16-4_rot_pos_bot" x="-0.0590610984790547" y="-0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal16-4_pos_neg_bot" x="-189.96397879845415" y="-74.108374317979" z="1527.3078307282033" unit="mm" />
+      <rotation name="crystal16-4_rot_neg_bot" x="-0.0590610984790547" y="0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal16-4_pos_pos_top" x="275.32440401422616" y="75.008374317979" z="1527.3078307282033" unit="mm" />
+      <rotation name="crystal16-4_rot_pos_top" x="0.0590610984790547" y="-0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal16-4_pos_neg_top" x="-189.96397879845415" y="75.008374317979" z="1527.3078307282033" unit="mm" />
+      <rotation name="crystal16-4_rot_neg_top" x="0.0590610984790547" y="0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal17-4_pos_pos_bot" x="290.6548257567732" y="-74.108374317979" z="1527.0559139487518" unit="mm" />
+      <rotation name="crystal17-4_rot_pos_bot" x="-0.0590610984790547" y="-0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal17-4_pos_neg_bot" x="-205.2944005410012" y="-74.108374317979" z="1527.0559139487518" unit="mm" />
+      <rotation name="crystal17-4_rot_neg_bot" x="-0.0590610984790547" y="0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal17-4_pos_pos_top" x="290.6548257567732" y="75.008374317979" z="1527.0559139487518" unit="mm" />
+      <rotation name="crystal17-4_rot_pos_top" x="0.0590610984790547" y="-0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal17-4_pos_neg_top" x="-205.2944005410012" y="75.008374317979" z="1527.0559139487518" unit="mm" />
+      <rotation name="crystal17-4_rot_neg_top" x="0.0590610984790547" y="0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal18-4_pos_pos_bot" x="306.0475342431027" y="-74.108374317979" z="1526.7815743937024" unit="mm" />
+      <rotation name="crystal18-4_rot_pos_bot" x="-0.0590610984790547" y="-0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal18-4_pos_neg_bot" x="-220.68710902733068" y="-74.108374317979" z="1526.7815743937024" unit="mm" />
+      <rotation name="crystal18-4_rot_neg_bot" x="-0.0590610984790547" y="0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal18-4_pos_pos_top" x="306.0475342431027" y="75.008374317979" z="1526.7815743937024" unit="mm" />
+      <rotation name="crystal18-4_rot_pos_top" x="0.0590610984790547" y="-0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal18-4_pos_neg_top" x="-220.68710902733068" y="75.008374317979" z="1526.7815743937024" unit="mm" />
+      <rotation name="crystal18-4_rot_neg_top" x="0.0590610984790547" y="0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal19-4_pos_pos_bot" x="321.5067881308382" y="-74.108374317979" z="1526.4848901799687" unit="mm" />
+      <rotation name="crystal19-4_rot_pos_bot" x="-0.0590610984790547" y="-0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal19-4_pos_neg_bot" x="-236.14636291506616" y="-74.108374317979" z="1526.4848901799687" unit="mm" />
+      <rotation name="crystal19-4_rot_neg_bot" x="-0.0590610984790547" y="0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal19-4_pos_pos_top" x="321.5067881308382" y="75.008374317979" z="1526.4848901799687" unit="mm" />
+      <rotation name="crystal19-4_rot_pos_top" x="0.0590610984790547" y="-0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal19-4_pos_neg_top" x="-236.14636291506616" y="75.008374317979" z="1526.4848901799687" unit="mm" />
+      <rotation name="crystal19-4_rot_neg_top" x="0.0590610984790547" y="0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal20-4_pos_pos_bot" x="337.03696038609246" y="-74.108374317979" z="1526.165945787002" unit="mm" />
+      <rotation name="crystal20-4_rot_pos_bot" x="-0.0590610984790547" y="-0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal20-4_pos_neg_bot" x="-251.67653517032045" y="-74.108374317979" z="1526.165945787002" unit="mm" />
+      <rotation name="crystal20-4_rot_neg_bot" x="-0.0590610984790547" y="0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal20-4_pos_pos_top" x="337.03696038609246" y="75.008374317979" z="1526.165945787002" unit="mm" />
+      <rotation name="crystal20-4_rot_pos_top" x="0.0590610984790547" y="-0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal20-4_pos_neg_top" x="-251.67653517032045" y="75.008374317979" z="1526.165945787002" unit="mm" />
+      <rotation name="crystal20-4_rot_neg_top" x="0.0590610984790547" y="0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal21-4_pos_pos_bot" x="352.64254741924634" y="-74.108374317979" z="1525.8248320327364" unit="mm" />
+      <rotation name="crystal21-4_rot_pos_bot" x="-0.0590610984790547" y="-0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal21-4_pos_neg_bot" x="-267.28212220347433" y="-74.108374317979" z="1525.8248320327364" unit="mm" />
+      <rotation name="crystal21-4_rot_neg_bot" x="-0.0590610984790547" y="0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal21-4_pos_pos_top" x="352.64254741924634" y="75.008374317979" z="1525.8248320327364" unit="mm" />
+      <rotation name="crystal21-4_rot_pos_top" x="0.0590610984790547" y="-0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal21-4_pos_neg_top" x="-267.28212220347433" y="75.008374317979" z="1525.8248320327364" unit="mm" />
+      <rotation name="crystal21-4_rot_neg_top" x="0.0590610984790547" y="0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal22-4_pos_pos_bot" x="368.32817872130425" y="-74.108374317979" z="1525.4616460477282" unit="mm" />
+      <rotation name="crystal22-4_rot_pos_bot" x="-0.0590610984790547" y="-0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal22-4_pos_neg_bot" x="-282.96775350553224" y="-74.108374317979" z="1525.4616460477282" unit="mm" />
+      <rotation name="crystal22-4_rot_neg_bot" x="-0.0590610984790547" y="0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal22-4_pos_pos_top" x="368.32817872130425" y="75.008374317979" z="1525.4616460477282" unit="mm" />
+      <rotation name="crystal22-4_rot_pos_top" x="0.0590610984790547" y="-0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal22-4_pos_neg_top" x="-282.96775350553224" y="75.008374317979" z="1525.4616460477282" unit="mm" />
+      <rotation name="crystal22-4_rot_neg_top" x="0.0590610984790547" y="0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal23-4_pos_pos_bot" x="384.09862704978" y="-74.108374317979" z="1525.0764912474995" unit="mm" />
+      <rotation name="crystal23-4_rot_pos_bot" x="-0.0590610984790547" y="-0.3796784902224945" z="0.0" unit="radian" />
+      <position name="crystal23-4_pos_neg_bot" x="-298.738201834008" y="-74.108374317979" z="1525.0764912474995" unit="mm" />
+      <rotation name="crystal23-4_rot_neg_bot" x="-0.0590610984790547" y="0.3796784902224945" z="0.0" unit="radian" />
+      <position name="crystal23-4_pos_pos_top" x="384.09862704978" y="75.008374317979" z="1525.0764912474995" unit="mm" />
+      <rotation name="crystal23-4_rot_pos_top" x="0.0590610984790547" y="-0.3796784902224945" z="0.0" unit="radian" />
+      <position name="crystal23-4_pos_neg_top" x="-298.738201834008" y="75.008374317979" z="1525.0764912474995" unit="mm" />
+      <rotation name="crystal23-4_rot_neg_top" x="0.0590610984790547" y="0.3796784902224945" z="0.0" unit="radian" />
+      <position name="crystal1-5_pos_pos_bot" x="50.20495188328156" y="-89.1427015552106" z="1528.3833170846683" unit="mm" />
+      <rotation name="crystal1-5_rot_pos_bot" x="-0.0759356980444989" y="-0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal1-5_pos_neg_bot" x="35.15547333249048" y="-89.1427015552106" z="1528.3833170846683" unit="mm" />
+      <rotation name="crystal1-5_rot_neg_bot" x="-0.0759356980444989" y="0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal1-5_pos_pos_top" x="50.20495188328156" y="90.0427015552106" z="1528.3833170846683" unit="mm" />
+      <rotation name="crystal1-5_rot_pos_top" x="0.0759356980444989" y="-0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal1-5_pos_neg_top" x="35.15547333249048" y="90.0427015552106" z="1528.3833170846683" unit="mm" />
+      <rotation name="crystal1-5_rot_neg_top" x="0.0759356980444989" y="0.0084372997827221" z="0.0" unit="radian" />
+      <position name="crystal2-5_pos_pos_bot" x="65.05802548582456" y="-89.1427015552106" z="1528.4727370465882" unit="mm" />
+      <rotation name="crystal2-5_rot_pos_bot" x="-0.0759356980444989" y="-0.0253118993481663" z="0.0" unit="radian" />
+      <position name="crystal2-5_pos_neg_bot" x="20.302399729947485" y="-89.1427015552106" z="1528.4727370465882" unit="mm" />
+      <rotation name="crystal2-5_rot_neg_bot" x="-0.0759356980444989" y="0.0253118993481663" z="0.0" unit="radian" />
+      <position name="crystal2-5_pos_pos_top" x="65.05802548582456" y="90.0427015552106" z="1528.4727370465882" unit="mm" />
+      <rotation name="crystal2-5_rot_pos_top" x="0.0759356980444989" y="-0.0253118993481663" z="0.0" unit="radian" />
+      <position name="crystal2-5_pos_neg_top" x="20.302399729947485" y="90.0427015552106" z="1528.4727370465882" unit="mm" />
+      <rotation name="crystal2-5_rot_neg_top" x="0.0759356980444989" y="0.0253118993481663" z="0.0" unit="radian" />
+      <position name="crystal3-5_pos_pos_bot" x="79.9180994782841" y="-89.1427015552106" z="1528.5393367528022" unit="mm" />
+      <rotation name="crystal3-5_rot_pos_bot" x="-0.0759356980444989" y="-0.042186498913610496" z="0.0" unit="radian" />
+      <position name="crystal3-5_pos_neg_bot" x="5.442325737487934" y="-89.1427015552106" z="1528.5393367528022" unit="mm" />
+      <rotation name="crystal3-5_rot_neg_bot" x="-0.0759356980444989" y="0.042186498913610496" z="0.0" unit="radian" />
+      <position name="crystal3-5_pos_pos_top" x="79.9180994782841" y="90.0427015552106" z="1528.5393367528022" unit="mm" />
+      <rotation name="crystal3-5_rot_pos_top" x="0.0759356980444989" y="-0.042186498913610496" z="0.0" unit="radian" />
+      <position name="crystal3-5_pos_neg_top" x="5.442325737487934" y="90.0427015552106" z="1528.5393367528022" unit="mm" />
+      <rotation name="crystal3-5_rot_neg_top" x="0.0759356980444989" y="0.042186498913610496" z="0.0" unit="radian" />
+      <position name="crystal4-5_pos_pos_bot" x="94.78858692586502" y="-89.1427015552106" z="1528.5830972393524" unit="mm" />
+      <rotation name="crystal4-5_rot_pos_bot" x="-0.0759356980444989" y="-0.0590610984790547" z="0.0" unit="radian" />
+      <position name="crystal4-5_pos_neg_bot" x="-9.42816171009298" y="-89.1427015552106" z="1528.5830972393524" unit="mm" />
+      <rotation name="crystal4-5_rot_neg_bot" x="-0.0759356980444989" y="0.0590610984790547" z="0.0" unit="radian" />
+      <position name="crystal4-5_pos_pos_top" x="94.78858692586502" y="90.0427015552106" z="1528.5830972393524" unit="mm" />
+      <rotation name="crystal4-5_rot_pos_top" x="0.0759356980444989" y="-0.0590610984790547" z="0.0" unit="radian" />
+      <position name="crystal4-5_pos_neg_top" x="-9.42816171009298" y="90.0427015552106" z="1528.5830972393524" unit="mm" />
+      <rotation name="crystal4-5_rot_neg_top" x="0.0759356980444989" y="0.0590610984790547" z="0.0" unit="radian" />
+      <position name="crystal5-5_pos_pos_bot" x="109.67291416309662" y="-89.1427015552106" z="1528.6040060456442" unit="mm" />
+      <rotation name="crystal5-5_rot_pos_bot" x="-0.0759356980444989" y="-0.0759356980444989" z="0.0" unit="radian" />
+      <position name="crystal5-5_pos_neg_bot" x="-24.31248894732458" y="-89.1427015552106" z="1528.6040060456442" unit="mm" />
+      <rotation name="crystal5-5_rot_neg_bot" x="-0.0759356980444989" y="0.0759356980444989" z="0.0" unit="radian" />
+      <position name="crystal5-5_pos_pos_top" x="109.67291416309662" y="90.0427015552106" z="1528.6040060456442" unit="mm" />
+      <rotation name="crystal5-5_rot_pos_top" x="0.0759356980444989" y="-0.0759356980444989" z="0.0" unit="radian" />
+      <position name="crystal5-5_pos_neg_top" x="-24.31248894732458" y="90.0427015552106" z="1528.6040060456442" unit="mm" />
+      <rotation name="crystal5-5_rot_neg_top" x="0.0759356980444989" y="0.0759356980444989" z="0.0" unit="radian" />
+      <position name="crystal6-5_pos_pos_bot" x="124.57452638340096" y="-89.1427015552106" z="1528.602057217992" unit="mm" />
+      <rotation name="crystal6-5_rot_pos_bot" x="-0.0759356980444989" y="-0.0928102976099431" z="0.0" unit="radian" />
+      <position name="crystal6-5_pos_neg_bot" x="-39.214101167628925" y="-89.1427015552106" z="1528.602057217992" unit="mm" />
+      <rotation name="crystal6-5_rot_neg_bot" x="-0.0759356980444989" y="0.0928102976099431" z="0.0" unit="radian" />
+      <position name="crystal6-5_pos_pos_top" x="124.57452638340096" y="90.0427015552106" z="1528.602057217992" unit="mm" />
+      <rotation name="crystal6-5_rot_pos_top" x="0.0759356980444989" y="-0.0928102976099431" z="0.0" unit="radian" />
+      <position name="crystal6-5_pos_neg_top" x="-39.214101167628925" y="90.0427015552106" z="1528.602057217992" unit="mm" />
+      <rotation name="crystal6-5_rot_neg_top" x="0.0759356980444989" y="0.0928102976099431" z="0.0" unit="radian" />
+      <position name="crystal7-5_pos_pos_bot" x="139.4968932952259" y="-89.1427015552106" z="1528.5772513113154" unit="mm" />
+      <rotation name="crystal7-5_rot_pos_bot" x="-0.0759356980444989" y="-0.10968489717538729" z="0.0" unit="radian" />
+      <position name="crystal7-5_pos_neg_bot" x="-54.13646807945388" y="-89.1427015552106" z="1528.5772513113154" unit="mm" />
+      <rotation name="crystal7-5_rot_neg_bot" x="-0.0759356980444989" y="0.10968489717538729" z="0.0" unit="radian" />
+      <position name="crystal7-5_pos_pos_top" x="139.4968932952259" y="90.0427015552106" z="1528.5772513113154" unit="mm" />
+      <rotation name="crystal7-5_rot_pos_top" x="0.0759356980444989" y="-0.10968489717538729" z="0.0" unit="radian" />
+      <position name="crystal7-5_pos_neg_top" x="-54.13646807945388" y="90.0427015552106" z="1528.5772513113154" unit="mm" />
+      <rotation name="crystal7-5_rot_neg_top" x="0.0759356980444989" y="0.10968489717538729" z="0.0" unit="radian" />
+      <position name="crystal8-5_pos_pos_bot" x="154.44351486445828" y="-89.1427015552106" z="1528.5295953889813" unit="mm" />
+      <rotation name="crystal8-5_rot_pos_bot" x="-0.0759356980444989" y="-0.1265594967408315" z="0.0" unit="radian" />
+      <position name="crystal8-5_pos_neg_bot" x="-69.08308964868624" y="-89.1427015552106" z="1528.5295953889813" unit="mm" />
+      <rotation name="crystal8-5_rot_neg_bot" x="-0.0759356980444989" y="0.1265594967408315" z="0.0" unit="radian" />
+      <position name="crystal8-5_pos_pos_top" x="154.44351486445828" y="90.0427015552106" z="1528.5295953889813" unit="mm" />
+      <rotation name="crystal8-5_rot_pos_top" x="0.0759356980444989" y="-0.1265594967408315" z="0.0" unit="radian" />
+      <position name="crystal8-5_pos_neg_top" x="-69.08308964868624" y="90.0427015552106" z="1528.5295953889813" unit="mm" />
+      <rotation name="crystal8-5_rot_neg_top" x="0.0759356980444989" y="0.1265594967408315" z="0.0" unit="radian" />
+      <position name="crystal9-5_pos_pos_bot" x="169.41792716339802" y="-89.1427015552106" z="1528.4591030207916" unit="mm" />
+      <rotation name="crystal9-5_rot_pos_bot" x="-0.0759356980444989" y="-0.14343409630627568" z="0.0" unit="radian" />
+      <position name="crystal9-5_pos_neg_bot" x="-84.057501947626" y="-89.1427015552106" z="1528.4591030207916" unit="mm" />
+      <rotation name="crystal9-5_rot_neg_bot" x="-0.0759356980444989" y="0.14343409630627568" z="0.0" unit="radian" />
+      <position name="crystal9-5_pos_pos_top" x="169.41792716339802" y="90.0427015552106" z="1528.4591030207916" unit="mm" />
+      <rotation name="crystal9-5_rot_pos_top" x="0.0759356980444989" y="-0.14343409630627568" z="0.0" unit="radian" />
+      <position name="crystal9-5_pos_neg_top" x="-84.057501947626" y="90.0427015552106" z="1528.4591030207916" unit="mm" />
+      <rotation name="crystal9-5_rot_neg_top" x="0.0759356980444989" y="0.14343409630627568" z="0.0" unit="radian" />
+      <position name="crystal10-5_pos_pos_bot" x="184.42370834727978" y="-89.1427015552106" z="1528.3657942791212" unit="mm" />
+      <rotation name="crystal10-5_rot_pos_bot" x="-0.0759356980444989" y="-0.1603086958717199" z="0.0" unit="radian" />
+      <position name="crystal10-5_pos_neg_bot" x="-99.06328313150773" y="-89.1427015552106" z="1528.3657942791212" unit="mm" />
+      <rotation name="crystal10-5_rot_neg_bot" x="-0.0759356980444989" y="0.1603086958717199" z="0.0" unit="radian" />
+      <position name="crystal10-5_pos_pos_top" x="184.42370834727978" y="90.0427015552106" z="1528.3657942791212" unit="mm" />
+      <rotation name="crystal10-5_rot_pos_top" x="0.0759356980444989" y="-0.1603086958717199" z="0.0" unit="radian" />
+      <position name="crystal10-5_pos_neg_top" x="-99.06328313150773" y="90.0427015552106" z="1528.3657942791212" unit="mm" />
+      <rotation name="crystal10-5_rot_neg_top" x="0.0759356980444989" y="0.1603086958717199" z="0.0" unit="radian" />
+      <position name="crystal11-5_pos_pos_bot" x="199.46448478017476" y="-89.1427015552106" z="1528.2496957332003" unit="mm" />
+      <rotation name="crystal11-5_rot_pos_bot" x="-0.0759356980444989" y="-0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal11-5_pos_neg_bot" x="-114.1040595644027" y="-89.1427015552106" z="1528.2496957332003" unit="mm" />
+      <rotation name="crystal11-5_rot_neg_bot" x="-0.0759356980444989" y="0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal11-5_pos_pos_top" x="199.46448478017476" y="90.0427015552106" z="1528.2496957332003" unit="mm" />
+      <rotation name="crystal11-5_rot_pos_top" x="0.0759356980444989" y="-0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal11-5_pos_neg_top" x="-114.1040595644027" y="90.0427015552106" z="1528.2496957332003" unit="mm" />
+      <rotation name="crystal11-5_rot_neg_top" x="0.0759356980444989" y="0.1771832954371641" z="0.0" unit="radian" />
+      <position name="crystal12-5_pos_pos_bot" x="214.5439373331128" y="-89.1427015552106" z="1528.1108404415506" unit="mm" />
+      <rotation name="crystal12-5_rot_pos_bot" x="-0.0759356980444989" y="-0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal12-5_pos_neg_bot" x="-129.1835121173408" y="-89.1427015552106" z="1528.1108404415506" unit="mm" />
+      <rotation name="crystal12-5_rot_neg_bot" x="-0.0759356980444989" y="0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal12-5_pos_pos_top" x="214.5439373331128" y="90.0427015552106" z="1528.1108404415506" unit="mm" />
+      <rotation name="crystal12-5_rot_pos_top" x="0.0759356980444989" y="-0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal12-5_pos_neg_top" x="-129.1835121173408" y="90.0427015552106" z="1528.1108404415506" unit="mm" />
+      <rotation name="crystal12-5_rot_neg_top" x="0.0759356980444989" y="0.19405789500260828" z="0.0" unit="radian" />
+      <position name="crystal13-5_pos_pos_bot" x="229.66580787843168" y="-89.1427015552106" z="1527.9492679425712" unit="mm" />
+      <rotation name="crystal13-5_rot_pos_bot" x="-0.0759356980444989" y="-0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal13-5_pos_neg_bot" x="-144.30538266265967" y="-89.1427015552106" z="1527.9492679425712" unit="mm" />
+      <rotation name="crystal13-5_rot_neg_bot" x="-0.0759356980444989" y="0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal13-5_pos_pos_top" x="229.66580787843168" y="90.0427015552106" z="1527.9492679425712" unit="mm" />
+      <rotation name="crystal13-5_rot_pos_top" x="0.0759356980444989" y="-0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal13-5_pos_neg_top" x="-144.30538266265967" y="90.0427015552106" z="1527.9492679425712" unit="mm" />
+      <rotation name="crystal13-5_rot_neg_top" x="0.0759356980444989" y="0.2109324945680525" z="0.0" unit="radian" />
+      <position name="crystal14-5_pos_pos_bot" x="244.83390600570817" y="-89.1427015552106" z="1527.7650242432805" unit="mm" />
+      <rotation name="crystal14-5_rot_pos_bot" x="-0.0759356980444989" y="-0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal14-5_pos_neg_bot" x="-159.47348078993616" y="-89.1427015552106" z="1527.7650242432805" unit="mm" />
+      <rotation name="crystal14-5_rot_neg_bot" x="-0.0759356980444989" y="0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal14-5_pos_pos_top" x="244.83390600570817" y="90.0427015552106" z="1527.7650242432805" unit="mm" />
+      <rotation name="crystal14-5_rot_pos_top" x="0.0759356980444989" y="-0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal14-5_pos_neg_top" x="-159.47348078993616" y="90.0427015552106" z="1527.7650242432805" unit="mm" />
+      <rotation name="crystal14-5_rot_neg_top" x="0.0759356980444989" y="0.22780709413349667" z="0.0" unit="radian" />
+      <position name="crystal15-5_pos_pos_bot" x="260.0521159861688" y="-89.1427015552106" z="1527.5581618062158" unit="mm" />
+      <rotation name="crystal15-5_rot_pos_bot" x="-0.0759356980444989" y="-0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal15-5_pos_neg_bot" x="-174.6916907703968" y="-89.1427015552106" z="1527.5581618062158" unit="mm" />
+      <rotation name="crystal15-5_rot_neg_bot" x="-0.0759356980444989" y="0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal15-5_pos_pos_top" x="260.0521159861688" y="90.0427015552106" z="1527.5581618062158" unit="mm" />
+      <rotation name="crystal15-5_rot_pos_top" x="0.0759356980444989" y="-0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal15-5_pos_neg_top" x="-174.6916907703968" y="90.0427015552106" z="1527.5581618062158" unit="mm" />
+      <rotation name="crystal15-5_rot_neg_top" x="0.0759356980444989" y="0.24468169369894088" z="0.0" unit="radian" />
+      <position name="crystal16-5_pos_pos_bot" x="275.32440401422616" y="-89.1427015552106" z="1527.328739534495" unit="mm" />
+      <rotation name="crystal16-5_rot_pos_bot" x="-0.0759356980444989" y="-0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal16-5_pos_neg_bot" x="-189.96397879845415" y="-89.1427015552106" z="1527.328739534495" unit="mm" />
+      <rotation name="crystal16-5_rot_neg_bot" x="-0.0759356980444989" y="0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal16-5_pos_pos_top" x="275.32440401422616" y="90.0427015552106" z="1527.328739534495" unit="mm" />
+      <rotation name="crystal16-5_rot_pos_top" x="0.0759356980444989" y="-0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal16-5_pos_neg_top" x="-189.96397879845415" y="90.0427015552106" z="1527.328739534495" unit="mm" />
+      <rotation name="crystal16-5_rot_neg_top" x="0.0759356980444989" y="0.26155629326438506" z="0.0" unit="radian" />
+      <position name="crystal17-5_pos_pos_bot" x="290.6548257567732" y="-89.1427015552106" z="1527.0768227550436" unit="mm" />
+      <rotation name="crystal17-5_rot_pos_bot" x="-0.0759356980444989" y="-0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal17-5_pos_neg_bot" x="-205.2944005410012" y="-89.1427015552106" z="1527.0768227550436" unit="mm" />
+      <rotation name="crystal17-5_rot_neg_bot" x="-0.0759356980444989" y="0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal17-5_pos_pos_top" x="290.6548257567732" y="90.0427015552106" z="1527.0768227550436" unit="mm" />
+      <rotation name="crystal17-5_rot_pos_top" x="0.0759356980444989" y="-0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal17-5_pos_neg_top" x="-205.2944005410012" y="90.0427015552106" z="1527.0768227550436" unit="mm" />
+      <rotation name="crystal17-5_rot_neg_top" x="0.0759356980444989" y="0.2784308928298293" z="0.0" unit="radian" />
+      <position name="crystal18-5_pos_pos_bot" x="306.0475342431027" y="-89.1427015552106" z="1526.8024831999942" unit="mm" />
+      <rotation name="crystal18-5_rot_pos_bot" x="-0.0759356980444989" y="-0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal18-5_pos_neg_bot" x="-220.68710902733068" y="-89.1427015552106" z="1526.8024831999942" unit="mm" />
+      <rotation name="crystal18-5_rot_neg_bot" x="-0.0759356980444989" y="0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal18-5_pos_pos_top" x="306.0475342431027" y="90.0427015552106" z="1526.8024831999942" unit="mm" />
+      <rotation name="crystal18-5_rot_pos_top" x="0.0759356980444989" y="-0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal18-5_pos_neg_top" x="-220.68710902733068" y="90.0427015552106" z="1526.8024831999942" unit="mm" />
+      <rotation name="crystal18-5_rot_neg_top" x="0.0759356980444989" y="0.2953054923952735" z="0.0" unit="radian" />
+      <position name="crystal19-5_pos_pos_bot" x="321.5067881308382" y="-89.1427015552106" z="1526.5057989862605" unit="mm" />
+      <rotation name="crystal19-5_rot_pos_bot" x="-0.0759356980444989" y="-0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal19-5_pos_neg_bot" x="-236.14636291506616" y="-89.1427015552106" z="1526.5057989862605" unit="mm" />
+      <rotation name="crystal19-5_rot_neg_bot" x="-0.0759356980444989" y="0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal19-5_pos_pos_top" x="321.5067881308382" y="90.0427015552106" z="1526.5057989862605" unit="mm" />
+      <rotation name="crystal19-5_rot_pos_top" x="0.0759356980444989" y="-0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal19-5_pos_neg_top" x="-236.14636291506616" y="90.0427015552106" z="1526.5057989862605" unit="mm" />
+      <rotation name="crystal19-5_rot_neg_top" x="0.0759356980444989" y="0.31218009196071766" z="0.0" unit="radian" />
+      <position name="crystal20-5_pos_pos_bot" x="337.03696038609246" y="-89.1427015552106" z="1526.186854593294" unit="mm" />
+      <rotation name="crystal20-5_rot_pos_bot" x="-0.0759356980444989" y="-0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal20-5_pos_neg_bot" x="-251.67653517032045" y="-89.1427015552106" z="1526.186854593294" unit="mm" />
+      <rotation name="crystal20-5_rot_neg_bot" x="-0.0759356980444989" y="0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal20-5_pos_pos_top" x="337.03696038609246" y="90.0427015552106" z="1526.186854593294" unit="mm" />
+      <rotation name="crystal20-5_rot_pos_top" x="0.0759356980444989" y="-0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal20-5_pos_neg_top" x="-251.67653517032045" y="90.0427015552106" z="1526.186854593294" unit="mm" />
+      <rotation name="crystal20-5_rot_neg_top" x="0.0759356980444989" y="0.3290546915261619" z="0.0" unit="radian" />
+      <position name="crystal21-5_pos_pos_bot" x="352.64254741924634" y="-89.1427015552106" z="1525.8457408390282" unit="mm" />
+      <rotation name="crystal21-5_rot_pos_bot" x="-0.0759356980444989" y="-0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal21-5_pos_neg_bot" x="-267.28212220347433" y="-89.1427015552106" z="1525.8457408390282" unit="mm" />
+      <rotation name="crystal21-5_rot_neg_bot" x="-0.0759356980444989" y="0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal21-5_pos_pos_top" x="352.64254741924634" y="90.0427015552106" z="1525.8457408390282" unit="mm" />
+      <rotation name="crystal21-5_rot_pos_top" x="0.0759356980444989" y="-0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal21-5_pos_neg_top" x="-267.28212220347433" y="90.0427015552106" z="1525.8457408390282" unit="mm" />
+      <rotation name="crystal21-5_rot_neg_top" x="0.0759356980444989" y="0.3459292910916061" z="0.0" unit="radian" />
+      <position name="crystal22-5_pos_pos_bot" x="368.32817872130425" y="-89.1427015552106" z="1525.48255485402" unit="mm" />
+      <rotation name="crystal22-5_rot_pos_bot" x="-0.0759356980444989" y="-0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal22-5_pos_neg_bot" x="-282.96775350553224" y="-89.1427015552106" z="1525.48255485402" unit="mm" />
+      <rotation name="crystal22-5_rot_neg_bot" x="-0.0759356980444989" y="0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal22-5_pos_pos_top" x="368.32817872130425" y="90.0427015552106" z="1525.48255485402" unit="mm" />
+      <rotation name="crystal22-5_rot_pos_top" x="0.0759356980444989" y="-0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal22-5_pos_neg_top" x="-282.96775350553224" y="90.0427015552106" z="1525.48255485402" unit="mm" />
+      <rotation name="crystal22-5_rot_neg_top" x="0.0759356980444989" y="0.36280389065705027" z="0.0" unit="radian" />
+      <position name="crystal23-5_pos_pos_bot" x="384.09862704978" y="-89.1427015552106" z="1525.0974000537913" unit="mm" />
+      <rotation name="crystal23-5_rot_pos_bot" x="-0.0759356980444989" y="-0.3796784902224945" z="0.0" unit="radian" />
+      <position name="crystal23-5_pos_neg_bot" x="-298.738201834008" y="-89.1427015552106" z="1525.0974000537913" unit="mm" />
+      <rotation name="crystal23-5_rot_neg_bot" x="-0.0759356980444989" y="0.3796784902224945" z="0.0" unit="radian" />
+      <position name="crystal23-5_pos_pos_top" x="384.09862704978" y="90.0427015552106" z="1525.0974000537913" unit="mm" />
+      <rotation name="crystal23-5_rot_pos_top" x="0.0759356980444989" y="-0.3796784902224945" z="0.0" unit="radian" />
+      <position name="crystal23-5_pos_neg_top" x="-298.738201834008" y="90.0427015552106" z="1525.0974000537913" unit="mm" />
+      <rotation name="crystal23-5_rot_neg_top" x="0.0759356980444989" y="0.3796784902224945" z="0.0" unit="radian" />
+      <rotation name="hodo_rot" x="0.0" y="0.0" z="0.0" unit="radian" />
+      <position name="hodo_pos_L1TP0" x="73.63" y="44.2" z="1103.5" unit="mm" />
+      <position name="hodo_forecover_pos_L1TP0" x="73.63" y="44.2" z="1098.625" unit="mm" />
+      <position name="hodo_postcover_pos_L1TP0" x="73.63" y="44.2" z="1108.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L1TP0" x="65.75500000000001" y="44.2" z="1103.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L1TP0" x="81.50500000000001" y="44.2" z="1103.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L1TP0" x="73.63" y="74.17500000000001" z="1103.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L1TP0" x="73.63" y="14.225000000000003" z="1103.5" unit="mm" />
+      <position name="hodo_pos_L1BP0" x="73.63" y="-44.2" z="1103.5" unit="mm" />
+      <position name="hodo_forecover_pos_L1BP0" x="73.63" y="-44.2" z="1098.625" unit="mm" />
+      <position name="hodo_postcover_pos_L1BP0" x="73.63" y="-44.2" z="1108.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L1BP0" x="65.75500000000001" y="-44.2" z="1103.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L1BP0" x="81.50500000000001" y="-44.2" z="1103.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L1BP0" x="73.63" y="-14.225000000000003" z="1103.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L1BP0" x="73.63" y="-74.17500000000001" z="1103.5" unit="mm" />
+      <position name="hodo_pos_L1TP1" x="98.63" y="44.2" z="1103.5" unit="mm" />
+      <position name="hodo_forecover_pos_L1TP1" x="98.63" y="44.2" z="1098.625" unit="mm" />
+      <position name="hodo_postcover_pos_L1TP1" x="98.63" y="44.2" z="1108.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L1TP1" x="81.555" y="44.2" z="1103.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L1TP1" x="115.70500000000001" y="44.2" z="1103.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L1TP1" x="98.63" y="74.17500000000001" z="1103.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L1TP1" x="98.63" y="14.225000000000003" z="1103.5" unit="mm" />
+      <position name="hodo_pos_L1BP1" x="98.63" y="-44.2" z="1103.5" unit="mm" />
+      <position name="hodo_forecover_pos_L1BP1" x="98.63" y="-44.2" z="1098.625" unit="mm" />
+      <position name="hodo_postcover_pos_L1BP1" x="98.63" y="-44.2" z="1108.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L1BP1" x="81.555" y="-44.2" z="1103.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L1BP1" x="115.70500000000001" y="-44.2" z="1103.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L1BP1" x="98.63" y="-14.225000000000003" z="1103.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L1BP1" x="98.63" y="-74.17500000000001" z="1103.5" unit="mm" />
+      <position name="hodo_pos_L1TP2" x="137.78" y="44.2" z="1103.5" unit="mm" />
+      <position name="hodo_forecover_pos_L1TP2" x="137.78" y="44.2" z="1098.625" unit="mm" />
+      <position name="hodo_postcover_pos_L1TP2" x="137.78" y="44.2" z="1108.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L1TP2" x="115.75500000000001" y="44.2" z="1103.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L1TP2" x="159.805" y="44.2" z="1103.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L1TP2" x="137.78" y="74.17500000000001" z="1103.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L1TP2" x="137.78" y="14.225000000000003" z="1103.5" unit="mm" />
+      <position name="hodo_pos_L1BP2" x="137.78" y="-44.2" z="1103.5" unit="mm" />
+      <position name="hodo_forecover_pos_L1BP2" x="137.78" y="-44.2" z="1098.625" unit="mm" />
+      <position name="hodo_postcover_pos_L1BP2" x="137.78" y="-44.2" z="1108.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L1BP2" x="115.75500000000001" y="-44.2" z="1103.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L1BP2" x="159.805" y="-44.2" z="1103.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L1BP2" x="137.78" y="-14.225000000000003" z="1103.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L1BP2" x="137.78" y="-74.17500000000001" z="1103.5" unit="mm" />
+      <position name="hodo_pos_L1TP3" x="181.88" y="44.2" z="1103.5" unit="mm" />
+      <position name="hodo_forecover_pos_L1TP3" x="181.88" y="44.2" z="1098.625" unit="mm" />
+      <position name="hodo_postcover_pos_L1TP3" x="181.88" y="44.2" z="1108.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L1TP3" x="159.855" y="44.2" z="1103.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L1TP3" x="203.905" y="44.2" z="1103.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L1TP3" x="181.88" y="74.17500000000001" z="1103.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L1TP3" x="181.88" y="14.225000000000003" z="1103.5" unit="mm" />
+      <position name="hodo_pos_L1BP3" x="181.88" y="-44.2" z="1103.5" unit="mm" />
+      <position name="hodo_forecover_pos_L1BP3" x="181.88" y="-44.2" z="1098.625" unit="mm" />
+      <position name="hodo_postcover_pos_L1BP3" x="181.88" y="-44.2" z="1108.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L1BP3" x="159.855" y="-44.2" z="1103.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L1BP3" x="203.905" y="-44.2" z="1103.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L1BP3" x="181.88" y="-14.225000000000003" z="1103.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L1BP3" x="181.88" y="-74.17500000000001" z="1103.5" unit="mm" />
+      <position name="hodo_pos_L1TP4" x="225.98000000000002" y="44.2" z="1103.5" unit="mm" />
+      <position name="hodo_forecover_pos_L1TP4" x="225.98000000000002" y="44.2" z="1098.625" unit="mm" />
+      <position name="hodo_postcover_pos_L1TP4" x="225.98000000000002" y="44.2" z="1108.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L1TP4" x="203.955" y="44.2" z="1103.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L1TP4" x="248.00500000000002" y="44.2" z="1103.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L1TP4" x="225.98000000000002" y="74.17500000000001" z="1103.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L1TP4" x="225.98000000000002" y="14.225000000000003" z="1103.5" unit="mm" />
+      <position name="hodo_pos_L1BP4" x="225.98000000000002" y="-44.2" z="1103.5" unit="mm" />
+      <position name="hodo_forecover_pos_L1BP4" x="225.98000000000002" y="-44.2" z="1098.625" unit="mm" />
+      <position name="hodo_postcover_pos_L1BP4" x="225.98000000000002" y="-44.2" z="1108.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L1BP4" x="203.955" y="-44.2" z="1103.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L1BP4" x="248.00500000000002" y="-44.2" z="1103.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L1BP4" x="225.98000000000002" y="-14.225000000000003" z="1103.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L1BP4" x="225.98000000000002" y="-74.17500000000001" z="1103.5" unit="mm" />
+      <position name="hodo_pos_L2TP0" x="78.61999999999999" y="44.2" z="1115.5" unit="mm" />
+      <position name="hodo_forecover_pos_L2TP0" x="78.61999999999999" y="44.2" z="1110.625" unit="mm" />
+      <position name="hodo_postcover_pos_L2TP0" x="78.61999999999999" y="44.2" z="1120.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L2TP0" x="69.095" y="44.2" z="1115.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L2TP0" x="88.145" y="44.2" z="1115.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L2TP0" x="78.61999999999999" y="74.17500000000001" z="1115.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L2TP0" x="78.61999999999999" y="14.225000000000003" z="1115.5" unit="mm" />
+      <position name="hodo_pos_L2BP0" x="78.61999999999999" y="-44.2" z="1115.5" unit="mm" />
+      <position name="hodo_forecover_pos_L2BP0" x="78.61999999999999" y="-44.2" z="1110.625" unit="mm" />
+      <position name="hodo_postcover_pos_L2BP0" x="78.61999999999999" y="-44.2" z="1120.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L2BP0" x="69.095" y="-44.2" z="1115.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L2BP0" x="88.145" y="-44.2" z="1115.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L2BP0" x="78.61999999999999" y="-14.225000000000003" z="1115.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L2BP0" x="78.61999999999999" y="-74.17500000000001" z="1115.5" unit="mm" />
+      <position name="hodo_pos_L2TP1" x="110.22" y="44.2" z="1115.5" unit="mm" />
+      <position name="hodo_forecover_pos_L2TP1" x="110.22" y="44.2" z="1110.625" unit="mm" />
+      <position name="hodo_postcover_pos_L2TP1" x="110.22" y="44.2" z="1120.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L2TP1" x="88.19500000000001" y="44.2" z="1115.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L2TP1" x="132.245" y="44.2" z="1115.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L2TP1" x="110.22" y="74.17500000000001" z="1115.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L2TP1" x="110.22" y="14.225000000000003" z="1115.5" unit="mm" />
+      <position name="hodo_pos_L2BP1" x="110.22" y="-44.2" z="1115.5" unit="mm" />
+      <position name="hodo_forecover_pos_L2BP1" x="110.22" y="-44.2" z="1110.625" unit="mm" />
+      <position name="hodo_postcover_pos_L2BP1" x="110.22" y="-44.2" z="1120.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L2BP1" x="88.19500000000001" y="-44.2" z="1115.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L2BP1" x="132.245" y="-44.2" z="1115.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L2BP1" x="110.22" y="-14.225000000000003" z="1115.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L2BP1" x="110.22" y="-74.17500000000001" z="1115.5" unit="mm" />
+      <position name="hodo_pos_L2TP2" x="154.32000000000002" y="44.2" z="1115.5" unit="mm" />
+      <position name="hodo_forecover_pos_L2TP2" x="154.32000000000002" y="44.2" z="1110.625" unit="mm" />
+      <position name="hodo_postcover_pos_L2TP2" x="154.32000000000002" y="44.2" z="1120.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L2TP2" x="132.29500000000002" y="44.2" z="1115.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L2TP2" x="176.34500000000003" y="44.2" z="1115.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L2TP2" x="154.32000000000002" y="74.17500000000001" z="1115.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L2TP2" x="154.32000000000002" y="14.225000000000003" z="1115.5" unit="mm" />
+      <position name="hodo_pos_L2BP2" x="154.32000000000002" y="-44.2" z="1115.5" unit="mm" />
+      <position name="hodo_forecover_pos_L2BP2" x="154.32000000000002" y="-44.2" z="1110.625" unit="mm" />
+      <position name="hodo_postcover_pos_L2BP2" x="154.32000000000002" y="-44.2" z="1120.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L2BP2" x="132.29500000000002" y="-44.2" z="1115.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L2BP2" x="176.34500000000003" y="-44.2" z="1115.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L2BP2" x="154.32000000000002" y="-14.225000000000003" z="1115.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L2BP2" x="154.32000000000002" y="-74.17500000000001" z="1115.5" unit="mm" />
+      <position name="hodo_pos_L2TP3" x="198.42000000000004" y="44.2" z="1115.5" unit="mm" />
+      <position name="hodo_forecover_pos_L2TP3" x="198.42000000000004" y="44.2" z="1110.625" unit="mm" />
+      <position name="hodo_postcover_pos_L2TP3" x="198.42000000000004" y="44.2" z="1120.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L2TP3" x="176.39500000000004" y="44.2" z="1115.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L2TP3" x="220.44500000000005" y="44.2" z="1115.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L2TP3" x="198.42000000000004" y="74.17500000000001" z="1115.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L2TP3" x="198.42000000000004" y="14.225000000000003" z="1115.5" unit="mm" />
+      <position name="hodo_pos_L2BP3" x="198.42000000000004" y="-44.2" z="1115.5" unit="mm" />
+      <position name="hodo_forecover_pos_L2BP3" x="198.42000000000004" y="-44.2" z="1110.625" unit="mm" />
+      <position name="hodo_postcover_pos_L2BP3" x="198.42000000000004" y="-44.2" z="1120.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L2BP3" x="176.39500000000004" y="-44.2" z="1115.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L2BP3" x="220.44500000000005" y="-44.2" z="1115.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L2BP3" x="198.42000000000004" y="-14.225000000000003" z="1115.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L2BP3" x="198.42000000000004" y="-74.17500000000001" z="1115.5" unit="mm" />
+      <position name="hodo_pos_L2TP4" x="235.92000000000002" y="44.2" z="1115.5" unit="mm" />
+      <position name="hodo_forecover_pos_L2TP4" x="235.92000000000002" y="44.2" z="1110.625" unit="mm" />
+      <position name="hodo_postcover_pos_L2TP4" x="235.92000000000002" y="44.2" z="1120.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L2TP4" x="220.495" y="44.2" z="1115.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L2TP4" x="251.34500000000003" y="44.2" z="1115.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L2TP4" x="235.92000000000002" y="74.17500000000001" z="1115.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L2TP4" x="235.92000000000002" y="14.225000000000003" z="1115.5" unit="mm" />
+      <position name="hodo_pos_L2BP4" x="235.92000000000002" y="-44.2" z="1115.5" unit="mm" />
+      <position name="hodo_forecover_pos_L2BP4" x="235.92000000000002" y="-44.2" z="1110.625" unit="mm" />
+      <position name="hodo_postcover_pos_L2BP4" x="235.92000000000002" y="-44.2" z="1120.375" unit="mm" />
+      <position name="hodo_sidereflR_pos_L2BP4" x="220.495" y="-44.2" z="1115.5" unit="mm" />
+      <position name="hodo_siderefl2L_pos_L2BP4" x="251.34500000000003" y="-44.2" z="1115.5" unit="mm" />
+      <position name="hodo_topreflT_pos_L2BP4" x="235.92000000000002" y="-14.225000000000003" z="1115.5" unit="mm" />
+      <position name="hodo_toprefl2B_pos_L2BP4" x="235.92000000000002" y="-74.17500000000001" z="1115.5" unit="mm" />
+      <position name="hodo_bufferT_pos" x="153.99" y="54.2" z="1109.5" unit="mm" />
+      <position name="hodo_bufferB_pos" x="153.99" y="-54.2" z="1109.5" unit="mm" />
+      <position name="front_flange_1inworld_volumepos" x="2.1420000000000003" y="0" z="137.80000000000001" unit="cm" />
+      <position name="back_flange_1inworld_volumepos" x="-12.608499999999999" y="0" z="180.80000000000001" unit="cm" />
+      <position name="ECAL_chamber_1inworld_volumepos" x="-11.940800000000001" y="0" z="159.30000000000001" unit="cm" />
+      <position name="al_honeycomb_1inworld_volumepos" x="-18.858000000000001" y="0" z="155.80000000000001" unit="cm" />
+      <position name="layer_1_top_1inworld_volumepos" x="4.1920000000000002" y="8.0999999999999996" z="152.80000000000001" unit="cm" />
+      <position name="layer_2_top_1inworld_volumepos" x="4.1920000000000002" y="6.6899999999999995" z="152.80000000000001" unit="cm" />
+      <position name="layer_3_top_1inworld_volumepos" x="4.1920000000000002" y="5.2799999999999994" z="152.80000000000001" unit="cm" />
+      <position name="layer_4_top_1inworld_volumepos" x="4.1920000000000002" y="3.8699999999999992" z="152.80000000000001" unit="cm" />
+      <position name="layer_1_bottom_1inworld_volumepos" x="4.1920000000000002" y="-4.0999999999999996" z="152.80000000000001" unit="cm" />
+      <position name="layer_2_bottom_1inworld_volumepos" x="4.1920000000000002" y="-5.5099999999999998" z="152.80000000000001" unit="cm" />
+      <position name="layer_3_bottom_1inworld_volumepos" x="4.1920000000000002" y="-6.9199999999999999" z="152.80000000000001" unit="cm" />
+      <position name="layer_4_bottom_1inworld_volumepos" x="4.1920000000000002" y="-8.3300000000000001" z="152.80000000000001" unit="cm" />
+      <position name="layer_5T_left_1inworld_volumepos" x="4.1920000000000002" y="2.46" z="152.80000000000001" unit="cm" />
+      <position name="layer_5B_left_1inworld_volumepos" x="4.1920000000000002" y="-2.6899999999999995" z="152.80000000000001" unit="cm" />
+      <position name="steel_bar_1inworld_volumepos" x="-35.357999999999997" y="0.90000000000000002" z="152.80000000000001" unit="cm" />
+      <position name="cu_Tpipe_inner_left_1inworld_volumepos" x="1.6420000000000003" y="2.7000000000000002" z="152.80000000000001" unit="cm" />
+      <rotation name="cu_Tpipe_inner_left_1inworld_volumerot" x="0" y="-0.95599999999999996" z="0" unit="deg" />
+      <position name="cu_Tpipe_inner_right_1inworld_volumepos" x="-9.1580000000000013" y="2.7000000000000002" z="152.80000000000001" unit="cm" />
+      <rotation name="cu_Tpipe_inner_right_1inworld_volumerot" x="0" y="9.6799999999999997" z="0" unit="deg" />
+      <position name="cu_Bpipe_inner_left_1inworld_volumepos" x="1.6420000000000003" y="-2.7000000000000002" z="152.80000000000001" unit="cm" />
+      <rotation name="cu_Bpipe_inner_left_1inworld_volumerot" x="0" y="-0.95599999999999996" z="0" unit="deg" />
+      <position name="cu_Bpipe_inner_right_1inworld_volumepos" x="-9.1580000000000013" y="-2.7000000000000002" z="152.80000000000001" unit="cm" />
+      <rotation name="cu_Bpipe_inner_right_1inworld_volumerot" x="0" y="9.6799999999999997" z="0" unit="deg" />
+      <position name="cu_Tpipe_outer_right1_1inworld_volumepos" x="-10.858000000000001" y="1.3999999999999999" z="154.30000000000001" unit="cm" />
+      <rotation name="cu_Tpipe_outer_right1_1inworld_volumerot" x="0" y="10" z="0" unit="deg" />
+      <position name="cu_Tpipe_outer_right2_1inworld_volumepos" x="-27.858000000000001" y="1.3999999999999999" z="154.30000000000001" unit="cm" />
+      <position name="cu_Tpipe_outer_right3_1inworld_volumepos" x="-34.857999999999997" y="1.5" z="142.10000000000002" unit="cm" />
+      <rotation name="cu_Tpipe_outer_right3_1inworld_volumerot" x="-0" y="90" z="0" unit="deg" />
+      <position name="cu_Bpipe_outer_right_1inworld_volumepos" x="-34.857999999999997" y="-1.5" z="142.10000000000002" unit="cm" />
+      <rotation name="cu_Bpipe_outer_right_1inworld_volumerot" x="-0" y="90" z="0" unit="deg" />
+      <position name="cu_Bpipe_outer_right1_1inworld_volumepos" x="-10.858000000000001" y="-1.3999999999999999" z="154.30000000000001" unit="cm" />
+      <rotation name="cu_Bpipe_outer_right1_1inworld_volumerot" x="0" y="10" z="0" unit="deg" />
+      <position name="cu_Bpipe_outer_right2_1inworld_volumepos" x="-27.858000000000001" y="-1.3999999999999999" z="154.30000000000001" unit="cm" />
+      <position name="al_pipe_across_top1_1inworld_volumepos" x="2.1420000000000003" y="9" z="142.10000000000002" unit="cm" />
+      <rotation name="al_pipe_across_top1_1inworld_volumerot" x="-90" y="86.999999999999957" z="180" unit="deg" />
+      <position name="al_pipe_across_top2_1inworld_volumepos" x="2.1420000000000003" y="4" z="142.10000000000002" unit="cm" />
+      <rotation name="al_pipe_across_top2_1inworld_volumerot" x="-90" y="89.000000000000099" z="180" unit="deg" />
+      <position name="al_pipe_across_bottom1_1inworld_volumepos" x="2.1420000000000003" y="-9" z="142.10000000000002" unit="cm" />
+      <rotation name="al_pipe_across_bottom1_1inworld_volumerot" x="90" y="86.999999999999957" z="0" unit="deg" />
+      <position name="al_pipe_across_bottom2_1inworld_volumepos" x="2.1420000000000003" y="-4" z="142.10000000000002" unit="cm" />
+      <rotation name="al_pipe_across_bottom2_1inworld_volumerot" x="90" y="89.000000000000099" z="0" unit="deg" />
+      <position name="cu_plate_top_left_1inworld_volumepos" x="22.141999999999999" y="1.6000000000000001" z="152.80000000000001" unit="cm" />
+      <position name="cu_plate_bottom_left_1inworld_volumepos" x="22.141999999999999" y="-1.6000000000000001" z="152.80000000000001" unit="cm" />
+      <position name="cu_plate_top_right_1inworld_volumepos" x="-20.858000000000001" y="1.6000000000000001" z="152.80000000000001" unit="cm" />
+      <position name="cu_plate_bottom_right_1inworld_volumepos" x="-20.858000000000001" y="-1.6000000000000001" z="152.80000000000001" unit="cm" />
+      <position name="cu_plate_top_middle_1inworld_volumepos" x="-3.3579999999999997" y="3.1000000000000001" z="152.80000000000001" unit="cm" />
+      <position name="cu_plate_bottom_middle_1inworld_volumepos" x="-3.3579999999999997" y="-3.1000000000000001" z="152.80000000000001" unit="cm" />
+      <position name="hodo_flange_1intracking_volumepos" x="2.1170000000000004" y="0" z="134.30000000000001" unit="cm" />
+      <position name="arms1_block1_1intracking_volumepos" x="21.517000000000003" y="14.938225000000001" z="132.70000000000002" unit="cm" />
+      <position name="arms1_block2_1intracking_volumepos" x="9.5170000000000012" y="14.938225000000001" z="132.70000000000002" unit="cm" />
+      <position name="arms1_block3_1intracking_volumepos" x="21.517000000000003" y="-14.938225000000001" z="132.70000000000002" unit="cm" />
+      <position name="arms1_block4_1intracking_volumepos" x="9.5170000000000012" y="-14.938225000000001" z="132.70000000000002" unit="cm" />
+      <position name="cross_bar_top_1intracking_volumepos" x="15.517000000000003" y="16.34" z="132.70000000000002" unit="cm" />
+      <position name="cross_bar_bottom_1intracking_volumepos" x="15.517000000000003" y="-16.34" z="132.70000000000002" unit="cm" />
+      <position name="support_arm_bottom_left_plus_block_1intracking_volumepos" x="21.517000000000003" y="-12.771562277258594" z="121.10000000000001" unit="cm" />
+      <position name="support_arm_bottom_right_1intracking_volumepos" x="9.5170000000000012" y="-12.771562277258594" z="121.10000000000001" unit="cm" />
+      <position name="support_arm_top_left_1intracking_volumepos" x="21.517000000000003" y="12.771562277258594" z="121.10000000000001" unit="cm" />
+      <rotation name="support_arm_top_left_1intracking_volumerot" x="0" y="-0" z="180" unit="deg" />
+      <position name="support_arm_top_right_1intracking_volumepos" x="9.5170000000000012" y="12.771562277258594" z="121.10000000000001" unit="cm" />
+      <rotation name="support_arm_top_right_1intracking_volumerot" x="0" y="-0" z="180" unit="deg" />
+      <position name="u_support_bar_bottom_1intracking_volumepos" x="15.517000000000003" y="-9.8400000000000034" z="110.899" unit="cm" />
+      <position name="u_support_bar_upper1_1intracking_volumepos" x="15.517000000000003" y="-8.5400000000000027" z="110.65000000000001" unit="cm" />
+      <position name="u_support_bar_upper2_1intracking_volumepos" x="15.517000000000003" y="-8.5400000000000027" z="111.2" unit="cm" />
+      <position name="u_support_bar_top_1intracking_volumepos" x="15.517000000000003" y="9.8400000000000034" z="110.899" unit="cm" />
+      <position name="u_support_bar_upper3_1intracking_volumepos" x="15.517000000000003" y="8.5400000000000027" z="110.65000000000001" unit="cm" />
+      <position name="u_support_bar_upper4_1intracking_volumepos" x="15.517000000000003" y="8.5400000000000027" z="111.2" unit="cm" />
+      <constant name="svt_chamber_box_z" value="609.6" />
+      <constant name="svt_chamber_flare1_z" value="1285.621" />
+      <constant name="svt_chamber_flare2_z" value="1478.407" />
+      <constant name="svt_chamber_flange_z" value="1614.297" />
+      <constant name="svt_chamber_x" value="21.17" />
+      <constant name="svt_chamber_z" value="1318-1623.822" />
+    </define>
+    <materials>
+      <element Z="1" formula="H" name="H">
+        <atom type="A" unit="g/mol" value="1.00794" />
+      </element>
+      <element Z="82" formula="Pb" name="Pb">
+        <atom type="A" unit="g/mol" value="207.217" />
+      </element>
+      <element Z="74" formula="W" name="W">
+        <atom type="A" unit="g/mol" value="183.842" />
+      </element>
+      <element Z="8" formula="O" name="O">
+        <atom type="A" unit="g/mol" value="15.9994" />
+      </element>
+      <element Z="6" formula="C" name="C">
+        <atom type="A" unit="g/mol" value="12.0107" />
+      </element>
+      <element Z="22" formula="Ti" name="Ti">
+        <atom type="A" unit="g/mol" value="47.8667" />
+      </element>
+      <material name="Vacuum">
+        <D type="density" unit="g/cm3" value="0.00000001" />
+        <fraction n="1" ref="H" />
+      </material>
+      <material name="WorldMaterial">
+        <D type="density" unit="g/cm3" value="0.0000000000000001" />
+        <fraction n="1.0" ref="Vacuum" />
+      </material>
+      <material name="TrackingMaterial">
+        <D type="density" unit="g/cm3" value="0.0000000000000001" />
+        <fraction n="1.0" ref="Vacuum" />
+      </material>
+      <material name="LeadTungstate">
+        <D value="8.28" unit="g/cm3" type="density" />
+        <composite n="1" ref="Pb" />
+        <composite n="1" ref="W" />
+        <composite n="4" ref="O" />
+      </material>
+      <material name="EJ204_PlasticScintillator">
+        <D value="1.032" unit="g/cm3" type="density" />
+        <fraction n="0.523618" ref="H" />
+        <fraction n="0.476382" ref="C" />
+      </material>
+      <material name="TitaniumDioxide">
+        <D value="4.23" unit="g/cm3" type="density" />
+        <composite n="1" ref="Ti" />
+        <composite n="2" ref="O" />
+      </material>
+      <material name="Mylar">
+        <D value="1.4" unit="g/cm3" type="density" />
+        <fraction n="0.041958" ref="H" />
+        <fraction n="0.625017" ref="C" />
+        <fraction n="0.333025" ref="O" />
+      </material>
+      <material name="GenericFoam">
+        <D value="0.052" unit="g/cm3" type="density" />
+        <fraction n="0.5" ref="H" />
+        <fraction n="0.5" ref="C" />
+      </material>
+      <element name="Al" formula="Al" Z="13">
+        <atom type="A" unit="g/mol" value="26.9815" />
+      </element>
+      <material name="Aluminum">
+        <RL type="X0" unit="cm" value="8.89632" />
+        <NIL type="lambda" unit="cm" value="38.8766" />
+        <D type="density" unit="g/cm3" value="2.699" />
+        <composite n="1" ref="Al" />
+      </material>
+      <element name="Si" formula="Si" Z="14">
+        <atom type="A" unit="g/mol" value="28.0854" />
+      </element>
+      <material name="Silicon">
+        <RL type="X0" unit="cm" value="9.36607" />
+        <NIL type="lambda" unit="cm" value="45.7531" />
+        <D type="density" unit="g/cm3" value="2.33" />
+        <composite n="1" ref="Si" />
+      </material>
+      <element name="N" formula="N" Z="7">
+        <atom type="A" unit="g/mol" value="14.0068" />
+      </element>
+      <material name="Kapton">
+        <D value="1.43" unit="g/cm3" />
+        <composite n="22" ref="C" />
+        <composite n="10" ref="H" />
+        <composite n="2" ref="N" />
+        <composite n="5" ref="O" />
+      </material>
+      <material name="Epoxy">
+        <D type="density" value="1.3" unit="g/cm3" />
+        <composite n="44" ref="H" />
+        <composite n="15" ref="C" />
+        <composite n="7" ref="O" />
+      </material>
+      <material name="CarbonFiber">
+        <D type="density" value="1.5" unit="g/cm3" />
+        <fraction n="0.65" ref="C" />
+        <fraction n="0.35" ref="Epoxy" />
+      </material>
+      <element name="Cl" formula="Cl" Z="17">
+        <atom type="A" unit="g/mol" value="35.4526" />
+      </element>
+      <material name="Quartz">
+        <D type="density" value="2.2" unit="g/cm3" />
+        <composite n="1" ref="Si" />
+        <composite n="2" ref="O" />
+      </material>
+      <material name="G10">
+        <D type="density" value="1.7" unit="g/cm3" />
+        <fraction n="0.08" ref="Cl" />
+        <fraction n="0.773" ref="Quartz" />
+        <fraction n="0.147" ref="Epoxy" />
+      </material>
+      <material name="Polystyrene">
+        <D value="1.032" unit="g/cm3" />
+        <composite n="19" ref="C" />
+        <composite n="21" ref="H" />
+      </material>
+      <material name="Carbon">
+        <RL type="X0" unit="cm" value="21.3485" />
+        <NIL type="lambda" unit="cm" value="40.1008" />
+        <D type="density" unit="g/cm3" value="2" />
+        <composite n="1" ref="C" />
+      </material>
+      <material name="G4_Al" Z="13">
+        <D unit="g/cm3" value="2.6989999999999998" />
+        <atom unit="g/mole" value="26.981538" />
+      </material>
+      <material name="AlHoneycomb" Z="13">
+        <D unit="g/cm3" value="0.13" />
+        <atom unit="g/mole" value="26.981538" />
+      </material>
+      <element name="MANGANESE_elm" formula="MN" Z="25">
+        <atom unit="g/mole" value="54.938048999999999" />
+      </element>
+      <element name="SILICON_elm" formula="SI" Z="14">
+        <atom unit="g/mole" value="28.0855" />
+      </element>
+      <element name="CHROMIUM_elm" formula="CR" Z="24">
+        <atom unit="g/mole" value="51.996099999999998" />
+      </element>
+      <element name="NICKEL_elm" formula="NI" Z="28">
+        <atom unit="g/mole" value="58.693399999999997" />
+      </element>
+      <element name="IRON_elm" formula="FE" Z="26">
+        <atom unit="g/mole" value="55.844999999999999" />
+      </element>
+      <material name="StainlessSteel">
+        <D unit="g/cm3" value="8.0199999999999996" />
+        <fraction n="0.18999999761581421" ref="CHROMIUM_elm" />
+        <fraction n="0.68000000715255737" ref="IRON_elm" />
+        <fraction n="0.019999999552965164" ref="MANGANESE_elm" />
+        <fraction n="0.10000000149011612" ref="NICKEL_elm" />
+        <fraction n="0.0099999997764825821" ref="SILICON_elm" />
+      </material>
+      <material name="G4_Cu" Z="29">
+        <D unit="g/cm3" value="8.9600000000000009" />
+        <atom unit="g/mole" value="63.545645059999998" />
+      </material>
+      <element name="OXYGEN_elm" formula="O" Z="8">
+        <atom unit="g/mole" value="15.9994" />
+      </element>
+      <element name="CARBON_elm" formula="C" Z="6">
+        <atom unit="g/mole" value="12.0107" />
+      </element>
+      <element name="HYDROGEN_elm" formula="H" Z="1">
+        <atom unit="g/mole" value="1.0079400000000001" />
+      </element>
+      <material name="G10_FR4">
+        <D unit="g/cm3" value="1.8500000000000001" />
+        <fraction n="0.40416482090950012" ref="CARBON_elm" />
+        <fraction n="0.067835167050361633" ref="HYDROGEN_elm" />
+        <fraction n="0.28119435906410217" ref="OXYGEN_elm" />
+        <fraction n="0.24680563807487488" ref="SILICON_elm" />
+      </material>
+      <material name="SiO2">
+        <D unit="g/cm3" value="2.2000000000000002" />
+        <fraction n="0.53256505727767944" ref="OXYGEN_elm" />
+        <fraction n="0.46743491291999817" ref="SILICON_elm" />
+      </material>
+      <element Z="26" formula="Fe" name="Iron">
+        <atom value="55.845" />
+      </element>
+      <element Z="24" formula="Cr" name="Chromium">
+        <atom value="51.9961" />
+      </element>
+      <element Z="28" formula="Ni" name="Nickel">
+        <atom value="58.6934" />
+      </element>
+      <material formula=" " name="Stainless_304">
+        <D value="8.00" />
+        <fraction n="0.733078" ref="Iron" />
+        <fraction n="0.191516" ref="Chromium" />
+        <fraction n="0.075406" ref="Nickel" />
+      </material>
+      <material Z="1" name="G4_Galactic" state="gas">
+        <T unit="K" value="2.73" />
+        <P unit="pascal" value="3e-18" />
+        <!-- <MEE unit="eV" value="21.8"/> -->
+        <D unit="g/cm3" value="2e-25" />
+        <atom unit="g/mole" value="1.01" />
+      </material>
+    </materials>
+    <solids>
+      <box name="world_box" x="world_x" y="world_y" z="world_z" />
+      <tube name="tracking_cylinder" deltaphi="6.283185307179586" rmin="0.0" rmax="tracking_region_radius" z="2*tracking_region_zmax" />
+      <box name="baseBox" x="406.4" y="1282.6999999999998" z="171.196" />
+      <box name="base_plateBox" x="406.4" y="1282.6999999999998" z="6.35" />
+      <box name="support_plate_bottom_L14Box" x="234.95" y="456.4" z="9.524999999999999" />
+      <box name="support_plate_top_L14Box" x="234.95" y="456.4" z="9.524999999999999" />
+      <box name="support_plate_bottom_L46Box" x="342.9" y="533.4" z="12.7" />
+      <box name="support_plate_top_L46Box" x="342.9" y="533.4" z="12.7" />
+      <box name="module_L1b_halfmodule_axialBox" x="14.525" y="30.0" z="0.2" />
+      <box name="module_L1b_halfmodule_axial_sensorBox" x="14.525" y="30.0" z="0.2" />
+      <box name="module_L1b_halfmodule_axial_sensor_activeBox" x="14.025" y="30.0" z="0.2" />
+      <box name="module_L1b_halfmodule_stereoBox" x="14.525" y="30.0" z="0.2" />
+      <box name="module_L1b_halfmodule_stereo_sensorBox" x="14.525" y="30.0" z="0.2" />
+      <box name="module_L1b_halfmodule_stereo_sensor_activeBox" x="14.025" y="30.0" z="0.2" />
+      <box name="module_L1t_halfmodule_axialBox" x="14.525" y="30.0" z="0.2" />
+      <box name="module_L1t_halfmodule_axial_sensorBox" x="14.525" y="30.0" z="0.2" />
+      <box name="module_L1t_halfmodule_axial_sensor_activeBox" x="14.025" y="30.0" z="0.2" />
+      <box name="module_L1t_halfmodule_stereoBox" x="14.525" y="30.0" z="0.2" />
+      <box name="module_L1t_halfmodule_stereo_sensorBox" x="14.525" y="30.0" z="0.2" />
+      <box name="module_L1t_halfmodule_stereo_sensor_activeBox" x="14.025" y="30.0" z="0.2" />
+      <box name="module_L2b_halfmodule_axialBox" x="14.525" y="30.0" z="0.2" />
+      <box name="module_L2b_halfmodule_axial_sensorBox" x="14.525" y="30.0" z="0.2" />
+      <box name="module_L2b_halfmodule_axial_sensor_activeBox" x="14.025" y="30.0" z="0.2" />
+      <box name="module_L2b_halfmodule_stereoBox" x="14.525" y="30.0" z="0.2" />
+      <box name="module_L2b_halfmodule_stereo_sensorBox" x="14.525" y="30.0" z="0.2" />
+      <box name="module_L2b_halfmodule_stereo_sensor_activeBox" x="14.025" y="30.0" z="0.2" />
+      <box name="module_L2t_halfmodule_axialBox" x="14.525" y="30.0" z="0.2" />
+      <box name="module_L2t_halfmodule_axial_sensorBox" x="14.525" y="30.0" z="0.2" />
+      <box name="module_L2t_halfmodule_axial_sensor_activeBox" x="14.025" y="30.0" z="0.2" />
+      <box name="module_L2t_halfmodule_stereoBox" x="14.525" y="30.0" z="0.2" />
+      <box name="module_L2t_halfmodule_stereo_sensorBox" x="14.525" y="30.0" z="0.2" />
+      <box name="module_L2t_halfmodule_stereo_sensor_activeBox" x="14.025" y="30.0" z="0.2" />
+      <box name="module_L3b_halfmodule_axialBox" x="47.17" y="200.0" z="1.8405" />
+      <box name="module_L3b_halfmodule_axial_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L3b_halfmodule_axial_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L3b_halfmodule_axial_laminationBox" x="38.0" y="100.0" z="0.05" />
+      <box name="module_L3b_halfmodule_axial_cfBox" x="36.02" y="100.0" z="0.203" />
+      <box name="module_L3b_halfmodule_axial_hybridBox" x="40.34" y="70.0" z="1.5875" />
+      <box name="module_L3b_halfmodule_stereoBox" x="47.17" y="200.0" z="1.8405" />
+      <box name="module_L3b_halfmodule_stereo_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L3b_halfmodule_stereo_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L3b_halfmodule_stereo_laminationBox" x="38.0" y="100.0" z="0.05" />
+      <box name="module_L3b_halfmodule_stereo_cfBox" x="36.02" y="100.0" z="0.203" />
+      <box name="module_L3b_halfmodule_stereo_hybridBox" x="40.34" y="70.0" z="1.5875" />
+      <box name="module_L3t_halfmodule_axialBox" x="47.17" y="200.0" z="1.8405" />
+      <box name="module_L3t_halfmodule_axial_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L3t_halfmodule_axial_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L3t_halfmodule_axial_laminationBox" x="38.0" y="100.0" z="0.05" />
+      <box name="module_L3t_halfmodule_axial_cfBox" x="36.02" y="100.0" z="0.203" />
+      <box name="module_L3t_halfmodule_axial_hybridBox" x="40.34" y="70.0" z="1.5875" />
+      <box name="module_L3t_halfmodule_stereoBox" x="47.17" y="200.0" z="1.8405" />
+      <box name="module_L3t_halfmodule_stereo_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L3t_halfmodule_stereo_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L3t_halfmodule_stereo_laminationBox" x="38.0" y="100.0" z="0.05" />
+      <box name="module_L3t_halfmodule_stereo_cfBox" x="36.02" y="100.0" z="0.203" />
+      <box name="module_L3t_halfmodule_stereo_hybridBox" x="40.34" y="70.0" z="1.5875" />
+      <box name="module_L4b_halfmodule_axialBox" x="47.17" y="200.0" z="1.8405" />
+      <box name="module_L4b_halfmodule_axial_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L4b_halfmodule_axial_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L4b_halfmodule_axial_laminationBox" x="38.0" y="100.0" z="0.05" />
+      <box name="module_L4b_halfmodule_axial_cfBox" x="36.02" y="100.0" z="0.203" />
+      <box name="module_L4b_halfmodule_axial_hybridBox" x="40.34" y="70.0" z="1.5875" />
+      <box name="module_L4b_halfmodule_stereoBox" x="47.17" y="200.0" z="1.8405" />
+      <box name="module_L4b_halfmodule_stereo_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L4b_halfmodule_stereo_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L4b_halfmodule_stereo_laminationBox" x="38.0" y="100.0" z="0.05" />
+      <box name="module_L4b_halfmodule_stereo_cfBox" x="36.02" y="100.0" z="0.203" />
+      <box name="module_L4b_halfmodule_stereo_hybridBox" x="40.34" y="70.0" z="1.5875" />
+      <box name="module_L4t_halfmodule_axialBox" x="47.17" y="200.0" z="1.8405" />
+      <box name="module_L4t_halfmodule_axial_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L4t_halfmodule_axial_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L4t_halfmodule_axial_laminationBox" x="38.0" y="100.0" z="0.05" />
+      <box name="module_L4t_halfmodule_axial_cfBox" x="36.02" y="100.0" z="0.203" />
+      <box name="module_L4t_halfmodule_axial_hybridBox" x="40.34" y="70.0" z="1.5875" />
+      <box name="module_L4t_halfmodule_stereoBox" x="47.17" y="200.0" z="1.8405" />
+      <box name="module_L4t_halfmodule_stereo_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L4t_halfmodule_stereo_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L4t_halfmodule_stereo_laminationBox" x="38.0" y="100.0" z="0.05" />
+      <box name="module_L4t_halfmodule_stereo_cfBox" x="36.02" y="100.0" z="0.203" />
+      <box name="module_L4t_halfmodule_stereo_hybridBox" x="40.34" y="70.0" z="1.5875" />
+      <box name="module_L5b_halfmodule_axial_holeBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L5b_halfmodule_axial_hole_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L5b_halfmodule_axial_hole_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L5b_halfmodule_axial_hole_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L5b_halfmodule_axial_slotBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L5b_halfmodule_axial_slot_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L5b_halfmodule_axial_slot_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L5b_halfmodule_axial_slot_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L5b_halfmodule_stereo_holeBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L5b_halfmodule_stereo_hole_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L5b_halfmodule_stereo_hole_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L5b_halfmodule_stereo_hole_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L5b_halfmodule_stereo_slotBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L5b_halfmodule_stereo_slot_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L5b_halfmodule_stereo_slot_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L5b_halfmodule_stereo_slot_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L5t_halfmodule_axial_holeBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L5t_halfmodule_axial_hole_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L5t_halfmodule_axial_hole_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L5t_halfmodule_axial_hole_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L5t_halfmodule_axial_slotBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L5t_halfmodule_axial_slot_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L5t_halfmodule_axial_slot_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L5t_halfmodule_axial_slot_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L5t_halfmodule_stereo_holeBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L5t_halfmodule_stereo_hole_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L5t_halfmodule_stereo_hole_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L5t_halfmodule_stereo_hole_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L5t_halfmodule_stereo_slotBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L5t_halfmodule_stereo_slot_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L5t_halfmodule_stereo_slot_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L5t_halfmodule_stereo_slot_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L6b_halfmodule_axial_holeBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L6b_halfmodule_axial_hole_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L6b_halfmodule_axial_hole_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L6b_halfmodule_axial_hole_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L6b_halfmodule_axial_slotBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L6b_halfmodule_axial_slot_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L6b_halfmodule_axial_slot_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L6b_halfmodule_axial_slot_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L6b_halfmodule_stereo_holeBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L6b_halfmodule_stereo_hole_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L6b_halfmodule_stereo_hole_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L6b_halfmodule_stereo_hole_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L6b_halfmodule_stereo_slotBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L6b_halfmodule_stereo_slot_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L6b_halfmodule_stereo_slot_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L6b_halfmodule_stereo_slot_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L6t_halfmodule_axial_holeBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L6t_halfmodule_axial_hole_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L6t_halfmodule_axial_hole_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L6t_halfmodule_axial_hole_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L6t_halfmodule_axial_slotBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L6t_halfmodule_axial_slot_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L6t_halfmodule_axial_slot_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L6t_halfmodule_axial_slot_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L6t_halfmodule_stereo_holeBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L6t_halfmodule_stereo_hole_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L6t_halfmodule_stereo_hole_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L6t_halfmodule_stereo_hole_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L6t_halfmodule_stereo_slotBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L6t_halfmodule_stereo_slot_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L6t_halfmodule_stereo_slot_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L6t_halfmodule_stereo_slot_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L7b_halfmodule_axial_holeBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L7b_halfmodule_axial_hole_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L7b_halfmodule_axial_hole_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L7b_halfmodule_axial_hole_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L7b_halfmodule_axial_slotBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L7b_halfmodule_axial_slot_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L7b_halfmodule_axial_slot_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L7b_halfmodule_axial_slot_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L7b_halfmodule_stereo_holeBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L7b_halfmodule_stereo_hole_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L7b_halfmodule_stereo_hole_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L7b_halfmodule_stereo_hole_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L7b_halfmodule_stereo_slotBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L7b_halfmodule_stereo_slot_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L7b_halfmodule_stereo_slot_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L7b_halfmodule_stereo_slot_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L7t_halfmodule_axial_holeBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L7t_halfmodule_axial_hole_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L7t_halfmodule_axial_hole_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L7t_halfmodule_axial_hole_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L7t_halfmodule_axial_slotBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L7t_halfmodule_axial_slot_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L7t_halfmodule_axial_slot_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L7t_halfmodule_axial_slot_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L7t_halfmodule_stereo_holeBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L7t_halfmodule_stereo_hole_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L7t_halfmodule_stereo_hole_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L7t_halfmodule_stereo_hole_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="module_L7t_halfmodule_stereo_slotBox" x="40.34" y="100.0" z="0.37" />
+      <box name="module_L7t_halfmodule_stereo_slot_sensorBox" x="40.34" y="100.0" z="0.32" />
+      <box name="module_L7t_halfmodule_stereo_slot_sensor_activeBox" x="38.3399" y="98.33" z="0.32" />
+      <box name="module_L7t_halfmodule_stereo_slot_laminationBox" x="40.34" y="100.0" z="0.05" />
+      <box name="BeamLeftBox" x="211.6" y="382.492" z="0.001" />
+      <box name="BeamLeftVolume_component0Box" x="211.6" y="382.492" z="0.001" />
+      <box name="BeamLeftVolume_component0Sensor0Box" x="211.6" y="382.492" z="0.001" />
+      <box name="ElectronGapBox" x="196.26999999999998" y="92.46999999999997" z="0.001" />
+      <box name="ElectronGapVolume_component0Box" x="196.26999999999998" y="92.46999999999997" z="0.001" />
+      <box name="ElectronGapVolume_component0Sensor0Box" x="196.26999999999998" y="92.46999999999997" z="0.001" />
+      <box name="BeamRightBox" x="214.6" y="293.38800000000003" z="0.001" />
+      <box name="BeamRightVolume_component0Box" x="214.6" y="293.38800000000003" z="0.001" />
+      <box name="BeamRightVolume_component0Sensor0Box" x="214.6" y="293.38800000000003" z="0.001" />
+      <trd name="crystal_trap" x1="13.3" x2="16.0" y1="13.3" y2="16.0" z="160.0" />
+      <box name="hodo_pixel_L1TP0" x="15.7" y="59.9" z="9.5" />
+      <box name="hodo_cover_L1TP0" x="15.7" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L1TP0" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L1TP0" x="15.799999999999999" y="0.05" z="10.0" />
+      <box name="hodo_pixel_L1BP0" x="15.7" y="59.9" z="9.5" />
+      <box name="hodo_cover_L1BP0" x="15.7" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L1BP0" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L1BP0" x="15.799999999999999" y="0.05" z="10.0" />
+      <box name="hodo_pixel_L1TP1" x="34.1" y="59.9" z="9.5" />
+      <box name="hodo_cover_L1TP1" x="34.1" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L1TP1" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L1TP1" x="34.2" y="0.05" z="10.0" />
+      <box name="hodo_pixel_L1BP1" x="34.1" y="59.9" z="9.5" />
+      <box name="hodo_cover_L1BP1" x="34.1" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L1BP1" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L1BP1" x="34.2" y="0.05" z="10.0" />
+      <box name="hodo_pixel_L1TP2" x="44.0" y="59.9" z="9.5" />
+      <box name="hodo_cover_L1TP2" x="44.0" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L1TP2" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L1TP2" x="44.1" y="0.05" z="10.0" />
+      <box name="hodo_pixel_L1BP2" x="44.0" y="59.9" z="9.5" />
+      <box name="hodo_cover_L1BP2" x="44.0" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L1BP2" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L1BP2" x="44.1" y="0.05" z="10.0" />
+      <box name="hodo_pixel_L1TP3" x="44.0" y="59.9" z="9.5" />
+      <box name="hodo_cover_L1TP3" x="44.0" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L1TP3" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L1TP3" x="44.1" y="0.05" z="10.0" />
+      <box name="hodo_pixel_L1BP3" x="44.0" y="59.9" z="9.5" />
+      <box name="hodo_cover_L1BP3" x="44.0" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L1BP3" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L1BP3" x="44.1" y="0.05" z="10.0" />
+      <box name="hodo_pixel_L1TP4" x="44.0" y="59.9" z="9.5" />
+      <box name="hodo_cover_L1TP4" x="44.0" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L1TP4" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L1TP4" x="44.1" y="0.05" z="10.0" />
+      <box name="hodo_pixel_L1BP4" x="44.0" y="59.9" z="9.5" />
+      <box name="hodo_cover_L1BP4" x="44.0" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L1BP4" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L1BP4" x="44.1" y="0.05" z="10.0" />
+      <box name="hodo_pixel_L2TP0" x="19.0" y="59.9" z="9.5" />
+      <box name="hodo_cover_L2TP0" x="19.0" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L2TP0" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L2TP0" x="19.1" y="0.05" z="10.0" />
+      <box name="hodo_pixel_L2BP0" x="19.0" y="59.9" z="9.5" />
+      <box name="hodo_cover_L2BP0" x="19.0" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L2BP0" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L2BP0" x="19.1" y="0.05" z="10.0" />
+      <box name="hodo_pixel_L2TP1" x="44.0" y="59.9" z="9.5" />
+      <box name="hodo_cover_L2TP1" x="44.0" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L2TP1" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L2TP1" x="44.1" y="0.05" z="10.0" />
+      <box name="hodo_pixel_L2BP1" x="44.0" y="59.9" z="9.5" />
+      <box name="hodo_cover_L2BP1" x="44.0" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L2BP1" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L2BP1" x="44.1" y="0.05" z="10.0" />
+      <box name="hodo_pixel_L2TP2" x="44.0" y="59.9" z="9.5" />
+      <box name="hodo_cover_L2TP2" x="44.0" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L2TP2" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L2TP2" x="44.1" y="0.05" z="10.0" />
+      <box name="hodo_pixel_L2BP2" x="44.0" y="59.9" z="9.5" />
+      <box name="hodo_cover_L2BP2" x="44.0" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L2BP2" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L2BP2" x="44.1" y="0.05" z="10.0" />
+      <box name="hodo_pixel_L2TP3" x="44.0" y="59.9" z="9.5" />
+      <box name="hodo_cover_L2TP3" x="44.0" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L2TP3" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L2TP3" x="44.1" y="0.05" z="10.0" />
+      <box name="hodo_pixel_L2BP3" x="44.0" y="59.9" z="9.5" />
+      <box name="hodo_cover_L2BP3" x="44.0" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L2BP3" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L2BP3" x="44.1" y="0.05" z="10.0" />
+      <box name="hodo_pixel_L2TP4" x="30.8" y="59.9" z="9.5" />
+      <box name="hodo_cover_L2TP4" x="30.8" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L2TP4" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L2TP4" x="30.900000000000002" y="0.05" z="10.0" />
+      <box name="hodo_pixel_L2BP4" x="30.8" y="59.9" z="9.5" />
+      <box name="hodo_cover_L2BP4" x="30.8" y="59.9" z="0.25" />
+      <box name="hodo_siderefl_L2BP4" x="0.05" y="59.9" z="10.0" />
+      <box name="hodo_toprefl_L2BP4" x="30.900000000000002" y="0.05" z="10.0" />
+      <box name="hodo_buffer" x="187.64" y="80.0" z="2.0" />
+      <box name="world_volume_solid" x="2000" y="2000" z="2000" lunit="cm" />
+      <box name="front_flange_box_shape" x="76.835000000000008" y="45.719999999999999" z="2" lunit="cm" />
+      <trap name="front_chamber_trap_shape" z="3" theta="-0.98799999999999999" phi="0" x1="33.119799999999998" x2="33.119799999999998" x3="33.406400000000005" x4="33.406400000000005" y1="1.6000000000000001" y2="1.6000000000000001" alpha1="0" alpha2="0" aunit="deg" lunit="cm" />
+      <subtraction name="front_minus_chamber_shape">
+        <first ref="front_flange_box_shape" />
+        <second ref="front_chamber_trap_shape" />
+        <position name="front_minus_chamber_shapefront_chamber_trap_shapepos" x="-14.6309" y="0" z="0" unit="cm" />
+      </subtraction>
+      <eltube name="flange_photontube_inside_shape" dx="1.1000000000000001" dy="1.1000000000000001" dz="3" lunit="cm" />
+      <subtraction name="front_minus_photontube_shape">
+        <first ref="front_minus_chamber_shape" />
+        <second ref="flange_photontube_inside_shape" />
+        <position name="front_minus_photontube_shapeflange_photontube_inside_shapepos" x="2.0007000000000001" y="0" z="0" unit="cm" />
+        <rotation name="front_minus_photontube_shapeflange_photontube_inside_shaperot" x="0" y="1.7480000000000002" z="0" unit="deg" />
+      </subtraction>
+      <trap name="front_egap_trap_shape" z="3" theta="-4.7960000000000003" phi="0" x1="2.5683000000000002" x2="2.5683000000000002" x3="2.9716000000000005" x4="2.9716000000000005" y1="5.266" y2="5.266" alpha1="0" alpha2="0" aunit="deg" lunit="cm" />
+      <subtraction name="front_minus_egap_shape">
+        <first ref="front_minus_photontube_shape" />
+        <second ref="front_egap_trap_shape" />
+        <position name="front_minus_egap_shapefront_egap_trap_shapepos" x="-4.4683000000000002" y="0" z="0" unit="cm" />
+      </subtraction>
+      <eltube name="flange_egap_inside_tube_shape" dx="2.633" dy="2.633" dz="3" lunit="cm" />
+      <subtraction name="front_minus_egapleft_shape">
+        <first ref="front_minus_egap_shape" />
+        <second ref="flange_egap_inside_tube_shape" />
+        <position name="front_minus_egapleft_shapeflange_egap_inside_tube_shapepos" x="-3.0832999999999999" y="0" z="0" unit="cm" />
+        <rotation name="front_minus_egapleft_shapeflange_egap_inside_tube_shaperot" x="0" y="-0.95599999999999996" z="0" unit="deg" />
+      </subtraction>
+      <eltube name="flange_egap_inside_tube2_shape" dx="2.633" dy="2.633" dz="3" lunit="cm" />
+      <subtraction name="front_flange_shape">
+        <first ref="front_minus_egapleft_shape" />
+        <second ref="flange_egap_inside_tube2_shape" />
+        <position name="front_flange_shapeflange_egap_inside_tube2_shapepos" x="-5.8532000000000002" y="0" z="0" unit="cm" />
+        <rotation name="front_flange_shapeflange_egap_inside_tube2_shaperot" x="0" y="-8.5939999999999994" z="0" unit="deg" />
+      </subtraction>
+      <box name="back_flange_box_shape" x="50.5" y="16" z="2" lunit="cm" />
+      <trap name="back_chamber_trap_shape" z="3" theta="-0.98799999999999999" phi="0" x1="37.227899999999998" x2="37.227899999999998" x3="37.514499999999998" x4="37.514499999999998" y1="1.6000000000000001" y2="1.6000000000000001" alpha1="0" alpha2="0" aunit="deg" lunit="cm" />
+      <subtraction name="back_minus_chamber_shape">
+        <first ref="back_flange_box_shape" />
+        <second ref="back_chamber_trap_shape" />
+        <position name="back_minus_chamber_shapeback_chamber_trap_shapepos" x="-0.62210000000000043" y="0" z="0" unit="cm" />
+      </subtraction>
+      <eltube name="flange_photontube_inside2_shape" dx="1.1000000000000001" dy="1.1000000000000001" dz="3" lunit="cm" />
+      <subtraction name="back_minus_photontube_shape">
+        <first ref="back_minus_chamber_shape" />
+        <second ref="flange_photontube_inside2_shape" />
+        <position name="back_minus_photontube_shapeflange_photontube_inside2_shapepos" x="18.063500000000001" y="0" z="0" unit="cm" />
+        <rotation name="back_minus_photontube_shapeflange_photontube_inside2_shaperot" x="0" y="1.7480000000000002" z="0" unit="deg" />
+      </subtraction>
+      <trap name="back_egap_trap_shape" z="3" theta="-4.7960000000000003" phi="0" x1="8.3492999999999995" x2="8.3492999999999995" x3="8.7525999999999993" x4="8.7525999999999993" y1="5.266" y2="5.266" alpha1="0" alpha2="0" aunit="deg" lunit="cm" />
+      <subtraction name="back_minus_egap_shape">
+        <first ref="back_minus_photontube_shape" />
+        <second ref="back_egap_trap_shape" />
+        <position name="back_minus_egap_shapeback_egap_trap_shapepos" x="6.674199999999999" y="0" z="0" unit="cm" />
+      </subtraction>
+      <eltube name="flange_egap_inside_tube3_shape" dx="2.633" dy="2.633" dz="3" lunit="cm" />
+      <subtraction name="back_minus_egapleft_shape">
+        <first ref="back_minus_egap_shape" />
+        <second ref="flange_egap_inside_tube3_shape" />
+        <position name="back_minus_egapleft_shapeflange_egap_inside_tube3_shapepos" x="10.9497" y="0" z="0" unit="cm" />
+        <rotation name="back_minus_egapleft_shapeflange_egap_inside_tube3_shaperot" x="0" y="-0.95599999999999996" z="0" unit="deg" />
+      </subtraction>
+      <eltube name="flange_egap_inside_tube4_shape" dx="2.633" dy="2.633" dz="3" lunit="cm" />
+      <subtraction name="back_flange_shape">
+        <first ref="back_minus_egapleft_shape" />
+        <second ref="flange_egap_inside_tube4_shape" />
+        <position name="back_flange_shapeflange_egap_inside_tube4_shapepos" x="2.3986999999999994" y="0" z="0" unit="cm" />
+        <rotation name="back_flange_shapeflange_egap_inside_tube4_shaperot" x="0" y="-8.5939999999999994" z="0" unit="deg" />
+      </subtraction>
+      <trap name="chamber_trap_shape" z="45" theta="-1.8640000000000001" phi="0" x1="37.700000000000003" x2="37.700000000000003" x3="40.629000000000005" x4="40.629000000000005" y1="2.8000000000000003" y2="2.8000000000000003" alpha1="0" alpha2="0" aunit="deg" lunit="cm" />
+      <box name="chamber_cutaway_box_shape" x="50" y="1" z="30" lunit="cm" />
+      <subtraction name="chamber_trim1_shape">
+        <first ref="chamber_trap_shape" />
+        <second ref="chamber_cutaway_box_shape" />
+        <position name="chamber_trim1_shapechamber_cutaway_box_shapepos" x="0" y="1.6000000000000001" z="-9" unit="cm" />
+      </subtraction>
+      <box name="chamber_cutaway_box2_shape" x="50" y="1" z="30" lunit="cm" />
+      <subtraction name="chamber_trim2_shape">
+        <first ref="chamber_trim1_shape" />
+        <second ref="chamber_cutaway_box2_shape" />
+        <position name="chamber_trim2_shapechamber_cutaway_box2_shapepos" x="0" y="-1.6000000000000001" z="-9" unit="cm" />
+      </subtraction>
+      <eltube name="photontube_outside_shape" dx="1.3" dy="1.3" dz="23.5" lunit="cm" />
+      <union name="chamber_with_photontube_shape">
+        <first ref="chamber_trim2_shape" />
+        <second ref="photontube_outside_shape" />
+        <position name="chamber_with_photontube_shapephotontube_outside_shapepos" x="16.739699999999999" y="0" z="0" unit="cm" />
+        <rotation name="chamber_with_photontube_shapephotontube_outside_shaperot" x="0" y="1.7480000000000002" z="0" unit="deg" />
+      </union>
+      <trap name="egap_outside_trap_upper_shape" z="45" theta="-4.7960000000000003" phi="0" x1="10.691200000000002" x2="5.2344000000000008" x3="16.741099999999999" x4="11.284300000000002" y1="3.2330000000000001" y2="3.2330000000000001" alpha1="0.26900000000000002" alpha2="0.26900000000000002" aunit="deg" lunit="cm" />
+      <union name="chamber_with_egap_upper_shape">
+        <first ref="chamber_with_photontube_shape" />
+        <second ref="egap_outside_trap_upper_shape" />
+        <position name="chamber_with_egap_upper_shapeegap_outside_trap_upper_shapepos" x="7.7018000000000004" y="1.6165" z="0" unit="cm" />
+      </union>
+      <trap name="egap_outside_trap_lower_shape" z="45" theta="-4.7960000000000003" phi="0" x1="5.2344000000000008" x2="10.691200000000002" x3="11.284300000000002" x4="16.741099999999999" y1="3.2330000000000001" y2="3.2330000000000001" alpha1="-0.26900000000000002" alpha2="-0.26900000000000002" aunit="deg" lunit="cm" />
+      <union name="chamber_with_egap_lower_shape">
+        <first ref="chamber_with_egap_upper_shape" />
+        <second ref="egap_outside_trap_lower_shape" />
+        <position name="chamber_with_egap_lower_shapeegap_outside_trap_lower_shapepos" x="7.7018000000000004" y="-1.6165" z="0" unit="cm" />
+      </union>
+      <box name="chamber_cutaway_box3_shape" x="50" y="1" z="30" lunit="cm" />
+      <subtraction name="chamber_with_egap_trimtop_shape">
+        <first ref="chamber_with_egap_lower_shape" />
+        <second ref="chamber_cutaway_box3_shape" />
+        <position name="chamber_with_egap_trimtop_shapechamber_cutaway_box3_shapepos" x="0" y="3.4329999999999998" z="-9" unit="cm" />
+      </subtraction>
+      <box name="chamber_cutaway_box4_shape" x="50" y="1" z="30" lunit="cm" />
+      <subtraction name="chamber_with_egap_trimbot_shape">
+        <first ref="chamber_with_egap_trimtop_shape" />
+        <second ref="chamber_cutaway_box4_shape" />
+        <position name="chamber_with_egap_trimbot_shapechamber_cutaway_box4_shapepos" x="0" y="-3.4329999999999998" z="-9" unit="cm" />
+      </subtraction>
+      <box name="back_end_box_shape" x="76.835000000000008" y="45.719999999999999" z="5" lunit="cm" />
+      <subtraction name="chamber_outside_trim1_shape">
+        <first ref="chamber_with_egap_trimbot_shape" />
+        <second ref="back_end_box_shape" />
+        <position name="chamber_outside_trim1_shapeback_end_box_shapepos" x="0" y="0" z="-23" unit="cm" />
+      </subtraction>
+      <box name="back_end_box2_shape" x="76.835000000000008" y="45.719999999999999" z="5" lunit="cm" />
+      <subtraction name="chamber_outside_trim2_shape">
+        <first ref="chamber_outside_trim1_shape" />
+        <second ref="back_end_box2_shape" />
+        <position name="chamber_outside_trim2_shapeback_end_box2_shapepos" x="0" y="0" z="23" unit="cm" />
+      </subtraction>
+      <eltube name="photontube_inside_shape" dx="1.1000000000000001" dy="1.1000000000000001" dz="23.5" lunit="cm" />
+      <subtraction name="chamber_minus_photontube_shape">
+        <first ref="chamber_outside_trim2_shape" />
+        <second ref="photontube_inside_shape" />
+        <position name="chamber_minus_photontube_shapephotontube_inside_shapepos" x="16.739699999999999" y="0" z="0" unit="cm" />
+        <rotation name="chamber_minus_photontube_shapephotontube_inside_shaperot" x="0" y="1.7480000000000002" z="0" unit="deg" />
+      </subtraction>
+      <trap name="chamber_inside_trap_shape" z="45.000100000000003" theta="-0.98799999999999999" phi="0" x1="33.1676" x2="33.1676" x3="37.466699999999996" x4="37.466699999999996" y1="1.6000000000000001" y2="1.6000000000000001" alpha1="0" alpha2="0" aunit="deg" lunit="cm" />
+      <subtraction name="chamber_minus_inside_shape">
+        <first ref="chamber_minus_photontube_shape" />
+        <second ref="chamber_inside_trap_shape" />
+        <position name="chamber_minus_inside_shapechamber_inside_trap_shapepos" x="-0.91889999999999938" y="0" z="0" unit="cm" />
+      </subtraction>
+      <trap name="egap_inside_trap_shape" z="45.000100000000003" theta="-4.7960000000000003" phi="0" x1="2.6355000000000004" x2="2.6355000000000004" x3="8.6853999999999996" x4="8.6853999999999996" y1="5.266" y2="5.266" alpha1="0" alpha2="0" aunit="deg" lunit="cm" />
+      <subtraction name="chamber_minus_egapinside_shape">
+        <first ref="chamber_minus_inside_shape" />
+        <second ref="egap_inside_trap_shape" />
+        <position name="chamber_minus_egapinside_shapeegap_inside_trap_shapepos" x="7.8105000000000011" y="0" z="0" unit="cm" />
+      </subtraction>
+      <eltube name="egap_inside_tube_shape" dx="2.633" dy="2.633" dz="24" lunit="cm" />
+      <subtraction name="chamber_minus_egap_left_shape">
+        <first ref="chamber_minus_egapinside_shape" />
+        <second ref="egap_inside_tube_shape" />
+        <position name="chamber_minus_egap_left_shapeegap_inside_tube_shapepos" x="10.640750000000001" y="0" z="0" unit="cm" />
+        <rotation name="chamber_minus_egap_left_shapeegap_inside_tube_shaperot" x="0" y="-0.95599999999999996" z="0" unit="deg" />
+      </subtraction>
+      <tube name="egap_inside_tube2_shape" rmin="0" rmax="2.633" z="48" startphi="0" deltaphi="360" aunit="deg" lunit="cm" />
+      <subtraction name="ECAL_chamber_shape">
+        <first ref="chamber_minus_egap_left_shape" />
+        <second ref="egap_inside_tube2_shape" />
+        <position name="ECAL_chamber_shapeegap_inside_tube2_shapepos" x="4.9802999999999997" y="0" z="0" unit="cm" />
+        <rotation name="ECAL_chamber_shapeegap_inside_tube2_shaperot" x="0" y="-8.5939999999999994" z="0" unit="deg" />
+      </subtraction>
+      <box name="al_honeycomb_shape" x="6" y="1.6000000000000001" z="6" lunit="cm" />
+      <box name="ecal_box_outer1_shape" x="80" y="1.3999999999999999" z="20.100000000000001" lunit="cm" />
+      <box name="ecal_box_inner1_shape" x="78" y="2" z="21" lunit="cm" />
+      <subtraction name="ecal_box_minus_inner1_shape">
+        <first ref="ecal_box_outer1_shape" />
+        <second ref="ecal_box_inner1_shape" />
+        <position name="ecal_box_minus_inner1_shapeecal_box_inner1_shapepos" x="0" y="0.16" z="1.8500000000000001" unit="cm" />
+      </subtraction>
+      <box name="ecal_box_inner2_shape" x="68" y="1.2" z="7.4199999999999999" lunit="cm" />
+      <subtraction name="ecal_box_minus_inner2_shape">
+        <first ref="ecal_box_minus_inner1_shape" />
+        <second ref="ecal_box_inner2_shape" />
+        <position name="ecal_box_minus_inner2_shapeecal_box_inner2_shapepos" x="0" y="0.16" z="-10.050000000000001" unit="cm" />
+      </subtraction>
+      <para name="ppd_0_shape" x="0.59999999999999998" y="1.3999999999999999" z="1.5" alpha="0" theta="0" phi="0" aunit="deg" lunit="cm" />
+      <union name="box_with_ppd_shape">
+        <first ref="ecal_box_minus_inner2_shape" />
+        <second ref="ppd_0_shape" />
+        <position name="box_with_ppd_shapeppd_0_shapepos" x="0" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <para name="ppd_1_shape" x="0.59999999999999998" y="1.3999999999999999" z="1.5" alpha="0" theta="-3.8700000000000001" phi="0" aunit="deg" lunit="cm" />
+      <union name="box_with_ppd1_shape">
+        <first ref="box_with_ppd_shape" />
+        <second ref="ppd_1_shape" />
+        <position name="box_with_ppd1_shapeppd_1_shapepos" x="-5.2400000000000002" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <para name="ppd_2_shape" x="0.59999999999999998" y="1.3999999999999999" z="1.5" alpha="0" theta="-7.7400000000000002" phi="0" aunit="deg" lunit="cm" />
+      <union name="box_with_ppd2_shape">
+        <first ref="box_with_ppd1_shape" />
+        <second ref="ppd_2_shape" />
+        <position name="box_with_ppd2_shapeppd_2_shapepos" x="-10.5" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <para name="ppd_3_shape" x="0.59999999999999998" y="1.3999999999999999" z="1.5" alpha="0" theta="-11.619999999999999" phi="0" aunit="deg" lunit="cm" />
+      <union name="box_with_ppd3_shape">
+        <first ref="box_with_ppd2_shape" />
+        <second ref="ppd_3_shape" />
+        <position name="box_with_ppd3_shapeppd_3_shapepos" x="-15.800000000000001" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <para name="ppd_4_shape" x="0.59999999999999998" y="1.3999999999999999" z="1.5" alpha="0" theta="-15.49" phi="0" aunit="deg" lunit="cm" />
+      <union name="box_with_ppd4_shape">
+        <first ref="box_with_ppd3_shape" />
+        <second ref="ppd_4_shape" />
+        <position name="box_with_ppd4_shapeppd_4_shapepos" x="-21.170000000000002" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <para name="ppd_5_shape" x="0.59999999999999998" y="1.3999999999999999" z="1.5" alpha="0" theta="-19.359999999999999" phi="0" aunit="deg" lunit="cm" />
+      <union name="box_with_ppd5_shape">
+        <first ref="box_with_ppd4_shape" />
+        <second ref="ppd_5_shape" />
+        <position name="box_with_ppd5_shapeppd_5_shapepos" x="-26.640000000000001" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <para name="ppd_6_shape" x="0.59999999999999998" y="1.3999999999999999" z="1.5" alpha="0" theta="3.8700000000000001" phi="0" aunit="deg" lunit="cm" />
+      <union name="box_with_ppd6_shape">
+        <first ref="box_with_ppd5_shape" />
+        <second ref="ppd_6_shape" />
+        <position name="box_with_ppd6_shapeppd_6_shapepos" x="5.2400000000000002" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <para name="ppd_7_shape" x="0.59999999999999998" y="1.3999999999999999" z="1.5" alpha="0" theta="7.7400000000000002" phi="0" aunit="deg" lunit="cm" />
+      <union name="box_with_ppd7_shape">
+        <first ref="box_with_ppd6_shape" />
+        <second ref="ppd_7_shape" />
+        <position name="box_with_ppd7_shapeppd_7_shapepos" x="10.5" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <para name="ppd_8_shape" x="0.59999999999999998" y="1.3999999999999999" z="1.5" alpha="0" theta="11.619999999999999" phi="0" aunit="deg" lunit="cm" />
+      <union name="box_with_ppd8_shape">
+        <first ref="box_with_ppd7_shape" />
+        <second ref="ppd_8_shape" />
+        <position name="box_with_ppd8_shapeppd_8_shapepos" x="15.800000000000001" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <para name="ppd_9_shape" x="0.59999999999999998" y="1.3999999999999999" z="1.5" alpha="0" theta="15.49" phi="0" aunit="deg" lunit="cm" />
+      <union name="box_with_ppd9_shape">
+        <first ref="box_with_ppd8_shape" />
+        <second ref="ppd_9_shape" />
+        <position name="box_with_ppd9_shapeppd_9_shapepos" x="21.170000000000002" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <para name="ppd_10_shape" x="0.59999999999999998" y="1.3999999999999999" z="1.5" alpha="0" theta="19.359999999999999" phi="0" aunit="deg" lunit="cm" />
+      <union name="layer_1_top_shape">
+        <first ref="box_with_ppd9_shape" />
+        <second ref="ppd_10_shape" />
+        <position name="layer_1_top_shapeppd_10_shapepos" x="26.640000000000001" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <union name="layer_2_top_shape">
+        <first ref="box_with_ppd9_shape" />
+        <second ref="ppd_10_shape" />
+        <position name="layer_2_top_shapeppd_10_shapepos" x="26.640000000000001" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <union name="layer_3_top_shape">
+        <first ref="box_with_ppd9_shape" />
+        <second ref="ppd_10_shape" />
+        <position name="layer_3_top_shapeppd_10_shapepos" x="26.640000000000001" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <union name="layer_4_top_shape">
+        <first ref="box_with_ppd9_shape" />
+        <second ref="ppd_10_shape" />
+        <position name="layer_4_top_shapeppd_10_shapepos" x="26.640000000000001" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <union name="layer_1_bottom_shape">
+        <first ref="box_with_ppd9_shape" />
+        <second ref="ppd_10_shape" />
+        <position name="layer_1_bottom_shapeppd_10_shapepos" x="26.640000000000001" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <union name="layer_2_bottom_shape">
+        <first ref="box_with_ppd9_shape" />
+        <second ref="ppd_10_shape" />
+        <position name="layer_2_bottom_shapeppd_10_shapepos" x="26.640000000000001" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <union name="layer_3_bottom_shape">
+        <first ref="box_with_ppd9_shape" />
+        <second ref="ppd_10_shape" />
+        <position name="layer_3_bottom_shapeppd_10_shapepos" x="26.640000000000001" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <union name="layer_4_bottom_shape">
+        <first ref="box_with_ppd9_shape" />
+        <second ref="ppd_10_shape" />
+        <position name="layer_4_bottom_shapeppd_10_shapepos" x="26.640000000000001" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <para name="ppd_left2_shape" x="0.40000000000000002" y="1.3999999999999999" z="20.100000000000001" alpha="0" theta="0.96999999999999997" phi="0" aunit="deg" lunit="cm" />
+      <union name="layer_5a1_1_shape">
+        <first ref="ecal_box_minus_inner2_shape" />
+        <second ref="ppd_left2_shape" />
+        <position name="layer_5a1_1_shapeppd_left2_shapepos" x="-1.903" y="0" z="0" unit="cm" />
+      </union>
+      <para name="ppd_left1_shape" x="0.502" y="1.3999999999999999" z="1.5" alpha="0" theta="0.96999999999999997" phi="0" aunit="deg" lunit="cm" />
+      <union name="layer_5a1_shape">
+        <first ref="layer_5a1_1_shape" />
+        <second ref="ppd_left1_shape" />
+        <position name="layer_5a1_shapeppd_left1_shapepos" x="-1.6499999999999999" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <trd name="electron_hole_left_shape" x1="38.177" x2="38.856999999999999" y1="4" y2="4" z="20.199999999999999" lunit="cm" />
+      <subtraction name="layer_5a2_shape">
+        <first ref="layer_5a1_shape" />
+        <second ref="electron_hole_left_shape" />
+        <position name="layer_5a2_shapeelectron_hole_left_shapepos" x="-21.361499999999999" y="0" z="0" unit="cm" />
+      </subtraction>
+      <union name="layer_5a3_shape">
+        <first ref="layer_5a2_shape" />
+        <second ref="ppd_6_shape" />
+        <position name="layer_5a3_shapeppd_6_shapepos" x="5.2400000000000002" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <union name="layer_5a4_shape">
+        <first ref="layer_5a3_shape" />
+        <second ref="ppd_7_shape" />
+        <position name="layer_5a4_shapeppd_7_shapepos" x="10.5" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <union name="layer_5a5_shape">
+        <first ref="layer_5a4_shape" />
+        <second ref="ppd_8_shape" />
+        <position name="layer_5a5_shapeppd_8_shapepos" x="15.800000000000001" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <union name="layer_5a6_shape">
+        <first ref="layer_5a5_shape" />
+        <second ref="ppd_9_shape" />
+        <position name="layer_5a6_shapeppd_9_shapepos" x="21.170000000000002" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <union name="layer_5a7_shape">
+        <first ref="layer_5a6_shape" />
+        <second ref="ppd_10_shape" />
+        <position name="layer_5a7_shapeppd_10_shapepos" x="26.640000000000001" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <union name="layer_5T_left_shape">
+        <first ref="layer_5a7_shape" />
+        <second ref="ppd_0_shape" />
+        <position name="layer_5T_left_shapeppd_0_shapepos" x="0" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <union name="layer_5B_left_shape">
+        <first ref="layer_5a7_shape" />
+        <second ref="ppd_0_shape" />
+        <position name="layer_5B_left_shapeppd_0_shapepos" x="0" y="0" z="-9.3000000000000007" unit="cm" />
+      </union>
+      <box name="steel_bar_shape" x="3" y="1.5" z="20" lunit="cm" />
+      <tube name="cu_Tpipe_inner_left_shape" rmin="0.29999999999999999" rmax="0.40000000000000002" z="20.100000000000001" startphi="0" deltaphi="360" aunit="deg" lunit="cm" />
+      <tube name="cu_Tpipe_inner_right_shape" rmin="0.29999999999999999" rmax="0.40000000000000002" z="20.100000000000001" startphi="0" deltaphi="360" aunit="deg" lunit="cm" />
+      <tube name="cu_Bpipe_inner_left_shape" rmin="0.29999999999999999" rmax="0.40000000000000002" z="20.100000000000001" startphi="0" deltaphi="360" aunit="deg" lunit="cm" />
+      <tube name="cu_Bpipe_inner_right_shape" rmin="0.29999999999999999" rmax="0.40000000000000002" z="20.100000000000001" startphi="0" deltaphi="360" aunit="deg" lunit="cm" />
+      <eltube name="cu_Tpipe_outer_right1_shape" dx="0.5" dy="0.10000000000000001" dz="10" lunit="cm" />
+      <eltube name="cu_Tpipe_outer_right2_shape" dx="0.5" dy="0.10000000000000001" dz="10" lunit="cm" />
+      <tube name="cu_Tpipe_outer_right3_shape" rmin="0.29999999999999999" rmax="0.40000000000000002" z="8" startphi="0" deltaphi="360" aunit="deg" lunit="cm" />
+      <tube name="cu_Bpipe_outer_right_shape" rmin="0.29999999999999999" rmax="0.40000000000000002" z="8" startphi="0" deltaphi="360" aunit="deg" lunit="cm" />
+      <eltube name="cu_Bpipe_outer_right1_shape" dx="0.5" dy="0.10000000000000001" dz="10" lunit="cm" />
+      <eltube name="cu_Bpipe_outer_right2_shape" dx="0.5" dy="0.10000000000000001" dz="10" lunit="cm" />
+      <tube name="al_pipe_across_top1_shape" rmin="0.29999999999999999" rmax="0.40000000000000002" z="66" startphi="0" deltaphi="360" aunit="deg" lunit="cm" />
+      <tube name="al_pipe_across_top2_shape" rmin="0.29999999999999999" rmax="0.40000000000000002" z="74" startphi="0" deltaphi="360" aunit="deg" lunit="cm" />
+      <tube name="al_pipe_across_bottom1_shape" rmin="0.29999999999999999" rmax="0.40000000000000002" z="70" startphi="0" deltaphi="360" aunit="deg" lunit="cm" />
+      <tube name="al_pipe_across_bottom2_shape" rmin="0.29999999999999999" rmax="0.40000000000000002" z="78" startphi="0" deltaphi="360" aunit="deg" lunit="cm" />
+      <para name="cu_plate_top_left_shape" x="40" y="0.10000000000000001" z="20" alpha="0" theta="0.96999999999999997" phi="0" aunit="deg" lunit="cm" />
+      <para name="cu_plate_bottom_left_shape" x="40" y="0.10000000000000001" z="20" alpha="0" theta="0.96999999999999997" phi="0" aunit="deg" lunit="cm" />
+      <para name="cu_plate_top_right_shape" x="22" y="0.10000000000000001" z="20" alpha="0" theta="9.6799999999999997" phi="180" aunit="deg" lunit="cm" />
+      <para name="cu_plate_bottom_right_shape" x="22" y="0.10000000000000001" z="20" alpha="0" theta="-9.6799999999999997" phi="0" aunit="deg" lunit="cm" />
+      <trd name="cu_plate_top_middle_shape" x1="7" x2="9.8000000000000007" y1="0.10000000000000001" y2="0.10000000000000001" z="20" lunit="cm" />
+      <trd name="cu_plate_bottom_middle_shape" x1="7" x2="9.8000000000000007" y1="0.10000000000000001" y2="0.10000000000000001" z="20" lunit="cm" />
+      <box name="tracking_volume_solid" x="2000" y="2000" z="2000" lunit="cm" />
+      <box name="hodo_flange_outer_shape" x="76.835000000000008" y="45.719999999999999" z="5" lunit="cm" />
+      <box name="hodo_flange_inner_shape" x="65.035000000000011" y="33.480000000000004" z="5.0010000000000003" lunit="cm" />
+      <subtraction name="hodo_flange_only_shape">
+        <first ref="hodo_flange_outer_shape" />
+        <second ref="hodo_flange_inner_shape" />
+      </subtraction>
+      <box name="Flange_extrusion_1_shape" x="2.5" y="3.5" z="1.5" lunit="cm" />
+      <union name="hodo_flange_ex1_shape">
+        <first ref="hodo_flange_only_shape" />
+        <second ref="Flange_extrusion_1_shape" />
+        <position name="hodo_flange_ex1_shapeFlange_extrusion_1_shapepos" x="19.400000000000002" y="14.990000000000002" z="-0.10000000000000001" unit="cm" />
+      </union>
+      <box name="Flange_extrusion_2_shape" x="2.5" y="3.5" z="1.5" lunit="cm" />
+      <union name="hodo_flange_ex2_shape">
+        <first ref="hodo_flange_ex1_shape" />
+        <second ref="Flange_extrusion_2_shape" />
+        <position name="hodo_flange_ex2_shapeFlange_extrusion_2_shapepos" x="19.400000000000002" y="-14.990000000000002" z="-0.10000000000000001" unit="cm" />
+      </union>
+      <box name="Flange_extrusion_3_shape" x="2.5" y="3.5" z="1.5" lunit="cm" />
+      <union name="hodo_flange_ex3_shape">
+        <first ref="hodo_flange_ex2_shape" />
+        <second ref="Flange_extrusion_3_shape" />
+        <position name="hodo_flange_ex3_shapeFlange_extrusion_3_shapepos" x="7.4000000000000004" y="14.990000000000002" z="-0.10000000000000001" unit="cm" />
+      </union>
+      <box name="Flange_extrusion_4_shape" x="2.5" y="3.5" z="1.5" lunit="cm" />
+      <union name="hodo_flange_shape">
+        <first ref="hodo_flange_ex3_shape" />
+        <second ref="Flange_extrusion_4_shape" />
+        <position name="hodo_flange_shapeFlange_extrusion_4_shapepos" x="7.4000000000000004" y="-14.990000000000002" z="-0.10000000000000001" unit="cm" />
+      </union>
+      <trap name="arms1_block1_shape" z="1.5" theta="3.9490533936242498" phi="90" x1="2.5" x2="2.5" x3="2.5" x4="2.5" y1="3.7071000000000001" y2="3.5" alpha1="0" alpha2="0" aunit="deg" lunit="cm" />
+      <trap name="arms1_block2_shape" z="1.5" theta="3.9490533936242498" phi="90" x1="2.5" x2="2.5" x3="2.5" x4="2.5" y1="3.7071000000000001" y2="3.5" alpha1="0" alpha2="0" aunit="deg" lunit="cm" />
+      <trap name="arms1_block3_shape" z="1.5" theta="-3.9490533936242498" phi="90" x1="2.5" x2="2.5" x3="2.5" x4="2.5" y1="3.7071000000000001" y2="3.5" alpha1="0" alpha2="0" aunit="deg" lunit="cm" />
+      <trap name="arms1_block4_shape" z="1.5" theta="-3.9490533936242498" phi="90" x1="2.5" x2="2.5" x3="2.5" x4="2.5" y1="3.7071000000000001" y2="3.5" alpha1="0" alpha2="0" aunit="deg" lunit="cm" />
+      <box name="cross_bar_top_shape" x="9.5" y="0.80000000000000004" z="1.5" lunit="cm" />
+      <box name="cross_bar_bottom_shape" x="9.5" y="0.80000000000000004" z="1.5" lunit="cm" />
+      <trap name="support_arm_bottom_left_arm_shape" z="21.700000000000003" theta="-9.8039344658558196" phi="90" x1="0.60000000000000009" x2="0.60000000000000009" x3="0.60000000000000009" x4="0.60000000000000009" y1="2.2938300486668619" y2="3.2271000000000001" alpha1="0" alpha2="0" aunit="deg" lunit="cm" />
+      <box name="support_arm_bottom_left_notch_shape" x="2" y="1.7800000000000002" z="1.401" lunit="cm" />
+      <box name="end_block_bottom_left_block_shape" x="2" y="0.78000000000000003" z="1.4000000000000001" lunit="cm" />
+      <box name="end_block_bottom_left_subs_shape" x="2.0010000000000003" y="1" z="1.401" lunit="cm" />
+      <subtraction name="support_arm_bottom_left_with_notch_shape">
+        <first ref="support_arm_bottom_left_arm_shape" />
+        <second ref="support_arm_bottom_left_notch_shape" />
+        <position name="support_arm_bottom_left_with_notch_shapesupport_arm_bottom_left_notch_shapepos" x="0" y="2.9215622772585932" z="-10.151000000000002" unit="cm" />
+      </subtraction>
+      <subtraction name="end_block_bottom_left_shape">
+        <first ref="end_block_bottom_left_block_shape" />
+        <second ref="end_block_bottom_left_subs_shape" />
+        <position name="end_block_bottom_left_shapeend_block_bottom_left_subs_shapepos" x="0" y="0.60999999999999999" z="-0.30099999999999999" unit="cm" />
+      </subtraction>
+      <union name="support_arm_bottom_left_plus_block_shape">
+        <first ref="support_arm_bottom_left_with_notch_shape" />
+        <second ref="end_block_bottom_left_shape" />
+        <position name="support_arm_bottom_left_plus_block_shapeend_block_bottom_left_shapepos" x="0" y="2.4215622772585932" z="-10.15" unit="cm" />
+      </union>
+      <union name="support_arm_bottom_right_shape">
+        <first ref="support_arm_bottom_left_with_notch_shape" />
+        <second ref="end_block_bottom_left_shape" />
+        <position name="support_arm_bottom_right_shapeend_block_bottom_left_shapepos" x="0" y="2.4215622772585932" z="-10.15" unit="cm" />
+      </union>
+      <union name="support_arm_top_left_shape">
+        <first ref="support_arm_bottom_left_with_notch_shape" />
+        <second ref="end_block_bottom_left_shape" />
+        <position name="support_arm_top_left_shapeend_block_bottom_left_shapepos" x="0" y="2.4215622772585932" z="-10.15" unit="cm" />
+      </union>
+      <union name="support_arm_top_right_shape">
+        <first ref="support_arm_bottom_left_with_notch_shape" />
+        <second ref="end_block_bottom_left_shape" />
+        <position name="support_arm_top_right_shapeend_block_bottom_left_shapepos" x="0" y="2.4215622772585932" z="-10.15" unit="cm" />
+      </union>
+      <box name="u_support_bar_bottom_shape" x="16" y="0.80000000000000004" z="0.90000000000000002" lunit="cm" />
+      <box name="u_support_bar_upper1_shape" x="16" y="1.8" z="0.40000000000000002" lunit="cm" />
+      <box name="u_support_bar_upper2_shape" x="16" y="1.8" z="0.30000000000000004" lunit="cm" />
+      <box name="u_support_bar_top_shape" x="16" y="0.80000000000000004" z="0.90000000000000002" lunit="cm" />
+      <box name="u_support_bar_upper3_shape" x="16" y="1.8" z="0.40000000000000002" lunit="cm" />
+      <box name="u_support_bar_upper4_shape" x="16" y="1.8" z="0.30000000000000004" lunit="cm" />
+      <box lunit="mm" name="svt_chamber_outer_box" x="454.152" y="203.2" z="1219.2" />
+      <box lunit="mm" name="svt_chamber_inner_box" x="416.052" y="177.8" z="1221.2" />
+      <subtraction name="svt_chamber_box">
+        <first ref="svt_chamber_outer_box" />
+        <second ref="svt_chamber_inner_box" />
+      </subtraction>
+      <trd lunit="mm" name="svt_chamber_outer_flare1" x1="454.152" x2="454.152" y1="203.2" y2="254.832" z="132.842" />
+      <trd lunit="mm" name="svt_chamber_inner_flare1" x1="416.052" x2="416.052" y1="172.864" y2="234.368" z="158.242" />
+      <subtraction name="svt_chamber_flare1">
+        <first ref="svt_chamber_outer_flare1" />
+        <second ref="svt_chamber_inner_flare1" />
+      </subtraction>
+      <trd lunit="mm" name="svt_chamber_outer_flare2" x1="454.152" x2="679.704" y1="254.832" y2="353.06" z="252.73" />
+      <trd lunit="mm" name="svt_chamber_inner_flare2" x1="404.718" x2="652.938" y1="224.496" y2="332.596" z="278.13" />
+      <subtraction name="svt_chamber_flare2">
+        <first ref="svt_chamber_outer_flare2" />
+        <second ref="svt_chamber_inner_flare2" />
+      </subtraction>
+      <box lunit="mm" name="svt_chamber_outer_flange" x="768.35" y="457.2" z="19.05" />
+      <box lunit="mm" name="svt_chamber_inner_flange" x="654.05" y="342.9" z="25.4" />
+      <subtraction name="svt_chamber_flange">
+        <first ref="svt_chamber_outer_flange" />
+        <second ref="svt_chamber_inner_flange" />
+      </subtraction>
+      <box lunit="mm" name="WorldBox" x="80000" y="80000" z="80000" />
+    </solids>
+    <structure>
+      <volume name="base_plate_volume">
+        <materialref ref="Aluminum" />
+        <solidref ref="base_plateBox" />
+        <visref ref="BasePlateVis" />
+      </volume>
+      <volume name="support_plate_bottom_L14_volume">
+        <materialref ref="Aluminum" />
+        <solidref ref="support_plate_bottom_L14Box" />
+        <visref ref="SupportPlateVis" />
+      </volume>
+      <volume name="support_plate_top_L14_volume">
+        <materialref ref="Aluminum" />
+        <solidref ref="support_plate_top_L14Box" />
+        <visref ref="SupportPlateVis" />
+      </volume>
+      <volume name="support_plate_bottom_L46_volume">
+        <materialref ref="Aluminum" />
+        <solidref ref="support_plate_bottom_L46Box" />
+        <visref ref="SupportPlateVis" />
+      </volume>
+      <volume name="support_plate_top_L46_volume">
+        <materialref ref="Aluminum" />
+        <solidref ref="support_plate_top_L46Box" />
+        <visref ref="SupportPlateVis" />
+      </volume>
+      <volume name="module_L1b_halfmodule_axial_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L1b_halfmodule_axial_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L1b_halfmodule_axial_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L1b_halfmodule_axial_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L1b_halfmodule_axial_sensor_active_volume" />
+          <positionref ref="module_L1b_halfmodule_axial_sensor_active_position" />
+          <rotationref ref="module_L1b_halfmodule_axial_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L1b_halfmodule_axial_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L1b_halfmodule_axialBox" />
+        <physvol>
+          <volumeref ref="module_L1b_halfmodule_axial_sensor_volume" />
+          <positionref ref="module_L1b_halfmodule_axial_sensor_position" />
+          <rotationref ref="module_L1b_halfmodule_axial_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <visref ref="HalfModuleVis" />
+      </volume>
+      <volume name="module_L1b_halfmodule_stereo_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L1b_halfmodule_stereo_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L1b_halfmodule_stereo_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L1b_halfmodule_stereo_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L1b_halfmodule_stereo_sensor_active_volume" />
+          <positionref ref="module_L1b_halfmodule_stereo_sensor_active_position" />
+          <rotationref ref="module_L1b_halfmodule_stereo_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L1b_halfmodule_stereo_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L1b_halfmodule_stereoBox" />
+        <physvol>
+          <volumeref ref="module_L1b_halfmodule_stereo_sensor_volume" />
+          <positionref ref="module_L1b_halfmodule_stereo_sensor_position" />
+          <rotationref ref="module_L1b_halfmodule_stereo_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <visref ref="HalfModuleVis" />
+      </volume>
+      <volume name="module_L1t_halfmodule_axial_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L1t_halfmodule_axial_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L1t_halfmodule_axial_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L1t_halfmodule_axial_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L1t_halfmodule_axial_sensor_active_volume" />
+          <positionref ref="module_L1t_halfmodule_axial_sensor_active_position" />
+          <rotationref ref="module_L1t_halfmodule_axial_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L1t_halfmodule_axial_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L1t_halfmodule_axialBox" />
+        <physvol>
+          <volumeref ref="module_L1t_halfmodule_axial_sensor_volume" />
+          <positionref ref="module_L1t_halfmodule_axial_sensor_position" />
+          <rotationref ref="module_L1t_halfmodule_axial_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <visref ref="HalfModuleVis" />
+      </volume>
+      <volume name="module_L1t_halfmodule_stereo_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L1t_halfmodule_stereo_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L1t_halfmodule_stereo_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L1t_halfmodule_stereo_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L1t_halfmodule_stereo_sensor_active_volume" />
+          <positionref ref="module_L1t_halfmodule_stereo_sensor_active_position" />
+          <rotationref ref="module_L1t_halfmodule_stereo_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L1t_halfmodule_stereo_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L1t_halfmodule_stereoBox" />
+        <physvol>
+          <volumeref ref="module_L1t_halfmodule_stereo_sensor_volume" />
+          <positionref ref="module_L1t_halfmodule_stereo_sensor_position" />
+          <rotationref ref="module_L1t_halfmodule_stereo_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <visref ref="HalfModuleVis" />
+      </volume>
+      <volume name="module_L2b_halfmodule_axial_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L2b_halfmodule_axial_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L2b_halfmodule_axial_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L2b_halfmodule_axial_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L2b_halfmodule_axial_sensor_active_volume" />
+          <positionref ref="module_L2b_halfmodule_axial_sensor_active_position" />
+          <rotationref ref="module_L2b_halfmodule_axial_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L2b_halfmodule_axial_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L2b_halfmodule_axialBox" />
+        <physvol>
+          <volumeref ref="module_L2b_halfmodule_axial_sensor_volume" />
+          <positionref ref="module_L2b_halfmodule_axial_sensor_position" />
+          <rotationref ref="module_L2b_halfmodule_axial_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <visref ref="HalfModuleVis" />
+      </volume>
+      <volume name="module_L2b_halfmodule_stereo_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L2b_halfmodule_stereo_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L2b_halfmodule_stereo_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L2b_halfmodule_stereo_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L2b_halfmodule_stereo_sensor_active_volume" />
+          <positionref ref="module_L2b_halfmodule_stereo_sensor_active_position" />
+          <rotationref ref="module_L2b_halfmodule_stereo_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L2b_halfmodule_stereo_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L2b_halfmodule_stereoBox" />
+        <physvol>
+          <volumeref ref="module_L2b_halfmodule_stereo_sensor_volume" />
+          <positionref ref="module_L2b_halfmodule_stereo_sensor_position" />
+          <rotationref ref="module_L2b_halfmodule_stereo_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <visref ref="HalfModuleVis" />
+      </volume>
+      <volume name="module_L2t_halfmodule_axial_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L2t_halfmodule_axial_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L2t_halfmodule_axial_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L2t_halfmodule_axial_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L2t_halfmodule_axial_sensor_active_volume" />
+          <positionref ref="module_L2t_halfmodule_axial_sensor_active_position" />
+          <rotationref ref="module_L2t_halfmodule_axial_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L2t_halfmodule_axial_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L2t_halfmodule_axialBox" />
+        <physvol>
+          <volumeref ref="module_L2t_halfmodule_axial_sensor_volume" />
+          <positionref ref="module_L2t_halfmodule_axial_sensor_position" />
+          <rotationref ref="module_L2t_halfmodule_axial_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <visref ref="HalfModuleVis" />
+      </volume>
+      <volume name="module_L2t_halfmodule_stereo_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L2t_halfmodule_stereo_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L2t_halfmodule_stereo_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L2t_halfmodule_stereo_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L2t_halfmodule_stereo_sensor_active_volume" />
+          <positionref ref="module_L2t_halfmodule_stereo_sensor_active_position" />
+          <rotationref ref="module_L2t_halfmodule_stereo_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L2t_halfmodule_stereo_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L2t_halfmodule_stereoBox" />
+        <physvol>
+          <volumeref ref="module_L2t_halfmodule_stereo_sensor_volume" />
+          <positionref ref="module_L2t_halfmodule_stereo_sensor_position" />
+          <rotationref ref="module_L2t_halfmodule_stereo_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <visref ref="HalfModuleVis" />
+      </volume>
+      <volume name="module_L3b_halfmodule_axial_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L3b_halfmodule_axial_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L3b_halfmodule_axial_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L3b_halfmodule_axial_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L3b_halfmodule_axial_sensor_active_volume" />
+          <positionref ref="module_L3b_halfmodule_axial_sensor_active_position" />
+          <rotationref ref="module_L3b_halfmodule_axial_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L3b_halfmodule_axial_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L3b_halfmodule_axial_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L3b_halfmodule_axial_cf_volume">
+        <materialref ref="CarbonFiber" />
+        <solidref ref="module_L3b_halfmodule_axial_cfBox" />
+        <visref ref="CarbonFiberVis" />
+      </volume>
+      <volume name="module_L3b_halfmodule_axial_hybrid_volume">
+        <materialref ref="G10" />
+        <solidref ref="module_L3b_halfmodule_axial_hybridBox" />
+        <visref ref="HybridVis" />
+      </volume>
+      <volume name="module_L3b_halfmodule_axial_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L3b_halfmodule_axialBox" />
+        <physvol>
+          <volumeref ref="module_L3b_halfmodule_axial_sensor_volume" />
+          <positionref ref="module_L3b_halfmodule_axial_sensor_position" />
+          <rotationref ref="module_L3b_halfmodule_axial_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L3b_halfmodule_axial_lamination_volume" />
+          <positionref ref="module_L3b_halfmodule_axial_lamination_position" />
+          <rotationref ref="module_L3b_halfmodule_axial_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L3b_halfmodule_axial_cf_volume" />
+          <positionref ref="module_L3b_halfmodule_axial_cf_position" />
+          <rotationref ref="module_L3b_halfmodule_axial_cf_rotation" />
+          <physvolid field_name="component" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L3b_halfmodule_axial_hybrid_volume" />
+          <positionref ref="module_L3b_halfmodule_axial_hybrid_position" />
+          <rotationref ref="module_L3b_halfmodule_axial_hybrid_rotation" />
+          <physvolid field_name="component" value="3" />
+        </physvol>
+        <visref ref="HalfModuleVis" />
+      </volume>
+      <volume name="module_L3b_halfmodule_stereo_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L3b_halfmodule_stereo_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L3b_halfmodule_stereo_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L3b_halfmodule_stereo_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L3b_halfmodule_stereo_sensor_active_volume" />
+          <positionref ref="module_L3b_halfmodule_stereo_sensor_active_position" />
+          <rotationref ref="module_L3b_halfmodule_stereo_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L3b_halfmodule_stereo_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L3b_halfmodule_stereo_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L3b_halfmodule_stereo_cf_volume">
+        <materialref ref="CarbonFiber" />
+        <solidref ref="module_L3b_halfmodule_stereo_cfBox" />
+        <visref ref="CarbonFiberVis" />
+      </volume>
+      <volume name="module_L3b_halfmodule_stereo_hybrid_volume">
+        <materialref ref="G10" />
+        <solidref ref="module_L3b_halfmodule_stereo_hybridBox" />
+        <visref ref="HybridVis" />
+      </volume>
+      <volume name="module_L3b_halfmodule_stereo_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L3b_halfmodule_stereoBox" />
+        <physvol>
+          <volumeref ref="module_L3b_halfmodule_stereo_sensor_volume" />
+          <positionref ref="module_L3b_halfmodule_stereo_sensor_position" />
+          <rotationref ref="module_L3b_halfmodule_stereo_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L3b_halfmodule_stereo_lamination_volume" />
+          <positionref ref="module_L3b_halfmodule_stereo_lamination_position" />
+          <rotationref ref="module_L3b_halfmodule_stereo_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L3b_halfmodule_stereo_cf_volume" />
+          <positionref ref="module_L3b_halfmodule_stereo_cf_position" />
+          <rotationref ref="module_L3b_halfmodule_stereo_cf_rotation" />
+          <physvolid field_name="component" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L3b_halfmodule_stereo_hybrid_volume" />
+          <positionref ref="module_L3b_halfmodule_stereo_hybrid_position" />
+          <rotationref ref="module_L3b_halfmodule_stereo_hybrid_rotation" />
+          <physvolid field_name="component" value="3" />
+        </physvol>
+        <visref ref="HalfModuleVis" />
+      </volume>
+      <volume name="module_L3t_halfmodule_axial_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L3t_halfmodule_axial_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L3t_halfmodule_axial_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L3t_halfmodule_axial_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L3t_halfmodule_axial_sensor_active_volume" />
+          <positionref ref="module_L3t_halfmodule_axial_sensor_active_position" />
+          <rotationref ref="module_L3t_halfmodule_axial_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L3t_halfmodule_axial_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L3t_halfmodule_axial_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L3t_halfmodule_axial_cf_volume">
+        <materialref ref="CarbonFiber" />
+        <solidref ref="module_L3t_halfmodule_axial_cfBox" />
+        <visref ref="CarbonFiberVis" />
+      </volume>
+      <volume name="module_L3t_halfmodule_axial_hybrid_volume">
+        <materialref ref="G10" />
+        <solidref ref="module_L3t_halfmodule_axial_hybridBox" />
+        <visref ref="HybridVis" />
+      </volume>
+      <volume name="module_L3t_halfmodule_axial_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L3t_halfmodule_axialBox" />
+        <physvol>
+          <volumeref ref="module_L3t_halfmodule_axial_sensor_volume" />
+          <positionref ref="module_L3t_halfmodule_axial_sensor_position" />
+          <rotationref ref="module_L3t_halfmodule_axial_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L3t_halfmodule_axial_lamination_volume" />
+          <positionref ref="module_L3t_halfmodule_axial_lamination_position" />
+          <rotationref ref="module_L3t_halfmodule_axial_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L3t_halfmodule_axial_cf_volume" />
+          <positionref ref="module_L3t_halfmodule_axial_cf_position" />
+          <rotationref ref="module_L3t_halfmodule_axial_cf_rotation" />
+          <physvolid field_name="component" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L3t_halfmodule_axial_hybrid_volume" />
+          <positionref ref="module_L3t_halfmodule_axial_hybrid_position" />
+          <rotationref ref="module_L3t_halfmodule_axial_hybrid_rotation" />
+          <physvolid field_name="component" value="3" />
+        </physvol>
+        <visref ref="HalfModuleVis" />
+      </volume>
+      <volume name="module_L3t_halfmodule_stereo_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L3t_halfmodule_stereo_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L3t_halfmodule_stereo_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L3t_halfmodule_stereo_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L3t_halfmodule_stereo_sensor_active_volume" />
+          <positionref ref="module_L3t_halfmodule_stereo_sensor_active_position" />
+          <rotationref ref="module_L3t_halfmodule_stereo_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L3t_halfmodule_stereo_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L3t_halfmodule_stereo_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L3t_halfmodule_stereo_cf_volume">
+        <materialref ref="CarbonFiber" />
+        <solidref ref="module_L3t_halfmodule_stereo_cfBox" />
+        <visref ref="CarbonFiberVis" />
+      </volume>
+      <volume name="module_L3t_halfmodule_stereo_hybrid_volume">
+        <materialref ref="G10" />
+        <solidref ref="module_L3t_halfmodule_stereo_hybridBox" />
+        <visref ref="HybridVis" />
+      </volume>
+      <volume name="module_L3t_halfmodule_stereo_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L3t_halfmodule_stereoBox" />
+        <physvol>
+          <volumeref ref="module_L3t_halfmodule_stereo_sensor_volume" />
+          <positionref ref="module_L3t_halfmodule_stereo_sensor_position" />
+          <rotationref ref="module_L3t_halfmodule_stereo_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L3t_halfmodule_stereo_lamination_volume" />
+          <positionref ref="module_L3t_halfmodule_stereo_lamination_position" />
+          <rotationref ref="module_L3t_halfmodule_stereo_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L3t_halfmodule_stereo_cf_volume" />
+          <positionref ref="module_L3t_halfmodule_stereo_cf_position" />
+          <rotationref ref="module_L3t_halfmodule_stereo_cf_rotation" />
+          <physvolid field_name="component" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L3t_halfmodule_stereo_hybrid_volume" />
+          <positionref ref="module_L3t_halfmodule_stereo_hybrid_position" />
+          <rotationref ref="module_L3t_halfmodule_stereo_hybrid_rotation" />
+          <physvolid field_name="component" value="3" />
+        </physvol>
+        <visref ref="HalfModuleVis" />
+      </volume>
+      <volume name="module_L4b_halfmodule_axial_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L4b_halfmodule_axial_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L4b_halfmodule_axial_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L4b_halfmodule_axial_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L4b_halfmodule_axial_sensor_active_volume" />
+          <positionref ref="module_L4b_halfmodule_axial_sensor_active_position" />
+          <rotationref ref="module_L4b_halfmodule_axial_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L4b_halfmodule_axial_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L4b_halfmodule_axial_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L4b_halfmodule_axial_cf_volume">
+        <materialref ref="CarbonFiber" />
+        <solidref ref="module_L4b_halfmodule_axial_cfBox" />
+        <visref ref="CarbonFiberVis" />
+      </volume>
+      <volume name="module_L4b_halfmodule_axial_hybrid_volume">
+        <materialref ref="G10" />
+        <solidref ref="module_L4b_halfmodule_axial_hybridBox" />
+        <visref ref="HybridVis" />
+      </volume>
+      <volume name="module_L4b_halfmodule_axial_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L4b_halfmodule_axialBox" />
+        <physvol>
+          <volumeref ref="module_L4b_halfmodule_axial_sensor_volume" />
+          <positionref ref="module_L4b_halfmodule_axial_sensor_position" />
+          <rotationref ref="module_L4b_halfmodule_axial_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L4b_halfmodule_axial_lamination_volume" />
+          <positionref ref="module_L4b_halfmodule_axial_lamination_position" />
+          <rotationref ref="module_L4b_halfmodule_axial_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L4b_halfmodule_axial_cf_volume" />
+          <positionref ref="module_L4b_halfmodule_axial_cf_position" />
+          <rotationref ref="module_L4b_halfmodule_axial_cf_rotation" />
+          <physvolid field_name="component" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L4b_halfmodule_axial_hybrid_volume" />
+          <positionref ref="module_L4b_halfmodule_axial_hybrid_position" />
+          <rotationref ref="module_L4b_halfmodule_axial_hybrid_rotation" />
+          <physvolid field_name="component" value="3" />
+        </physvol>
+        <visref ref="HalfModuleVis" />
+      </volume>
+      <volume name="module_L4b_halfmodule_stereo_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L4b_halfmodule_stereo_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L4b_halfmodule_stereo_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L4b_halfmodule_stereo_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L4b_halfmodule_stereo_sensor_active_volume" />
+          <positionref ref="module_L4b_halfmodule_stereo_sensor_active_position" />
+          <rotationref ref="module_L4b_halfmodule_stereo_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L4b_halfmodule_stereo_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L4b_halfmodule_stereo_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L4b_halfmodule_stereo_cf_volume">
+        <materialref ref="CarbonFiber" />
+        <solidref ref="module_L4b_halfmodule_stereo_cfBox" />
+        <visref ref="CarbonFiberVis" />
+      </volume>
+      <volume name="module_L4b_halfmodule_stereo_hybrid_volume">
+        <materialref ref="G10" />
+        <solidref ref="module_L4b_halfmodule_stereo_hybridBox" />
+        <visref ref="HybridVis" />
+      </volume>
+      <volume name="module_L4b_halfmodule_stereo_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L4b_halfmodule_stereoBox" />
+        <physvol>
+          <volumeref ref="module_L4b_halfmodule_stereo_sensor_volume" />
+          <positionref ref="module_L4b_halfmodule_stereo_sensor_position" />
+          <rotationref ref="module_L4b_halfmodule_stereo_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L4b_halfmodule_stereo_lamination_volume" />
+          <positionref ref="module_L4b_halfmodule_stereo_lamination_position" />
+          <rotationref ref="module_L4b_halfmodule_stereo_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L4b_halfmodule_stereo_cf_volume" />
+          <positionref ref="module_L4b_halfmodule_stereo_cf_position" />
+          <rotationref ref="module_L4b_halfmodule_stereo_cf_rotation" />
+          <physvolid field_name="component" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L4b_halfmodule_stereo_hybrid_volume" />
+          <positionref ref="module_L4b_halfmodule_stereo_hybrid_position" />
+          <rotationref ref="module_L4b_halfmodule_stereo_hybrid_rotation" />
+          <physvolid field_name="component" value="3" />
+        </physvol>
+        <visref ref="HalfModuleVis" />
+      </volume>
+      <volume name="module_L4t_halfmodule_axial_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L4t_halfmodule_axial_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L4t_halfmodule_axial_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L4t_halfmodule_axial_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L4t_halfmodule_axial_sensor_active_volume" />
+          <positionref ref="module_L4t_halfmodule_axial_sensor_active_position" />
+          <rotationref ref="module_L4t_halfmodule_axial_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L4t_halfmodule_axial_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L4t_halfmodule_axial_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L4t_halfmodule_axial_cf_volume">
+        <materialref ref="CarbonFiber" />
+        <solidref ref="module_L4t_halfmodule_axial_cfBox" />
+        <visref ref="CarbonFiberVis" />
+      </volume>
+      <volume name="module_L4t_halfmodule_axial_hybrid_volume">
+        <materialref ref="G10" />
+        <solidref ref="module_L4t_halfmodule_axial_hybridBox" />
+        <visref ref="HybridVis" />
+      </volume>
+      <volume name="module_L4t_halfmodule_axial_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L4t_halfmodule_axialBox" />
+        <physvol>
+          <volumeref ref="module_L4t_halfmodule_axial_sensor_volume" />
+          <positionref ref="module_L4t_halfmodule_axial_sensor_position" />
+          <rotationref ref="module_L4t_halfmodule_axial_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L4t_halfmodule_axial_lamination_volume" />
+          <positionref ref="module_L4t_halfmodule_axial_lamination_position" />
+          <rotationref ref="module_L4t_halfmodule_axial_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L4t_halfmodule_axial_cf_volume" />
+          <positionref ref="module_L4t_halfmodule_axial_cf_position" />
+          <rotationref ref="module_L4t_halfmodule_axial_cf_rotation" />
+          <physvolid field_name="component" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L4t_halfmodule_axial_hybrid_volume" />
+          <positionref ref="module_L4t_halfmodule_axial_hybrid_position" />
+          <rotationref ref="module_L4t_halfmodule_axial_hybrid_rotation" />
+          <physvolid field_name="component" value="3" />
+        </physvol>
+        <visref ref="HalfModuleVis" />
+      </volume>
+      <volume name="module_L4t_halfmodule_stereo_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L4t_halfmodule_stereo_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L4t_halfmodule_stereo_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L4t_halfmodule_stereo_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L4t_halfmodule_stereo_sensor_active_volume" />
+          <positionref ref="module_L4t_halfmodule_stereo_sensor_active_position" />
+          <rotationref ref="module_L4t_halfmodule_stereo_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L4t_halfmodule_stereo_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L4t_halfmodule_stereo_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L4t_halfmodule_stereo_cf_volume">
+        <materialref ref="CarbonFiber" />
+        <solidref ref="module_L4t_halfmodule_stereo_cfBox" />
+        <visref ref="CarbonFiberVis" />
+      </volume>
+      <volume name="module_L4t_halfmodule_stereo_hybrid_volume">
+        <materialref ref="G10" />
+        <solidref ref="module_L4t_halfmodule_stereo_hybridBox" />
+        <visref ref="HybridVis" />
+      </volume>
+      <volume name="module_L4t_halfmodule_stereo_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L4t_halfmodule_stereoBox" />
+        <physvol>
+          <volumeref ref="module_L4t_halfmodule_stereo_sensor_volume" />
+          <positionref ref="module_L4t_halfmodule_stereo_sensor_position" />
+          <rotationref ref="module_L4t_halfmodule_stereo_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L4t_halfmodule_stereo_lamination_volume" />
+          <positionref ref="module_L4t_halfmodule_stereo_lamination_position" />
+          <rotationref ref="module_L4t_halfmodule_stereo_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L4t_halfmodule_stereo_cf_volume" />
+          <positionref ref="module_L4t_halfmodule_stereo_cf_position" />
+          <rotationref ref="module_L4t_halfmodule_stereo_cf_rotation" />
+          <physvolid field_name="component" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L4t_halfmodule_stereo_hybrid_volume" />
+          <positionref ref="module_L4t_halfmodule_stereo_hybrid_position" />
+          <rotationref ref="module_L4t_halfmodule_stereo_hybrid_rotation" />
+          <physvolid field_name="component" value="3" />
+        </physvol>
+        <visref ref="HalfModuleVis" />
+      </volume>
+      <volume name="module_L5b_halfmodule_axial_hole_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L5b_halfmodule_axial_hole_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L5b_halfmodule_axial_hole_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L5b_halfmodule_axial_hole_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L5b_halfmodule_axial_hole_sensor_active_volume" />
+          <positionref ref="module_L5b_halfmodule_axial_hole_sensor_active_position" />
+          <rotationref ref="module_L5b_halfmodule_axial_hole_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L5b_halfmodule_axial_hole_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L5b_halfmodule_axial_hole_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L5b_halfmodule_axial_hole_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L5b_halfmodule_axial_holeBox" />
+        <physvol>
+          <volumeref ref="module_L5b_halfmodule_axial_hole_sensor_volume" />
+          <positionref ref="module_L5b_halfmodule_axial_hole_sensor_position" />
+          <rotationref ref="module_L5b_halfmodule_axial_hole_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L5b_halfmodule_axial_hole_lamination_volume" />
+          <positionref ref="module_L5b_halfmodule_axial_hole_lamination_position" />
+          <rotationref ref="module_L5b_halfmodule_axial_hole_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L5b_halfmodule_axial_slot_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L5b_halfmodule_axial_slot_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L5b_halfmodule_axial_slot_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L5b_halfmodule_axial_slot_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L5b_halfmodule_axial_slot_sensor_active_volume" />
+          <positionref ref="module_L5b_halfmodule_axial_slot_sensor_active_position" />
+          <rotationref ref="module_L5b_halfmodule_axial_slot_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L5b_halfmodule_axial_slot_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L5b_halfmodule_axial_slot_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L5b_halfmodule_axial_slot_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L5b_halfmodule_axial_slotBox" />
+        <physvol>
+          <volumeref ref="module_L5b_halfmodule_axial_slot_sensor_volume" />
+          <positionref ref="module_L5b_halfmodule_axial_slot_sensor_position" />
+          <rotationref ref="module_L5b_halfmodule_axial_slot_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L5b_halfmodule_axial_slot_lamination_volume" />
+          <positionref ref="module_L5b_halfmodule_axial_slot_lamination_position" />
+          <rotationref ref="module_L5b_halfmodule_axial_slot_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L5b_halfmodule_stereo_hole_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L5b_halfmodule_stereo_hole_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L5b_halfmodule_stereo_hole_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L5b_halfmodule_stereo_hole_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L5b_halfmodule_stereo_hole_sensor_active_volume" />
+          <positionref ref="module_L5b_halfmodule_stereo_hole_sensor_active_position" />
+          <rotationref ref="module_L5b_halfmodule_stereo_hole_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L5b_halfmodule_stereo_hole_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L5b_halfmodule_stereo_hole_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L5b_halfmodule_stereo_hole_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L5b_halfmodule_stereo_holeBox" />
+        <physvol>
+          <volumeref ref="module_L5b_halfmodule_stereo_hole_sensor_volume" />
+          <positionref ref="module_L5b_halfmodule_stereo_hole_sensor_position" />
+          <rotationref ref="module_L5b_halfmodule_stereo_hole_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L5b_halfmodule_stereo_hole_lamination_volume" />
+          <positionref ref="module_L5b_halfmodule_stereo_hole_lamination_position" />
+          <rotationref ref="module_L5b_halfmodule_stereo_hole_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L5b_halfmodule_stereo_slot_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L5b_halfmodule_stereo_slot_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L5b_halfmodule_stereo_slot_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L5b_halfmodule_stereo_slot_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L5b_halfmodule_stereo_slot_sensor_active_volume" />
+          <positionref ref="module_L5b_halfmodule_stereo_slot_sensor_active_position" />
+          <rotationref ref="module_L5b_halfmodule_stereo_slot_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L5b_halfmodule_stereo_slot_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L5b_halfmodule_stereo_slot_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L5b_halfmodule_stereo_slot_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L5b_halfmodule_stereo_slotBox" />
+        <physvol>
+          <volumeref ref="module_L5b_halfmodule_stereo_slot_sensor_volume" />
+          <positionref ref="module_L5b_halfmodule_stereo_slot_sensor_position" />
+          <rotationref ref="module_L5b_halfmodule_stereo_slot_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L5b_halfmodule_stereo_slot_lamination_volume" />
+          <positionref ref="module_L5b_halfmodule_stereo_slot_lamination_position" />
+          <rotationref ref="module_L5b_halfmodule_stereo_slot_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L5t_halfmodule_axial_hole_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L5t_halfmodule_axial_hole_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L5t_halfmodule_axial_hole_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L5t_halfmodule_axial_hole_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L5t_halfmodule_axial_hole_sensor_active_volume" />
+          <positionref ref="module_L5t_halfmodule_axial_hole_sensor_active_position" />
+          <rotationref ref="module_L5t_halfmodule_axial_hole_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L5t_halfmodule_axial_hole_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L5t_halfmodule_axial_hole_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L5t_halfmodule_axial_hole_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L5t_halfmodule_axial_holeBox" />
+        <physvol>
+          <volumeref ref="module_L5t_halfmodule_axial_hole_sensor_volume" />
+          <positionref ref="module_L5t_halfmodule_axial_hole_sensor_position" />
+          <rotationref ref="module_L5t_halfmodule_axial_hole_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L5t_halfmodule_axial_hole_lamination_volume" />
+          <positionref ref="module_L5t_halfmodule_axial_hole_lamination_position" />
+          <rotationref ref="module_L5t_halfmodule_axial_hole_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L5t_halfmodule_axial_slot_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L5t_halfmodule_axial_slot_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L5t_halfmodule_axial_slot_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L5t_halfmodule_axial_slot_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L5t_halfmodule_axial_slot_sensor_active_volume" />
+          <positionref ref="module_L5t_halfmodule_axial_slot_sensor_active_position" />
+          <rotationref ref="module_L5t_halfmodule_axial_slot_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L5t_halfmodule_axial_slot_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L5t_halfmodule_axial_slot_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L5t_halfmodule_axial_slot_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L5t_halfmodule_axial_slotBox" />
+        <physvol>
+          <volumeref ref="module_L5t_halfmodule_axial_slot_sensor_volume" />
+          <positionref ref="module_L5t_halfmodule_axial_slot_sensor_position" />
+          <rotationref ref="module_L5t_halfmodule_axial_slot_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L5t_halfmodule_axial_slot_lamination_volume" />
+          <positionref ref="module_L5t_halfmodule_axial_slot_lamination_position" />
+          <rotationref ref="module_L5t_halfmodule_axial_slot_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L5t_halfmodule_stereo_hole_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L5t_halfmodule_stereo_hole_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L5t_halfmodule_stereo_hole_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L5t_halfmodule_stereo_hole_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L5t_halfmodule_stereo_hole_sensor_active_volume" />
+          <positionref ref="module_L5t_halfmodule_stereo_hole_sensor_active_position" />
+          <rotationref ref="module_L5t_halfmodule_stereo_hole_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L5t_halfmodule_stereo_hole_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L5t_halfmodule_stereo_hole_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L5t_halfmodule_stereo_hole_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L5t_halfmodule_stereo_holeBox" />
+        <physvol>
+          <volumeref ref="module_L5t_halfmodule_stereo_hole_sensor_volume" />
+          <positionref ref="module_L5t_halfmodule_stereo_hole_sensor_position" />
+          <rotationref ref="module_L5t_halfmodule_stereo_hole_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L5t_halfmodule_stereo_hole_lamination_volume" />
+          <positionref ref="module_L5t_halfmodule_stereo_hole_lamination_position" />
+          <rotationref ref="module_L5t_halfmodule_stereo_hole_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L5t_halfmodule_stereo_slot_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L5t_halfmodule_stereo_slot_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L5t_halfmodule_stereo_slot_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L5t_halfmodule_stereo_slot_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L5t_halfmodule_stereo_slot_sensor_active_volume" />
+          <positionref ref="module_L5t_halfmodule_stereo_slot_sensor_active_position" />
+          <rotationref ref="module_L5t_halfmodule_stereo_slot_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L5t_halfmodule_stereo_slot_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L5t_halfmodule_stereo_slot_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L5t_halfmodule_stereo_slot_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L5t_halfmodule_stereo_slotBox" />
+        <physvol>
+          <volumeref ref="module_L5t_halfmodule_stereo_slot_sensor_volume" />
+          <positionref ref="module_L5t_halfmodule_stereo_slot_sensor_position" />
+          <rotationref ref="module_L5t_halfmodule_stereo_slot_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L5t_halfmodule_stereo_slot_lamination_volume" />
+          <positionref ref="module_L5t_halfmodule_stereo_slot_lamination_position" />
+          <rotationref ref="module_L5t_halfmodule_stereo_slot_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L6b_halfmodule_axial_hole_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L6b_halfmodule_axial_hole_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L6b_halfmodule_axial_hole_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L6b_halfmodule_axial_hole_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L6b_halfmodule_axial_hole_sensor_active_volume" />
+          <positionref ref="module_L6b_halfmodule_axial_hole_sensor_active_position" />
+          <rotationref ref="module_L6b_halfmodule_axial_hole_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L6b_halfmodule_axial_hole_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L6b_halfmodule_axial_hole_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L6b_halfmodule_axial_hole_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L6b_halfmodule_axial_holeBox" />
+        <physvol>
+          <volumeref ref="module_L6b_halfmodule_axial_hole_sensor_volume" />
+          <positionref ref="module_L6b_halfmodule_axial_hole_sensor_position" />
+          <rotationref ref="module_L6b_halfmodule_axial_hole_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L6b_halfmodule_axial_hole_lamination_volume" />
+          <positionref ref="module_L6b_halfmodule_axial_hole_lamination_position" />
+          <rotationref ref="module_L6b_halfmodule_axial_hole_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L6b_halfmodule_axial_slot_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L6b_halfmodule_axial_slot_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L6b_halfmodule_axial_slot_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L6b_halfmodule_axial_slot_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L6b_halfmodule_axial_slot_sensor_active_volume" />
+          <positionref ref="module_L6b_halfmodule_axial_slot_sensor_active_position" />
+          <rotationref ref="module_L6b_halfmodule_axial_slot_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L6b_halfmodule_axial_slot_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L6b_halfmodule_axial_slot_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L6b_halfmodule_axial_slot_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L6b_halfmodule_axial_slotBox" />
+        <physvol>
+          <volumeref ref="module_L6b_halfmodule_axial_slot_sensor_volume" />
+          <positionref ref="module_L6b_halfmodule_axial_slot_sensor_position" />
+          <rotationref ref="module_L6b_halfmodule_axial_slot_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L6b_halfmodule_axial_slot_lamination_volume" />
+          <positionref ref="module_L6b_halfmodule_axial_slot_lamination_position" />
+          <rotationref ref="module_L6b_halfmodule_axial_slot_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L6b_halfmodule_stereo_hole_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L6b_halfmodule_stereo_hole_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L6b_halfmodule_stereo_hole_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L6b_halfmodule_stereo_hole_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L6b_halfmodule_stereo_hole_sensor_active_volume" />
+          <positionref ref="module_L6b_halfmodule_stereo_hole_sensor_active_position" />
+          <rotationref ref="module_L6b_halfmodule_stereo_hole_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L6b_halfmodule_stereo_hole_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L6b_halfmodule_stereo_hole_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L6b_halfmodule_stereo_hole_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L6b_halfmodule_stereo_holeBox" />
+        <physvol>
+          <volumeref ref="module_L6b_halfmodule_stereo_hole_sensor_volume" />
+          <positionref ref="module_L6b_halfmodule_stereo_hole_sensor_position" />
+          <rotationref ref="module_L6b_halfmodule_stereo_hole_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L6b_halfmodule_stereo_hole_lamination_volume" />
+          <positionref ref="module_L6b_halfmodule_stereo_hole_lamination_position" />
+          <rotationref ref="module_L6b_halfmodule_stereo_hole_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L6b_halfmodule_stereo_slot_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L6b_halfmodule_stereo_slot_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L6b_halfmodule_stereo_slot_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L6b_halfmodule_stereo_slot_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L6b_halfmodule_stereo_slot_sensor_active_volume" />
+          <positionref ref="module_L6b_halfmodule_stereo_slot_sensor_active_position" />
+          <rotationref ref="module_L6b_halfmodule_stereo_slot_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L6b_halfmodule_stereo_slot_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L6b_halfmodule_stereo_slot_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L6b_halfmodule_stereo_slot_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L6b_halfmodule_stereo_slotBox" />
+        <physvol>
+          <volumeref ref="module_L6b_halfmodule_stereo_slot_sensor_volume" />
+          <positionref ref="module_L6b_halfmodule_stereo_slot_sensor_position" />
+          <rotationref ref="module_L6b_halfmodule_stereo_slot_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L6b_halfmodule_stereo_slot_lamination_volume" />
+          <positionref ref="module_L6b_halfmodule_stereo_slot_lamination_position" />
+          <rotationref ref="module_L6b_halfmodule_stereo_slot_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L6t_halfmodule_axial_hole_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L6t_halfmodule_axial_hole_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L6t_halfmodule_axial_hole_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L6t_halfmodule_axial_hole_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L6t_halfmodule_axial_hole_sensor_active_volume" />
+          <positionref ref="module_L6t_halfmodule_axial_hole_sensor_active_position" />
+          <rotationref ref="module_L6t_halfmodule_axial_hole_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L6t_halfmodule_axial_hole_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L6t_halfmodule_axial_hole_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L6t_halfmodule_axial_hole_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L6t_halfmodule_axial_holeBox" />
+        <physvol>
+          <volumeref ref="module_L6t_halfmodule_axial_hole_sensor_volume" />
+          <positionref ref="module_L6t_halfmodule_axial_hole_sensor_position" />
+          <rotationref ref="module_L6t_halfmodule_axial_hole_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L6t_halfmodule_axial_hole_lamination_volume" />
+          <positionref ref="module_L6t_halfmodule_axial_hole_lamination_position" />
+          <rotationref ref="module_L6t_halfmodule_axial_hole_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L6t_halfmodule_axial_slot_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L6t_halfmodule_axial_slot_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L6t_halfmodule_axial_slot_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L6t_halfmodule_axial_slot_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L6t_halfmodule_axial_slot_sensor_active_volume" />
+          <positionref ref="module_L6t_halfmodule_axial_slot_sensor_active_position" />
+          <rotationref ref="module_L6t_halfmodule_axial_slot_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L6t_halfmodule_axial_slot_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L6t_halfmodule_axial_slot_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L6t_halfmodule_axial_slot_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L6t_halfmodule_axial_slotBox" />
+        <physvol>
+          <volumeref ref="module_L6t_halfmodule_axial_slot_sensor_volume" />
+          <positionref ref="module_L6t_halfmodule_axial_slot_sensor_position" />
+          <rotationref ref="module_L6t_halfmodule_axial_slot_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L6t_halfmodule_axial_slot_lamination_volume" />
+          <positionref ref="module_L6t_halfmodule_axial_slot_lamination_position" />
+          <rotationref ref="module_L6t_halfmodule_axial_slot_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L6t_halfmodule_stereo_hole_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L6t_halfmodule_stereo_hole_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L6t_halfmodule_stereo_hole_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L6t_halfmodule_stereo_hole_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L6t_halfmodule_stereo_hole_sensor_active_volume" />
+          <positionref ref="module_L6t_halfmodule_stereo_hole_sensor_active_position" />
+          <rotationref ref="module_L6t_halfmodule_stereo_hole_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L6t_halfmodule_stereo_hole_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L6t_halfmodule_stereo_hole_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L6t_halfmodule_stereo_hole_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L6t_halfmodule_stereo_holeBox" />
+        <physvol>
+          <volumeref ref="module_L6t_halfmodule_stereo_hole_sensor_volume" />
+          <positionref ref="module_L6t_halfmodule_stereo_hole_sensor_position" />
+          <rotationref ref="module_L6t_halfmodule_stereo_hole_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L6t_halfmodule_stereo_hole_lamination_volume" />
+          <positionref ref="module_L6t_halfmodule_stereo_hole_lamination_position" />
+          <rotationref ref="module_L6t_halfmodule_stereo_hole_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L6t_halfmodule_stereo_slot_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L6t_halfmodule_stereo_slot_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L6t_halfmodule_stereo_slot_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L6t_halfmodule_stereo_slot_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L6t_halfmodule_stereo_slot_sensor_active_volume" />
+          <positionref ref="module_L6t_halfmodule_stereo_slot_sensor_active_position" />
+          <rotationref ref="module_L6t_halfmodule_stereo_slot_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L6t_halfmodule_stereo_slot_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L6t_halfmodule_stereo_slot_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L6t_halfmodule_stereo_slot_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L6t_halfmodule_stereo_slotBox" />
+        <physvol>
+          <volumeref ref="module_L6t_halfmodule_stereo_slot_sensor_volume" />
+          <positionref ref="module_L6t_halfmodule_stereo_slot_sensor_position" />
+          <rotationref ref="module_L6t_halfmodule_stereo_slot_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L6t_halfmodule_stereo_slot_lamination_volume" />
+          <positionref ref="module_L6t_halfmodule_stereo_slot_lamination_position" />
+          <rotationref ref="module_L6t_halfmodule_stereo_slot_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L7b_halfmodule_axial_hole_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L7b_halfmodule_axial_hole_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L7b_halfmodule_axial_hole_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L7b_halfmodule_axial_hole_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L7b_halfmodule_axial_hole_sensor_active_volume" />
+          <positionref ref="module_L7b_halfmodule_axial_hole_sensor_active_position" />
+          <rotationref ref="module_L7b_halfmodule_axial_hole_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L7b_halfmodule_axial_hole_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L7b_halfmodule_axial_hole_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L7b_halfmodule_axial_hole_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L7b_halfmodule_axial_holeBox" />
+        <physvol>
+          <volumeref ref="module_L7b_halfmodule_axial_hole_sensor_volume" />
+          <positionref ref="module_L7b_halfmodule_axial_hole_sensor_position" />
+          <rotationref ref="module_L7b_halfmodule_axial_hole_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L7b_halfmodule_axial_hole_lamination_volume" />
+          <positionref ref="module_L7b_halfmodule_axial_hole_lamination_position" />
+          <rotationref ref="module_L7b_halfmodule_axial_hole_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L7b_halfmodule_axial_slot_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L7b_halfmodule_axial_slot_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L7b_halfmodule_axial_slot_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L7b_halfmodule_axial_slot_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L7b_halfmodule_axial_slot_sensor_active_volume" />
+          <positionref ref="module_L7b_halfmodule_axial_slot_sensor_active_position" />
+          <rotationref ref="module_L7b_halfmodule_axial_slot_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L7b_halfmodule_axial_slot_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L7b_halfmodule_axial_slot_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L7b_halfmodule_axial_slot_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L7b_halfmodule_axial_slotBox" />
+        <physvol>
+          <volumeref ref="module_L7b_halfmodule_axial_slot_sensor_volume" />
+          <positionref ref="module_L7b_halfmodule_axial_slot_sensor_position" />
+          <rotationref ref="module_L7b_halfmodule_axial_slot_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L7b_halfmodule_axial_slot_lamination_volume" />
+          <positionref ref="module_L7b_halfmodule_axial_slot_lamination_position" />
+          <rotationref ref="module_L7b_halfmodule_axial_slot_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L7b_halfmodule_stereo_hole_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L7b_halfmodule_stereo_hole_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L7b_halfmodule_stereo_hole_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L7b_halfmodule_stereo_hole_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L7b_halfmodule_stereo_hole_sensor_active_volume" />
+          <positionref ref="module_L7b_halfmodule_stereo_hole_sensor_active_position" />
+          <rotationref ref="module_L7b_halfmodule_stereo_hole_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L7b_halfmodule_stereo_hole_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L7b_halfmodule_stereo_hole_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L7b_halfmodule_stereo_hole_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L7b_halfmodule_stereo_holeBox" />
+        <physvol>
+          <volumeref ref="module_L7b_halfmodule_stereo_hole_sensor_volume" />
+          <positionref ref="module_L7b_halfmodule_stereo_hole_sensor_position" />
+          <rotationref ref="module_L7b_halfmodule_stereo_hole_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L7b_halfmodule_stereo_hole_lamination_volume" />
+          <positionref ref="module_L7b_halfmodule_stereo_hole_lamination_position" />
+          <rotationref ref="module_L7b_halfmodule_stereo_hole_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L7b_halfmodule_stereo_slot_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L7b_halfmodule_stereo_slot_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L7b_halfmodule_stereo_slot_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L7b_halfmodule_stereo_slot_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L7b_halfmodule_stereo_slot_sensor_active_volume" />
+          <positionref ref="module_L7b_halfmodule_stereo_slot_sensor_active_position" />
+          <rotationref ref="module_L7b_halfmodule_stereo_slot_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L7b_halfmodule_stereo_slot_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L7b_halfmodule_stereo_slot_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L7b_halfmodule_stereo_slot_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L7b_halfmodule_stereo_slotBox" />
+        <physvol>
+          <volumeref ref="module_L7b_halfmodule_stereo_slot_sensor_volume" />
+          <positionref ref="module_L7b_halfmodule_stereo_slot_sensor_position" />
+          <rotationref ref="module_L7b_halfmodule_stereo_slot_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L7b_halfmodule_stereo_slot_lamination_volume" />
+          <positionref ref="module_L7b_halfmodule_stereo_slot_lamination_position" />
+          <rotationref ref="module_L7b_halfmodule_stereo_slot_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L7t_halfmodule_axial_hole_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L7t_halfmodule_axial_hole_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L7t_halfmodule_axial_hole_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L7t_halfmodule_axial_hole_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L7t_halfmodule_axial_hole_sensor_active_volume" />
+          <positionref ref="module_L7t_halfmodule_axial_hole_sensor_active_position" />
+          <rotationref ref="module_L7t_halfmodule_axial_hole_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L7t_halfmodule_axial_hole_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L7t_halfmodule_axial_hole_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L7t_halfmodule_axial_hole_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L7t_halfmodule_axial_holeBox" />
+        <physvol>
+          <volumeref ref="module_L7t_halfmodule_axial_hole_sensor_volume" />
+          <positionref ref="module_L7t_halfmodule_axial_hole_sensor_position" />
+          <rotationref ref="module_L7t_halfmodule_axial_hole_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L7t_halfmodule_axial_hole_lamination_volume" />
+          <positionref ref="module_L7t_halfmodule_axial_hole_lamination_position" />
+          <rotationref ref="module_L7t_halfmodule_axial_hole_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L7t_halfmodule_axial_slot_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L7t_halfmodule_axial_slot_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L7t_halfmodule_axial_slot_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L7t_halfmodule_axial_slot_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L7t_halfmodule_axial_slot_sensor_active_volume" />
+          <positionref ref="module_L7t_halfmodule_axial_slot_sensor_active_position" />
+          <rotationref ref="module_L7t_halfmodule_axial_slot_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L7t_halfmodule_axial_slot_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L7t_halfmodule_axial_slot_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L7t_halfmodule_axial_slot_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L7t_halfmodule_axial_slotBox" />
+        <physvol>
+          <volumeref ref="module_L7t_halfmodule_axial_slot_sensor_volume" />
+          <positionref ref="module_L7t_halfmodule_axial_slot_sensor_position" />
+          <rotationref ref="module_L7t_halfmodule_axial_slot_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L7t_halfmodule_axial_slot_lamination_volume" />
+          <positionref ref="module_L7t_halfmodule_axial_slot_lamination_position" />
+          <rotationref ref="module_L7t_halfmodule_axial_slot_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L7t_halfmodule_stereo_hole_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L7t_halfmodule_stereo_hole_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L7t_halfmodule_stereo_hole_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L7t_halfmodule_stereo_hole_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L7t_halfmodule_stereo_hole_sensor_active_volume" />
+          <positionref ref="module_L7t_halfmodule_stereo_hole_sensor_active_position" />
+          <rotationref ref="module_L7t_halfmodule_stereo_hole_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L7t_halfmodule_stereo_hole_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L7t_halfmodule_stereo_hole_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L7t_halfmodule_stereo_hole_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L7t_halfmodule_stereo_holeBox" />
+        <physvol>
+          <volumeref ref="module_L7t_halfmodule_stereo_hole_sensor_volume" />
+          <positionref ref="module_L7t_halfmodule_stereo_hole_sensor_position" />
+          <rotationref ref="module_L7t_halfmodule_stereo_hole_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L7t_halfmodule_stereo_hole_lamination_volume" />
+          <positionref ref="module_L7t_halfmodule_stereo_hole_lamination_position" />
+          <rotationref ref="module_L7t_halfmodule_stereo_hole_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="module_L7t_halfmodule_stereo_slot_sensor_active_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L7t_halfmodule_stereo_slot_sensor_activeBox" />
+        <sdref ref="Tracker" />
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L7t_halfmodule_stereo_slot_sensor_volume">
+        <materialref ref="Silicon" />
+        <solidref ref="module_L7t_halfmodule_stereo_slot_sensorBox" />
+        <physvol>
+          <volumeref ref="module_L7t_halfmodule_stereo_slot_sensor_active_volume" />
+          <positionref ref="module_L7t_halfmodule_stereo_slot_sensor_active_position" />
+          <rotationref ref="module_L7t_halfmodule_stereo_slot_sensor_active_rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+        <visref ref="SensorVis" />
+      </volume>
+      <volume name="module_L7t_halfmodule_stereo_slot_lamination_volume">
+        <materialref ref="Kapton" />
+        <solidref ref="module_L7t_halfmodule_stereo_slot_laminationBox" />
+        <visref ref="KaptonVis" />
+      </volume>
+      <volume name="module_L7t_halfmodule_stereo_slot_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="module_L7t_halfmodule_stereo_slotBox" />
+        <physvol>
+          <volumeref ref="module_L7t_halfmodule_stereo_slot_sensor_volume" />
+          <positionref ref="module_L7t_halfmodule_stereo_slot_sensor_position" />
+          <rotationref ref="module_L7t_halfmodule_stereo_slot_sensor_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L7t_halfmodule_stereo_slot_lamination_volume" />
+          <positionref ref="module_L7t_halfmodule_stereo_slot_lamination_position" />
+          <rotationref ref="module_L7t_halfmodule_stereo_slot_lamination_rotation" />
+          <physvolid field_name="component" value="2" />
+        </physvol>
+        <visref ref="ModuleVis" />
+      </volume>
+      <volume name="base_volume">
+        <materialref ref="Vacuum" />
+        <solidref ref="baseBox" />
+        <physvol>
+          <volumeref ref="base_plate_volume" />
+          <positionref ref="base_plate_position" />
+          <rotationref ref="base_plate_rotation" />
+        </physvol>
+        <physvol>
+          <volumeref ref="support_plate_bottom_L14_volume" />
+          <positionref ref="support_plate_bottom_L14_position" />
+          <rotationref ref="support_plate_bottom_L14_rotation" />
+        </physvol>
+        <physvol>
+          <volumeref ref="support_plate_top_L14_volume" />
+          <positionref ref="support_plate_top_L14_position" />
+          <rotationref ref="support_plate_top_L14_rotation" />
+        </physvol>
+        <physvol>
+          <volumeref ref="support_plate_bottom_L46_volume" />
+          <positionref ref="support_plate_bottom_L46_position" />
+          <rotationref ref="support_plate_bottom_L46_rotation" />
+        </physvol>
+        <physvol>
+          <volumeref ref="support_plate_top_L46_volume" />
+          <positionref ref="support_plate_top_L46_position" />
+          <rotationref ref="support_plate_top_L46_rotation" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L1b_halfmodule_axial_volume" />
+          <positionref ref="module_L1b_halfmodule_axial_position" />
+          <rotationref ref="module_L1b_halfmodule_axial_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="2" />
+          <physvolid field_name="module" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L1b_halfmodule_stereo_volume" />
+          <positionref ref="module_L1b_halfmodule_stereo_position" />
+          <rotationref ref="module_L1b_halfmodule_stereo_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="1" />
+          <physvolid field_name="module" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L1t_halfmodule_axial_volume" />
+          <positionref ref="module_L1t_halfmodule_axial_position" />
+          <rotationref ref="module_L1t_halfmodule_axial_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="1" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L1t_halfmodule_stereo_volume" />
+          <positionref ref="module_L1t_halfmodule_stereo_position" />
+          <rotationref ref="module_L1t_halfmodule_stereo_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="2" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L2b_halfmodule_axial_volume" />
+          <positionref ref="module_L2b_halfmodule_axial_position" />
+          <rotationref ref="module_L2b_halfmodule_axial_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="4" />
+          <physvolid field_name="module" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L2b_halfmodule_stereo_volume" />
+          <positionref ref="module_L2b_halfmodule_stereo_position" />
+          <rotationref ref="module_L2b_halfmodule_stereo_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="3" />
+          <physvolid field_name="module" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L2t_halfmodule_axial_volume" />
+          <positionref ref="module_L2t_halfmodule_axial_position" />
+          <rotationref ref="module_L2t_halfmodule_axial_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="3" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L2t_halfmodule_stereo_volume" />
+          <positionref ref="module_L2t_halfmodule_stereo_position" />
+          <rotationref ref="module_L2t_halfmodule_stereo_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="4" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L3b_halfmodule_axial_volume" />
+          <positionref ref="module_L3b_halfmodule_axial_position" />
+          <rotationref ref="module_L3b_halfmodule_axial_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="6" />
+          <physvolid field_name="module" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L3b_halfmodule_stereo_volume" />
+          <positionref ref="module_L3b_halfmodule_stereo_position" />
+          <rotationref ref="module_L3b_halfmodule_stereo_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="5" />
+          <physvolid field_name="module" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L3t_halfmodule_axial_volume" />
+          <positionref ref="module_L3t_halfmodule_axial_position" />
+          <rotationref ref="module_L3t_halfmodule_axial_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="5" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L3t_halfmodule_stereo_volume" />
+          <positionref ref="module_L3t_halfmodule_stereo_position" />
+          <rotationref ref="module_L3t_halfmodule_stereo_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="6" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L4b_halfmodule_axial_volume" />
+          <positionref ref="module_L4b_halfmodule_axial_position" />
+          <rotationref ref="module_L4b_halfmodule_axial_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="8" />
+          <physvolid field_name="module" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L4b_halfmodule_stereo_volume" />
+          <positionref ref="module_L4b_halfmodule_stereo_position" />
+          <rotationref ref="module_L4b_halfmodule_stereo_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="7" />
+          <physvolid field_name="module" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L4t_halfmodule_axial_volume" />
+          <positionref ref="module_L4t_halfmodule_axial_position" />
+          <rotationref ref="module_L4t_halfmodule_axial_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="7" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L4t_halfmodule_stereo_volume" />
+          <positionref ref="module_L4t_halfmodule_stereo_position" />
+          <rotationref ref="module_L4t_halfmodule_stereo_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="8" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L5b_halfmodule_axial_hole_volume" />
+          <positionref ref="module_L5b_halfmodule_axial_hole_position" />
+          <rotationref ref="module_L5b_halfmodule_axial_hole_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="10" />
+          <physvolid field_name="module" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L5b_halfmodule_axial_slot_volume" />
+          <positionref ref="module_L5b_halfmodule_axial_slot_position" />
+          <rotationref ref="module_L5b_halfmodule_axial_slot_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="10" />
+          <physvolid field_name="module" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L5b_halfmodule_stereo_hole_volume" />
+          <positionref ref="module_L5b_halfmodule_stereo_hole_position" />
+          <rotationref ref="module_L5b_halfmodule_stereo_hole_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="9" />
+          <physvolid field_name="module" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L5b_halfmodule_stereo_slot_volume" />
+          <positionref ref="module_L5b_halfmodule_stereo_slot_position" />
+          <rotationref ref="module_L5b_halfmodule_stereo_slot_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="9" />
+          <physvolid field_name="module" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L5t_halfmodule_axial_hole_volume" />
+          <positionref ref="module_L5t_halfmodule_axial_hole_position" />
+          <rotationref ref="module_L5t_halfmodule_axial_hole_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="9" />
+          <physvolid field_name="module" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L5t_halfmodule_axial_slot_volume" />
+          <positionref ref="module_L5t_halfmodule_axial_slot_position" />
+          <rotationref ref="module_L5t_halfmodule_axial_slot_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="9" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L5t_halfmodule_stereo_hole_volume" />
+          <positionref ref="module_L5t_halfmodule_stereo_hole_position" />
+          <rotationref ref="module_L5t_halfmodule_stereo_hole_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="10" />
+          <physvolid field_name="module" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L5t_halfmodule_stereo_slot_volume" />
+          <positionref ref="module_L5t_halfmodule_stereo_slot_position" />
+          <rotationref ref="module_L5t_halfmodule_stereo_slot_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="10" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L6b_halfmodule_axial_hole_volume" />
+          <positionref ref="module_L6b_halfmodule_axial_hole_position" />
+          <rotationref ref="module_L6b_halfmodule_axial_hole_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="12" />
+          <physvolid field_name="module" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L6b_halfmodule_axial_slot_volume" />
+          <positionref ref="module_L6b_halfmodule_axial_slot_position" />
+          <rotationref ref="module_L6b_halfmodule_axial_slot_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="12" />
+          <physvolid field_name="module" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L6b_halfmodule_stereo_hole_volume" />
+          <positionref ref="module_L6b_halfmodule_stereo_hole_position" />
+          <rotationref ref="module_L6b_halfmodule_stereo_hole_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="11" />
+          <physvolid field_name="module" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L6b_halfmodule_stereo_slot_volume" />
+          <positionref ref="module_L6b_halfmodule_stereo_slot_position" />
+          <rotationref ref="module_L6b_halfmodule_stereo_slot_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="11" />
+          <physvolid field_name="module" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L6t_halfmodule_axial_hole_volume" />
+          <positionref ref="module_L6t_halfmodule_axial_hole_position" />
+          <rotationref ref="module_L6t_halfmodule_axial_hole_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="11" />
+          <physvolid field_name="module" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L6t_halfmodule_axial_slot_volume" />
+          <positionref ref="module_L6t_halfmodule_axial_slot_position" />
+          <rotationref ref="module_L6t_halfmodule_axial_slot_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="11" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L6t_halfmodule_stereo_hole_volume" />
+          <positionref ref="module_L6t_halfmodule_stereo_hole_position" />
+          <rotationref ref="module_L6t_halfmodule_stereo_hole_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="12" />
+          <physvolid field_name="module" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L6t_halfmodule_stereo_slot_volume" />
+          <positionref ref="module_L6t_halfmodule_stereo_slot_position" />
+          <rotationref ref="module_L6t_halfmodule_stereo_slot_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="12" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L7b_halfmodule_axial_hole_volume" />
+          <positionref ref="module_L7b_halfmodule_axial_hole_position" />
+          <rotationref ref="module_L7b_halfmodule_axial_hole_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="14" />
+          <physvolid field_name="module" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L7b_halfmodule_axial_slot_volume" />
+          <positionref ref="module_L7b_halfmodule_axial_slot_position" />
+          <rotationref ref="module_L7b_halfmodule_axial_slot_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="14" />
+          <physvolid field_name="module" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L7b_halfmodule_stereo_hole_volume" />
+          <positionref ref="module_L7b_halfmodule_stereo_hole_position" />
+          <rotationref ref="module_L7b_halfmodule_stereo_hole_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="13" />
+          <physvolid field_name="module" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L7b_halfmodule_stereo_slot_volume" />
+          <positionref ref="module_L7b_halfmodule_stereo_slot_position" />
+          <rotationref ref="module_L7b_halfmodule_stereo_slot_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="13" />
+          <physvolid field_name="module" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L7t_halfmodule_axial_hole_volume" />
+          <positionref ref="module_L7t_halfmodule_axial_hole_position" />
+          <rotationref ref="module_L7t_halfmodule_axial_hole_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="13" />
+          <physvolid field_name="module" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L7t_halfmodule_axial_slot_volume" />
+          <positionref ref="module_L7t_halfmodule_axial_slot_position" />
+          <rotationref ref="module_L7t_halfmodule_axial_slot_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="13" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L7t_halfmodule_stereo_hole_volume" />
+          <positionref ref="module_L7t_halfmodule_stereo_hole_position" />
+          <rotationref ref="module_L7t_halfmodule_stereo_hole_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="14" />
+          <physvolid field_name="module" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="module_L7t_halfmodule_stereo_slot_volume" />
+          <positionref ref="module_L7t_halfmodule_stereo_slot_position" />
+          <rotationref ref="module_L7t_halfmodule_stereo_slot_rotation" />
+          <physvolid field_name="system" value="1" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="14" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <visref ref="SvtBoxVis" />
+      </volume>
+      <volume name="BeamLeftVolume_component0Sensor0">
+        <materialref ref="Vacuum" />
+        <solidref ref="BeamLeftVolume_component0Sensor0Box" />
+        <sdref ref="ECalScoring" />
+      </volume>
+      <volume name="BeamLeftVolume_component0">
+        <materialref ref="Vacuum" />
+        <solidref ref="BeamLeftVolume_component0Box" />
+        <physvol>
+          <volumeref ref="BeamLeftVolume_component0Sensor0" />
+          <positionref ref="BeamLeftVolume_component0Sensor0Position" />
+          <rotationref ref="BeamLeftVolume_component0Sensor0Rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+      </volume>
+      <volume name="BeamLeftVolume">
+        <materialref ref="Vacuum" />
+        <solidref ref="BeamLeftBox" />
+        <physvol>
+          <volumeref ref="BeamLeftVolume_component0" />
+          <positionref ref="BeamLeftVolume_component0_position" />
+          <rotationref ref="BeamLeftVolume_component0_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+      </volume>
+      <volume name="ElectronGapVolume_component0Sensor0">
+        <materialref ref="Vacuum" />
+        <solidref ref="ElectronGapVolume_component0Sensor0Box" />
+        <sdref ref="ECalScoring" />
+      </volume>
+      <volume name="ElectronGapVolume_component0">
+        <materialref ref="Vacuum" />
+        <solidref ref="ElectronGapVolume_component0Box" />
+        <physvol>
+          <volumeref ref="ElectronGapVolume_component0Sensor0" />
+          <positionref ref="ElectronGapVolume_component0Sensor0Position" />
+          <rotationref ref="ElectronGapVolume_component0Sensor0Rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+      </volume>
+      <volume name="ElectronGapVolume">
+        <materialref ref="Vacuum" />
+        <solidref ref="ElectronGapBox" />
+        <physvol>
+          <volumeref ref="ElectronGapVolume_component0" />
+          <positionref ref="ElectronGapVolume_component0_position" />
+          <rotationref ref="ElectronGapVolume_component0_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+      </volume>
+      <volume name="BeamRightVolume_component0Sensor0">
+        <materialref ref="Vacuum" />
+        <solidref ref="BeamRightVolume_component0Sensor0Box" />
+        <sdref ref="ECalScoring" />
+      </volume>
+      <volume name="BeamRightVolume_component0">
+        <materialref ref="Vacuum" />
+        <solidref ref="BeamRightVolume_component0Box" />
+        <physvol>
+          <volumeref ref="BeamRightVolume_component0Sensor0" />
+          <positionref ref="BeamRightVolume_component0Sensor0Position" />
+          <rotationref ref="BeamRightVolume_component0Sensor0Rotation" />
+          <physvolid field_name="sensor" value="0" />
+        </physvol>
+      </volume>
+      <volume name="BeamRightVolume">
+        <materialref ref="Vacuum" />
+        <solidref ref="BeamRightBox" />
+        <physvol>
+          <volumeref ref="BeamRightVolume_component0" />
+          <positionref ref="BeamRightVolume_component0_position" />
+          <rotationref ref="BeamRightVolume_component0_rotation" />
+          <physvolid field_name="component" value="0" />
+        </physvol>
+      </volume>
+      <volume name="crystal_volume">
+        <materialref ref="LeadTungstate" />
+        <solidref ref="crystal_trap" />
+        <sdref ref="Ecal" />
+        <visref ref="ECALVis" />
+      </volume>
+      <volume name="hodo_vol_L1TP0">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L1TP0" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L1TP0">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L1TP0" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L1TP0">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L1TP0" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L1TP0">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L1TP0" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_vol_L1BP0">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L1BP0" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L1BP0">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L1BP0" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L1BP0">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L1BP0" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L1BP0">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L1BP0" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_vol_L1TP1">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L1TP1" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L1TP1">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L1TP1" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L1TP1">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L1TP1" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L1TP1">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L1TP1" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_vol_L1BP1">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L1BP1" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L1BP1">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L1BP1" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L1BP1">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L1BP1" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L1BP1">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L1BP1" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_vol_L1TP2">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L1TP2" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L1TP2">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L1TP2" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L1TP2">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L1TP2" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L1TP2">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L1TP2" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_vol_L1BP2">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L1BP2" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L1BP2">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L1BP2" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L1BP2">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L1BP2" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L1BP2">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L1BP2" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_vol_L1TP3">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L1TP3" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L1TP3">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L1TP3" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L1TP3">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L1TP3" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L1TP3">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L1TP3" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_vol_L1BP3">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L1BP3" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L1BP3">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L1BP3" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L1BP3">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L1BP3" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L1BP3">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L1BP3" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_vol_L1TP4">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L1TP4" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L1TP4">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L1TP4" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L1TP4">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L1TP4" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L1TP4">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L1TP4" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_vol_L1BP4">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L1BP4" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L1BP4">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L1BP4" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L1BP4">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L1BP4" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L1BP4">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L1BP4" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_vol_L2TP0">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L2TP0" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L2TP0">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L2TP0" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L2TP0">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L2TP0" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L2TP0">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L2TP0" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_vol_L2BP0">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L2BP0" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L2BP0">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L2BP0" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L2BP0">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L2BP0" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L2BP0">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L2BP0" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_vol_L2TP1">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L2TP1" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L2TP1">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L2TP1" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L2TP1">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L2TP1" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L2TP1">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L2TP1" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_vol_L2BP1">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L2BP1" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L2BP1">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L2BP1" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L2BP1">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L2BP1" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L2BP1">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L2BP1" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_vol_L2TP2">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L2TP2" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L2TP2">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L2TP2" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L2TP2">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L2TP2" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L2TP2">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L2TP2" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_vol_L2BP2">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L2BP2" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L2BP2">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L2BP2" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L2BP2">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L2BP2" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L2BP2">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L2BP2" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_vol_L2TP3">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L2TP3" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L2TP3">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L2TP3" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L2TP3">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L2TP3" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L2TP3">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L2TP3" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_vol_L2BP3">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L2BP3" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L2BP3">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L2BP3" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L2BP3">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L2BP3" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L2BP3">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L2BP3" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_vol_L2TP4">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L2TP4" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L2TP4">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L2TP4" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L2TP4">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L2TP4" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L2TP4">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L2TP4" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_vol_L2BP4">
+        <materialref ref="Polystyrene" />
+        <solidref ref="hodo_pixel_L2BP4" />
+        <sdref ref="Hodoscope" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_cover_vol_L2BP4">
+        <materialref ref="TitaniumDioxide" />
+        <solidref ref="hodo_cover_L2BP4" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_siderefl_vol_L2BP4">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_siderefl_L2BP4" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_toprefl_vol_L2BP4">
+        <materialref ref="Mylar" />
+        <solidref ref="hodo_toprefl_L2BP4" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="hodo_buffer_vol">
+        <materialref ref="Carbon" />
+        <solidref ref="hodo_buffer" />
+        <visref ref="HodoscopeVis" />
+      </volume>
+      <volume name="front_flange">
+        <materialref ref="G4_Al" />
+        <solidref ref="front_flange_shape" />
+      </volume>
+      <volume name="back_flange">
+        <materialref ref="G4_Al" />
+        <solidref ref="back_flange_shape" />
+      </volume>
+      <volume name="ECAL_chamber">
+        <materialref ref="G4_Al" />
+        <solidref ref="ECAL_chamber_shape" />
+      </volume>
+      <volume name="al_honeycomb">
+        <materialref ref="AlHoneycomb" />
+        <solidref ref="al_honeycomb_shape" />
+      </volume>
+      <volume name="layer_1_top">
+        <materialref ref="G4_Al" />
+        <solidref ref="layer_1_top_shape" />
+      </volume>
+      <volume name="layer_2_top">
+        <materialref ref="G4_Al" />
+        <solidref ref="layer_2_top_shape" />
+      </volume>
+      <volume name="layer_3_top">
+        <materialref ref="G4_Al" />
+        <solidref ref="layer_3_top_shape" />
+      </volume>
+      <volume name="layer_4_top">
+        <materialref ref="G4_Al" />
+        <solidref ref="layer_4_top_shape" />
+      </volume>
+      <volume name="layer_1_bottom">
+        <materialref ref="G4_Al" />
+        <solidref ref="layer_1_bottom_shape" />
+      </volume>
+      <volume name="layer_2_bottom">
+        <materialref ref="G4_Al" />
+        <solidref ref="layer_2_bottom_shape" />
+      </volume>
+      <volume name="layer_3_bottom">
+        <materialref ref="G4_Al" />
+        <solidref ref="layer_3_bottom_shape" />
+      </volume>
+      <volume name="layer_4_bottom">
+        <materialref ref="G4_Al" />
+        <solidref ref="layer_4_bottom_shape" />
+      </volume>
+      <volume name="layer_5T_left">
+        <materialref ref="G4_Al" />
+        <solidref ref="layer_5T_left_shape" />
+      </volume>
+      <volume name="layer_5B_left">
+        <materialref ref="G4_Al" />
+        <solidref ref="layer_5B_left_shape" />
+      </volume>
+      <volume name="steel_bar">
+        <materialref ref="StainlessSteel" />
+        <solidref ref="steel_bar_shape" />
+      </volume>
+      <volume name="cu_Tpipe_inner_left">
+        <materialref ref="G4_Cu" />
+        <solidref ref="cu_Tpipe_inner_left_shape" />
+      </volume>
+      <volume name="cu_Tpipe_inner_right">
+        <materialref ref="G4_Cu" />
+        <solidref ref="cu_Tpipe_inner_right_shape" />
+      </volume>
+      <volume name="cu_Bpipe_inner_left">
+        <materialref ref="G4_Cu" />
+        <solidref ref="cu_Bpipe_inner_left_shape" />
+      </volume>
+      <volume name="cu_Bpipe_inner_right">
+        <materialref ref="G4_Cu" />
+        <solidref ref="cu_Bpipe_inner_right_shape" />
+      </volume>
+      <volume name="cu_Tpipe_outer_right1">
+        <materialref ref="G4_Cu" />
+        <solidref ref="cu_Tpipe_outer_right1_shape" />
+      </volume>
+      <volume name="cu_Tpipe_outer_right2">
+        <materialref ref="G4_Cu" />
+        <solidref ref="cu_Tpipe_outer_right2_shape" />
+      </volume>
+      <volume name="cu_Tpipe_outer_right3">
+        <materialref ref="G4_Cu" />
+        <solidref ref="cu_Tpipe_outer_right3_shape" />
+      </volume>
+      <volume name="cu_Bpipe_outer_right">
+        <materialref ref="G4_Cu" />
+        <solidref ref="cu_Bpipe_outer_right_shape" />
+      </volume>
+      <volume name="cu_Bpipe_outer_right1">
+        <materialref ref="G4_Cu" />
+        <solidref ref="cu_Bpipe_outer_right1_shape" />
+      </volume>
+      <volume name="cu_Bpipe_outer_right2">
+        <materialref ref="G4_Cu" />
+        <solidref ref="cu_Bpipe_outer_right2_shape" />
+      </volume>
+      <volume name="al_pipe_across_top1">
+        <materialref ref="G4_Al" />
+        <solidref ref="al_pipe_across_top1_shape" />
+      </volume>
+      <volume name="al_pipe_across_top2">
+        <materialref ref="G4_Al" />
+        <solidref ref="al_pipe_across_top2_shape" />
+      </volume>
+      <volume name="al_pipe_across_bottom1">
+        <materialref ref="G4_Al" />
+        <solidref ref="al_pipe_across_bottom1_shape" />
+      </volume>
+      <volume name="al_pipe_across_bottom2">
+        <materialref ref="G4_Al" />
+        <solidref ref="al_pipe_across_bottom2_shape" />
+      </volume>
+      <volume name="cu_plate_top_left">
+        <materialref ref="G4_Cu" />
+        <solidref ref="cu_plate_top_left_shape" />
+      </volume>
+      <volume name="cu_plate_bottom_left">
+        <materialref ref="G4_Cu" />
+        <solidref ref="cu_plate_bottom_left_shape" />
+      </volume>
+      <volume name="cu_plate_top_right">
+        <materialref ref="G4_Cu" />
+        <solidref ref="cu_plate_top_right_shape" />
+      </volume>
+      <volume name="cu_plate_bottom_right">
+        <materialref ref="G4_Cu" />
+        <solidref ref="cu_plate_bottom_right_shape" />
+      </volume>
+      <volume name="cu_plate_top_middle">
+        <materialref ref="G4_Cu" />
+        <solidref ref="cu_plate_top_middle_shape" />
+      </volume>
+      <volume name="cu_plate_bottom_middle">
+        <materialref ref="G4_Cu" />
+        <solidref ref="cu_plate_bottom_middle_shape" />
+      </volume>
+      <volume name="hodo_flange">
+        <materialref ref="Aluminum" />
+        <solidref ref="hodo_flange_shape" />
+      </volume>
+      <volume name="arms1_block1">
+        <materialref ref="G10_FR4" />
+        <solidref ref="arms1_block1_shape" />
+      </volume>
+      <volume name="arms1_block2">
+        <materialref ref="G10_FR4" />
+        <solidref ref="arms1_block2_shape" />
+      </volume>
+      <volume name="arms1_block3">
+        <materialref ref="G10_FR4" />
+        <solidref ref="arms1_block3_shape" />
+      </volume>
+      <volume name="arms1_block4">
+        <materialref ref="G10_FR4" />
+        <solidref ref="arms1_block4_shape" />
+      </volume>
+      <volume name="cross_bar_top">
+        <materialref ref="G10_FR4" />
+        <solidref ref="cross_bar_top_shape" />
+      </volume>
+      <volume name="cross_bar_bottom">
+        <materialref ref="G10_FR4" />
+        <solidref ref="cross_bar_bottom_shape" />
+      </volume>
+      <volume name="support_arm_bottom_left_plus_block">
+        <materialref ref="G10_FR4" />
+        <solidref ref="support_arm_bottom_left_plus_block_shape" />
+      </volume>
+      <volume name="support_arm_bottom_right">
+        <materialref ref="G10_FR4" />
+        <solidref ref="support_arm_bottom_right_shape" />
+      </volume>
+      <volume name="support_arm_top_left">
+        <materialref ref="G10_FR4" />
+        <solidref ref="support_arm_top_left_shape" />
+      </volume>
+      <volume name="support_arm_top_right">
+        <materialref ref="G10_FR4" />
+        <solidref ref="support_arm_top_right_shape" />
+      </volume>
+      <volume name="u_support_bar_bottom">
+        <materialref ref="G10_FR4" />
+        <solidref ref="u_support_bar_bottom_shape" />
+      </volume>
+      <volume name="u_support_bar_upper1">
+        <materialref ref="G10_FR4" />
+        <solidref ref="u_support_bar_upper1_shape" />
+      </volume>
+      <volume name="u_support_bar_upper2">
+        <materialref ref="G10_FR4" />
+        <solidref ref="u_support_bar_upper2_shape" />
+      </volume>
+      <volume name="u_support_bar_top">
+        <materialref ref="G10_FR4" />
+        <solidref ref="u_support_bar_top_shape" />
+      </volume>
+      <volume name="u_support_bar_upper3">
+        <materialref ref="G10_FR4" />
+        <solidref ref="u_support_bar_upper3_shape" />
+      </volume>
+      <volume name="u_support_bar_upper4">
+        <materialref ref="G10_FR4" />
+        <solidref ref="u_support_bar_upper4_shape" />
+      </volume>
+      <volume name="svt_chamber_box_vol">
+        <materialref ref="Stainless_304" />
+        <solidref ref="svt_chamber_box" />
+      </volume>
+      <volume name="svt_chamber_flare1_vol">
+        <materialref ref="Stainless_304" />
+        <solidref ref="svt_chamber_flare1" />
+      </volume>
+      <volume name="svt_chamber_flare2_vol">
+        <materialref ref="Stainless_304" />
+        <solidref ref="svt_chamber_flare2" />
+      </volume>
+      <volume name="svt_chamber_flange_vol">
+        <materialref ref="Stainless_304" />
+        <solidref ref="svt_chamber_flange" />
+      </volume>
+      <volume name="tracking_volume">
+        <materialref ref="TrackingMaterial" />
+        <solidref ref="tracking_cylinder" />
+        <physvol>
+          <volumeref ref="base_volume" />
+          <positionref ref="base_position" />
+          <rotationref ref="base_rotation" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L1TP0" />
+          <positionref ref="hodo_pos_L1TP0" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="0" />
+          <physvolid field_name="ix" value="0" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1TP0" />
+          <positionref ref="hodo_forecover_pos_L1TP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1TP0" />
+          <positionref ref="hodo_postcover_pos_L1TP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1TP0" />
+          <positionref ref="hodo_sidereflR_pos_L1TP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1TP0" />
+          <positionref ref="hodo_siderefl2L_pos_L1TP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1TP0" />
+          <positionref ref="hodo_topreflT_pos_L1TP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1TP0" />
+          <positionref ref="hodo_toprefl2B_pos_L1TP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L1BP0" />
+          <positionref ref="hodo_pos_L1BP0" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="0" />
+          <physvolid field_name="ix" value="0" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1BP0" />
+          <positionref ref="hodo_forecover_pos_L1BP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1BP0" />
+          <positionref ref="hodo_postcover_pos_L1BP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1BP0" />
+          <positionref ref="hodo_sidereflR_pos_L1BP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1BP0" />
+          <positionref ref="hodo_siderefl2L_pos_L1BP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1BP0" />
+          <positionref ref="hodo_topreflT_pos_L1BP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1BP0" />
+          <positionref ref="hodo_toprefl2B_pos_L1BP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L1TP1" />
+          <positionref ref="hodo_pos_L1TP1" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="0" />
+          <physvolid field_name="ix" value="1" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1TP1" />
+          <positionref ref="hodo_forecover_pos_L1TP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1TP1" />
+          <positionref ref="hodo_postcover_pos_L1TP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1TP1" />
+          <positionref ref="hodo_sidereflR_pos_L1TP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1TP1" />
+          <positionref ref="hodo_siderefl2L_pos_L1TP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1TP1" />
+          <positionref ref="hodo_topreflT_pos_L1TP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1TP1" />
+          <positionref ref="hodo_toprefl2B_pos_L1TP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L1BP1" />
+          <positionref ref="hodo_pos_L1BP1" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="0" />
+          <physvolid field_name="ix" value="1" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1BP1" />
+          <positionref ref="hodo_forecover_pos_L1BP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1BP1" />
+          <positionref ref="hodo_postcover_pos_L1BP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1BP1" />
+          <positionref ref="hodo_sidereflR_pos_L1BP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1BP1" />
+          <positionref ref="hodo_siderefl2L_pos_L1BP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1BP1" />
+          <positionref ref="hodo_topreflT_pos_L1BP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1BP1" />
+          <positionref ref="hodo_toprefl2B_pos_L1BP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L1TP2" />
+          <positionref ref="hodo_pos_L1TP2" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="0" />
+          <physvolid field_name="ix" value="2" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1TP2" />
+          <positionref ref="hodo_forecover_pos_L1TP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1TP2" />
+          <positionref ref="hodo_postcover_pos_L1TP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1TP2" />
+          <positionref ref="hodo_sidereflR_pos_L1TP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1TP2" />
+          <positionref ref="hodo_siderefl2L_pos_L1TP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1TP2" />
+          <positionref ref="hodo_topreflT_pos_L1TP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1TP2" />
+          <positionref ref="hodo_toprefl2B_pos_L1TP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L1BP2" />
+          <positionref ref="hodo_pos_L1BP2" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="0" />
+          <physvolid field_name="ix" value="2" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1BP2" />
+          <positionref ref="hodo_forecover_pos_L1BP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1BP2" />
+          <positionref ref="hodo_postcover_pos_L1BP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1BP2" />
+          <positionref ref="hodo_sidereflR_pos_L1BP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1BP2" />
+          <positionref ref="hodo_siderefl2L_pos_L1BP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1BP2" />
+          <positionref ref="hodo_topreflT_pos_L1BP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1BP2" />
+          <positionref ref="hodo_toprefl2B_pos_L1BP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L1TP3" />
+          <positionref ref="hodo_pos_L1TP3" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="0" />
+          <physvolid field_name="ix" value="3" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1TP3" />
+          <positionref ref="hodo_forecover_pos_L1TP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1TP3" />
+          <positionref ref="hodo_postcover_pos_L1TP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1TP3" />
+          <positionref ref="hodo_sidereflR_pos_L1TP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1TP3" />
+          <positionref ref="hodo_siderefl2L_pos_L1TP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1TP3" />
+          <positionref ref="hodo_topreflT_pos_L1TP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1TP3" />
+          <positionref ref="hodo_toprefl2B_pos_L1TP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L1BP3" />
+          <positionref ref="hodo_pos_L1BP3" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="0" />
+          <physvolid field_name="ix" value="3" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1BP3" />
+          <positionref ref="hodo_forecover_pos_L1BP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1BP3" />
+          <positionref ref="hodo_postcover_pos_L1BP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1BP3" />
+          <positionref ref="hodo_sidereflR_pos_L1BP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1BP3" />
+          <positionref ref="hodo_siderefl2L_pos_L1BP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1BP3" />
+          <positionref ref="hodo_topreflT_pos_L1BP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1BP3" />
+          <positionref ref="hodo_toprefl2B_pos_L1BP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L1TP4" />
+          <positionref ref="hodo_pos_L1TP4" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="0" />
+          <physvolid field_name="ix" value="4" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1TP4" />
+          <positionref ref="hodo_forecover_pos_L1TP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1TP4" />
+          <positionref ref="hodo_postcover_pos_L1TP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1TP4" />
+          <positionref ref="hodo_sidereflR_pos_L1TP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1TP4" />
+          <positionref ref="hodo_siderefl2L_pos_L1TP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1TP4" />
+          <positionref ref="hodo_topreflT_pos_L1TP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1TP4" />
+          <positionref ref="hodo_toprefl2B_pos_L1TP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L1BP4" />
+          <positionref ref="hodo_pos_L1BP4" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="0" />
+          <physvolid field_name="ix" value="4" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1BP4" />
+          <positionref ref="hodo_forecover_pos_L1BP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L1BP4" />
+          <positionref ref="hodo_postcover_pos_L1BP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1BP4" />
+          <positionref ref="hodo_sidereflR_pos_L1BP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L1BP4" />
+          <positionref ref="hodo_siderefl2L_pos_L1BP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1BP4" />
+          <positionref ref="hodo_topreflT_pos_L1BP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L1BP4" />
+          <positionref ref="hodo_toprefl2B_pos_L1BP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L2TP0" />
+          <positionref ref="hodo_pos_L2TP0" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="1" />
+          <physvolid field_name="ix" value="0" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2TP0" />
+          <positionref ref="hodo_forecover_pos_L2TP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2TP0" />
+          <positionref ref="hodo_postcover_pos_L2TP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2TP0" />
+          <positionref ref="hodo_sidereflR_pos_L2TP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2TP0" />
+          <positionref ref="hodo_siderefl2L_pos_L2TP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2TP0" />
+          <positionref ref="hodo_topreflT_pos_L2TP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2TP0" />
+          <positionref ref="hodo_toprefl2B_pos_L2TP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L2BP0" />
+          <positionref ref="hodo_pos_L2BP0" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="1" />
+          <physvolid field_name="ix" value="0" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2BP0" />
+          <positionref ref="hodo_forecover_pos_L2BP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2BP0" />
+          <positionref ref="hodo_postcover_pos_L2BP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2BP0" />
+          <positionref ref="hodo_sidereflR_pos_L2BP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2BP0" />
+          <positionref ref="hodo_siderefl2L_pos_L2BP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2BP0" />
+          <positionref ref="hodo_topreflT_pos_L2BP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2BP0" />
+          <positionref ref="hodo_toprefl2B_pos_L2BP0" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L2TP1" />
+          <positionref ref="hodo_pos_L2TP1" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="1" />
+          <physvolid field_name="ix" value="1" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2TP1" />
+          <positionref ref="hodo_forecover_pos_L2TP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2TP1" />
+          <positionref ref="hodo_postcover_pos_L2TP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2TP1" />
+          <positionref ref="hodo_sidereflR_pos_L2TP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2TP1" />
+          <positionref ref="hodo_siderefl2L_pos_L2TP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2TP1" />
+          <positionref ref="hodo_topreflT_pos_L2TP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2TP1" />
+          <positionref ref="hodo_toprefl2B_pos_L2TP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L2BP1" />
+          <positionref ref="hodo_pos_L2BP1" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="1" />
+          <physvolid field_name="ix" value="1" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2BP1" />
+          <positionref ref="hodo_forecover_pos_L2BP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2BP1" />
+          <positionref ref="hodo_postcover_pos_L2BP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2BP1" />
+          <positionref ref="hodo_sidereflR_pos_L2BP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2BP1" />
+          <positionref ref="hodo_siderefl2L_pos_L2BP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2BP1" />
+          <positionref ref="hodo_topreflT_pos_L2BP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2BP1" />
+          <positionref ref="hodo_toprefl2B_pos_L2BP1" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L2TP2" />
+          <positionref ref="hodo_pos_L2TP2" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="1" />
+          <physvolid field_name="ix" value="2" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2TP2" />
+          <positionref ref="hodo_forecover_pos_L2TP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2TP2" />
+          <positionref ref="hodo_postcover_pos_L2TP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2TP2" />
+          <positionref ref="hodo_sidereflR_pos_L2TP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2TP2" />
+          <positionref ref="hodo_siderefl2L_pos_L2TP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2TP2" />
+          <positionref ref="hodo_topreflT_pos_L2TP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2TP2" />
+          <positionref ref="hodo_toprefl2B_pos_L2TP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L2BP2" />
+          <positionref ref="hodo_pos_L2BP2" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="1" />
+          <physvolid field_name="ix" value="2" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2BP2" />
+          <positionref ref="hodo_forecover_pos_L2BP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2BP2" />
+          <positionref ref="hodo_postcover_pos_L2BP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2BP2" />
+          <positionref ref="hodo_sidereflR_pos_L2BP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2BP2" />
+          <positionref ref="hodo_siderefl2L_pos_L2BP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2BP2" />
+          <positionref ref="hodo_topreflT_pos_L2BP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2BP2" />
+          <positionref ref="hodo_toprefl2B_pos_L2BP2" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L2TP3" />
+          <positionref ref="hodo_pos_L2TP3" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="1" />
+          <physvolid field_name="ix" value="3" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2TP3" />
+          <positionref ref="hodo_forecover_pos_L2TP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2TP3" />
+          <positionref ref="hodo_postcover_pos_L2TP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2TP3" />
+          <positionref ref="hodo_sidereflR_pos_L2TP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2TP3" />
+          <positionref ref="hodo_siderefl2L_pos_L2TP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2TP3" />
+          <positionref ref="hodo_topreflT_pos_L2TP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2TP3" />
+          <positionref ref="hodo_toprefl2B_pos_L2TP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L2BP3" />
+          <positionref ref="hodo_pos_L2BP3" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="1" />
+          <physvolid field_name="ix" value="3" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2BP3" />
+          <positionref ref="hodo_forecover_pos_L2BP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2BP3" />
+          <positionref ref="hodo_postcover_pos_L2BP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2BP3" />
+          <positionref ref="hodo_sidereflR_pos_L2BP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2BP3" />
+          <positionref ref="hodo_siderefl2L_pos_L2BP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2BP3" />
+          <positionref ref="hodo_topreflT_pos_L2BP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2BP3" />
+          <positionref ref="hodo_toprefl2B_pos_L2BP3" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L2TP4" />
+          <positionref ref="hodo_pos_L2TP4" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="1" />
+          <physvolid field_name="ix" value="4" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2TP4" />
+          <positionref ref="hodo_forecover_pos_L2TP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2TP4" />
+          <positionref ref="hodo_postcover_pos_L2TP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2TP4" />
+          <positionref ref="hodo_sidereflR_pos_L2TP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2TP4" />
+          <positionref ref="hodo_siderefl2L_pos_L2TP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2TP4" />
+          <positionref ref="hodo_topreflT_pos_L2TP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2TP4" />
+          <positionref ref="hodo_toprefl2B_pos_L2TP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_vol_L2BP4" />
+          <positionref ref="hodo_pos_L2BP4" />
+          <rotationref ref="hodo_rot" />
+          <physvolid field_name="system" value="30" />
+          <physvolid field_name="barrel" value="1" />
+          <physvolid field_name="layer" value="1" />
+          <physvolid field_name="ix" value="4" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2BP4" />
+          <positionref ref="hodo_forecover_pos_L2BP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_cover_vol_L2BP4" />
+          <positionref ref="hodo_postcover_pos_L2BP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2BP4" />
+          <positionref ref="hodo_sidereflR_pos_L2BP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_siderefl_vol_L2BP4" />
+          <positionref ref="hodo_siderefl2L_pos_L2BP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2BP4" />
+          <positionref ref="hodo_topreflT_pos_L2BP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_toprefl_vol_L2BP4" />
+          <positionref ref="hodo_toprefl2B_pos_L2BP4" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_buffer_vol" />
+          <positionref ref="hodo_bufferT_pos" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="hodo_buffer_vol" />
+          <positionref ref="hodo_bufferB_pos" />
+          <rotationref ref="hodo_rot" />
+        </physvol>
+        <physvol name="hodo_flange_1">
+          <volumeref ref="hodo_flange" />
+          <positionref ref="hodo_flange_1intracking_volumepos" />
+        </physvol>
+        <physvol name="arms1_block1_1">
+          <volumeref ref="arms1_block1" />
+          <positionref ref="arms1_block1_1intracking_volumepos" />
+        </physvol>
+        <physvol name="arms1_block2_1">
+          <volumeref ref="arms1_block2" />
+          <positionref ref="arms1_block2_1intracking_volumepos" />
+        </physvol>
+        <physvol name="arms1_block3_1">
+          <volumeref ref="arms1_block3" />
+          <positionref ref="arms1_block3_1intracking_volumepos" />
+        </physvol>
+        <physvol name="arms1_block4_1">
+          <volumeref ref="arms1_block4" />
+          <positionref ref="arms1_block4_1intracking_volumepos" />
+        </physvol>
+        <physvol name="cross_bar_top_1">
+          <volumeref ref="cross_bar_top" />
+          <positionref ref="cross_bar_top_1intracking_volumepos" />
+        </physvol>
+        <physvol name="cross_bar_bottom_1">
+          <volumeref ref="cross_bar_bottom" />
+          <positionref ref="cross_bar_bottom_1intracking_volumepos" />
+        </physvol>
+        <physvol name="support_arm_bottom_left_plus_block_1">
+          <volumeref ref="support_arm_bottom_left_plus_block" />
+          <positionref ref="support_arm_bottom_left_plus_block_1intracking_volumepos" />
+        </physvol>
+        <physvol name="support_arm_bottom_right_1">
+          <volumeref ref="support_arm_bottom_right" />
+          <positionref ref="support_arm_bottom_right_1intracking_volumepos" />
+        </physvol>
+        <physvol name="support_arm_top_left_1">
+          <volumeref ref="support_arm_top_left" />
+          <positionref ref="support_arm_top_left_1intracking_volumepos" />
+          <rotationref ref="support_arm_top_left_1intracking_volumerot" />
+        </physvol>
+        <physvol name="support_arm_top_right_1">
+          <volumeref ref="support_arm_top_right" />
+          <positionref ref="support_arm_top_right_1intracking_volumepos" />
+          <rotationref ref="support_arm_top_right_1intracking_volumerot" />
+        </physvol>
+        <physvol name="u_support_bar_bottom_1">
+          <volumeref ref="u_support_bar_bottom" />
+          <positionref ref="u_support_bar_bottom_1intracking_volumepos" />
+        </physvol>
+        <physvol name="u_support_bar_upper1_1">
+          <volumeref ref="u_support_bar_upper1" />
+          <positionref ref="u_support_bar_upper1_1intracking_volumepos" />
+        </physvol>
+        <physvol name="u_support_bar_upper2_1">
+          <volumeref ref="u_support_bar_upper2" />
+          <positionref ref="u_support_bar_upper2_1intracking_volumepos" />
+        </physvol>
+        <physvol name="u_support_bar_top_1">
+          <volumeref ref="u_support_bar_top" />
+          <positionref ref="u_support_bar_top_1intracking_volumepos" />
+        </physvol>
+        <physvol name="u_support_bar_upper3_1">
+          <volumeref ref="u_support_bar_upper3" />
+          <positionref ref="u_support_bar_upper3_1intracking_volumepos" />
+        </physvol>
+        <physvol name="u_support_bar_upper4_1">
+          <volumeref ref="u_support_bar_upper4" />
+          <positionref ref="u_support_bar_upper4_1intracking_volumepos" />
+        </physvol>
+        <physvol>
+          <volumeref ref="svt_chamber_box_vol" />
+          <position name="svt_chamber_box_position" x="svt_chamber_x" y="0" z="svt_chamber_z+svt_chamber_box_z" />
+        </physvol>
+        <physvol>
+          <volumeref ref="svt_chamber_flare1_vol" />
+          <position name="svt_chamber_flare1_position" x="svt_chamber_x" y="0" z="svt_chamber_z+svt_chamber_flare1_z" />
+        </physvol>
+        <physvol>
+          <volumeref ref="svt_chamber_flare2_vol" />
+          <position name="svt_chamber_flare2_position" x="svt_chamber_x" y="0" z="svt_chamber_z+svt_chamber_flare2_z" />
+        </physvol>
+        <physvol>
+          <volumeref ref="svt_chamber_flange_vol" />
+          <position name="svt_chamber_flange_position" x="svt_chamber_x" y="0" z="svt_chamber_z+svt_chamber_flange_z" />
+        </physvol>
+        <regionref ref="TrackingRegion" />
+        <visref ref="TrackingVis" />
+      </volume>
+      <volume name="world_volume">
+        <materialref ref="WorldMaterial" />
+        <solidref ref="world_box" />
+        <physvol>
+          <volumeref ref="tracking_volume" />
+          <positionref ref="tracking_region_pos" />
+          <rotationref ref="identity_rot" />
+        </physvol>
+        <physvol>
+          <volumeref ref="BeamLeftVolume" />
+          <positionref ref="ECalScoring_BeamLeft_layer1_module0_position" />
+          <rotationref ref="ECalScoring_BeamLeft_layer1_module0_rotation" />
+          <physvolid field_name="system" value="29" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="1" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="ElectronGapVolume" />
+          <positionref ref="ECalScoring_ElectronGap_layer1_module0_position" />
+          <rotationref ref="ECalScoring_ElectronGap_layer1_module0_rotation" />
+          <physvolid field_name="system" value="29" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="1" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="BeamRightVolume" />
+          <positionref ref="ECalScoring_BeamRight_layer1_module0_position" />
+          <rotationref ref="ECalScoring_BeamRight_layer1_module0_rotation" />
+          <physvolid field_name="system" value="29" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="1" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="BeamLeftVolume" />
+          <positionref ref="ECalScoring_BeamLeft_layer2_module0_position" />
+          <rotationref ref="ECalScoring_BeamLeft_layer2_module0_rotation" />
+          <physvolid field_name="system" value="29" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="2" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="ElectronGapVolume" />
+          <positionref ref="ECalScoring_ElectronGap_layer2_module0_position" />
+          <rotationref ref="ECalScoring_ElectronGap_layer2_module0_rotation" />
+          <physvolid field_name="system" value="29" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="2" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="BeamRightVolume" />
+          <positionref ref="ECalScoring_BeamRight_layer2_module0_position" />
+          <rotationref ref="ECalScoring_BeamRight_layer2_module0_rotation" />
+          <physvolid field_name="system" value="29" />
+          <physvolid field_name="barrel" value="0" />
+          <physvolid field_name="layer" value="2" />
+          <physvolid field_name="module" value="0" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-1_pos_pos_bot" />
+          <rotationref ref="crystal1-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="1" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-1_pos_neg_bot" />
+          <rotationref ref="crystal1-1_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-1" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-1_pos_pos_top" />
+          <rotationref ref="crystal1-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="1" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-1_pos_neg_top" />
+          <rotationref ref="crystal1-1_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-1" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal2-1_pos_pos_bot" />
+          <rotationref ref="crystal2-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="2" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal2-1_pos_pos_top" />
+          <rotationref ref="crystal2-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="2" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal3-1_pos_pos_bot" />
+          <rotationref ref="crystal3-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="3" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal3-1_pos_pos_top" />
+          <rotationref ref="crystal3-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="3" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal4-1_pos_pos_bot" />
+          <rotationref ref="crystal4-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="4" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal4-1_pos_pos_top" />
+          <rotationref ref="crystal4-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="4" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal5-1_pos_pos_bot" />
+          <rotationref ref="crystal5-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="5" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal5-1_pos_pos_top" />
+          <rotationref ref="crystal5-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="5" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal6-1_pos_pos_bot" />
+          <rotationref ref="crystal6-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="6" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal6-1_pos_pos_top" />
+          <rotationref ref="crystal6-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="6" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal7-1_pos_pos_bot" />
+          <rotationref ref="crystal7-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="7" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal7-1_pos_pos_top" />
+          <rotationref ref="crystal7-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="7" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal8-1_pos_pos_bot" />
+          <rotationref ref="crystal8-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="8" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal8-1_pos_pos_top" />
+          <rotationref ref="crystal8-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="8" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal9-1_pos_pos_bot" />
+          <rotationref ref="crystal9-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="9" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal9-1_pos_pos_top" />
+          <rotationref ref="crystal9-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="9" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal10-1_pos_pos_bot" />
+          <rotationref ref="crystal10-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="10" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal10-1_pos_pos_top" />
+          <rotationref ref="crystal10-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="10" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-1_pos_pos_bot" />
+          <rotationref ref="crystal11-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="11" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-1_pos_neg_bot" />
+          <rotationref ref="crystal11-1_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-11" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-1_pos_pos_top" />
+          <rotationref ref="crystal11-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="11" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-1_pos_neg_top" />
+          <rotationref ref="crystal11-1_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-11" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-1_pos_pos_bot" />
+          <rotationref ref="crystal12-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="12" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-1_pos_neg_bot" />
+          <rotationref ref="crystal12-1_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-12" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-1_pos_pos_top" />
+          <rotationref ref="crystal12-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="12" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-1_pos_neg_top" />
+          <rotationref ref="crystal12-1_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-12" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-1_pos_pos_bot" />
+          <rotationref ref="crystal13-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="13" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-1_pos_neg_bot" />
+          <rotationref ref="crystal13-1_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-13" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-1_pos_pos_top" />
+          <rotationref ref="crystal13-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="13" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-1_pos_neg_top" />
+          <rotationref ref="crystal13-1_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-13" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-1_pos_pos_bot" />
+          <rotationref ref="crystal14-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="14" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-1_pos_neg_bot" />
+          <rotationref ref="crystal14-1_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-14" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-1_pos_pos_top" />
+          <rotationref ref="crystal14-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="14" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-1_pos_neg_top" />
+          <rotationref ref="crystal14-1_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-14" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-1_pos_pos_bot" />
+          <rotationref ref="crystal15-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="15" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-1_pos_neg_bot" />
+          <rotationref ref="crystal15-1_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-15" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-1_pos_pos_top" />
+          <rotationref ref="crystal15-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="15" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-1_pos_neg_top" />
+          <rotationref ref="crystal15-1_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-15" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-1_pos_pos_bot" />
+          <rotationref ref="crystal16-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="16" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-1_pos_neg_bot" />
+          <rotationref ref="crystal16-1_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-16" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-1_pos_pos_top" />
+          <rotationref ref="crystal16-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="16" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-1_pos_neg_top" />
+          <rotationref ref="crystal16-1_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-16" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-1_pos_pos_bot" />
+          <rotationref ref="crystal17-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="17" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-1_pos_neg_bot" />
+          <rotationref ref="crystal17-1_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-17" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-1_pos_pos_top" />
+          <rotationref ref="crystal17-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="17" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-1_pos_neg_top" />
+          <rotationref ref="crystal17-1_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-17" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-1_pos_pos_bot" />
+          <rotationref ref="crystal18-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="18" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-1_pos_neg_bot" />
+          <rotationref ref="crystal18-1_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-18" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-1_pos_pos_top" />
+          <rotationref ref="crystal18-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="18" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-1_pos_neg_top" />
+          <rotationref ref="crystal18-1_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-18" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-1_pos_pos_bot" />
+          <rotationref ref="crystal19-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="19" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-1_pos_neg_bot" />
+          <rotationref ref="crystal19-1_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-19" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-1_pos_pos_top" />
+          <rotationref ref="crystal19-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="19" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-1_pos_neg_top" />
+          <rotationref ref="crystal19-1_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-19" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-1_pos_pos_bot" />
+          <rotationref ref="crystal20-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="20" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-1_pos_neg_bot" />
+          <rotationref ref="crystal20-1_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-20" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-1_pos_pos_top" />
+          <rotationref ref="crystal20-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="20" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-1_pos_neg_top" />
+          <rotationref ref="crystal20-1_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-20" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-1_pos_pos_bot" />
+          <rotationref ref="crystal21-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="21" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-1_pos_neg_bot" />
+          <rotationref ref="crystal21-1_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-21" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-1_pos_pos_top" />
+          <rotationref ref="crystal21-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="21" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-1_pos_neg_top" />
+          <rotationref ref="crystal21-1_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-21" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-1_pos_pos_bot" />
+          <rotationref ref="crystal22-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="22" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-1_pos_neg_bot" />
+          <rotationref ref="crystal22-1_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-22" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-1_pos_pos_top" />
+          <rotationref ref="crystal22-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="22" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-1_pos_neg_top" />
+          <rotationref ref="crystal22-1_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-22" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-1_pos_pos_bot" />
+          <rotationref ref="crystal23-1_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="23" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-1_pos_neg_bot" />
+          <rotationref ref="crystal23-1_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-23" />
+          <physvolid field_name="iy" value="-1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-1_pos_pos_top" />
+          <rotationref ref="crystal23-1_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="23" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-1_pos_neg_top" />
+          <rotationref ref="crystal23-1_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-23" />
+          <physvolid field_name="iy" value="1" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-2_pos_pos_bot" />
+          <rotationref ref="crystal1-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="1" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-2_pos_neg_bot" />
+          <rotationref ref="crystal1-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-1" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-2_pos_pos_top" />
+          <rotationref ref="crystal1-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="1" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-2_pos_neg_top" />
+          <rotationref ref="crystal1-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-1" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal2-2_pos_pos_bot" />
+          <rotationref ref="crystal2-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="2" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal2-2_pos_neg_bot" />
+          <rotationref ref="crystal2-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-2" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal2-2_pos_pos_top" />
+          <rotationref ref="crystal2-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="2" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal2-2_pos_neg_top" />
+          <rotationref ref="crystal2-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-2" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal3-2_pos_pos_bot" />
+          <rotationref ref="crystal3-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="3" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal3-2_pos_neg_bot" />
+          <rotationref ref="crystal3-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-3" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal3-2_pos_pos_top" />
+          <rotationref ref="crystal3-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="3" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal3-2_pos_neg_top" />
+          <rotationref ref="crystal3-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-3" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal4-2_pos_pos_bot" />
+          <rotationref ref="crystal4-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="4" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal4-2_pos_neg_bot" />
+          <rotationref ref="crystal4-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-4" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal4-2_pos_pos_top" />
+          <rotationref ref="crystal4-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="4" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal4-2_pos_neg_top" />
+          <rotationref ref="crystal4-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-4" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal5-2_pos_pos_bot" />
+          <rotationref ref="crystal5-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="5" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal5-2_pos_neg_bot" />
+          <rotationref ref="crystal5-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-5" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal5-2_pos_pos_top" />
+          <rotationref ref="crystal5-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="5" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal5-2_pos_neg_top" />
+          <rotationref ref="crystal5-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-5" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal6-2_pos_pos_bot" />
+          <rotationref ref="crystal6-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="6" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal6-2_pos_neg_bot" />
+          <rotationref ref="crystal6-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-6" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal6-2_pos_pos_top" />
+          <rotationref ref="crystal6-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="6" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal6-2_pos_neg_top" />
+          <rotationref ref="crystal6-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-6" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal7-2_pos_pos_bot" />
+          <rotationref ref="crystal7-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="7" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal7-2_pos_neg_bot" />
+          <rotationref ref="crystal7-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-7" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal7-2_pos_pos_top" />
+          <rotationref ref="crystal7-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="7" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal7-2_pos_neg_top" />
+          <rotationref ref="crystal7-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-7" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal8-2_pos_pos_bot" />
+          <rotationref ref="crystal8-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="8" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal8-2_pos_neg_bot" />
+          <rotationref ref="crystal8-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-8" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal8-2_pos_pos_top" />
+          <rotationref ref="crystal8-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="8" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal8-2_pos_neg_top" />
+          <rotationref ref="crystal8-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-8" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal9-2_pos_pos_bot" />
+          <rotationref ref="crystal9-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="9" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal9-2_pos_neg_bot" />
+          <rotationref ref="crystal9-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-9" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal9-2_pos_pos_top" />
+          <rotationref ref="crystal9-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="9" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal9-2_pos_neg_top" />
+          <rotationref ref="crystal9-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-9" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal10-2_pos_pos_bot" />
+          <rotationref ref="crystal10-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="10" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal10-2_pos_neg_bot" />
+          <rotationref ref="crystal10-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-10" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal10-2_pos_pos_top" />
+          <rotationref ref="crystal10-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="10" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal10-2_pos_neg_top" />
+          <rotationref ref="crystal10-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-10" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-2_pos_pos_bot" />
+          <rotationref ref="crystal11-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="11" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-2_pos_neg_bot" />
+          <rotationref ref="crystal11-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-11" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-2_pos_pos_top" />
+          <rotationref ref="crystal11-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="11" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-2_pos_neg_top" />
+          <rotationref ref="crystal11-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-11" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-2_pos_pos_bot" />
+          <rotationref ref="crystal12-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="12" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-2_pos_neg_bot" />
+          <rotationref ref="crystal12-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-12" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-2_pos_pos_top" />
+          <rotationref ref="crystal12-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="12" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-2_pos_neg_top" />
+          <rotationref ref="crystal12-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-12" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-2_pos_pos_bot" />
+          <rotationref ref="crystal13-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="13" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-2_pos_neg_bot" />
+          <rotationref ref="crystal13-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-13" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-2_pos_pos_top" />
+          <rotationref ref="crystal13-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="13" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-2_pos_neg_top" />
+          <rotationref ref="crystal13-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-13" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-2_pos_pos_bot" />
+          <rotationref ref="crystal14-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="14" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-2_pos_neg_bot" />
+          <rotationref ref="crystal14-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-14" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-2_pos_pos_top" />
+          <rotationref ref="crystal14-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="14" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-2_pos_neg_top" />
+          <rotationref ref="crystal14-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-14" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-2_pos_pos_bot" />
+          <rotationref ref="crystal15-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="15" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-2_pos_neg_bot" />
+          <rotationref ref="crystal15-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-15" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-2_pos_pos_top" />
+          <rotationref ref="crystal15-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="15" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-2_pos_neg_top" />
+          <rotationref ref="crystal15-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-15" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-2_pos_pos_bot" />
+          <rotationref ref="crystal16-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="16" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-2_pos_neg_bot" />
+          <rotationref ref="crystal16-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-16" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-2_pos_pos_top" />
+          <rotationref ref="crystal16-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="16" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-2_pos_neg_top" />
+          <rotationref ref="crystal16-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-16" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-2_pos_pos_bot" />
+          <rotationref ref="crystal17-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="17" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-2_pos_neg_bot" />
+          <rotationref ref="crystal17-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-17" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-2_pos_pos_top" />
+          <rotationref ref="crystal17-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="17" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-2_pos_neg_top" />
+          <rotationref ref="crystal17-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-17" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-2_pos_pos_bot" />
+          <rotationref ref="crystal18-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="18" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-2_pos_neg_bot" />
+          <rotationref ref="crystal18-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-18" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-2_pos_pos_top" />
+          <rotationref ref="crystal18-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="18" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-2_pos_neg_top" />
+          <rotationref ref="crystal18-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-18" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-2_pos_pos_bot" />
+          <rotationref ref="crystal19-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="19" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-2_pos_neg_bot" />
+          <rotationref ref="crystal19-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-19" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-2_pos_pos_top" />
+          <rotationref ref="crystal19-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="19" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-2_pos_neg_top" />
+          <rotationref ref="crystal19-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-19" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-2_pos_pos_bot" />
+          <rotationref ref="crystal20-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="20" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-2_pos_neg_bot" />
+          <rotationref ref="crystal20-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-20" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-2_pos_pos_top" />
+          <rotationref ref="crystal20-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="20" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-2_pos_neg_top" />
+          <rotationref ref="crystal20-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-20" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-2_pos_pos_bot" />
+          <rotationref ref="crystal21-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="21" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-2_pos_neg_bot" />
+          <rotationref ref="crystal21-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-21" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-2_pos_pos_top" />
+          <rotationref ref="crystal21-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="21" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-2_pos_neg_top" />
+          <rotationref ref="crystal21-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-21" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-2_pos_pos_bot" />
+          <rotationref ref="crystal22-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="22" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-2_pos_neg_bot" />
+          <rotationref ref="crystal22-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-22" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-2_pos_pos_top" />
+          <rotationref ref="crystal22-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="22" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-2_pos_neg_top" />
+          <rotationref ref="crystal22-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-22" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-2_pos_pos_bot" />
+          <rotationref ref="crystal23-2_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="23" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-2_pos_neg_bot" />
+          <rotationref ref="crystal23-2_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-23" />
+          <physvolid field_name="iy" value="-2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-2_pos_pos_top" />
+          <rotationref ref="crystal23-2_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="23" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-2_pos_neg_top" />
+          <rotationref ref="crystal23-2_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-23" />
+          <physvolid field_name="iy" value="2" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-3_pos_pos_bot" />
+          <rotationref ref="crystal1-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="1" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-3_pos_neg_bot" />
+          <rotationref ref="crystal1-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-1" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-3_pos_pos_top" />
+          <rotationref ref="crystal1-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="1" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-3_pos_neg_top" />
+          <rotationref ref="crystal1-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-1" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal2-3_pos_pos_bot" />
+          <rotationref ref="crystal2-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="2" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal2-3_pos_neg_bot" />
+          <rotationref ref="crystal2-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-2" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal2-3_pos_pos_top" />
+          <rotationref ref="crystal2-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="2" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal2-3_pos_neg_top" />
+          <rotationref ref="crystal2-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-2" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal3-3_pos_pos_bot" />
+          <rotationref ref="crystal3-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="3" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal3-3_pos_neg_bot" />
+          <rotationref ref="crystal3-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-3" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal3-3_pos_pos_top" />
+          <rotationref ref="crystal3-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="3" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal3-3_pos_neg_top" />
+          <rotationref ref="crystal3-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-3" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal4-3_pos_pos_bot" />
+          <rotationref ref="crystal4-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="4" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal4-3_pos_neg_bot" />
+          <rotationref ref="crystal4-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-4" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal4-3_pos_pos_top" />
+          <rotationref ref="crystal4-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="4" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal4-3_pos_neg_top" />
+          <rotationref ref="crystal4-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-4" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal5-3_pos_pos_bot" />
+          <rotationref ref="crystal5-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="5" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal5-3_pos_neg_bot" />
+          <rotationref ref="crystal5-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-5" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal5-3_pos_pos_top" />
+          <rotationref ref="crystal5-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="5" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal5-3_pos_neg_top" />
+          <rotationref ref="crystal5-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-5" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal6-3_pos_pos_bot" />
+          <rotationref ref="crystal6-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="6" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal6-3_pos_neg_bot" />
+          <rotationref ref="crystal6-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-6" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal6-3_pos_pos_top" />
+          <rotationref ref="crystal6-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="6" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal6-3_pos_neg_top" />
+          <rotationref ref="crystal6-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-6" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal7-3_pos_pos_bot" />
+          <rotationref ref="crystal7-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="7" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal7-3_pos_neg_bot" />
+          <rotationref ref="crystal7-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-7" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal7-3_pos_pos_top" />
+          <rotationref ref="crystal7-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="7" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal7-3_pos_neg_top" />
+          <rotationref ref="crystal7-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-7" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal8-3_pos_pos_bot" />
+          <rotationref ref="crystal8-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="8" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal8-3_pos_neg_bot" />
+          <rotationref ref="crystal8-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-8" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal8-3_pos_pos_top" />
+          <rotationref ref="crystal8-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="8" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal8-3_pos_neg_top" />
+          <rotationref ref="crystal8-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-8" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal9-3_pos_pos_bot" />
+          <rotationref ref="crystal9-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="9" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal9-3_pos_neg_bot" />
+          <rotationref ref="crystal9-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-9" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal9-3_pos_pos_top" />
+          <rotationref ref="crystal9-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="9" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal9-3_pos_neg_top" />
+          <rotationref ref="crystal9-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-9" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal10-3_pos_pos_bot" />
+          <rotationref ref="crystal10-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="10" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal10-3_pos_neg_bot" />
+          <rotationref ref="crystal10-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-10" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal10-3_pos_pos_top" />
+          <rotationref ref="crystal10-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="10" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal10-3_pos_neg_top" />
+          <rotationref ref="crystal10-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-10" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-3_pos_pos_bot" />
+          <rotationref ref="crystal11-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="11" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-3_pos_neg_bot" />
+          <rotationref ref="crystal11-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-11" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-3_pos_pos_top" />
+          <rotationref ref="crystal11-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="11" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-3_pos_neg_top" />
+          <rotationref ref="crystal11-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-11" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-3_pos_pos_bot" />
+          <rotationref ref="crystal12-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="12" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-3_pos_neg_bot" />
+          <rotationref ref="crystal12-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-12" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-3_pos_pos_top" />
+          <rotationref ref="crystal12-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="12" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-3_pos_neg_top" />
+          <rotationref ref="crystal12-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-12" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-3_pos_pos_bot" />
+          <rotationref ref="crystal13-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="13" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-3_pos_neg_bot" />
+          <rotationref ref="crystal13-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-13" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-3_pos_pos_top" />
+          <rotationref ref="crystal13-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="13" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-3_pos_neg_top" />
+          <rotationref ref="crystal13-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-13" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-3_pos_pos_bot" />
+          <rotationref ref="crystal14-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="14" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-3_pos_neg_bot" />
+          <rotationref ref="crystal14-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-14" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-3_pos_pos_top" />
+          <rotationref ref="crystal14-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="14" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-3_pos_neg_top" />
+          <rotationref ref="crystal14-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-14" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-3_pos_pos_bot" />
+          <rotationref ref="crystal15-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="15" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-3_pos_neg_bot" />
+          <rotationref ref="crystal15-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-15" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-3_pos_pos_top" />
+          <rotationref ref="crystal15-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="15" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-3_pos_neg_top" />
+          <rotationref ref="crystal15-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-15" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-3_pos_pos_bot" />
+          <rotationref ref="crystal16-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="16" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-3_pos_neg_bot" />
+          <rotationref ref="crystal16-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-16" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-3_pos_pos_top" />
+          <rotationref ref="crystal16-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="16" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-3_pos_neg_top" />
+          <rotationref ref="crystal16-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-16" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-3_pos_pos_bot" />
+          <rotationref ref="crystal17-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="17" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-3_pos_neg_bot" />
+          <rotationref ref="crystal17-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-17" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-3_pos_pos_top" />
+          <rotationref ref="crystal17-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="17" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-3_pos_neg_top" />
+          <rotationref ref="crystal17-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-17" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-3_pos_pos_bot" />
+          <rotationref ref="crystal18-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="18" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-3_pos_neg_bot" />
+          <rotationref ref="crystal18-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-18" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-3_pos_pos_top" />
+          <rotationref ref="crystal18-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="18" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-3_pos_neg_top" />
+          <rotationref ref="crystal18-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-18" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-3_pos_pos_bot" />
+          <rotationref ref="crystal19-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="19" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-3_pos_neg_bot" />
+          <rotationref ref="crystal19-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-19" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-3_pos_pos_top" />
+          <rotationref ref="crystal19-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="19" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-3_pos_neg_top" />
+          <rotationref ref="crystal19-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-19" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-3_pos_pos_bot" />
+          <rotationref ref="crystal20-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="20" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-3_pos_neg_bot" />
+          <rotationref ref="crystal20-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-20" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-3_pos_pos_top" />
+          <rotationref ref="crystal20-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="20" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-3_pos_neg_top" />
+          <rotationref ref="crystal20-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-20" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-3_pos_pos_bot" />
+          <rotationref ref="crystal21-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="21" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-3_pos_neg_bot" />
+          <rotationref ref="crystal21-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-21" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-3_pos_pos_top" />
+          <rotationref ref="crystal21-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="21" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-3_pos_neg_top" />
+          <rotationref ref="crystal21-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-21" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-3_pos_pos_bot" />
+          <rotationref ref="crystal22-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="22" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-3_pos_neg_bot" />
+          <rotationref ref="crystal22-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-22" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-3_pos_pos_top" />
+          <rotationref ref="crystal22-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="22" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-3_pos_neg_top" />
+          <rotationref ref="crystal22-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-22" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-3_pos_pos_bot" />
+          <rotationref ref="crystal23-3_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="23" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-3_pos_neg_bot" />
+          <rotationref ref="crystal23-3_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-23" />
+          <physvolid field_name="iy" value="-3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-3_pos_pos_top" />
+          <rotationref ref="crystal23-3_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="23" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-3_pos_neg_top" />
+          <rotationref ref="crystal23-3_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-23" />
+          <physvolid field_name="iy" value="3" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-4_pos_pos_bot" />
+          <rotationref ref="crystal1-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="1" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-4_pos_neg_bot" />
+          <rotationref ref="crystal1-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-1" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-4_pos_pos_top" />
+          <rotationref ref="crystal1-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="1" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-4_pos_neg_top" />
+          <rotationref ref="crystal1-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-1" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal2-4_pos_pos_bot" />
+          <rotationref ref="crystal2-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="2" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal2-4_pos_neg_bot" />
+          <rotationref ref="crystal2-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-2" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal2-4_pos_pos_top" />
+          <rotationref ref="crystal2-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="2" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal2-4_pos_neg_top" />
+          <rotationref ref="crystal2-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-2" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal3-4_pos_pos_bot" />
+          <rotationref ref="crystal3-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="3" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal3-4_pos_neg_bot" />
+          <rotationref ref="crystal3-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-3" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal3-4_pos_pos_top" />
+          <rotationref ref="crystal3-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="3" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal3-4_pos_neg_top" />
+          <rotationref ref="crystal3-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-3" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal4-4_pos_pos_bot" />
+          <rotationref ref="crystal4-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="4" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal4-4_pos_neg_bot" />
+          <rotationref ref="crystal4-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-4" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal4-4_pos_pos_top" />
+          <rotationref ref="crystal4-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="4" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal4-4_pos_neg_top" />
+          <rotationref ref="crystal4-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-4" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal5-4_pos_pos_bot" />
+          <rotationref ref="crystal5-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="5" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal5-4_pos_neg_bot" />
+          <rotationref ref="crystal5-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-5" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal5-4_pos_pos_top" />
+          <rotationref ref="crystal5-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="5" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal5-4_pos_neg_top" />
+          <rotationref ref="crystal5-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-5" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal6-4_pos_pos_bot" />
+          <rotationref ref="crystal6-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="6" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal6-4_pos_neg_bot" />
+          <rotationref ref="crystal6-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-6" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal6-4_pos_pos_top" />
+          <rotationref ref="crystal6-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="6" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal6-4_pos_neg_top" />
+          <rotationref ref="crystal6-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-6" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal7-4_pos_pos_bot" />
+          <rotationref ref="crystal7-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="7" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal7-4_pos_neg_bot" />
+          <rotationref ref="crystal7-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-7" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal7-4_pos_pos_top" />
+          <rotationref ref="crystal7-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="7" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal7-4_pos_neg_top" />
+          <rotationref ref="crystal7-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-7" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal8-4_pos_pos_bot" />
+          <rotationref ref="crystal8-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="8" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal8-4_pos_neg_bot" />
+          <rotationref ref="crystal8-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-8" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal8-4_pos_pos_top" />
+          <rotationref ref="crystal8-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="8" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal8-4_pos_neg_top" />
+          <rotationref ref="crystal8-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-8" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal9-4_pos_pos_bot" />
+          <rotationref ref="crystal9-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="9" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal9-4_pos_neg_bot" />
+          <rotationref ref="crystal9-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-9" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal9-4_pos_pos_top" />
+          <rotationref ref="crystal9-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="9" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal9-4_pos_neg_top" />
+          <rotationref ref="crystal9-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-9" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal10-4_pos_pos_bot" />
+          <rotationref ref="crystal10-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="10" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal10-4_pos_neg_bot" />
+          <rotationref ref="crystal10-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-10" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal10-4_pos_pos_top" />
+          <rotationref ref="crystal10-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="10" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal10-4_pos_neg_top" />
+          <rotationref ref="crystal10-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-10" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-4_pos_pos_bot" />
+          <rotationref ref="crystal11-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="11" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-4_pos_neg_bot" />
+          <rotationref ref="crystal11-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-11" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-4_pos_pos_top" />
+          <rotationref ref="crystal11-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="11" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-4_pos_neg_top" />
+          <rotationref ref="crystal11-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-11" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-4_pos_pos_bot" />
+          <rotationref ref="crystal12-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="12" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-4_pos_neg_bot" />
+          <rotationref ref="crystal12-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-12" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-4_pos_pos_top" />
+          <rotationref ref="crystal12-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="12" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-4_pos_neg_top" />
+          <rotationref ref="crystal12-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-12" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-4_pos_pos_bot" />
+          <rotationref ref="crystal13-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="13" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-4_pos_neg_bot" />
+          <rotationref ref="crystal13-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-13" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-4_pos_pos_top" />
+          <rotationref ref="crystal13-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="13" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-4_pos_neg_top" />
+          <rotationref ref="crystal13-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-13" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-4_pos_pos_bot" />
+          <rotationref ref="crystal14-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="14" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-4_pos_neg_bot" />
+          <rotationref ref="crystal14-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-14" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-4_pos_pos_top" />
+          <rotationref ref="crystal14-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="14" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-4_pos_neg_top" />
+          <rotationref ref="crystal14-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-14" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-4_pos_pos_bot" />
+          <rotationref ref="crystal15-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="15" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-4_pos_neg_bot" />
+          <rotationref ref="crystal15-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-15" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-4_pos_pos_top" />
+          <rotationref ref="crystal15-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="15" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-4_pos_neg_top" />
+          <rotationref ref="crystal15-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-15" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-4_pos_pos_bot" />
+          <rotationref ref="crystal16-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="16" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-4_pos_neg_bot" />
+          <rotationref ref="crystal16-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-16" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-4_pos_pos_top" />
+          <rotationref ref="crystal16-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="16" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-4_pos_neg_top" />
+          <rotationref ref="crystal16-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-16" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-4_pos_pos_bot" />
+          <rotationref ref="crystal17-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="17" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-4_pos_neg_bot" />
+          <rotationref ref="crystal17-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-17" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-4_pos_pos_top" />
+          <rotationref ref="crystal17-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="17" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-4_pos_neg_top" />
+          <rotationref ref="crystal17-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-17" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-4_pos_pos_bot" />
+          <rotationref ref="crystal18-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="18" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-4_pos_neg_bot" />
+          <rotationref ref="crystal18-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-18" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-4_pos_pos_top" />
+          <rotationref ref="crystal18-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="18" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-4_pos_neg_top" />
+          <rotationref ref="crystal18-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-18" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-4_pos_pos_bot" />
+          <rotationref ref="crystal19-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="19" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-4_pos_neg_bot" />
+          <rotationref ref="crystal19-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-19" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-4_pos_pos_top" />
+          <rotationref ref="crystal19-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="19" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-4_pos_neg_top" />
+          <rotationref ref="crystal19-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-19" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-4_pos_pos_bot" />
+          <rotationref ref="crystal20-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="20" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-4_pos_neg_bot" />
+          <rotationref ref="crystal20-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-20" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-4_pos_pos_top" />
+          <rotationref ref="crystal20-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="20" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-4_pos_neg_top" />
+          <rotationref ref="crystal20-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-20" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-4_pos_pos_bot" />
+          <rotationref ref="crystal21-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="21" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-4_pos_neg_bot" />
+          <rotationref ref="crystal21-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-21" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-4_pos_pos_top" />
+          <rotationref ref="crystal21-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="21" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-4_pos_neg_top" />
+          <rotationref ref="crystal21-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-21" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-4_pos_pos_bot" />
+          <rotationref ref="crystal22-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="22" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-4_pos_neg_bot" />
+          <rotationref ref="crystal22-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-22" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-4_pos_pos_top" />
+          <rotationref ref="crystal22-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="22" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-4_pos_neg_top" />
+          <rotationref ref="crystal22-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-22" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-4_pos_pos_bot" />
+          <rotationref ref="crystal23-4_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="23" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-4_pos_neg_bot" />
+          <rotationref ref="crystal23-4_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-23" />
+          <physvolid field_name="iy" value="-4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-4_pos_pos_top" />
+          <rotationref ref="crystal23-4_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="23" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-4_pos_neg_top" />
+          <rotationref ref="crystal23-4_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-23" />
+          <physvolid field_name="iy" value="4" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-5_pos_pos_bot" />
+          <rotationref ref="crystal1-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="1" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-5_pos_neg_bot" />
+          <rotationref ref="crystal1-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-1" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-5_pos_pos_top" />
+          <rotationref ref="crystal1-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="1" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal1-5_pos_neg_top" />
+          <rotationref ref="crystal1-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-1" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal2-5_pos_pos_bot" />
+          <rotationref ref="crystal2-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="2" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal2-5_pos_neg_bot" />
+          <rotationref ref="crystal2-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-2" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal2-5_pos_pos_top" />
+          <rotationref ref="crystal2-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="2" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal2-5_pos_neg_top" />
+          <rotationref ref="crystal2-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-2" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal3-5_pos_pos_bot" />
+          <rotationref ref="crystal3-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="3" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal3-5_pos_neg_bot" />
+          <rotationref ref="crystal3-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-3" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal3-5_pos_pos_top" />
+          <rotationref ref="crystal3-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="3" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal3-5_pos_neg_top" />
+          <rotationref ref="crystal3-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-3" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal4-5_pos_pos_bot" />
+          <rotationref ref="crystal4-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="4" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal4-5_pos_neg_bot" />
+          <rotationref ref="crystal4-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-4" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal4-5_pos_pos_top" />
+          <rotationref ref="crystal4-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="4" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal4-5_pos_neg_top" />
+          <rotationref ref="crystal4-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-4" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal5-5_pos_pos_bot" />
+          <rotationref ref="crystal5-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="5" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal5-5_pos_neg_bot" />
+          <rotationref ref="crystal5-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-5" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal5-5_pos_pos_top" />
+          <rotationref ref="crystal5-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="5" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal5-5_pos_neg_top" />
+          <rotationref ref="crystal5-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-5" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal6-5_pos_pos_bot" />
+          <rotationref ref="crystal6-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="6" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal6-5_pos_neg_bot" />
+          <rotationref ref="crystal6-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-6" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal6-5_pos_pos_top" />
+          <rotationref ref="crystal6-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="6" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal6-5_pos_neg_top" />
+          <rotationref ref="crystal6-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-6" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal7-5_pos_pos_bot" />
+          <rotationref ref="crystal7-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="7" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal7-5_pos_neg_bot" />
+          <rotationref ref="crystal7-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-7" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal7-5_pos_pos_top" />
+          <rotationref ref="crystal7-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="7" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal7-5_pos_neg_top" />
+          <rotationref ref="crystal7-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-7" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal8-5_pos_pos_bot" />
+          <rotationref ref="crystal8-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="8" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal8-5_pos_neg_bot" />
+          <rotationref ref="crystal8-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-8" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal8-5_pos_pos_top" />
+          <rotationref ref="crystal8-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="8" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal8-5_pos_neg_top" />
+          <rotationref ref="crystal8-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-8" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal9-5_pos_pos_bot" />
+          <rotationref ref="crystal9-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="9" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal9-5_pos_neg_bot" />
+          <rotationref ref="crystal9-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-9" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal9-5_pos_pos_top" />
+          <rotationref ref="crystal9-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="9" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal9-5_pos_neg_top" />
+          <rotationref ref="crystal9-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-9" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal10-5_pos_pos_bot" />
+          <rotationref ref="crystal10-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="10" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal10-5_pos_neg_bot" />
+          <rotationref ref="crystal10-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-10" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal10-5_pos_pos_top" />
+          <rotationref ref="crystal10-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="10" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal10-5_pos_neg_top" />
+          <rotationref ref="crystal10-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-10" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-5_pos_pos_bot" />
+          <rotationref ref="crystal11-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="11" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-5_pos_neg_bot" />
+          <rotationref ref="crystal11-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-11" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-5_pos_pos_top" />
+          <rotationref ref="crystal11-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="11" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal11-5_pos_neg_top" />
+          <rotationref ref="crystal11-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-11" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-5_pos_pos_bot" />
+          <rotationref ref="crystal12-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="12" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-5_pos_neg_bot" />
+          <rotationref ref="crystal12-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-12" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-5_pos_pos_top" />
+          <rotationref ref="crystal12-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="12" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal12-5_pos_neg_top" />
+          <rotationref ref="crystal12-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-12" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-5_pos_pos_bot" />
+          <rotationref ref="crystal13-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="13" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-5_pos_neg_bot" />
+          <rotationref ref="crystal13-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-13" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-5_pos_pos_top" />
+          <rotationref ref="crystal13-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="13" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal13-5_pos_neg_top" />
+          <rotationref ref="crystal13-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-13" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-5_pos_pos_bot" />
+          <rotationref ref="crystal14-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="14" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-5_pos_neg_bot" />
+          <rotationref ref="crystal14-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-14" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-5_pos_pos_top" />
+          <rotationref ref="crystal14-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="14" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal14-5_pos_neg_top" />
+          <rotationref ref="crystal14-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-14" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-5_pos_pos_bot" />
+          <rotationref ref="crystal15-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="15" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-5_pos_neg_bot" />
+          <rotationref ref="crystal15-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-15" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-5_pos_pos_top" />
+          <rotationref ref="crystal15-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="15" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal15-5_pos_neg_top" />
+          <rotationref ref="crystal15-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-15" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-5_pos_pos_bot" />
+          <rotationref ref="crystal16-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="16" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-5_pos_neg_bot" />
+          <rotationref ref="crystal16-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-16" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-5_pos_pos_top" />
+          <rotationref ref="crystal16-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="16" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal16-5_pos_neg_top" />
+          <rotationref ref="crystal16-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-16" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-5_pos_pos_bot" />
+          <rotationref ref="crystal17-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="17" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-5_pos_neg_bot" />
+          <rotationref ref="crystal17-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-17" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-5_pos_pos_top" />
+          <rotationref ref="crystal17-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="17" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal17-5_pos_neg_top" />
+          <rotationref ref="crystal17-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-17" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-5_pos_pos_bot" />
+          <rotationref ref="crystal18-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="18" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-5_pos_neg_bot" />
+          <rotationref ref="crystal18-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-18" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-5_pos_pos_top" />
+          <rotationref ref="crystal18-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="18" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal18-5_pos_neg_top" />
+          <rotationref ref="crystal18-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-18" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-5_pos_pos_bot" />
+          <rotationref ref="crystal19-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="19" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-5_pos_neg_bot" />
+          <rotationref ref="crystal19-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-19" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-5_pos_pos_top" />
+          <rotationref ref="crystal19-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="19" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal19-5_pos_neg_top" />
+          <rotationref ref="crystal19-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-19" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-5_pos_pos_bot" />
+          <rotationref ref="crystal20-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="20" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-5_pos_neg_bot" />
+          <rotationref ref="crystal20-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-20" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-5_pos_pos_top" />
+          <rotationref ref="crystal20-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="20" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal20-5_pos_neg_top" />
+          <rotationref ref="crystal20-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-20" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-5_pos_pos_bot" />
+          <rotationref ref="crystal21-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="21" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-5_pos_neg_bot" />
+          <rotationref ref="crystal21-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-21" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-5_pos_pos_top" />
+          <rotationref ref="crystal21-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="21" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal21-5_pos_neg_top" />
+          <rotationref ref="crystal21-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-21" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-5_pos_pos_bot" />
+          <rotationref ref="crystal22-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="22" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-5_pos_neg_bot" />
+          <rotationref ref="crystal22-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-22" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-5_pos_pos_top" />
+          <rotationref ref="crystal22-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="22" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal22-5_pos_neg_top" />
+          <rotationref ref="crystal22-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-22" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-5_pos_pos_bot" />
+          <rotationref ref="crystal23-5_rot_pos_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="23" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-5_pos_neg_bot" />
+          <rotationref ref="crystal23-5_rot_neg_bot" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-23" />
+          <physvolid field_name="iy" value="-5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-5_pos_pos_top" />
+          <rotationref ref="crystal23-5_rot_pos_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="23" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol>
+          <volumeref ref="crystal_volume" />
+          <positionref ref="crystal23-5_pos_neg_top" />
+          <rotationref ref="crystal23-5_rot_neg_top" />
+          <physvolid field_name="system" value="13" />
+          <physvolid field_name="ix" value="-23" />
+          <physvolid field_name="iy" value="5" />
+        </physvol>
+        <physvol name="front_flange_1">
+          <volumeref ref="front_flange" />
+          <positionref ref="front_flange_1inworld_volumepos" />
+        </physvol>
+        <physvol name="back_flange_1">
+          <volumeref ref="back_flange" />
+          <positionref ref="back_flange_1inworld_volumepos" />
+        </physvol>
+        <physvol name="ECAL_chamber_1">
+          <volumeref ref="ECAL_chamber" />
+          <positionref ref="ECAL_chamber_1inworld_volumepos" />
+        </physvol>
+        <physvol name="al_honeycomb_1">
+          <volumeref ref="al_honeycomb" />
+          <positionref ref="al_honeycomb_1inworld_volumepos" />
+        </physvol>
+        <physvol name="layer_1_top_1">
+          <volumeref ref="layer_1_top" />
+          <positionref ref="layer_1_top_1inworld_volumepos" />
+        </physvol>
+        <physvol name="layer_2_top_1">
+          <volumeref ref="layer_2_top" />
+          <positionref ref="layer_2_top_1inworld_volumepos" />
+        </physvol>
+        <physvol name="layer_3_top_1">
+          <volumeref ref="layer_3_top" />
+          <positionref ref="layer_3_top_1inworld_volumepos" />
+        </physvol>
+        <physvol name="layer_4_top_1">
+          <volumeref ref="layer_4_top" />
+          <positionref ref="layer_4_top_1inworld_volumepos" />
+        </physvol>
+        <physvol name="layer_1_bottom_1">
+          <volumeref ref="layer_1_bottom" />
+          <positionref ref="layer_1_bottom_1inworld_volumepos" />
+        </physvol>
+        <physvol name="layer_2_bottom_1">
+          <volumeref ref="layer_2_bottom" />
+          <positionref ref="layer_2_bottom_1inworld_volumepos" />
+        </physvol>
+        <physvol name="layer_3_bottom_1">
+          <volumeref ref="layer_3_bottom" />
+          <positionref ref="layer_3_bottom_1inworld_volumepos" />
+        </physvol>
+        <physvol name="layer_4_bottom_1">
+          <volumeref ref="layer_4_bottom" />
+          <positionref ref="layer_4_bottom_1inworld_volumepos" />
+        </physvol>
+        <physvol name="layer_5T_left_1">
+          <volumeref ref="layer_5T_left" />
+          <positionref ref="layer_5T_left_1inworld_volumepos" />
+        </physvol>
+        <physvol name="layer_5B_left_1">
+          <volumeref ref="layer_5B_left" />
+          <positionref ref="layer_5B_left_1inworld_volumepos" />
+        </physvol>
+        <physvol name="steel_bar_1">
+          <volumeref ref="steel_bar" />
+          <positionref ref="steel_bar_1inworld_volumepos" />
+        </physvol>
+        <physvol name="cu_Tpipe_inner_left_1">
+          <volumeref ref="cu_Tpipe_inner_left" />
+          <positionref ref="cu_Tpipe_inner_left_1inworld_volumepos" />
+          <rotationref ref="cu_Tpipe_inner_left_1inworld_volumerot" />
+        </physvol>
+        <physvol name="cu_Tpipe_inner_right_1">
+          <volumeref ref="cu_Tpipe_inner_right" />
+          <positionref ref="cu_Tpipe_inner_right_1inworld_volumepos" />
+          <rotationref ref="cu_Tpipe_inner_right_1inworld_volumerot" />
+        </physvol>
+        <physvol name="cu_Bpipe_inner_left_1">
+          <volumeref ref="cu_Bpipe_inner_left" />
+          <positionref ref="cu_Bpipe_inner_left_1inworld_volumepos" />
+          <rotationref ref="cu_Bpipe_inner_left_1inworld_volumerot" />
+        </physvol>
+        <physvol name="cu_Bpipe_inner_right_1">
+          <volumeref ref="cu_Bpipe_inner_right" />
+          <positionref ref="cu_Bpipe_inner_right_1inworld_volumepos" />
+          <rotationref ref="cu_Bpipe_inner_right_1inworld_volumerot" />
+        </physvol>
+        <physvol name="cu_Tpipe_outer_right1_1">
+          <volumeref ref="cu_Tpipe_outer_right1" />
+          <positionref ref="cu_Tpipe_outer_right1_1inworld_volumepos" />
+          <rotationref ref="cu_Tpipe_outer_right1_1inworld_volumerot" />
+        </physvol>
+        <physvol name="cu_Tpipe_outer_right2_1">
+          <volumeref ref="cu_Tpipe_outer_right2" />
+          <positionref ref="cu_Tpipe_outer_right2_1inworld_volumepos" />
+        </physvol>
+        <physvol name="cu_Tpipe_outer_right3_1">
+          <volumeref ref="cu_Tpipe_outer_right3" />
+          <positionref ref="cu_Tpipe_outer_right3_1inworld_volumepos" />
+          <rotationref ref="cu_Tpipe_outer_right3_1inworld_volumerot" />
+        </physvol>
+        <physvol name="cu_Bpipe_outer_right_1">
+          <volumeref ref="cu_Bpipe_outer_right" />
+          <positionref ref="cu_Bpipe_outer_right_1inworld_volumepos" />
+          <rotationref ref="cu_Bpipe_outer_right_1inworld_volumerot" />
+        </physvol>
+        <physvol name="cu_Bpipe_outer_right1_1">
+          <volumeref ref="cu_Bpipe_outer_right1" />
+          <positionref ref="cu_Bpipe_outer_right1_1inworld_volumepos" />
+          <rotationref ref="cu_Bpipe_outer_right1_1inworld_volumerot" />
+        </physvol>
+        <physvol name="cu_Bpipe_outer_right2_1">
+          <volumeref ref="cu_Bpipe_outer_right2" />
+          <positionref ref="cu_Bpipe_outer_right2_1inworld_volumepos" />
+        </physvol>
+        <physvol name="al_pipe_across_top1_1">
+          <volumeref ref="al_pipe_across_top1" />
+          <positionref ref="al_pipe_across_top1_1inworld_volumepos" />
+          <rotationref ref="al_pipe_across_top1_1inworld_volumerot" />
+        </physvol>
+        <physvol name="al_pipe_across_top2_1">
+          <volumeref ref="al_pipe_across_top2" />
+          <positionref ref="al_pipe_across_top2_1inworld_volumepos" />
+          <rotationref ref="al_pipe_across_top2_1inworld_volumerot" />
+        </physvol>
+        <physvol name="al_pipe_across_bottom1_1">
+          <volumeref ref="al_pipe_across_bottom1" />
+          <positionref ref="al_pipe_across_bottom1_1inworld_volumepos" />
+          <rotationref ref="al_pipe_across_bottom1_1inworld_volumerot" />
+        </physvol>
+        <physvol name="al_pipe_across_bottom2_1">
+          <volumeref ref="al_pipe_across_bottom2" />
+          <positionref ref="al_pipe_across_bottom2_1inworld_volumepos" />
+          <rotationref ref="al_pipe_across_bottom2_1inworld_volumerot" />
+        </physvol>
+        <physvol name="cu_plate_top_left_1">
+          <volumeref ref="cu_plate_top_left" />
+          <positionref ref="cu_plate_top_left_1inworld_volumepos" />
+        </physvol>
+        <physvol name="cu_plate_bottom_left_1">
+          <volumeref ref="cu_plate_bottom_left" />
+          <positionref ref="cu_plate_bottom_left_1inworld_volumepos" />
+        </physvol>
+        <physvol name="cu_plate_top_right_1">
+          <volumeref ref="cu_plate_top_right" />
+          <positionref ref="cu_plate_top_right_1inworld_volumepos" />
+        </physvol>
+        <physvol name="cu_plate_bottom_right_1">
+          <volumeref ref="cu_plate_bottom_right" />
+          <positionref ref="cu_plate_bottom_right_1inworld_volumepos" />
+        </physvol>
+        <physvol name="cu_plate_top_middle_1">
+          <volumeref ref="cu_plate_top_middle" />
+          <positionref ref="cu_plate_top_middle_1inworld_volumepos" />
+        </physvol>
+        <physvol name="cu_plate_bottom_middle_1">
+          <volumeref ref="cu_plate_bottom_middle" />
+          <positionref ref="cu_plate_bottom_middle_1inworld_volumepos" />
+        </physvol>
+        <visref ref="WorldVis" />
+      </volume>
+    </structure>
+    <setup name="Default" version="1.0">
+      <world ref="world_volume" />
+    </setup>
+  </gdml>
+  <fields>
+    <field_map_3d name="HPSDipoleFieldMap3D" lunit="mm" funit="tesla" filename="fieldmap/334acm3_8kg_corrected_unfolded_scaled_1.0508.dat" xoffset="21.17" yoffset="0.0" zoffset="457.2" />
+  </fields>
+</lcdd>
+

--- a/detector-data/detectors/HPS_Run2021Pass2FEE_fixed/SamplingFractions/Ecal.properties
+++ b/detector-data/detectors/HPS_Run2021Pass2FEE_fixed/SamplingFractions/Ecal.properties
@@ -1,0 +1,1 @@
+samplingFraction: 1.0

--- a/detector-data/detectors/HPS_Run2021Pass2FEE_fixed/SamplingFractions/Hodoscope.properties
+++ b/detector-data/detectors/HPS_Run2021Pass2FEE_fixed/SamplingFractions/Hodoscope.properties
@@ -1,0 +1,1 @@
+samplingFraction: 1.0

--- a/detector-data/detectors/HPS_Run2021Pass2FEE_fixed/compact.xml
+++ b/detector-data/detectors/HPS_Run2021Pass2FEE_fixed/compact.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <lccdd xmlns:compact="http://www.lcsim.org/schemas/compact/1.0" xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/compact/1.0/compact.xsd">
 
-<info name="HPS_Run2021Pass0_v1_1pt92GeV">
+<info name="HPS_Run2021Pass2FEE_fixed">
     <comment>HPS detector for 2021 run with fieldmap,
     Tracker at nominal opening angle, no SVT survey,
-    this detector uses the corrected fieldmap scaled for 3.74 GeV beam.
+    this detector uses the corrected fieldmap scaled to -1.022T for 3.7 GeV.
     Includes L0 and Hodoscope.
     ECAL with survey alignment for HPSEcal3 (global y/z translations).
     This detector has the full hierarchical alignment structure
@@ -33,7 +33,7 @@
     <constant name="dipoleMagnetHeight" value="100*cm" />
     <constant name="dipoleMagnetWidth" value="100*cm" />
     <constant name="dipoleMagnetLength" value="108*cm" />
-    <constant name="constBFieldY" value="-0.437" /><!-- set for 1.92 GeV running -->
+    <constant name="constBFieldY" value="-1.08" /><!-- set for 4.5GeV running -->
 
 
     <!-- ECAL crystal dimensions -->
@@ -197,26 +197,26 @@
       <millepede_constants>
 
         <!-- top half-module translations -->
-        <millepede_constant name="11101" value="0.0 + 0.014799 + 0.008569 - -0.065199 - -0.037883 - 0.01 - 0.003" />
-        <millepede_constant name="11102" value="0.0 + 0.036097 + 0.008870 - -0.054012 - -0.027420 - -0.008920 - 0.007 - 0.003" />
-        <millepede_constant name="11103" value="0.0 + -0.020397 + 0.006024 - -0.036267 - -0.028236 - 0.01 + 0.005" />
+        <millepede_constant name="11101" value="0.0 + 0.014799 + 0.008569 - -0.065199 - -0.037883" />
+        <millepede_constant name="11102" value="0.0 + 0.036097 + 0.008870 - -0.054012 - -0.027420 - -0.008920" />
+        <millepede_constant name="11103" value="0.0 + -0.020397 + 0.006024 - -0.036267 - -0.028236" />
         <millepede_constant name="11104" value="0.0 + 0.045729 + 0.006918 - -0.036733 - -0.019597 - -0.002183" />
         <millepede_constant name="11105" value="0.0 + 0.007688 + 0.005676 - -0.012362" />
-        <millepede_constant name="11106" value="0.0 + -0.010664 + -0.001609 - 0.006721 - 0.005305 - -0.001660 - 0.001480 - 0.020 - 0.015" /> <!-- HERE -->
-        <millepede_constant name="11107" value="0.0 + 0.004072 + 0.003523 - 0.007062 - -0.003817 - 0.001975 - 0.003762 - 0.030 - 0.02 + 0.005 + 0.005 - 0.01" /> 
+        <millepede_constant name="11106" value="0.0 + -0.010664 + -0.001609 - 0.006721 - 0.005305 - -0.001660 - 0.001480" />
+        <millepede_constant name="11107" value="0.0 + 0.004072 + 0.003523 - 0.007062 - -0.003817 - 0.001975 - 0.003762" />
         <millepede_constant name="11108" value="0.0 + -0.000794 + 0.000946 - -0.003989" />
-        <millepede_constant name="11109" value="0.0 - 0.018517 - 0.003440 - -0.005945 - 0.038002 - -0.031681" />
-        <millepede_constant name="11110" value="0.0 - -0.002565 - -0.005478 - 0.035065 - 0.016357 - 0.006881 - -0.006770 - -0.000414 - 0.007 + 0.007 + 0.005 + 0.01 - 0.016272 - 0.003394 - 0.035070 - 0.014843 - 0.003355 + 0.01 + 0.005 - 0.013350 - -0.038048 - 0.013055 - 0.000808 - 0.000077 - -0.019605 - 0.018048" />
-        <millepede_constant name="11111" value="0.0 - -0.027900 - -0.007513 - 0.012648 - -0.043451 - -0.065284" />
-        <millepede_constant name="11112" value="0.035655 - -0.014005 - -0.039993 - -0.011733 - -0.007860 - 0.035467 + 0.100 - 0.024782 - 0.022333 - -0.044758 - 0.051211 - 0.006091 - 0.01 - 0.005 + 0.002 - 0.003 - 0.043504 - -0.078576 - -0.014604 - -0.002392 - 0.136530 - -0.028722" /> 
-        <millepede_constant name="11113" value="0.0 - 0.048022 - 0.008019 - 0.026847 - -0.087271" />
-        <millepede_constant name="11114" value="0.0 - -0.010339 - 0.024258 - 0.011054 - 0.007932 - -0.059523 - 0.05 + 0.03 + 0.02 + 0.005 + 0.01 + 0.01 + 0.01 + 0.025 - 0.008013 - 0.003514 - 0.123270 - 0.026882 - 0.004377 + 0.01 + 0.01 + 0.01 - 0.024533 - -0.026879 - 0.019210 - 0.000367 - 0.000016 - 0.028655 - 0.048132" />
-        <millepede_constant name="11115" value="0.0 - -0.037736 - 0.001172 - -0.124470 - 0.083991" />
-        <millepede_constant name="11116" value="0.0 - -0.010376 - -0.045688 - -0.004289 - -0.008223 - 0.000515 - 0.023764 - -0.170300 - 0.165900 - 0.026027 + 0.03 + 0.003 - 0.124620 - -0.096263 - 0.005989 - 0.001142 - -0.041266 - -0.054556" />
-        <millepede_constant name="11117" value="0.0 - 0.089312 - 0.015816 + 0.003 - 0.018062 - -0.185950" />
-        <millepede_constant name="11118" value="0.008210 - -0.015812 - -0.066323 - -0.027323 - 0.006333 - -0.080147 + 0.03 + 0.01 + 0.01 + 0.02 + 0.045 - -0.008958 - 0.001975 - 0.246890 - 0.002482 - 0.001309 - -0.010665 - -0.018083 - 0.027693 - -0.000635 - -0.000105 - 0.108960 - 0.095626" />
-        <millepede_constant name="11119" value="0.0 - -0.079247 - 0.008245 - -0.238820 - 0.289240" />
-        <millepede_constant name="11120" value="-0.065534 - -0.043456 - -0.023106 - 0.036114 - 0.039496 - -0.005295 - 0.037244 - 0.054889 - -0.330230 - 0.312240 - 0.053709 + 0.02 + 0.01 + 0.005 + 0.005 - 0.239110 - -0.196730 - 0.004699 - 0.001197 - -0.164800 - -0.103970" />
+        <millepede_constant name="11109" value="0.0 - 0.018517 - 0.003440" />
+        <millepede_constant name="11110" value="0.0 - -0.002565 - -0.005478 - 0.035065 - 0.016357 - 0.006881" />
+        <millepede_constant name="11111" value="0.0 - -0.027900 - -0.007513" />
+        <millepede_constant name="11112" value="0.035655 - -0.014005 - -0.039993 - -0.011733 - -0.007860" />
+        <millepede_constant name="11113" value="0.0 - 0.048022 - 0.008019" />
+        <millepede_constant name="11114" value="0.0 - -0.010339 - 0.024258 - 0.011054 - 0.007932" />
+        <millepede_constant name="11115" value="0.0 - -0.037736 - 0.001172" />
+        <millepede_constant name="11116" value="0.0 - -0.010376 - -0.045688 - -0.004289 - -0.008223" />
+        <millepede_constant name="11117" value="0.0 - 0.089312 - 0.015816" />
+        <millepede_constant name="11118" value="0.008210 - -0.015812 - -0.066323 - -0.027323 - 0.006333" />
+        <millepede_constant name="11119" value="0.0 - -0.079247 - 0.008245" />
+        <millepede_constant name="11120" value="-0.065534 - -0.043456 - -0.023106 - 0.036114 - 0.039496 - -0.005295" />
         <millepede_constant name="11121" value="0.0" />
         <millepede_constant name="11122" value="0.0" />
 
@@ -322,43 +322,43 @@
         <millepede_constant name="12306" value="0.0" />
         <millepede_constant name="12307" value="0.0" />
         <millepede_constant name="12308" value="0.0" />
-        <millepede_constant name="12309" value="0.0 - 0.000205 + 0.000202" />
-        <millepede_constant name="12310" value="0.0 - 0.000113 + 0.000793" />
-        <millepede_constant name="12311" value="0.0 - -0.000219 + 0.002355" />
-        <millepede_constant name="12312" value="0.0 - -0.000665 + -0.003668" />
-        <millepede_constant name="12313" value="0.0 + -0.001213" />
-        <millepede_constant name="12314" value="0.0 + 0.001614" />
-        <millepede_constant name="12315" value="0.0 + 0.003976" />
-        <millepede_constant name="12316" value="0.0 + -0.003284" />
-        <millepede_constant name="12317" value="0.0 + -0.001738" />
-        <millepede_constant name="12318" value="0.0 + 0.000933" />
-        <millepede_constant name="12319" value="0.0 + 0.004628" />
-        <millepede_constant name="12320" value="0.0 + -0.004674" />
+        <millepede_constant name="12309" value="0.0" />
+        <millepede_constant name="12310" value="0.0" />
+        <millepede_constant name="12311" value="0.0" />
+        <millepede_constant name="12312" value="0.0" />
+        <millepede_constant name="12313" value="0.0" />
+        <millepede_constant name="12314" value="0.0" />
+        <millepede_constant name="12315" value="0.0" />
+        <millepede_constant name="12316" value="0.0" />
+        <millepede_constant name="12317" value="0.0" />
+        <millepede_constant name="12318" value="0.0" />
+        <millepede_constant name="12319" value="0.0" />
+        <millepede_constant name="12320" value="0.0" />
         <millepede_constant name="12321" value="0.0" />
         <millepede_constant name="12322" value="0.0" />
 
         <!-- bottom half-module translations -->
 
-        <millepede_constant name="21101" value="0.0 - 0.107190 - 0.005866 - 0.060341 - 0.003872" />
-        <millepede_constant name="21102" value="0.0 - 0.059475 - 0.027066 - 0.000800" />
-        <millepede_constant name="21103" value="0.0 - 0.079522 - -0.001877 - 0.042242 - 0.003328" />
-        <millepede_constant name="21104" value="0.0 - 0.047102 - -0.004770 - -0.002447" />
-        <millepede_constant name="21105" value="0.0 - -0.014915 - 0.013450 - -0.026219 - -0.009611 + 0.005" />
+        <millepede_constant name="21101" value="0.0 - 0.107190 - 0.005866 - 0.060341" />
+        <millepede_constant name="21102" value="0.0 - 0.059475 - 0.027066" />
+        <millepede_constant name="21103" value="0.0 - 0.079522 - -0.001877 - 0.042242" />
+        <millepede_constant name="21104" value="0.0 - 0.047102 - -0.004770" />
+        <millepede_constant name="21105" value="0.0 - -0.014915 - 0.013450 - -0.026219 - -0.009611" />
         <millepede_constant name="21106" value="0.0 - 0.031471 - -0.000722" />
-        <millepede_constant name="21107" value="0.0 - -0.029044 - 0.008449 - -0.018252 - -0.012929 + 0.010" />
+        <millepede_constant name="21107" value="0.0 - -0.029044 - 0.008449 - -0.018252 - -0.012929" />
         <millepede_constant name="21108" value="0.0 - 0.006131" />
         <millepede_constant name="21109" value="0.0" />
         <millepede_constant name="21110" value="0.0" />
-        <millepede_constant name="21111" value="-0.0203 - -0.042235 - 0.034795 - -0.044844 - -0.000811 - 0.001150 - 0.007410 - -0.037481 - 0.046508 - 0.006683 + 0.007 - 0.035346 - -0.025149 - -0.020406" />
-        <millepede_constant name="21112" value="-0.082 - 0.050569 - 0.004122 - -0.035304 - 0.036576" />
-        <millepede_constant name="21113" value="0.0 - -0.104520 - 0.106240 - 0.001598 - 0.002801 - -0.000999 - -0.042308 - 0.134950 - 0.025829" />
-        <millepede_constant name="21114" value="0.0 - -0.113090 - -0.003659 - 0.042258 - -0.142120" />
-        <millepede_constant name="21115" value="0.0 - 0.101260 - -0.113530 - -0.000371 - -0.003598 - -0.005391 - -0.092678 - 0.097442 - 0.016330 + 0.010 - 0.007 - 0.094864 - -0.152070 - -0.036997" />
-        <millepede_constant name="21116" value="0.0 - 0.119860 - 0.008016 - -0.094750 - 0.177580" />
-        <millepede_constant name="21117" value="0.0 - -0.070300 - -0.183510 - 0.210600 - 0.003086 - 0.007767 - 0.002723 + 0.002 - -0.067666 - 0.249320 - 0.049407" />
-        <millepede_constant name="21118" value="0.0 - -0.221920 - -0.013386 - 0.067585 - -0.290160" />
-        <millepede_constant name="21119" value="0.0 - 0.032623 - 0.172330 - -0.215950 - -0.002618 - -0.005793 - -0.008341 - -0.185020 - 0.187560 - 0.032886 - 0.01 - 0.218070 - -0.329270 - -0.081435" />
-        <millepede_constant name="21120" value="0.0 - 0.230800 - 0.012574 - 0.01 - -0.217800 - 0.365860" />
+        <millepede_constant name="21111" value="-0.0203 - -0.042235 - 0.034795 - -0.044844 - -0.000811 - 0.001150" />
+        <millepede_constant name="21112" value="-0.082 - 0.050569 - 0.004122" />
+        <millepede_constant name="21113" value="0.0 - -0.104520 - 0.106240 - 0.001598 - 0.002801" />
+        <millepede_constant name="21114" value="0.0 - -0.113090 - -0.003659" />
+        <millepede_constant name="21115" value="0.0 - 0.101260 - -0.113530 - -0.000371 - -0.003598" />
+        <millepede_constant name="21116" value="0.0 - 0.119860 - 0.008016" />
+        <millepede_constant name="21117" value="0.0 - -0.070300 - -0.183510 - 0.210600 - 0.003086 - 0.007767" />
+        <millepede_constant name="21118" value="0.0 - -0.221920 - -0.013386" />
+        <millepede_constant name="21119" value="0.0 - 0.032623 - 0.172330 - -0.215950 - -0.002618 - -0.005793" />
+        <millepede_constant name="21120" value="0.0 - 0.230800 - 0.012574" />
         <millepede_constant name="21121" value="0.0" />
         <millepede_constant name="21122" value="0.0" />
 
@@ -456,26 +456,26 @@
         <millepede_constant name="22221" value="0.0" />
         <millepede_constant name="22222" value="0.0" />
 
-        <millepede_constant name="22301" value="0.0 + -0.011634" />
-        <millepede_constant name="22302" value="0.0 + 0.008585" />
-        <millepede_constant name="22303" value="0.0 + -0.005113" />
-        <millepede_constant name="22304" value="0.0 + 0.001496" />
+        <millepede_constant name="22301" value="0.0" />
+        <millepede_constant name="22302" value="0.0" />
+        <millepede_constant name="22303" value="0.0" />
+        <millepede_constant name="22304" value="0.0" />
         <millepede_constant name="22305" value="0.0" />
         <millepede_constant name="22306" value="0.0" />
         <millepede_constant name="22307" value="0.0" />
         <millepede_constant name="22308" value="0.0" />
         <millepede_constant name="22309" value="0.0" />
         <millepede_constant name="22310" value="0.0" />
-        <millepede_constant name="22311" value="0.0 + -0.000782" />
-        <millepede_constant name="22312" value="0.0 + 0.001015" />
-        <millepede_constant name="22313" value="0.0 + 0.000359" />
-        <millepede_constant name="22314" value="0.0 + -0.001675" />
-        <millepede_constant name="22315" value="0.0 + -0.001699" />
-        <millepede_constant name="22316" value="0.0 + 0.002011" />
-        <millepede_constant name="22317" value="0.0 + 0.001003" />
-        <millepede_constant name="22318" value="0.0 + -0.002004" />
-        <millepede_constant name="22319" value="0.0 + -0.002691" />
-        <millepede_constant name="22320" value="0.0 + 0.002836" />
+        <millepede_constant name="22311" value="0.0" />
+        <millepede_constant name="22312" value="0.0" />
+        <millepede_constant name="22313" value="0.0" />
+        <millepede_constant name="22314" value="0.0" />
+        <millepede_constant name="22315" value="0.0" />
+        <millepede_constant name="22316" value="0.0" />
+        <millepede_constant name="22317" value="0.0" />
+        <millepede_constant name="22318" value="0.0" />
+        <millepede_constant name="22319" value="0.0" />
+        <millepede_constant name="22320" value="0.0" />
         <millepede_constant name="22321" value="0.0" />
         <millepede_constant name="22322" value="0.0" />
 
@@ -504,14 +504,14 @@
 
 
         <!-- L1Top Module translations and angles -->
-        <millepede_constant name="11161" value="0.0 + 0.029119 - -0.051153 - 0.038288" /> <!-- u  -> global Y   -->
+        <millepede_constant name="11161" value="0.0 + 0.029119 - -0.051153" /> <!-- u  -> global Y   -->
         <millepede_constant name="11261" value="0.0" /> <!-- v  -> X+svtAngle -->
         <millepede_constant name="11361" value="0.0" /> <!-- w  -> Z+svtAngle -->
         <millepede_constant name="12161" value="0.0" /> <!-- ru -->
         <millepede_constant name="12261" value="0.0" /> <!-- rv -->
         <millepede_constant name="12361" value="0.0" /> <!-- rw -->
 
-        <millepede_constant name="21161" value="0.0 + -0.142600 + -0.071162 - 0.086198 - 0.023561" /> <!-- u -->
+        <millepede_constant name="21161" value="0.0 + -0.142600 + -0.071162 - 0.086198" /> <!-- u -->
         <millepede_constant name="21261" value="0.0" /> <!-- v -->
         <millepede_constant name="21361" value="0.0" /> <!-- w -->
         <millepede_constant name="22161" value="0.0" /> <!-- ru -->
@@ -519,14 +519,14 @@
         <millepede_constant name="22361" value="0.0" /> <!-- rw -->
 
         <!-- L2 Top/Bottom translations and angles -->
-        <millepede_constant name="11162" value="0.0 + -0.022437 - -0.057777 - 0.027096" /> <!-- u  -> global Y   -->
+        <millepede_constant name="11162" value="0.0 + -0.022437 - -0.057777" /> <!-- u  -> global Y   -->
         <millepede_constant name="11262" value="0.0" /> <!-- v  -> X+svtAngle -->
         <millepede_constant name="11362" value="0.0" /> <!-- w  -> Z+svtAngle -->
         <millepede_constant name="12162" value="0.0" /> <!-- ru -->
         <millepede_constant name="12262" value="0.0" /> <!-- rv -->
         <millepede_constant name="12362" value="0.0" /> <!-- rw -->
 
-        <millepede_constant name="21162" value="0.0 + -0.055978 + -0.025022 - 0.087956 - 0.031777" /> <!-- u -->
+        <millepede_constant name="21162" value="0.0 + -0.055978 + -0.025022 - 0.087956" /> <!-- u -->
         <millepede_constant name="21262" value="0.0" /> <!-- v -->
         <millepede_constant name="21362" value="0.0" /> <!-- w -->
         <millepede_constant name="22162" value="0.0" /> <!-- ru -->
@@ -534,14 +534,14 @@
         <millepede_constant name="22362" value="0.0" /> <!-- rw -->
 
         <!-- L3 Top/Bottom translations and angles -->
-        <millepede_constant name="11163" value="0.0 + 0.000678 - -0.059459 - 0.012216 - 0.006668 - 0.002504 + -0.7" /> <!-- u  -> global Y   -->
+        <millepede_constant name="11163" value="0.0 + 0.000678 - -0.059459" /> <!-- u  -> global Y   -->
         <millepede_constant name="11263" value="0.0" /> <!-- v  -> X+svtAngle -->
         <millepede_constant name="11363" value="0.0" /> <!-- w  -> Z+svtAngle -->
         <millepede_constant name="12163" value="0.0" /> <!-- ru -->
         <millepede_constant name="12263" value="0.0" /> <!-- rv -->
         <millepede_constant name="12363" value="0.0" /> <!-- rw -->
 
-        <millepede_constant name="21163" value="0.0 + -0.046884 + -0.010228 - 0.075913 - 0.001767 - 0.023862 + -0.7" /> <!-- u -->
+        <millepede_constant name="21163" value="0.0 + -0.046884 + -0.010228 - 0.075913" /> <!-- u -->
         <millepede_constant name="21263" value="0.0" /> <!-- v -->
         <millepede_constant name="21363" value="0.0" /> <!-- w -->
         <millepede_constant name="22163" value="0.0" /> <!-- ru -->
@@ -549,14 +549,14 @@
         <millepede_constant name="22363" value="0.0" /> <!-- rw -->
 
         <!-- L4 Top/Bottom translations and angles -->
-        <millepede_constant name="11164" value="0.0 + -0.007361 - -0.033468 - -0.017968 - -0.013564 - 0.001690 + -0.7" /> <!-- u  -> global Y   -->
+        <millepede_constant name="11164" value="0.0 + -0.007361 - -0.033468" /> <!-- u  -> global Y   -->
         <millepede_constant name="11264" value="0.0" /> <!-- v  -> X+svtAngle -->
         <millepede_constant name="11364" value="0.0" /> <!-- w  -> Z+svtAngle -->
         <millepede_constant name="12164" value="0.0" /> <!-- ru -->
         <millepede_constant name="12264" value="0.0" /> <!-- rv -->
         <millepede_constant name="12364" value="0.0" /> <!-- rw -->
 
-        <millepede_constant name="21164" value="0.0 + -0.033974 + -0.006749 - 0.051528 - -0.004088 - 0.021074 - 0.001095 + -0.7" /> <!-- u -->
+        <millepede_constant name="21164" value="0.0 + -0.033974 + -0.006749 - 0.051528" /> <!-- u -->
         <millepede_constant name="21264" value="0.0" /> <!-- v -->
         <millepede_constant name="21364" value="0.0" /> <!-- w -->
         <millepede_constant name="22164" value="0.0" /> <!-- ru -->
@@ -772,7 +772,7 @@
   </readouts>
 
   <fields>
-      <field type="FieldMap3D" name="HPSDipoleFieldMap3D" filename="fieldmap/166acm2_4kg_corrected_unfolded_scaled_1.090896.dat" url="https://github.com/JeffersonLab/hps-fieldmaps/raw/master/166acm2_4kg_corrected_unfolded_scaled_1.090896.tar.gz" xoffset="2.117*cm" yoffset="0.0*cm" zoffset="45.72*cm" />
+    <field type="FieldMap3D" name="HPSDipoleFieldMap3D" filename="fieldmap/334acm3_8kg_corrected_unfolded_scaled_1.0508.dat" url="https://github.com/JeffersonLab/hps-fieldmaps/raw/master/334acm3_8kg_corrected_unfolded_scaled_1.0508.tar.gz" xoffset="2.117*cm" yoffset="0.0*cm" zoffset="45.72*cm" />
   </fields>
 
   <!--

--- a/detector-data/detectors/HPS_Run2021Pass2FEE_fixed/detector.properties
+++ b/detector-data/detectors/HPS_Run2021Pass2FEE_fixed/detector.properties
@@ -1,0 +1,1 @@
+name: HPS_Run2021Pass2FEE_fixed


### PR DESCRIPTION
tl;dr:
DETNAME_fixed: always use this version
DETNAME: only use this version if you need pre-bug-fix (wrong) geometry

To ensure that the same detector name always refers to the same geometry, I went back and adjusted the detectors pointed out by @normangraf to represent the same geometry as before the geometry bug fix (https://github.com/JeffersonLab/hps-java/pull/1001). This includes removing the top back survey constants (which have previously not been used due to a typo) and introducing a 700um shift of layers 3 and 4 towards the beam. I copied the unmodified version to DETNAME_fixed which should be used from now on for further alignment and analysis work unless you want to specifically analyze MC data generated before the fix or other scenarios where you need the pre-bug-fix version of the detector.