### PR TITLE
Update PhysicsRun2021_pass0_recon.lcsim

### DIFF
--- a/steering-files/src/main/resources/org/hps/steering/recon/PhysicsRun2021_pass0_recon.lcsim
+++ b/steering-files/src/main/resources/org/hps/steering/recon/PhysicsRun2021_pass0_recon.lcsim
@@ -98,10 +98,36 @@
 	    <debug>false</debug>
         </driver>
         <driver name="KalmanPatRecDriver" type="org.hps.recon.tracking.kalman.KalmanPatRecDriver">
-            <!--<doDebugPlots>false</doDebugPlots>-->
-            <!-- <siHitsLimit>50</siHitsLimit> -->
-            <seedCompThr>0.05</seedCompThr>
-            <verbose>false</verbose>
+	    <numPatRecIteration> 3 </numPatRecIteration>
+            <numKalmanIteration> 1 </numKalmanIteration>
+            <maxPtInverse> 8.757651 </maxPtInverse>
+            <maxDZero> 38.0487 </maxDZero>
+            <maxZZero> 3.98915 </maxZZero>
+            <maxChiTwo> 11.777395 </maxChiTwo>
+            <minHits> 0  </minHits>
+            <minStereo> 3  </minStereo>
+            <maxSharedHits> 3 </maxSharedHits>
+            <maxTimeRange> 39.95028 </maxTimeRange>
+            <maxTanLambda> 8.186345 </maxTanLambda>
+            <maxResidual> 13.71568 </maxResidual>
+            <maxChiTwoInc> 13.52662 </maxChiTwoInc>
+            <minChiTwoIncBad> 7.00678 </minChiTwoIncBad>
+            <maxResidShare> 13.967129 </maxResidShare>
+            <maxChiTwoIncShare> 9.771546584 </maxChiTwoIncShare>
+            <mxChiTwoVtx> 1.7652935 </mxChiTwoVtx>
+            <numEvtPlots> 5 </numEvtPlots>
+            <doDebugPlots> false </doDebugPlots>
+            <siHitsLimit> 466 </siHitsLimit>
+            <seedCompThr> .725912 </seedCompThr>
+            <!--numStrategyIter1></numStrategyIter1 tthe mxChi2Vtx was 1.0-->
+            <beamPositionZ> 0.0 </beamPositionZ>
+            <beamSigmaZ> 0.02 </beamSigmaZ>
+            <beamPositionX> 0.0 </beamPositionX>
+            <beamSigmaX> 0.05 </beamSigmaX>
+            <beamPositionY> 0.0 </beamPositionY>
+            <beamSigmaY> 1.0 </beamSigmaY>
+            <lowPhThresh> 7.204329 </lowPhThresh>
+            <verbose> false </verbose>
         </driver>
         <driver name="ReconParticleDriver_Kalman" type="org.hps.recon.particle.HpsReconParticleDriver" > 
             <ecalClusterCollectionName>EcalClustersCorr</ecalClusterCollectionName>


### PR DESCRIPTION
I am adding validated kalman filter tracking algorithm parameter optimizations to the steering file for the first pass. The optimization method you are familiar with (likely from the last collaboration meeting) was used w/ 1000 iterations to obtain settings which improved MC efficiency 4% and increased data track number 10% in run 14185. I believe the reason MC only increased marginally compared to data track number is because MC already is quite clean and easy to construct well. The info pertaining to MC optimization (and its validation) was already included in previous talks. I had to manually include new optimization constraints for data, because I realized that some parameters relevant to data could not have been optimized for MC. The reward function was updated to optimized efficiency in MC and track no in a single data file in run 14185; the MC efficiency is not increasing as high as it did before after 1000 iterations but I suspect as much is expected because now it has to simultaneously work in a clean and messy environment. I am doing some further validation, but I would be comfortable using this steering file in the run. Here is a plot showing the track number increase between the two iterations:

![image](https://github.com/user-attachments/assets/3046c955-df40-4634-8bea-7ddd1342572a)
Red is old, blue is new; it is shifted into higher track no per event. In total we find 10% more tracks while retaining the same MC efficiency and negligible change in fake rate or duplicates (atleast when training on 14185). I can characterize its behavior on other runs, and more extensively if requested.