### PR TITLE
add first and last hit bfieldY to TrackData

### DIFF
--- a/tracking/src/main/java/org/hps/recon/tracking/TrackData.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/TrackData.java
@@ -18,7 +18,7 @@ public class TrackData implements GenericObject {
     public static final int L1_ISOLATION_INDEX = 0;
     public static final int L2_ISOLATION_INDEX = 1;
     public static final int N_ISOLATIONS = 14;  //Default
-    public static final int N_TRACK_PARAMS = 7;
+    public static final int N_TRACK_PARAMS = 9;
     public static final int TRACK_TIME_INDEX = 0;
     public static final int PX_INDEX = 1;
     public static final int PY_INDEX = 2;
@@ -26,6 +26,8 @@ public class TrackData implements GenericObject {
     public static final int ORIGIN_BFY_INDEX = 4; //BFieldY at Origin
     public static final int TARGET_BFY_INDEX = 5; //BFieldY at Target TrackState
     public static final int ECAL_BFY_INDEX = 6;   //BFieldY at ECal TrackState
+    public static final int FIRST_BFY_INDEX = 7;   //BFieldY at FirstHit TrackState
+    public static final int LAST_BFY_INDEX = 8;   //BFieldY at LastHit TrackState
     public static final int TRACK_VOLUME_INDEX = 0;
     public static final String TRACK_DATA_COLLECTION = "TrackData";
     public static final String TRACK_DATA_RELATION_COLLECTION = "TrackDataRelations";
@@ -96,11 +98,13 @@ public class TrackData implements GenericObject {
      * @param origin_bfieldY : value of BfieldY at origin ref
      * @param target_bfieldY : value of BfieldY at Target Track State
      * @param ecal_bfieldY   : value of BfieldY at ECal Track State
+     * @param first_bfieldY   : value of BfieldY at FirstHit Track State
+     * @param last_bfieldY   : value of BfieldY at LastHit Track State
      */
-    public TrackData(int trackVolume, float trackTime, double[] isolations, float[] momentum, float origin_bfieldY, float target_bfieldY, float ecal_bfieldY) {
+    public TrackData(int trackVolume, float trackTime, double[] isolations, float[] momentum, float origin_bfieldY, float target_bfieldY, float ecal_bfieldY, float first_bfieldY, float last_bfieldY) {
 
         this.doubles = isolations;
-        this.floats = new float[]{trackTime,momentum[0],momentum[1],momentum[2],origin_bfieldY,target_bfieldY,ecal_bfieldY};
+        this.floats = new float[]{trackTime,momentum[0],momentum[1],momentum[2],origin_bfieldY,target_bfieldY,ecal_bfieldY, first_bfieldY, last_bfieldY};
         this.ints = new int[]{trackVolume};
     }
         

--- a/tracking/src/main/java/org/hps/recon/tracking/kalman/KalmanPatRecDriver.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/kalman/KalmanPatRecDriver.java
@@ -493,7 +493,7 @@ public class KalmanPatRecDriver extends Driver {
                 double ecal_bFieldY = -999.9;
                 if (TrackUtils.getTrackStateAtECal(KalmanTrackHPS) != null)
                 {
-                    Hep3Vector ecal_pos = new BasicHep3Vector(TrackStateUtils.getTrackStateAtECal(KalmanTrackHPS).getReferencePoint());
+                    Hep3Vector ecal_pos = new BasicHep3Vector(TrackUtils.getTrackStateAtECal(KalmanTrackHPS).getReferencePoint());
                     ecal_bFieldY = fm.getField(CoordinateTransformations.transformVectorToDetector(ecal_pos)).y();
                 }          
 

--- a/tracking/src/main/java/org/hps/recon/tracking/kalman/KalmanPatRecDriver.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/kalman/KalmanPatRecDriver.java
@@ -21,6 +21,7 @@ import org.hps.recon.tracking.MaterialSupervisor.ScatteringDetectorVolume;
 import org.hps.recon.tracking.MaterialSupervisor.SiStripPlane;
 import org.hps.recon.tracking.gbl.GBLStripClusterData;
 import org.hps.recon.tracking.TrackUtils;
+import org.hps.recon.tracking.TrackStateUtils;
 import org.hps.util.Pair;
 import org.lcsim.detector.tracker.silicon.HpsSiSensor;
 import org.lcsim.event.EventHeader;
@@ -487,15 +488,30 @@ public class KalmanPatRecDriver extends Driver {
                 {
                     Hep3Vector target_pos = new BasicHep3Vector(TrackUtils.getTrackStateAtTarget(KalmanTrackHPS).getReferencePoint());
                     target_bFieldY = fm.getField(CoordinateTransformations.transformVectorToDetector(target_pos)).y();
-
                 }
                 //Get Bfield at ecal
                 double ecal_bFieldY = -999.9;
                 if (TrackUtils.getTrackStateAtECal(KalmanTrackHPS) != null)
                 {
-                    Hep3Vector ecal_pos = new BasicHep3Vector(TrackUtils.getTrackStateAtECal(KalmanTrackHPS).getReferencePoint());
+                    Hep3Vector ecal_pos = new BasicHep3Vector(TrackStateUtils.getTrackStateAtECal(KalmanTrackHPS).getReferencePoint());
                     ecal_bFieldY = fm.getField(CoordinateTransformations.transformVectorToDetector(ecal_pos)).y();
                 }          
+
+		//Get Bfield at FirstHit
+		double firsthit_bFieldY = -999.9;
+		if (TrackStateUtils.getTrackStateAtFirst(KalmanTrackHPS) != null)
+		{
+                    Hep3Vector firsthit_pos = new BasicHep3Vector(TrackStateUtils.getTrackStateAtFirst(KalmanTrackHPS).getReferencePoint());
+                    firsthit_bFieldY = fm.getField(firsthit_pos).y();
+		}
+
+		//Get Bfield at LastHit
+		double lasthit_bFieldY = -999.9;
+		if (TrackStateUtils.getTrackStateAtLast(KalmanTrackHPS) != null)
+		{
+                    Hep3Vector lasthit_pos = new BasicHep3Vector(TrackStateUtils.getTrackStateAtLast(KalmanTrackHPS).getReferencePoint());
+                    lasthit_bFieldY = fm.getField(lasthit_pos).y();
+		}
 
                 //Add the TrackResiduals
                 List<Integer> layers    = new ArrayList<Integer>();
@@ -523,7 +539,7 @@ public class KalmanPatRecDriver extends Driver {
                 }//Loop on layers
                 
                 //Add the Track Data 
-                TrackData KFtrackData = new TrackData(trackerVolume, (float) kTk.getTime(), qualityArray, momentum_f, (float) origin_bFieldY, (float) target_bFieldY, (float) ecal_bFieldY);
+                TrackData KFtrackData = new TrackData(trackerVolume, (float) kTk.getTime(), qualityArray, momentum_f, (float) origin_bFieldY, (float) target_bFieldY, (float) ecal_bFieldY, (float) firsthit_bFieldY, (float) lasthit_bFieldY);
                 trackDataCollection.add(KFtrackData);
                 trackDataRelations.add(new BaseLCRelation(KFtrackData, KalmanTrackHPS));
 


### PR DESCRIPTION
Add the bfieldY value for the track states and first and last hit on track
These are stored in TrackData, and can be used to calculate momentum in hpstr, as is already done for the target and ecal track states. 