### PR TITLE
Update track chi2 skimming cut

### DIFF
--- a/recon/src/main/java/org/hps/recon/skims/V0Skimmer.java
+++ b/recon/src/main/java/org/hps/recon/skims/V0Skimmer.java
@@ -73,7 +73,7 @@ public class V0Skimmer extends Skimmer {
 		if(_debug)System.out.println(this.getClass().getName()+"::  failed nHitsMin "+electron.getTracks().get(0).getTrackerHits().size()+"  "+positron.getTracks().get(0).getTrackerHits().size()+" nHitsMin = "+_nHitsMin);
                 continue;
             }
-            if ((electron.getTracks().get(0).getChi2()/electron.getTracks().getNDF(0).ndf()) > _trackChi2Cut
+            if ((electron.getTracks().get(0).getChi2()/electron.getTracks().getNDF(0)) > _trackChi2Cut
                     || (positron.getTracks().get(0).getChi2()/positron.getTracks().get(0).getNDF()) > _trackChi2Cut) {
 		if(_debug)System.out.println(this.getClass().getName()+"::  failed track chi2");
                 continue;

--- a/recon/src/main/java/org/hps/recon/skims/V0Skimmer.java
+++ b/recon/src/main/java/org/hps/recon/skims/V0Skimmer.java
@@ -73,7 +73,7 @@ public class V0Skimmer extends Skimmer {
 		if(_debug)System.out.println(this.getClass().getName()+"::  failed nHitsMin "+electron.getTracks().get(0).getTrackerHits().size()+"  "+positron.getTracks().get(0).getTrackerHits().size()+" nHitsMin = "+_nHitsMin);
                 continue;
             }
-            if ((electron.getTracks().get(0).getChi2()/electron.getTracks().getNDF(0)) > _trackChi2Cut
+            if ((electron.getTracks().get(0).getChi2()/electron.getTracks().get(0).getNDF()) > _trackChi2Cut
                     || (positron.getTracks().get(0).getChi2()/positron.getTracks().get(0).getNDF()) > _trackChi2Cut) {
 		if(_debug)System.out.println(this.getClass().getName()+"::  failed track chi2");
                 continue;

--- a/recon/src/main/java/org/hps/recon/skims/V0Skimmer.java
+++ b/recon/src/main/java/org/hps/recon/skims/V0Skimmer.java
@@ -28,7 +28,7 @@ public class V0Skimmer extends Skimmer {
     //private double _clusterTimingCut = 20.0; // only used if _tight is true
     private double _posClusterEnergy =  0.2; //GeV
     private double _v0Chi2Cut = 100.0;
-    private double _trackChi2Cut = 80.0;
+    private double _trackChi2Cut = 30.0;
     private double _trackDtCut = 20.0; // the 2-track time difference
     private double _trackPMax = 4.5; //GeV
     private double _elePMax = 9999; //GeV

--- a/recon/src/main/java/org/hps/recon/skims/V0Skimmer.java
+++ b/recon/src/main/java/org/hps/recon/skims/V0Skimmer.java
@@ -73,8 +73,8 @@ public class V0Skimmer extends Skimmer {
 		if(_debug)System.out.println(this.getClass().getName()+"::  failed nHitsMin "+electron.getTracks().get(0).getTrackerHits().size()+"  "+positron.getTracks().get(0).getTrackerHits().size()+" nHitsMin = "+_nHitsMin);
                 continue;
             }
-            if (electron.getTracks().get(0).getChi2() > _trackChi2Cut
-                    || positron.getTracks().get(0).getChi2() > _trackChi2Cut) {
+            if ((electron.getTracks().get(0).getChi2()/electron.getTracks().getNDF(0).ndf()) > _trackChi2Cut
+                    || (positron.getTracks().get(0).getChi2()/positron.getTracks().get(0).getNDF()) > _trackChi2Cut) {
 		if(_debug)System.out.println(this.getClass().getName()+"::  failed track chi2");
                 continue;
             }

--- a/recon/src/main/resources/org/hps/recon/skims/v0skim_parameters_ver0.txt
+++ b/recon/src/main/resources/org/hps/recon/skims/v0skim_parameters_ver0.txt
@@ -1,5 +1,5 @@
 V0CandidateCollectionName	  UnconstrainedV0Candidates_KF
-trackChi2Cut			  80.0
+trackChi2Cut			  30.0
 nHitsMin			  9
 v0Chi2Cut			  30.0
 trackDtCut			  20.0

--- a/recon/src/main/resources/org/hps/recon/skims/v0skim_parameters_ver1.txt
+++ b/recon/src/main/resources/org/hps/recon/skims/v0skim_parameters_ver1.txt
@@ -1,5 +1,5 @@
 V0CandidateCollectionName	  UnconstrainedV0Candidates_KF
-trackChi2Cut			  80.0
+trackChi2Cut			  30.0
 nHitsMin			  9
 v0Chi2Cut			  30.0
 trackDtCut			  20.0

--- a/steering-files/src/main/resources/org/hps/steering/recon/PhysicsRun2021_pass2_recon_skimmed.lcsim
+++ b/steering-files/src/main/resources/org/hps/steering/recon/PhysicsRun2021_pass2_recon_skimmed.lcsim
@@ -176,6 +176,7 @@
 	    <skimMoller>false</skimMoller>
 	    <v0ParamFile>v0skim_parameters_ver1.txt</v0ParamFile>  
 	    <v0OutputFile>${outputFile}_v0skim.slcio</v0OutputFile>
+            <ignoreCollections>FPGAData HelicalTrackHitRelations HelicalTrackHits HelicalTrackMCRelations KFGBLStripClusterData KFGBLStripClusterDataRelations ReadoutTimestamps RotatedHelicalTrackHitRelations RotatedHelicalTrackHits RotatedHelicalTrackMCRelations SVTFittedRawTrackerHits SVTShapeFitParameters SVTTrueHitRelations StripClusterer_SiTrackerHitStrip1D SVTRawTrackerHits FADCGenericHits HodoReadoutHits HodoCalHits EcalReadoutHits EcalUncalHits HodoGenericClusters VTPBank EcalClusters</ignoreCollections>
          </driver>
         <driver name="CleanupDriver" type="org.lcsim.recon.tracking.digitization.sisim.config.ReadoutCleanupDriver"/>
         <driver name="LCIOWriter" type="org.lcsim.util.loop.LCIODriver">

--- a/steering-files/src/main/resources/org/hps/steering/recon/PhysicsRun2021_pass2_recon_skimmed_dataqual.lcsim
+++ b/steering-files/src/main/resources/org/hps/steering/recon/PhysicsRun2021_pass2_recon_skimmed_dataqual.lcsim
@@ -186,9 +186,8 @@
 	    <skimMoller>false</skimMoller>
 	    <v0ParamFile>v0skim_parameters_ver1.txt</v0ParamFile>  
 	    <v0OutputFile>${outputFile}_v0skim.slcio</v0OutputFile>
+            <ignoreCollections>FPGAData HelicalTrackHitRelations HelicalTrackHits HelicalTrackMCRelations KFGBLStripClusterData KFGBLStripClusterDataRelations ReadoutTimestamps RotatedHelicalTrackHitRelations RotatedHelicalTrackHits RotatedHelicalTrackMCRelations SVTFittedRawTrackerHits SVTShapeFitParameters SVTTrueHitRelations StripClusterer_SiTrackerHitStrip1D SVTRawTrackerHits FADCGenericHits HodoReadoutHits HodoCalHits EcalReadoutHits EcalUncalHits HodoGenericClusters VTPBank EcalClusters</ignoreCollections>
         </driver>
-
-
 	<driver name="EcalMonitoring" type="org.hps.analysis.dataquality.EcalMonitoring">         
             <triggerType>all</triggerType>
             <clusterCollectionName>EcalClustersCorr</clusterCollectionName>


### PR DESCRIPTION
Change definition of track chi2 cut to divide through by nDOF. Update default cut value and steering files to use a cut value of 30 (in analysis it's 20). 

Also add ignore collections to recon files. 