### PR TITLE
Remove requirement for only 2 electrons in the event.

### DIFF
--- a/recon/src/main/java/org/hps/recon/particle/HpsReconParticleDriver.java
+++ b/recon/src/main/java/org/hps/recon/particle/HpsReconParticleDriver.java
@@ -431,15 +431,17 @@ public class HpsReconParticleDriver extends ReconParticleDriver {
                 botElectrons.add(electron);
             }
         }
-
-        if (topElectrons.size() > 1 || botElectrons.size() > 1) {
-            return;
-        }
+// ---- This requirement is too strict, and cuts out a lot of events.
+//      It can cut *all* moller events if both KF and GBL are used.
+//
+//        if (topElectrons.size() > 1 || botElectrons.size() > 1) {
+//            return;
+//        }
 
         // Iterate over the collection of electrons and create e-e- pairs 
         for (ReconstructedParticle topElectron : topElectrons) {
             for (ReconstructedParticle botElectron : botElectrons) {
-                // Don't vertex a GBL track with a SeedTrack.
+                // Don't vertex a GBL track with a SeedTrack or KF track.
                 if (TrackType.isGBL(topElectron.getType()) != TrackType.isGBL(botElectron.getType())) {
                     continue;
                 }


### PR DESCRIPTION
See the related issue: https://github.com/JeffersonLab/hps-java/issues/1054
