### PR TITLE
Deploy maven automatically

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,3 +26,4 @@ jobs:
         env:
           CI_DEPLOY_USERNAME: ${{ secrets.CI_DEPLOY_USERNAME }}
           CI_DEPLOY_PASSWORD: ${{ secrets.CI_DEPLOY_PASSWORD }}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This will likely enable github hosting maven snapshots off master.  Need to check the limits ...