### PR TITLE
fix 2019 MC reconstruction file

### DIFF
--- a/steering-files/src/main/resources/org/hps/steering/recon/PhysicsRun2019MCRecon.lcsim
+++ b/steering-files/src/main/resources/org/hps/steering/recon/PhysicsRun2019MCRecon.lcsim
@@ -179,6 +179,7 @@
             <maxVertexP>7.0</maxVertexP>
             <requireClustersForV0>false</requireClustersForV0>
             <applyClusterCorrections>false</applyClusterCorrections>
+	    <isMC>true</isMC>
         </driver>         
         <driver name="ReconParticleDriver_Kalman" type="org.hps.recon.particle.HpsReconParticleDriver" > 
             <ecalClusterCollectionName>EcalClustersCorr</ecalClusterCollectionName>
@@ -206,6 +207,7 @@
             <maxVertexP>7.0</maxVertexP>
             <requireClustersForV0>false</requireClustersForV0>
             <applyClusterCorrections>true</applyClusterCorrections>
+	    <isMC>true</isMC>
         </driver>         
         <driver name="GBLRefitterDriver" type="org.hps.recon.tracking.gbl.GBLRefitterDriver"/>        
         <driver name="KalmanPatRecDriver" type="org.hps.recon.tracking.kalman.KalmanPatRecDriver">

--- a/steering-files/src/main/resources/org/hps/steering/recon/PhysicsRun2019MCRecon_LCIO.lcsim
+++ b/steering-files/src/main/resources/org/hps/steering/recon/PhysicsRun2019MCRecon_LCIO.lcsim
@@ -237,6 +237,7 @@
             <requireClustersForV0>false</requireClustersForV0>
             <applyClusterCorrections>false</applyClusterCorrections>
             <disablePID>true</disablePID>
+	    <isMC>true</isMC>
         </driver>         
 
 
@@ -263,6 +264,7 @@
             <requireClustersForV0>false</requireClustersForV0>
             <applyClusterCorrections>true</applyClusterCorrections>
             <disablePID>true</disablePID>
+	    <isMC>true</isMC>
         </driver>         
 
 


### PR DESCRIPTION
Andrea found that \<isMC\>true\</isMC\> was not set for HpsReconParticleDriver in 2019 MC reconstruction steering files. It needs to be set so that MC parameterization is applied for Ecal correction.