### PR TITLE
Add jeffersonlab github maven repos

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,11 @@
       <url>https://srs.slac.stanford.edu/nexus/content/groups/lcsim-maven2-public/</url>
     </repository>
     <repository>
+      <id>github</id>
+      <name>GitHub JeffersonLab Apache Maven Packages</name>
+      <url>https://maven.pkg.github.com/jeffersonlab/hps-lcsim</url>
+    </repository>
+    <repository>
       <id>jlab-coda-repo-public</id>
       <name>CODA</name>
       <url>https://coda.jlab.org/maven/</url>


### PR DESCRIPTION
We'll know for sure at [lcsim/4.5](https://github.com/JeffersonLab/hps-lcsim/pull/3l), as it will only be available from github, at least for now ...