### PR TITLE
fix trackstate at first and last hit to actually require hits

### DIFF
--- a/tracking/src/main/java/org/hps/recon/tracking/TrackData.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/TrackData.java
@@ -18,7 +18,7 @@ public class TrackData implements GenericObject {
     public static final int L1_ISOLATION_INDEX = 0;
     public static final int L2_ISOLATION_INDEX = 1;
     public static final int N_ISOLATIONS = 14;  //Default
-    public static final int N_TRACK_PARAMS = 9;
+    public static final int N_TRACK_PARAMS = 8;
     public static final int TRACK_TIME_INDEX = 0;
     public static final int PX_INDEX = 1;
     public static final int PY_INDEX = 2;
@@ -26,8 +26,7 @@ public class TrackData implements GenericObject {
     public static final int ORIGIN_BFY_INDEX = 4; //BFieldY at Origin
     public static final int TARGET_BFY_INDEX = 5; //BFieldY at Target TrackState
     public static final int ECAL_BFY_INDEX = 6;   //BFieldY at ECal TrackState
-    public static final int FIRST_BFY_INDEX = 7;   //BFieldY at FirstHit TrackState
-    public static final int LAST_BFY_INDEX = 8;   //BFieldY at LastHit TrackState
+    public static final int SVTCENTER_BFY_INDEX = 7;   //BFieldY at SVT Center
     public static final int TRACK_VOLUME_INDEX = 0;
     public static final String TRACK_DATA_COLLECTION = "TrackData";
     public static final String TRACK_DATA_RELATION_COLLECTION = "TrackDataRelations";
@@ -101,10 +100,10 @@ public class TrackData implements GenericObject {
      * @param first_bfieldY   : value of BfieldY at FirstHit Track State
      * @param last_bfieldY   : value of BfieldY at LastHit Track State
      */
-    public TrackData(int trackVolume, float trackTime, double[] isolations, float[] momentum, float origin_bfieldY, float target_bfieldY, float ecal_bfieldY, float first_bfieldY, float last_bfieldY) {
+    public TrackData(int trackVolume, float trackTime, double[] isolations, float[] momentum, float origin_bfieldY, float target_bfieldY, float ecal_bfieldY, float svtCenter_bfieldY) {
 
         this.doubles = isolations;
-        this.floats = new float[]{trackTime,momentum[0],momentum[1],momentum[2],origin_bfieldY,target_bfieldY,ecal_bfieldY, first_bfieldY, last_bfieldY};
+        this.floats = new float[]{trackTime,momentum[0],momentum[1],momentum[2],origin_bfieldY,target_bfieldY,ecal_bfieldY, svtCenter_bfieldY};
         this.ints = new int[]{trackVolume};
     }
         

--- a/tracking/src/main/java/org/hps/recon/tracking/kalman/KalmanInterface.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/kalman/KalmanInterface.java
@@ -84,7 +84,7 @@ public class KalmanInterface {
     private double[] beamPosition = null;
     
     private static final boolean debug = false;    
-    private static final double SVTcenter = 505.57;
+    static final double SVTcenter = 505.57;
     private static final double c = 2.99793e8; // Speed of light in m/s
     
     private int runNumber = 14168;
@@ -570,8 +570,14 @@ public class KalmanInterface {
         }
         
         // Add the hits to the track
+	int firstHit_idx = -1;
+	int lastHit_idx = -1;
+	int idx = -1;
         for (MeasurementSite site : kT.SiteList) {
+	    idx = idx + 1;
             if (site.hitID < 0) continue;
+	    if (firstHit_idx < 0) firstHit_idx = idx;
+	    lastHit_idx = idx;
             newTrack.addHit(getHpsHit(site.m.hits.get(site.hitID)));
         }
         //System.out.printf("PF::Debug::newTrack site size %d \n",newTrack.getTrackerHits().size());
@@ -586,9 +592,9 @@ public class KalmanInterface {
             //int lay = hssd.getMillepedeId();
             // System.out.printf("ssp id %d \n", hssd.getMillepedeId());
 
-            if (i == 0) {
+            if (i == firstHit_idx) {
                 loc = TrackState.AtFirstHit;
-            } else if (i == kT.SiteList.size() - 1) 
+            } else if (i == lastHit_idx) 
                 loc = TrackState.AtLastHit;
             
             /*

--- a/tracking/src/main/java/org/hps/recon/tracking/kalman/KalmanPatRecDriver.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/kalman/KalmanPatRecDriver.java
@@ -5,11 +5,6 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.io.File;
-import java.io.FileWriter;
-import java.io.PrintWriter;
-import java.io.IOException;
-import java.lang.Math;
 
 import hep.physics.vec.Hep3Vector;
 import hep.physics.vec.BasicHep3Vector;

--- a/tracking/src/main/java/org/hps/recon/tracking/kalman/KalmanPatRecDriver.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/kalman/KalmanPatRecDriver.java
@@ -5,6 +5,11 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.PrintWriter;
+import java.io.IOException;
+import java.lang.Math;
 
 import hep.physics.vec.Hep3Vector;
 import hep.physics.vec.BasicHep3Vector;
@@ -482,6 +487,9 @@ public class KalmanPatRecDriver extends Driver {
                 //Get Bfield at origin
                 double origin_bFieldY = fm.getField((new BasicHep3Vector(0.0, 0.0, 0.0))).y();
 
+                //Get Bfield at SVT Center
+                double svtCenter_bFieldY = fm.getField((new BasicHep3Vector(0.0, 0.0, KI.SVTcenter))).y();
+
                 //Get Bfield at target
                 double target_bFieldY = -999.9;
                 if (TrackUtils.getTrackStateAtTarget(KalmanTrackHPS) != null)
@@ -496,22 +504,6 @@ public class KalmanPatRecDriver extends Driver {
                     Hep3Vector ecal_pos = new BasicHep3Vector(TrackUtils.getTrackStateAtECal(KalmanTrackHPS).getReferencePoint());
                     ecal_bFieldY = fm.getField(CoordinateTransformations.transformVectorToDetector(ecal_pos)).y();
                 }          
-
-		//Get Bfield at FirstHit
-		double firsthit_bFieldY = -999.9;
-		if (TrackStateUtils.getTrackStateAtFirst(KalmanTrackHPS) != null)
-		{
-                    Hep3Vector firsthit_pos = new BasicHep3Vector(TrackStateUtils.getTrackStateAtFirst(KalmanTrackHPS).getReferencePoint());
-                    firsthit_bFieldY = fm.getField(firsthit_pos).y();
-		}
-
-		//Get Bfield at LastHit
-		double lasthit_bFieldY = -999.9;
-		if (TrackStateUtils.getTrackStateAtLast(KalmanTrackHPS) != null)
-		{
-                    Hep3Vector lasthit_pos = new BasicHep3Vector(TrackStateUtils.getTrackStateAtLast(KalmanTrackHPS).getReferencePoint());
-                    lasthit_bFieldY = fm.getField(lasthit_pos).y();
-		}
 
                 //Add the TrackResiduals
                 List<Integer> layers    = new ArrayList<Integer>();
@@ -539,7 +531,7 @@ public class KalmanPatRecDriver extends Driver {
                 }//Loop on layers
                 
                 //Add the Track Data 
-                TrackData KFtrackData = new TrackData(trackerVolume, (float) kTk.getTime(), qualityArray, momentum_f, (float) origin_bFieldY, (float) target_bFieldY, (float) ecal_bFieldY, (float) firsthit_bFieldY, (float) lasthit_bFieldY);
+                TrackData KFtrackData = new TrackData(trackerVolume, (float) kTk.getTime(), qualityArray, momentum_f, (float) origin_bFieldY, (float) target_bFieldY, (float) ecal_bFieldY, (float) svtCenter_bFieldY);
                 trackDataCollection.add(KFtrackData);
                 trackDataRelations.add(new BaseLCRelation(KFtrackData, KalmanTrackHPS));
 


### PR DESCRIPTION
Previously, AtFirstHit and AtLastHit track states used measurement sites, not sites with hits.
Fixed this.