### PR TITLE
comment out the maxResidual setting in KalmanPatRecDriver block

### DIFF
--- a/steering-files/src/main/resources/org/hps/steering/recon/PhysicsRun2021_pass1_recon.lcsim
+++ b/steering-files/src/main/resources/org/hps/steering/recon/PhysicsRun2021_pass1_recon.lcsim
@@ -109,7 +109,7 @@
             <maxSharedHits> 3 </maxSharedHits>
             <maxTimeRange> 39.95028 </maxTimeRange>
             <maxTanLambda> 8.186345 </maxTanLambda>
-            <maxResidual> 13.71568 </maxResidual>
+<!--            <maxResidual> 13.71568 </maxResidual>   -->
             <maxChi2Inc> 13.52662 </maxChi2Inc>
             <minChi2IncBad> 7.00678 </minChi2IncBad>
             <maxResidShare> 13.967129 </maxResidShare>

--- a/steering-files/src/main/resources/org/hps/steering/recon/PhysicsRun2021_pass1_recon.lcsim
+++ b/steering-files/src/main/resources/org/hps/steering/recon/PhysicsRun2021_pass1_recon.lcsim
@@ -112,7 +112,7 @@
 <!--            <maxResidual> 13.71568 </maxResidual>   -->
             <maxChi2Inc> 13.52662 </maxChi2Inc>
             <minChi2IncBad> 7.00678 </minChi2IncBad>
-            <maxResidShare> 13.967129 </maxResidShare>
+<!--            <maxResidShare> 13.967129 </maxResidShare>   -->
             <maxChi2IncShare> 9.771546584 </maxChi2IncShare>
             <mxChi2Vtx> 1.7652935 </mxChi2Vtx>
             <numEvtPlots> 5 </numEvtPlots>


### PR DESCRIPTION
It was the cause of the problems with the momentum...I think it was basically kicking out good hits.  The default for this is 50.0, the setter in the steering file had it at ~13, which is apparently too low.  

See [https://jira.slac.stanford.edu/browse/HPSANA-62](https://jira.slac.stanford.edu/browse/HPSANA-62)