### PR TITLE
lcsim 4.5.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,10 +12,10 @@ jobs:
       - name: Checkout source code
         uses: actions/checkout@v3
 
-      - name: Set up JDK 1.8
+      - name: Set up JDK 21
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 21
 
       - name: Build and run tests
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,4 +19,4 @@ jobs:
 
       - name: Build and run tests
         run: |
-          mvn -B install -T4
+          mvn -B install #-T4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,10 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 21
+          server-id: github
 
       - name: Build and run tests
         run: |
           mvn -B install #-T4
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN }}

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <skipSite>false</skipSite>
     <skipPlugin>true</skipPlugin>
     <skipCheckstyle>true</skipCheckstyle>
-    <lcsimVersion>4.4.0</lcsimVersion>
+    <lcsimVersion>4.5.0</lcsimVersion>
     <etVersion>14.1</etVersion>
     <evioVersion>4.4.6</evioVersion>
     <junitVersion>4.13.1</junitVersion>


### PR DESCRIPTION
This won't build unless it uses the new github maven repo for lcsim (_which only contains 4.5.0 and is the only maven repo containing 4.5.0_).  And the build should fail with this (I assume):

```
[ERROR] /u/scihome/baltzell/sw/hps-java/tracking/src/main/java/org/hps/recon/tracking/kalman/KalmanDriverHPS.java:[530,59] method computeMomentum in class org.lcsim.event.base.BaseTrackState cannot be applied to given types;
[ERROR]   required: no arguments
[ERROR]   found:    double
[ERROR]   reason: actual and formal argument lists differ in length
```