### PR TITLE
Fix an issue in SinglesTrigger2019ReadoutDriver 

### DIFF
--- a/ecal-readout-sim/src/main/java/org/hps/readout/trigger2019/SinglesTrigger2019ReadoutDriver.java
+++ b/ecal-readout-sim/src/main/java/org/hps/readout/trigger2019/SinglesTrigger2019ReadoutDriver.java
@@ -141,18 +141,31 @@ public class SinglesTrigger2019ReadoutDriver extends TriggerDriver {
         // Check that clusters are available for the trigger.
         Collection<Cluster> clusters = null;
         Collection<HodoscopePattern> hodoPatterns = null;
-        ArrayList<HodoscopePattern> hodoPatternList = null;
-        if(ReadoutDataManager.checkCollectionStatus(inputCollectionNameEcal, localTime) && ReadoutDataManager.checkCollectionStatus(inputCollectionNameHodo, localTime)) {
-            clusters = ReadoutDataManager.getData(localTime, localTime + 4.0, inputCollectionNameEcal, Cluster.class);
-            hodoPatterns = ReadoutDataManager.getData(localTime, localTime + 4.0, inputCollectionNameHodo, HodoscopePattern.class);
-            
-            localTime += 4.0;
-            
-            if(clusters.size() == 0 || hodoPatterns.size() == 0) return;
-                       
-            hodoPatternList = new ArrayList<>(hodoPatterns);
-            
-        } else { return; }
+        ArrayList<HodoscopePattern> hodoPatternList = new ArrayList<>();
+        
+        if(triggerType.equals("singles3")) {
+            if(ReadoutDataManager.checkCollectionStatus(inputCollectionNameEcal, localTime) && ReadoutDataManager.checkCollectionStatus(inputCollectionNameHodo, localTime)) {
+                clusters = ReadoutDataManager.getData(localTime, localTime + 4.0, inputCollectionNameEcal, Cluster.class);
+                hodoPatterns = ReadoutDataManager.getData(localTime, localTime + 4.0, inputCollectionNameHodo, HodoscopePattern.class);
+                
+                localTime += 4.0;
+                
+                if(clusters.size() == 0 || hodoPatterns.size() == 0) return;
+                           
+                hodoPatternList.addAll(hodoPatterns);
+                
+            } else { return; }
+        }
+        else {
+            if(ReadoutDataManager.checkCollectionStatus(inputCollectionNameEcal, localTime)) {
+                clusters = ReadoutDataManager.getData(localTime, localTime + 4.0, inputCollectionNameEcal, Cluster.class);
+                
+                localTime += 4.0;
+                
+                if(clusters.size() == 0) return;
+                
+            } else { return; }
+        }
         
         // Track whether or not a trigger was seen.
         boolean triggered = false;


### PR DESCRIPTION
The driver is supposed to process any single trigger.
However, codes https://github.com/JeffersonLab/hps-java/blob/054ee5d43d5e36618d248d41a6b8c124d2be3304/ecal-readout-sim/src/main/java/org/hps/readout/trigger2019/SinglesTrigger2019ReadoutDriver.java#L145C9-L155C27 requires that sizes for both GTP clusters and hodo patterns are larger than 0.
It is requirement for single3 trigger. Update for the codes was missed when I did readout update for processing multiple triggers.
The bug causes issue when we process other single triggers except single3 trigger.