### PR TITLE
Inverse Variance Track Time Averages.

### DIFF
--- a/tracking/src/main/java/org/hps/recon/tracking/kalman/KalTrack.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/kalman/KalTrack.java
@@ -19,6 +19,8 @@ import org.ejml.dense.row.factory.LinearSolverFactory_DDRM;
 import org.ejml.interfaces.linsol.LinearSolverDense;
 import org.hps.util.Pair;
 
+import org.lcsim.event.TrackerHit;
+
 /**
  * Track followed and fitted by the Kalman filter
  */
@@ -138,6 +140,7 @@ public class KalTrack {
         Cp = null;
         // Fill the maps
         time = 0.;
+	double terr = 0.0;
         tMin = 9.9e9;
         tMax = -9.9e9;
         this.chi2 = 0.;
@@ -150,7 +153,9 @@ public class KalTrack {
                 continue;
             }
             nHits++;
-            time += site.m.hits.get(site.hitID).time;
+	    double hTV = site.m.hits.get(site.hitID).timeErr;
+            time += site.m.hits.get(site.hitID).time/hTV;
+	    terr += 1.0/hTV;
             tMin = Math.min(tMin, site.m.hits.get(site.hitID).time);
             tMax = Math.max(tMax, site.m.hits.get(site.hitID).time);
             this.chi2 += site.chi2inc;
@@ -158,7 +163,7 @@ public class KalTrack {
                 System.out.format("  Layer %d, chi^2 increment=%10.5f, a=%s\n", site.m.Layer, site.chi2inc, site.aS.helix.a.toString());
             }
         }
-        time = time / (double) nHits;
+        time = time / terr;
         reducedChi2 = chi2 / (double) nHits;
         lyrMap = null;
         millipedeMap = null;

--- a/tracking/src/main/java/org/hps/recon/tracking/kalman/Measurement.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/kalman/Measurement.java
@@ -28,6 +28,19 @@ class Measurement { //
         tksMC = null;
     }
     
+    Measurement(double value, double xStrip, double resolution, double t, double E, double terr) {
+        v = value;
+        x = xStrip;
+        sigma = resolution;
+        time = t;
+        timeErr = terr;
+        energy = E;
+        tracks = new ArrayList<KalTrack>();
+        vTrue = 0.;
+        rGlobal = null;
+        tksMC = null;
+    }
+    
     Measurement(double value, double xStrip, double resolution, double t, double E, Vec rGlobal, double vTrue) {
         v = value;
         x = xStrip;

--- a/tracking/src/main/java/org/hps/recon/tracking/kalman/Measurement.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/kalman/Measurement.java
@@ -10,6 +10,7 @@ class Measurement { //
     double x; // X of the center of the strip in the detector frame
     double sigma; // Measurement uncertainty
     double time;  // Time of the hit in ns
+    double timeErr; // Standard deviation of time measurement.
     double energy; // Energy deposited in the silicon
     double vTrue; // MC truth measurement value
     Vec rGlobal; // Global MC truth


### PR DESCRIPTION
It is mathematically proven that the way to take a weighted average of independently, possibly nonidentically distributed, normal distributions is through inverse variance sampling. Namely you weight a time sample by the inverse of the square of its error. This push request aims to implement this change. It does so fairly successfully; I include a number of html files with various information about how the changes work. There are two caveats about this weighting scheme that are important to note. They first arises from the broad shoulder issue we have in the first two layers; the second from just hps-java architecture. That is, due to an irreducible degeneracy in hits (that was only partially solved by previous chi square probability manipulation) there is a significant degree of non gaussianity to the first two layer hit time distributions (particularly in layers nearmost to the detector). 
1. This seems to occasionally make the inverse variance timing average worse. To counteract this, the first two layers are removed from the averaging step. Don't worry; this doesn't mean they aren't involved in momentum and other things they are critical for; their removal just noticeably and significantly improves the mean. This makes this change almost uniformly an improvement.
2. The HPS track time is calculated from Measurement site object in java. This is an object that, while it retains amplitude error information, it forgets everything to do with the time error. You can be sure about this because the KalmanPlotting classes have to re-obtain the Hit objects whenever they want to plot information about the time errors of hits. To circumvent this issue, I rerun fitting for hits on track to obtain their hit time error at the time that we cant to calculate track time. Luckily this change is ~10 lines; we don't need to do all the time translation junk that has to be done at the hit time step because the time error is invariant under time translation. Thats with the exception of the pileUp decision, where we retain the time closer to the track time. In this ase, I make the reasonable assumption that the hit time error of the chosen hit will be less than the other and use that time error (this is almost always true). It is with this choice I see the almost uniform improvement in the following plots:

Track Time:https://s3df.slac.stanford.edu/people/rodwyer1/timeFix/orChange/tracktime.html
Z Momentum of Track:https://s3df.slac.stanford.edu/people/rodwyer1/timeFix/orChange/pzonTrack.html (seemingly completely unchanged).

The change is small, but theoretically motivated. When yall look at the plots, and are convinced it is fine, I will also make changes to the jlab plot stuff (that will probably need to be done again)