### PR TITLE
add readout steering file for 2021 MC with single2&single3 triggers

### DIFF
--- a/steering-files/src/main/resources/org/hps/steering/readout/PhysicsRun2019TrigMultiSingles.lcsim
+++ b/steering-files/src/main/resources/org/hps/steering/readout/PhysicsRun2019TrigMultiSingles.lcsim
@@ -2,7 +2,7 @@
 <lcsim xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
        xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/lcsim/1.0/lcsim.xsd">
     <!-- 
-      @Readout steering file with pairs trigger for 2019 MC.
+      @Readout steering file with single2 and single3 triggers for 2019 MC.
       @author <a href="mailto:caot@jlab.org">Tongtong Cao</a>
     -->
     <execute>

--- a/steering-files/src/main/resources/org/hps/steering/readout/PhysicsRun2019TrigPulse.lcsim
+++ b/steering-files/src/main/resources/org/hps/steering/readout/PhysicsRun2019TrigPulse.lcsim
@@ -2,7 +2,7 @@
 <lcsim xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
        xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/lcsim/1.0/lcsim.xsd">
     <!-- 
-      @Readout steering file with pairs trigger for 2019 MC.
+      @Readout steering file with random trigger for 2019 MC.
       @author <a href="mailto:caot@jlab.org">Tongtong Cao</a>
     -->
     <execute>

--- a/steering-files/src/main/resources/org/hps/steering/readout/PhysicsRun2019TrigSingles.lcsim
+++ b/steering-files/src/main/resources/org/hps/steering/readout/PhysicsRun2019TrigSingles.lcsim
@@ -2,7 +2,7 @@
 <lcsim xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
        xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/lcsim/1.0/lcsim.xsd">
     <!-- 
-      @Readout steering file with pairs trigger for 2019 MC.
+      @Readout steering file with single3 trigger for 2019 MC.
       @author <a href="mailto:caot@jlab.org">Tongtong Cao</a>
     -->
     <execute>

--- a/steering-files/src/main/resources/org/hps/steering/readout/PhysicsRun2019TrigSingles2.lcsim
+++ b/steering-files/src/main/resources/org/hps/steering/readout/PhysicsRun2019TrigSingles2.lcsim
@@ -2,7 +2,7 @@
 <lcsim xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
        xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/lcsim/1.0/lcsim.xsd">
     <!-- 
-      @Readout steering file with pairs trigger for 2019 MC.
+      @Readout steering file with single2 trigger for 2019 MC.
       @author <a href="mailto:caot@jlab.org">Tongtong Cao</a>
     -->
     <execute>

--- a/steering-files/src/main/resources/org/hps/steering/readout/PhysicsRun2019TrigSinglesWithPulserDataMerging.lcsim
+++ b/steering-files/src/main/resources/org/hps/steering/readout/PhysicsRun2019TrigSinglesWithPulserDataMerging.lcsim
@@ -2,7 +2,7 @@
 <lcsim xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
        xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/lcsim/1.0/lcsim.xsd">
     <!-- 
-      @Readout steering file with pairs trigger for 2019 MC.
+      @Readout steering file with 2019 single2 and single3 triggers for 2019 MC with pulser data as background.
       @author <a href="mailto:caot@jlab.org">Tongtong Cao</a>
     -->
     <execute>

--- a/steering-files/src/main/resources/org/hps/steering/readout/PhysicsRun2021TrigMultiSingles.lcsim
+++ b/steering-files/src/main/resources/org/hps/steering/readout/PhysicsRun2021TrigMultiSingles.lcsim
@@ -2,7 +2,7 @@
 <lcsim xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
        xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/lcsim/1.0/lcsim.xsd">
     <!-- 
-      @Readout steering file with pairs trigger for 2019 MC.
+      @Readout steering file with single2 and single3 triggers for 2021 MC.
       @author <a href="mailto:caot@jlab.org">Tongtong Cao</a>
     -->
     <execute>

--- a/steering-files/src/main/resources/org/hps/steering/readout/PhysicsRun2021TrigSinglesWithPulserDataMerging.lcsim
+++ b/steering-files/src/main/resources/org/hps/steering/readout/PhysicsRun2021TrigSinglesWithPulserDataMerging.lcsim
@@ -2,7 +2,7 @@
 <lcsim xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
        xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/lcsim/1.0/lcsim.xsd">
     <!-- 
-      @Readout steering file with pairs trigger for 2021 MC.
+      @Readout steering file with single2 and single3 triggers for 2021 MC with pulser data as background.
       @author <a href="mailto:caot@jlab.org">Tongtong Cao</a>
     -->
     <execute>

--- a/steering-files/src/main/resources/org/hps/steering/readout/PhysicsRun2021TrigSinglesWithPulserDataMerging.lcsim
+++ b/steering-files/src/main/resources/org/hps/steering/readout/PhysicsRun2021TrigSinglesWithPulserDataMerging.lcsim
@@ -2,7 +2,7 @@
 <lcsim xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
        xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/lcsim/1.0/lcsim.xsd">
     <!-- 
-      @Readout steering file with Moller/single1 trigger for 2021 MC.
+      @Readout steering file with pairs trigger for 2021 MC.
       @author <a href="mailto:caot@jlab.org">Tongtong Cao</a>
     -->
     <execute>
@@ -35,7 +35,8 @@
 
        
         <!-- Trigger Simulation -->
-        <driver name="SinglesTrigger1"/>
+        <driver name="SinglesTrigger2"/>
+        <driver name="SinglesTrigger3"/>
 
 	<driver name="SvtDigitizationWithPulserDataMergingDriver"/>
 
@@ -392,14 +393,27 @@
             <daqConfigurationAppliedintoReadout>true</daqConfigurationAppliedintoReadout>   
 
 			<persistent>false</persistent>
-	</driver>          
+	</driver>  
 
-        <driver name="SinglesTrigger1" type="org.hps.readout.trigger2019.SinglesTrigger2019ReadoutDriver">
+        
+        <driver name="SinglesTrigger3" type="org.hps.readout.trigger2019.SinglesTrigger2019ReadoutDriver">
             <inputCollectionNameEcal>EcalClustersGTP</inputCollectionNameEcal>
 
             <inputCollectionNameHodo>HodoscopePatterns</inputCollectionNameHodo>
 
-            <triggerType>singles1</triggerType>
+            <daqConfigurationAppliedintoReadout>true</daqConfigurationAppliedintoReadout>   
+            
+            <!-- Units of 2 ns beam bunches. -->
+            <deadTime>15</deadTime>            
+
+        </driver>
+
+        <driver name="SinglesTrigger2" type="org.hps.readout.trigger2019.SinglesTrigger2019ReadoutDriver">
+            <inputCollectionNameEcal>EcalClustersGTP</inputCollectionNameEcal>
+
+            <inputCollectionNameHodo>HodoscopePatterns</inputCollectionNameHodo>
+
+            <triggerType>singles2</triggerType>
 
             <daqConfigurationAppliedintoReadout>true</daqConfigurationAppliedintoReadout>
 


### PR DESCRIPTION
The new steering file for 2021 MC with single2&single3 triggers is a copy of the steering file for 2019 MC: PhysicsRun2019TrigSinglesWithPulserDataMerging.lcsim.
The only change is factorGainConversion from 0.000833333 for 4.55 GeV beam of 2019 to 0.0008125 for 3.74 GeV beam of 2021. 
The factor is for hodoscope gain conversion from self-defined unit/ADC to MeV/ADC. 
Parameter setup is determined by distribution of energy deposit for hodoscope hits from SLIC.
Effect of the change on hodoscope patterns in the readout system is almost negligible since the change is slight and threshold for hodoscope hits is quite low.