### PR TITLE
Shifting MC time peaks

### DIFF
--- a/digi/src/main/java/org/hps/digi/SvtDigitizationWithPulserDataMergingReadoutDriver.java
+++ b/digi/src/main/java/org/hps/digi/SvtDigitizationWithPulserDataMergingReadoutDriver.java
@@ -58,6 +58,7 @@ public class SvtDigitizationWithPulserDataMergingReadoutDriver extends ReadoutDr
     private double readoutOffset = 0.0;
     private double readoutLatency = 280.0;
     private double pileupCutoff = 300.0;
+    private double simHitTimeOffset=0.0;
     private String readout = "TrackerHits";
     private double timeOffset = 30.0;
     private boolean noPileup = false;
@@ -193,6 +194,16 @@ public class SvtDigitizationWithPulserDataMergingReadoutDriver extends ReadoutDr
      */
     public void setReadoutLatency(double readoutLatency) {
         this.readoutLatency = readoutLatency;
+    }
+
+    
+    /**
+     * Set the time offset for the SimTrackerHit
+     * inside the APV25 window
+     * @param simHitTimeOffset - The offset to use
+     */
+    public void setSimHitTimeOffset(double simHitTimeOffset) {
+        this.simHitTimeOffset = simHitTimeOffset;
     }
     
     /**
@@ -473,7 +484,7 @@ public class SvtDigitizationWithPulserDataMergingReadoutDriver extends ReadoutDr
                         // SimTrackerHit.
                         double time = 0.0;
                         for(SimTrackerHit hit : simHits) {
-                            time += hit.getTime();
+                            time += hit.getTime()+simHitTimeOffset;
                         }
                         time /= simHits.size();
                         time += ReadoutDataManager.getCurrentTime();
@@ -628,6 +639,7 @@ public class SvtDigitizationWithPulserDataMergingReadoutDriver extends ReadoutDr
         List<SimTrackerHit> truthHits = new ArrayList<SimTrackerHit>();
         List<LCRelation> trueHitRelations = new ArrayList<LCRelation>();      
         // Calculate time of first sample
+
         double firstSample = Math.floor(((triggerTime + 256) - readoutLatency - readoutOffset) / HPSSVTConstants.SAMPLING_INTERVAL)
                 * HPSSVTConstants.SAMPLING_INTERVAL + readoutOffset;
         

--- a/ecal-recon/src/main/java/org/hps/recon/ecal/EcalTimeCorrectionDriver.java
+++ b/ecal-recon/src/main/java/org/hps/recon/ecal/EcalTimeCorrectionDriver.java
@@ -30,6 +30,7 @@ public class EcalTimeCorrectionDriver extends Driver {
     private boolean mode3 = false;
     private boolean useFit = true;
     private boolean useTimeWalkCondition = true;
+    private double additionalShift = 0.0;
 
     private EcalConditions ecalConditions = null;
 
@@ -39,6 +40,10 @@ public class EcalTimeCorrectionDriver extends Driver {
 
     public void setUseFit(boolean useFit) {
         this.useFit = useFit;
+    }
+
+    public void setAdditionalShift(double additionalShift) {
+        this.additionalShift = additionalShift;
     }
 
     public void setUseTimeWalkCondition(boolean useTimeWalkCondition) {
@@ -110,6 +115,7 @@ public class EcalTimeCorrectionDriver extends Driver {
 
             // Apply overall time offset
             time -= findChannel(hit.getCellID()).getTimeShift().getTimeShift();
+	    time += additionalShift;
 
             newHits.add(CalorimeterHitUtilities.create(energy, time, hit.getCellID()));
         }

--- a/ecal-recon/src/main/java/org/hps/recon/ecal/EcalTimeCorrectionDriver.java
+++ b/ecal-recon/src/main/java/org/hps/recon/ecal/EcalTimeCorrectionDriver.java
@@ -115,7 +115,7 @@ public class EcalTimeCorrectionDriver extends Driver {
 
             // Apply overall time offset
             time -= findChannel(hit.getCellID()).getTimeShift().getTimeShift();
-	    time += additionalShift;
+    	    time += additionalShift;
 
             newHits.add(CalorimeterHitUtilities.create(energy, time, hit.getCellID()));
         }

--- a/steering-files/src/main/resources/org/hps/steering/readout/PhysicsRun2021TrigSinglesWithPulserDataMerging.lcsim
+++ b/steering-files/src/main/resources/org/hps/steering/readout/PhysicsRun2021TrigSinglesWithPulserDataMerging.lcsim
@@ -427,6 +427,7 @@
           <pulserDataCollectionName>PulserDataSVTRawTrackerHits</pulserDataCollectionName>
             <enablePileupCut>false</enablePileupCut>
             <useTimingConditions>true</useTimingConditions>
+	    <simHitTimeOffset>-10</simHitTimeOffset>
             <addNoise>true</addNoise>
         </driver>
 

--- a/steering-files/src/main/resources/org/hps/steering/recon/PhysicsRun2021MCRecon_KF_WithSpacing_pass3.lcsim
+++ b/steering-files/src/main/resources/org/hps/steering/recon/PhysicsRun2021MCRecon_KF_WithSpacing_pass3.lcsim
@@ -32,7 +32,9 @@
         </driver>
         <!-- Ecal reconstruction drivers -->
         <driver name="EcalRawConverter" type="org.hps.recon.ecal.EcalRawConverter2Driver"/>
-        <driver name="EcalTimeCorrection" type="org.hps.recon.ecal.EcalTimeCorrectionDriver"/>
+        <driver name="EcalTimeCorrection" type="org.hps.recon.ecal.EcalTimeCorrectionDriver">
+	    <additionalShift>13.3</additionalShift>
+	</driver>
         <driver name="ReconClusterer" type="org.hps.recon.ecal.cluster.ReconClusterDriver">
             <logLevel>WARNING</logLevel>
             <outputClusterCollectionName>EcalClusters</outputClusterCollectionName>

--- a/steering-files/src/main/resources/org/hps/steering/recon/PhysicsRun2021MCRecon_KF_WithSpacing_pass3.lcsim
+++ b/steering-files/src/main/resources/org/hps/steering/recon/PhysicsRun2021MCRecon_KF_WithSpacing_pass3.lcsim
@@ -33,8 +33,8 @@
         <!-- Ecal reconstruction drivers -->
         <driver name="EcalRawConverter" type="org.hps.recon.ecal.EcalRawConverter2Driver"/>
         <driver name="EcalTimeCorrection" type="org.hps.recon.ecal.EcalTimeCorrectionDriver">
-	    <additionalShift>13.3</additionalShift>
-	</driver>
+	        <additionalShift>13.3</additionalShift>
+	    </driver>
         <driver name="ReconClusterer" type="org.hps.recon.ecal.cluster.ReconClusterDriver">
             <logLevel>WARNING</logLevel>
             <outputClusterCollectionName>EcalClusters</outputClusterCollectionName>
@@ -51,49 +51,49 @@
             <isMC>true</isMC>
         </driver>
         <driver name="HodoRawConverter" type="org.hps.recon.ecal.HodoRawConverterDriver">
-           <useRunningPedestal>true</useRunningPedestal>
+            <useRunningPedestal>true</useRunningPedestal>
             <inputCollectionName>HodoscopeReadoutHits</inputCollectionName>
-           <tETAllChannels>8</tETAllChannels>
-           <logLevel>CONFIG</logLevel>
+            <tETAllChannels>8</tETAllChannels>
+            <logLevel>CONFIG</logLevel>
             <isMC>true</isMC>
         </driver>
         <!-- SVT reconstruction drivers -->
         <!-- Driver used to associate raw tracker hits to corresponding sensor. -->
         <driver name="RawTrackerHitSensorSetup" type="org.lcsim.recon.tracking.digitization.sisim.config.RawTrackerHitSensorSetup">
-          <readoutCollections>SVTRawTrackerHits</readoutCollections>
+            <readoutCollections>SVTRawTrackerHits</readoutCollections>
         </driver>
         <!-- Fit the six raw samples and extract the amplitude and t0. --> 
         <driver name="RawTrackerHitFitterDriver" type="org.hps.recon.tracking.RawTrackerHitFitterDriver">
-          <chiSqrThresh>.5</chiSqrThresh>
-          <doOldDT>1</doOldDT>
-	  <fitAlgorithm>Pileup</fitAlgorithm>
-          <fitTimeMinimizer>Migrad</fitTimeMinimizer>
-          <!--use this to correct for trigger time in MC instead of subtractTriggerTime-->   
-          <useTimestamps>true</useTimestamps>     
-          <!--offset to get times centered at 0 after timestamp correction-->                 
-	  <!-- set to 0 for unspaced; ~112 for spaced -->
-	  <tsCorrectionScale>120</tsCorrectionScale>
-          <!--correct for the SVT fit time offset...this should be on if <useTimingConditions> is turned on in readout-->        
-          <correctTimeOffset>true</correctTimeOffset>   
-          <!--per sensor shift...set false becasue it's not in readout sim-->       
-          <correctT0Shift>true</correctT0Shift>      
-          <!--use truth time for MC???  typically not used-->             
-          <useTruthTime>false</useTruthTime>    
-          <!--time of flight corrections-->              
-          <subtractTOF>true</subtractTOF>     
-          <!--set this false for MC, true for data-->              
-          <subtractTriggerTime>false</subtractTriggerTime>           
-          <!--per-strip timing correction from database...this should be on i f <useTimingConditions> is turned on in readout  -->  
-          <correctChanT0>false</correctChanT0>          
-          <isMC>true</isMC>
-          <debug>false</debug>
+            <chiSqrThresh>.5</chiSqrThresh>
+            <doOldDT>1</doOldDT>
+	        <fitAlgorithm>Pileup</fitAlgorithm>
+            <fitTimeMinimizer>Migrad</fitTimeMinimizer>
+            <!--use this to correct for trigger time in MC instead of subtractTriggerTime-->   
+            <useTimestamps>true</useTimestamps>     
+            <!--offset to get times centered at 0 after timestamp correction-->                 
+	        <!-- set to 0 for unspaced; ~112 for spaced -->
+	        <tsCorrectionScale>165</tsCorrectionScale>
+            <!--correct for the SVT fit time offset...this should be on if <useTimingConditions> is turned on in readout-->        
+            <correctTimeOffset>true</correctTimeOffset>   
+            <!--per sensor shift...set false becasue it's not in readout sim-->       
+            <correctT0Shift>true</correctT0Shift>      
+            <!--use truth time for MC???  typically not used-->             
+            <useTruthTime>false</useTruthTime>    
+            <!--time of flight corrections-->              
+            <subtractTOF>true</subtractTOF>     
+            <!--set this false for MC, true for data-->              
+            <subtractTriggerTime>false</subtractTriggerTime>           
+            <!--per-strip timing correction from database...this should be on i f <useTimingConditions> is turned on in readout  -->  
+            <correctChanT0>false</correctChanT0>          
+            <isMC>true</isMC>
+            <debug>false</debug>
         </driver>
         <!-- 
              Use the fitted raw tracker hits and create 1D clusters using a 
              nearest neighbor algorithm. 
         --> 
         <driver name="TrackerHitDriver" type="org.hps.recon.tracking.DataTrackerHitDriver">
-             <neighborDeltaT>24.0</neighborDeltaT>
+            <neighborDeltaT>24.0</neighborDeltaT>
             <neighborDeltaTSigma>3.0</neighborDeltaTSigma>
             <saveMonsterEvents>false</saveMonsterEvents>
             <thresholdMonsterEvents>400</thresholdMonsterEvents>


### PR DESCRIPTION
There are some differences in the track and cluster time distributions between data and MC that needed to be addressed.
The `simHitTimeOffset` introduced in `SvtDigitizationWithPulserDataMergingReadoutDriver` shifts the time of the simulated signal (tritrig, wab) hits with respect to the pulser hits. This is needed to mimic the turn-off of the track time distribution in data. This value can be set in the readout steering file and should be around -10ns.
The `additionalShift` introduced in `EcalTimeCorrectionDriver` globally moves the ECAL cluster time. This is needed to put the time peak in MC at the same time as in data to avoid cutoffs introduced at other points in the pipeline. Without the shift, the cluster time in MC peaks at 24ns, in data at 37.3. So the shift should be 13.3ns. 
Note: I have tried shifting both cluster time peaks to 0ns, however this breaks things since there is a hard cut at 0ns that is implemented somewhere else. Matching data and MC appears to be the safer approach.

I have also changed the `tsCorrectionScale` value in the `RawTrackerHitFitterDriver` setting to the value needed to match MC to data. This correction scale globally shifts the hit time of pulser and simulated hits in the pulser overlayed-MC sample.