### PR TITLE
disable KFOutputDriver for MC recon

### DIFF
--- a/steering-files/src/main/resources/org/hps/steering/recon/PhysicsRun2019MCRecon_KF_WithSpacing.lcsim
+++ b/steering-files/src/main/resources/org/hps/steering/recon/PhysicsRun2019MCRecon_KF_WithSpacing.lcsim
@@ -20,8 +20,9 @@
 
         <driver name="KalmanPatRecDriver"/> 
         <driver name="TrackTruthMatching_KF" />
-        <driver name="ReconParticleDriver_Kalman" />
-	<driver name="KFOutputDriver"/>
+	<driver name="ReconParticleDriver_Kalman" />
+	<!-- KFOutputDriver uses too much memory to run during production -->
+	<!--<driver name="KFOutputDriver"/>-->
 
         <driver name="LCIOWriter"/>
         <driver name="CleanupDriver"/>


### PR DESCRIPTION
I mean KFOutputDriver, GBL is a typo in the PR