### PR TITLE
Change setup for trackClusterTimeOffset and beam sigma in 2016 MC reconstruction steering files

### DIFF
--- a/steering-files/src/main/resources/org/hps/steering/recon/KalmanAndGBLRecoMC.lcsim
+++ b/steering-files/src/main/resources/org/hps/steering/recon/KalmanAndGBLRecoMC.lcsim
@@ -142,11 +142,11 @@
           <targetConV0CandidatesColName>TargetConstrainedV0Candidates_KF</targetConV0CandidatesColName>
           <targetConV0VerticesColName>TargetConstrainedV0Vertices_KF</targetConV0VerticesColName>
           <beamPositionX> -0.224 </beamPositionX>
-          <beamSigmaX> 0.125 </beamSigmaX>
+          <beamSigmaX> 0.275 </beamSigmaX>
           <beamPositionY> -0.08 </beamPositionY>
-          <beamSigmaY> 0.030 </beamSigmaY>
+          <beamSigmaY> 0.060 </beamSigmaY>
           <beamPositionZ> -4.3 </beamPositionZ>
-          <trackClusterTimeOffset>44.8</trackClusterTimeOffset>
+          <trackClusterTimeOffset>36.8</trackClusterTimeOffset>
           <isMC>true</isMC>
           <useInternalVertexXYPositions>false</useInternalVertexXYPositions>
           <minVertexChisqProb> 0.0 </minVertexChisqProb>
@@ -165,11 +165,11 @@
           <!--<trackCollectionNames>${trackColl}</trackCollectionNames> -->
           <trackCollectionNames>GBLTracks</trackCollectionNames>
           <beamPositionX> -0.224 </beamPositionX>
-          <beamSigmaX> 0.125 </beamSigmaX>
+          <beamSigmaX> 0.275 </beamSigmaX>
           <beamPositionY> -0.08 </beamPositionY>
-          <beamSigmaY> 0.030 </beamSigmaY>
+          <beamSigmaY> 0.060 </beamSigmaY>
           <beamPositionZ> -4.3 </beamPositionZ>
-          <trackClusterTimeOffset>44.8</trackClusterTimeOffset>
+          <trackClusterTimeOffset>36.8</trackClusterTimeOffset>
           <isMC>true</isMC>
           <useInternalVertexXYPositions>false</useInternalVertexXYPositions>
           <minVertexChisqProb> 0.0 </minVertexChisqProb>

--- a/steering-files/src/main/resources/org/hps/steering/recon/PhysicsRun2016FullReconMC.lcsim
+++ b/steering-files/src/main/resources/org/hps/steering/recon/PhysicsRun2016FullReconMC.lcsim
@@ -153,9 +153,9 @@
             <ecalClusterCollectionName>EcalClustersCorr</ecalClusterCollectionName>
             <trackCollectionNames>GBLTracks</trackCollectionNames>
             <beamPositionX> -0.224 </beamPositionX>
-            <beamSigmaX> 0.125 </beamSigmaX>
+            <beamSigmaX> 0.275 </beamSigmaX>
             <beamPositionY> -0.08 </beamPositionY>
-            <beamSigmaY> 0.030 </beamSigmaY>
+            <beamSigmaY> 0.060 </beamSigmaY>
             <beamPositionZ> -4.3 </beamPositionZ>
             <trackClusterTimeOffset>36.8</trackClusterTimeOffset>
             <isMC>true</isMC>

--- a/steering-files/src/main/resources/org/hps/steering/recon/PhysicsRun2016FullReconMCWithTruthTuple.lcsim
+++ b/steering-files/src/main/resources/org/hps/steering/recon/PhysicsRun2016FullReconMCWithTruthTuple.lcsim
@@ -155,9 +155,9 @@
             <ecalClusterCollectionName>EcalClustersCorr</ecalClusterCollectionName>
             <trackCollectionNames>GBLTracks</trackCollectionNames>
             <beamPositionX> -0.224 </beamPositionX>
-            <beamSigmaX> 0.125 </beamSigmaX>
+            <beamSigmaX> 0.275 </beamSigmaX>
             <beamPositionY> -0.08 </beamPositionY>
-            <beamSigmaY> 0.030 </beamSigmaY>
+            <beamSigmaY> 0.060 </beamSigmaY>
             <beamPositionZ> -4.3 </beamPositionZ>
             <trackClusterTimeOffset>36.8</trackClusterTimeOffset>
             <maxElectronP> 2.15 </maxElectronP>

--- a/steering-files/src/main/resources/org/hps/steering/recon/PhysicsRun2016FullReconMC_GBL_TrackClusterMatcher.lcsim
+++ b/steering-files/src/main/resources/org/hps/steering/recon/PhysicsRun2016FullReconMC_GBL_TrackClusterMatcher.lcsim
@@ -278,9 +278,9 @@
             <trackCollectionNames>GBLTracks</trackCollectionNames>
             <matcherTrackCollectionName>GBLTracks</matcherTrackCollectionName>
             <beamPositionX> -0.224 </beamPositionX>
-            <beamSigmaX> 0.125 </beamSigmaX>
+            <beamSigmaX> 0.275 </beamSigmaX>
             <beamPositionY> -0.08 </beamPositionY>
-            <beamSigmaY> 0.030 </beamSigmaY>
+            <beamSigmaY> 0.060 </beamSigmaY>
             <beamPositionZ> -4.3 </beamPositionZ>
             <trackClusterTimeOffset>36.8</trackClusterTimeOffset>
             <isMC>true</isMC>

--- a/steering-files/src/main/resources/org/hps/steering/recon/PhysicsRun2016FullReconMC_GBL_TrackClusterMatcher_SlopeKiller.lcsim
+++ b/steering-files/src/main/resources/org/hps/steering/recon/PhysicsRun2016FullReconMC_GBL_TrackClusterMatcher_SlopeKiller.lcsim
@@ -230,11 +230,11 @@
             <trackCollectionNames>GBLTracks</trackCollectionNames>
             <matcherTrackCollectionName>GBLTracks</matcherTrackCollectionName>
             <beamPositionX> -0.224 </beamPositionX>
-            <beamSigmaX> 0.125 </beamSigmaX>
+            <beamSigmaX> 0.275 </beamSigmaX>
             <beamPositionY> -0.08 </beamPositionY>
-            <beamSigmaY> 0.030 </beamSigmaY>
+            <beamSigmaY> 0.060 </beamSigmaY>
             <beamPositionZ> -4.3 </beamPositionZ>
-            <trackClusterTimeOffset>44.8</trackClusterTimeOffset>
+            <trackClusterTimeOffset>36.8</trackClusterTimeOffset>
             <isMC>true</isMC>
             <useInternalVertexXYPositions>false</useInternalVertexXYPositions>
             <minVertexChisqProb> 0.0 </minVertexChisqProb>
@@ -252,11 +252,11 @@
             <trackCollectionNames>GBLTracks</trackCollectionNames>
             <matcherTrackCollectionName>GBLTracks</matcherTrackCollectionName>
             <beamPositionX> -0.224 </beamPositionX>
-            <beamSigmaX> 0.125 </beamSigmaX>
+            <beamSigmaX> 0.275 </beamSigmaX>
             <beamPositionY> -0.08 </beamPositionY>
-            <beamSigmaY> 0.030 </beamSigmaY>
+            <beamSigmaY> 0.060 </beamSigmaY>
             <beamPositionZ> -4.3 </beamPositionZ>
-            <trackClusterTimeOffset>44.8</trackClusterTimeOffset>
+            <trackClusterTimeOffset>36.8</trackClusterTimeOffset>
             <isMC>true</isMC>
             <useInternalVertexXYPositions>false</useInternalVertexXYPositions>
             <minVertexChisqProb> 0.0 </minVertexChisqProb>

--- a/steering-files/src/main/resources/org/hps/steering/recon/PhysicsRun2016FullReconMC_KF_TrackClusterMatcher.lcsim
+++ b/steering-files/src/main/resources/org/hps/steering/recon/PhysicsRun2016FullReconMC_KF_TrackClusterMatcher.lcsim
@@ -130,9 +130,9 @@
             <includeUnmatchedTracksInFSP>true</includeUnmatchedTracksInFSP>
             <useInternalVertexXYPositions>false</useInternalVertexXYPositions>
             <beamPositionX>-0.224</beamPositionX>
-            <beamSigmaX>0.125</beamSigmaX>
+            <beamSigmaX>0.275</beamSigmaX>
             <beamPositionY>-0.08</beamPositionY>
-            <beamSigmaY>0.030</beamSigmaY>
+            <beamSigmaY>0.060</beamSigmaY>
             <beamPositionZ>-4.3</beamPositionZ>
             <maxElectronP>2.15</maxElectronP>
             <maxVertexP>2.8</maxVertexP>

--- a/steering-files/src/main/resources/org/hps/steering/recon/PhysicsRun2016FullReconMC_KF_TrackClusterMatcher_SlopeKiller.lcsim
+++ b/steering-files/src/main/resources/org/hps/steering/recon/PhysicsRun2016FullReconMC_KF_TrackClusterMatcher_SlopeKiller.lcsim
@@ -184,16 +184,16 @@
             <includeUnmatchedTracksInFSP>true</includeUnmatchedTracksInFSP>
             <useInternalVertexXYPositions>false</useInternalVertexXYPositions>
             <beamPositionX>-0.224</beamPositionX>
-            <beamSigmaX>0.125</beamSigmaX>
+            <beamSigmaX>0.275</beamSigmaX>
             <beamPositionY>-0.08</beamPositionY>
-            <beamSigmaY>0.030</beamSigmaY>
+            <beamSigmaY>0.060</beamSigmaY>
             <beamPositionZ>-4.3</beamPositionZ>
             <maxElectronP>2.15</maxElectronP>
             <maxVertexP>2.8</maxVertexP>
             <minVertexChisqProb>0.0</minVertexChisqProb>
             <maxVertexClusterDt>5.0</maxVertexClusterDt>
             <maxMatchDt>10</maxMatchDt>
-            <trackClusterTimeOffset>44.8</trackClusterTimeOffset>
+            <trackClusterTimeOffset>36.8</trackClusterTimeOffset>
             <isMC>true</isMC>
             <trackClusterMatchPlots>false</trackClusterMatchPlots>
             <trackClusterMatcherAlgo>TrackClusterMatcherMinDistance</trackClusterMatcherAlgo>
@@ -215,16 +215,16 @@
             <includeUnmatchedTracksInFSP>true</includeUnmatchedTracksInFSP>
             <useInternalVertexXYPositions>false</useInternalVertexXYPositions>
             <beamPositionX>-0.224</beamPositionX>
-            <beamSigmaX>0.125</beamSigmaX>
+            <beamSigmaX>0.275</beamSigmaX>
             <beamPositionY>-0.08</beamPositionY>
-            <beamSigmaY>0.030</beamSigmaY>
+            <beamSigmaY>0.060</beamSigmaY>
             <beamPositionZ>-4.3</beamPositionZ>
             <maxElectronP>2.15</maxElectronP>
             <maxVertexP>2.8</maxVertexP>
             <minVertexChisqProb>0.0</minVertexChisqProb>
             <maxVertexClusterDt>5.0</maxVertexClusterDt>
             <maxMatchDt>10</maxMatchDt>
-            <trackClusterTimeOffset>44.8</trackClusterTimeOffset>
+            <trackClusterTimeOffset>36.8</trackClusterTimeOffset>
             <isMC>true</isMC>
             <trackClusterMatchPlots>false</trackClusterMatchPlots>
             <trackClusterMatcherAlgo>TrackClusterMatcherMinDistance</trackClusterMatcherAlgo>

--- a/steering-files/src/main/resources/org/hps/steering/recon/PhysicsRun2016FullReconMC_KF_TrackClusterMatcher_StripHitKiller.lcsim
+++ b/steering-files/src/main/resources/org/hps/steering/recon/PhysicsRun2016FullReconMC_KF_TrackClusterMatcher_StripHitKiller.lcsim
@@ -144,16 +144,16 @@
             <includeUnmatchedTracksInFSP>true</includeUnmatchedTracksInFSP>
             <useInternalVertexXYPositions>false</useInternalVertexXYPositions>
             <beamPositionX>-0.224</beamPositionX>
-            <beamSigmaX>0.125</beamSigmaX>
+            <beamSigmaX>0.275</beamSigmaX>
             <beamPositionY>-0.08</beamPositionY>
-            <beamSigmaY>0.030</beamSigmaY>
+            <beamSigmaY>0.060</beamSigmaY>
             <beamPositionZ>-4.3</beamPositionZ>
             <maxElectronP>2.15</maxElectronP>
             <maxVertexP>2.8</maxVertexP>
             <minVertexChisqProb>0.0</minVertexChisqProb>
             <maxVertexClusterDt>5.0</maxVertexClusterDt>
             <maxMatchDt>10</maxMatchDt>
-            <trackClusterTimeOffset>44.8</trackClusterTimeOffset>
+            <trackClusterTimeOffset>36.8</trackClusterTimeOffset>
             <isMC>true</isMC>
             <trackClusterMatchPlots>true</trackClusterMatchPlots>
             <trackClusterMatcherAlgo>TrackClusterMatcherMinDistance</trackClusterMatcherAlgo>

--- a/steering-files/src/main/resources/org/hps/steering/recon/PhysicsRun2016FullRecon_Kalman_simps_noClustersRequired.lcsim
+++ b/steering-files/src/main/resources/org/hps/steering/recon/PhysicsRun2016FullRecon_Kalman_simps_noClustersRequired.lcsim
@@ -260,7 +260,7 @@
             <beamPositionY> -0.08 </beamPositionY>
             <beamSigmaY> 0.030 </beamSigmaY>
             <beamPositionZ> -4.3 </beamPositionZ>
-            <trackClusterTimeOffset>44.8</trackClusterTimeOffset>
+            <trackClusterTimeOffset>36.8</trackClusterTimeOffset>
             <requireClustersForV0>false</requireClustersForV0>
             <isMC>true</isMC>
             <useInternalVertexXYPositions>false</useInternalVertexXYPositions>
@@ -304,7 +304,7 @@
             <minVertexChisqProb>0.0</minVertexChisqProb>
             <maxVertexClusterDt>5.0</maxVertexClusterDt>
             <maxMatchDt>10</maxMatchDt>
-            <trackClusterTimeOffset>44.8</trackClusterTimeOffset>
+            <trackClusterTimeOffset>36.8</trackClusterTimeOffset>
             <debug>false</debug>
             <makeMollerCols>false</makeMollerCols>
              <isMC>true</isMC>


### PR DESCRIPTION
The timing of the ECal changes when using the daq config for the trigger instead of the old way, this is a change that should have happened before when these files were added. We are also updating the beam profile parameters as extracted by the analysis of Alic.