### PR TITLE
Protect debug statement

### DIFF
--- a/analysis/src/main/java/org/hps/analysis/MC/TrackToMCParticleRelationsDriver.java
+++ b/analysis/src/main/java/org/hps/analysis/MC/TrackToMCParticleRelationsDriver.java
@@ -167,7 +167,9 @@ public class TrackToMCParticleRelationsDriver extends Driver {
                     }
                 }//mcp not null
                 else {
-                    System.out.printf("PF::FakeTrack");
+                    if( debug ){
+                      System.out.printf("TrackToMCParticleRelationsDriver::WARNING Track does not have truth hits associated to it! Either fake, or from pulser overlay.");
+                    }
                 }
             } //ttm not null
             else {


### PR DESCRIPTION
Protect "fake track" statement to avoid being haunted from PF while running MC recon with pulser overlay.