### PR TITLE
make an MC recon file for 2019, 2021 spaced readout

### DIFF
--- a/steering-files/src/main/resources/org/hps/steering/recon/PhysicsRun2019MCRecon_KF_WithSpacing.lcsim
+++ b/steering-files/src/main/resources/org/hps/steering/recon/PhysicsRun2019MCRecon_KF_WithSpacing.lcsim
@@ -142,9 +142,36 @@
         </driver>         
         <driver name="GBLRefitterDriver" type="org.hps.recon.tracking.gbl.GBLRefitterDriver"/>        
         <driver name="KalmanPatRecDriver" type="org.hps.recon.tracking.kalman.KalmanPatRecDriver">
-          <!-- <doDebugPlots>true</doDebugPlots> --> 
-          <seedCompThr>0.05</seedCompThr>
-          <verbose>false</verbose>
+	    <numPatRecIteration> 3 </numPatRecIteration>
+            <numKalmanIteration> 1 </numKalmanIteration>
+            <maxPtInverse> 8.757651 </maxPtInverse>
+            <maxDZero> 38.0487 </maxDZero>
+            <maxZZero> 3.98915 </maxZZero>
+            <maxChiTwo> 11.777395 </maxChiTwo>
+            <minHits> 0  </minHits>
+            <minStereo> 3  </minStereo>
+            <maxSharedHits> 3 </maxSharedHits>
+            <maxTimeRange> 39.95028 </maxTimeRange>
+            <maxTanLambda> 8.186345 </maxTanLambda>
+            <maxResidual> 13.71568 </maxResidual>
+            <maxChiTwoInc> 13.52662 </maxChiTwoInc>
+            <minChiTwoIncBad> 7.00678 </minChiTwoIncBad>
+            <maxResidShare> 13.967129 </maxResidShare>
+            <maxChiTwoIncShare> 9.771546584 </maxChiTwoIncShare>
+            <mxChiTwoVtx> 1.7652935 </mxChiTwoVtx>
+            <numEvtPlots> 5 </numEvtPlots>
+            <doDebugPlots> false </doDebugPlots>
+            <siHitsLimit> 466 </siHitsLimit>
+            <seedCompThr> .725912 </seedCompThr>
+            <!--numStrategyIter1></numStrategyIter1 tthe mxChi2Vtx was 1.0-->
+            <beamPositionZ> 0.0 </beamPositionZ>
+            <beamSigmaZ> 0.02 </beamSigmaZ>
+            <beamPositionX> 0.0 </beamPositionX>
+            <beamSigmaX> 0.05 </beamSigmaX>
+            <beamPositionY> 0.0 </beamPositionY>
+            <beamSigmaY> 1.0 </beamSigmaY>
+            <lowPhThresh> 7.204329 </lowPhThresh>
+            <verbose> false </verbose>
         </driver>
         <driver name="TrackTruthMatching_KF" type="org.hps.analysis.MC.TrackToMCParticleRelationsDriver">
             <trackCollectionName>KalmanFullTracks</trackCollectionName>

--- a/steering-files/src/main/resources/org/hps/steering/recon/PhysicsRun2019MCRecon_KF_WithSpacing.lcsim
+++ b/steering-files/src/main/resources/org/hps/steering/recon/PhysicsRun2019MCRecon_KF_WithSpacing.lcsim
@@ -1,0 +1,175 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lcsim xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="http://www.lcsim.org/schemas/lcsim/1.0/lcsim.xsd">
+    <!-- 
+      @brief Steering file that will be used for the reconstruction of 2019 MC. 
+      @author <a href="mailto:omoreno1@ucsc.edu">Omar Moreno</a>
+    -->
+    <execute>
+        <driver name="EventMarkerDriver"/>
+        <!-- Ecal reconstruction drivers -->        
+        <driver name="EcalRawConverter" />
+        <driver name="EcalTimeCorrection"/>
+        <driver name="ReconClusterer" />
+        <driver name="CopyCluster" />
+        <driver name="HodoRunningPedestal"/>
+        <driver name="HodoRawConverter"/>
+        <!-- SVT hit reconstruction drivers -->
+        <driver name="RawTrackerHitSensorSetup"/>
+        <driver name="RawTrackerHitFitterDriver" />
+        <driver name="TrackerHitDriver"/>
+
+        <driver name="KalmanPatRecDriver"/> 
+        <driver name="TrackTruthMatching_KF" />
+        <driver name="ReconParticleDriver_Kalman" />
+	<driver name="KFOutputDriver"/>
+
+        <driver name="LCIOWriter"/>
+        <driver name="CleanupDriver"/>
+    </execute>    
+    <drivers>
+        <driver name="EventMarkerDriver" type="org.lcsim.job.EventMarkerDriver">
+            <eventInterval>1000</eventInterval>
+        </driver>
+        <!-- Ecal reconstruction drivers -->
+        <driver name="EcalRawConverter" type="org.hps.recon.ecal.EcalRawConverter2Driver"/>
+        <driver name="EcalTimeCorrection" type="org.hps.recon.ecal.EcalTimeCorrectionDriver"/>
+        <driver name="ReconClusterer" type="org.hps.recon.ecal.cluster.ReconClusterDriver">
+            <logLevel>WARNING</logLevel>
+            <outputClusterCollectionName>EcalClusters</outputClusterCollectionName>
+            <hitEnergyThreshold>0.030</hitEnergyThreshold>
+            <minTime>-5.0</minTime>
+        </driver>
+        <driver name="CopyCluster" type="org.hps.recon.ecal.cluster.CopyClusterCollectionDriver">
+            <inputCollectionName>EcalClusters</inputCollectionName>
+            <outputCollectionName>EcalClustersCorr</outputCollectionName>
+        </driver>
+        <!-- Hodo reconstruction drivers -->
+        <driver name="HodoRunningPedestal"
+		type="org.hps.recon.ecal.HodoRunningPedestalDriver">
+            <inputCollectionName>HodoscopeReadoutHits</inputCollectionName>
+            <logLevel>CONFIG</logLevel>
+            <isMC>true</isMC>
+        </driver>
+        <driver name="HodoRawConverter" type="org.hps.recon.ecal.HodoRawConverterDriver">
+           <useRunningPedestal>true</useRunningPedestal>
+            <inputCollectionName>HodoscopeReadoutHits</inputCollectionName>
+           <tETAllChannels>8</tETAllChannels>
+           <logLevel>CONFIG</logLevel>
+            <isMC>true</isMC>
+        </driver>
+        <!-- SVT reconstruction drivers -->
+        <!-- Driver used to associate raw tracker hits to corresponding sensor. -->
+        <driver name="RawTrackerHitSensorSetup" type="org.lcsim.recon.tracking.digitization.sisim.config.RawTrackerHitSensorSetup">
+          <readoutCollections>SVTRawTrackerHits</readoutCollections>
+        </driver>
+        <!-- Fit the six raw samples and extract the amplitude and t0. --> 
+        <driver name="RawTrackerHitFitterDriver" type="org.hps.recon.tracking.RawTrackerHitFitterDriver">
+          <chiSqrThresh>.5</chiSqrThresh>
+          <doOldDT>1</doOldDT>
+	  <fitAlgorithm>Pileup</fitAlgorithm>
+          <fitTimeMinimizer>Migrad</fitTimeMinimizer>
+          <!--use this to correct for trigger time in MC instead of subtractTriggerTime-->   
+          <useTimestamps>true</useTimestamps>     
+          <!--offset to get times centered at 0 after timestamp correction-->                 
+	  <!-- set to 0 for unspaced; ~112 for spaced -->
+	  <tsCorrectionScale>120</tsCorrectionScale>
+          <!--correct for the SVT fit time offset...this should be on if <useTimingConditions> is turned on in readout-->        
+          <correctTimeOffset>true</correctTimeOffset>   
+          <!--per sensor shift...set false becasue it's not in readout sim-->       
+          <correctT0Shift>true</correctT0Shift>      
+          <!--use truth time for MC???  typically not used-->             
+          <useTruthTime>false</useTruthTime>    
+          <!--time of flight corrections-->              
+          <subtractTOF>true</subtractTOF>     
+          <!--set this false for MC, true for data-->              
+          <subtractTriggerTime>false</subtractTriggerTime>           
+          <!--per-strip timing correction from database...this should be on i f <useTimingConditions> is turned on in readout  -->  
+          <correctChanT0>false</correctChanT0>          
+          <isMC>true</isMC>
+          <debug>false</debug>
+        </driver>
+        <!-- 
+             Use the fitted raw tracker hits and create 1D clusters using a 
+             nearest neighbor algorithm. 
+        --> 
+        <driver name="TrackerHitDriver" type="org.hps.recon.tracking.DataTrackerHitDriver">
+             <neighborDeltaT>24.0</neighborDeltaT>
+            <neighborDeltaTSigma>3.0</neighborDeltaTSigma>
+            <saveMonsterEvents>false</saveMonsterEvents>
+            <thresholdMonsterEvents>400</thresholdMonsterEvents>
+            <clusterSeedThreshold>4.0</clusterSeedThreshold>
+            <doTimeError>1.0</doTimeError> 
+            <clusterNeighborThreshold>3.0</clusterNeighborThreshold>
+            <clusterThreshold>3.0</clusterThreshold> 
+            <doDeadFix>true</doDeadFix>
+            <doVSplit>true</doVSplit>
+            <debug>false</debug>
+        </driver>
+    
+        <driver name="ReconParticleDriver_Kalman" type="org.hps.recon.particle.HpsReconParticleDriver" > 
+            <ecalClusterCollectionName>EcalClustersCorr</ecalClusterCollectionName>
+            <trackCollectionNames>KalmanFullTracks</trackCollectionNames>
+            <matcherTrackCollectionName>KalmanFullTracks</matcherTrackCollectionName>
+            <trackClusterMatcherAlgo>TrackClusterMatcherMinDistance</trackClusterMatcherAlgo>
+            <unconstrainedV0CandidatesColName>UnconstrainedV0Candidates_KF</unconstrainedV0CandidatesColName>
+            <unconstrainedV0VerticesColName>UnconstrainedV0Vertices_KF</unconstrainedV0VerticesColName>
+            <beamConV0CandidatesColName>BeamspotConstrainedV0Candidates_KF</beamConV0CandidatesColName>
+            <beamConV0VerticesColName>BeamspotConstrainedV0Vertices_KF</beamConV0VerticesColName>
+            <targetConV0CandidatesColName>TargetConstrainedV0Candidates_KF</targetConV0CandidatesColName>
+            <targetConV0VerticesColName>TargetConstrainedV0Vertices_KF</targetConV0VerticesColName>
+            <finalStateParticlesColName>FinalStateParticles_KF</finalStateParticlesColName>
+            <otherElectronsColName>OtherElectrons_KF</otherElectronsColName>
+	    <includeUnmatchedTracksInFSP>true</includeUnmatchedTracksInFSP>		       
+            <beamPositionX> 0.0  </beamPositionX>
+            <beamSigmaX> 0.3 </beamSigmaX>
+            <beamPositionY> 0.0 </beamPositionY>
+            <beamSigmaY> 0.02 </beamSigmaY>
+            <beamPositionZ> 0.0 </beamPositionZ>
+            <trackClusterTimeOffset>25</trackClusterTimeOffset>
+<!--            <maxMatchDt>40</maxMatchDt> -->
+	    <maxMatchDt>1000</maxMatchDt>
+            <useInternalVertexXYPositions>false</useInternalVertexXYPositions>
+            <minVertexChisqProb> 0.0 </minVertexChisqProb>
+            <maxVertexClusterDt>40.0</maxVertexClusterDt>
+	    <maxElectronP>7.0</maxElectronP>
+            <maxVertexP>7.0</maxVertexP>
+            <requireClustersForV0>false</requireClustersForV0>
+	    <useCorrectedClusterPositionsForMatching>false</useCorrectedClusterPositionsForMatching>
+            <applyClusterCorrections>true</applyClusterCorrections>
+            <useTrackPositionForClusterCorrection>true</useTrackPositionForClusterCorrection>  
+	    <isMC>true</isMC>
+	    <debug>false</debug>	    
+        </driver>         
+        <driver name="GBLRefitterDriver" type="org.hps.recon.tracking.gbl.GBLRefitterDriver"/>        
+        <driver name="KalmanPatRecDriver" type="org.hps.recon.tracking.kalman.KalmanPatRecDriver">
+          <!-- <doDebugPlots>true</doDebugPlots> --> 
+          <seedCompThr>0.05</seedCompThr>
+          <verbose>false</verbose>
+        </driver>
+        <driver name="TrackTruthMatching_KF" type="org.hps.analysis.MC.TrackToMCParticleRelationsDriver">
+            <trackCollectionName>KalmanFullTracks</trackCollectionName>
+            <kalmanTracks>true</kalmanTracks>
+            <debug>false</debug>
+        </driver>
+      
+        <driver name="LCIOWriter" type="org.lcsim.util.loop.LCIODriver">
+            <outputFilePath>${outputFile}.slcio</outputFilePath>
+        </driver>
+        <driver name="CleanupDriver" type="org.lcsim.recon.tracking.digitization.sisim.config.ReadoutCleanupDriver"/>
+
+	<driver name="KFOutputDriver" type="org.hps.recon.tracking.kalman.KFOutputDriver">
+          <outputPlotsFilename>${outputFile}.root</outputPlotsFilename>
+          <debug>false</debug>
+          <bsZ>0.0</bsZ>
+          <!--<trackCollectionName>GBLTracks</trackCollectionName> --> 
+          <trackCollectionName>KalmanFullTracks</trackCollectionName>
+          <minMom>0.1</minMom>
+          <maxMom>4.8</maxMom>
+          <chi2Cut>9999</chi2Cut>
+          <doKFresiduals>true</doKFresiduals>
+          <useParticles>true</useParticles>
+        </driver>
+
+
+      </drivers>
+</lcsim>

--- a/steering-files/src/main/resources/org/hps/steering/recon/PhysicsRun2019MCRecon_KF_WithSpacing.lcsim
+++ b/steering-files/src/main/resources/org/hps/steering/recon/PhysicsRun2019MCRecon_KF_WithSpacing.lcsim
@@ -36,8 +36,6 @@
         <driver name="ReconClusterer" type="org.hps.recon.ecal.cluster.ReconClusterDriver">
             <logLevel>WARNING</logLevel>
             <outputClusterCollectionName>EcalClusters</outputClusterCollectionName>
-            <hitEnergyThreshold>0.030</hitEnergyThreshold>
-            <minTime>-5.0</minTime>
         </driver>
         <driver name="CopyCluster" type="org.hps.recon.ecal.cluster.CopyClusterCollectionDriver">
             <inputCollectionName>EcalClusters</inputCollectionName>
@@ -126,8 +124,7 @@
             <beamSigmaY> 0.02 </beamSigmaY>
             <beamPositionZ> 0.0 </beamPositionZ>
             <trackClusterTimeOffset>25</trackClusterTimeOffset>
-<!--            <maxMatchDt>40</maxMatchDt> -->
-	    <maxMatchDt>1000</maxMatchDt>
+            <maxMatchDt>40</maxMatchDt>
             <useInternalVertexXYPositions>false</useInternalVertexXYPositions>
             <minVertexChisqProb> 0.0 </minVertexChisqProb>
             <maxVertexClusterDt>40.0</maxVertexClusterDt>
@@ -138,7 +135,14 @@
             <applyClusterCorrections>true</applyClusterCorrections>
             <useTrackPositionForClusterCorrection>true</useTrackPositionForClusterCorrection>  
 	    <isMC>true</isMC>
-	    <debug>false</debug>	    
+	    <debug>false</debug>
+	    <makeMollerCols>true</makeMollerCols>
+            <unconstrainedMollerCandidatesColName>UnconstrainedMollerCandidates_KF</unconstrainedMollerCandidatesColName>
+            <unconstrainedMollerVerticesColName>UnconstrainedMollerVertices_KF</unconstrainedMollerVerticesColName>
+            <beamConMollerCandidatesColName>BeamspotConstrainedMollerCandidates_KF</beamConMollerCandidatesColName>
+            <beamConMollerVerticesColName>BeamspotConstrainedMollerVertices_KF</beamConMollerVerticesColName>
+            <targetConMollerCandidatesColName>TargetConstrainedMollerCandidates_KF</targetConMollerCandidatesColName>
+            <targetConMollerVerticesColName>TargetConstrainedMollerVertices_KF</targetConMollerVerticesColName>	    
         </driver>         
         <driver name="GBLRefitterDriver" type="org.hps.recon.tracking.gbl.GBLRefitterDriver"/>        
         <driver name="KalmanPatRecDriver" type="org.hps.recon.tracking.kalman.KalmanPatRecDriver">


### PR DESCRIPTION
Added a steering file for 2019/2021 MC readout.  This has Rory's fitting/clustering fixes.  The SVT hit time corrections should put the track time to around ~0 and the cluster-track time offset in the recon-particle driver should be correct.  

I ran this on some MC I had and it runs and gives decent tracks/clusters.    