### PR TITLE
Iss1147 -- Add hole-accounting to tracks

### DIFF
--- a/tracking/src/main/java/org/hps/recon/tracking/kalman/KalmanInterface.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/kalman/KalmanInterface.java
@@ -101,7 +101,6 @@ public class KalmanInterface {
     private int nBigEvents;
     private int eventNumber;
     private static double target_pos = -999.9;
-    private static boolean addTrackStateAtTarget = false;
     private double[] beamPosition = null;
     
     private static final boolean debug = false;    
@@ -653,27 +652,10 @@ public class KalmanInterface {
             ts = null;
             int loc = TrackState.AtOther;
 
-            //HpsSiSensor hssd = (HpsSiSensor) moduleMap.get(site.m).getSensor();
-            //int lay = hssd.getMillepedeId();
-            // System.out.printf("ssp id %d \n", hssd.getMillepedeId());
-
             if (i == firstHit_idx) {
                 loc = TrackState.AtFirstHit;
             } else if (i == lastHit_idx) 
-                loc = TrackState.AtLastHit;
-            
-            /*
-              //DO Not att the missing layer track states yet.
-            if (storeTrackStates) {
-                for (int k = 1; k < lay - prevID; k++) {
-                    // uses new lcsim constructor
-                    BaseTrackState dummy = new BaseTrackState(dummyCounter);
-                    newTrack.getTrackStates().add(dummy);
-                    dummyCounter--;
-                }
-                prevID = lay;
-            }
-            */
+                loc = TrackState.AtLastHit;                      
                         
             if (loc == TrackState.AtFirstHit || loc == TrackState.AtLastHit || storeTrackStates) {
                 ts = createTrackState(site, loc, true, saveTrackStateAtIntercept);
@@ -694,24 +676,6 @@ public class KalmanInterface {
         double BAtEcal = BfieldAtEcal.mag();
         double alphaAtEcal = conFac/ BAtEcal;
 
-	/*
-	
-	DMatrixRMaj ecalCov = new DMatrixRMaj(getCovarianceFromHelix(helixAtEcal));
-	double[] ecalParams = helixAtEcal.a.v.clone();
-        double[] ecalLCSimParams = getLCSimParams(ecalParams, alphaAtEcal);
-        double[] ecalLCSimCov = getLCSimCov(ecalCov, alphaAtEcal).asPackedArray(true);
-	double[] refAtEcal = localKalToHps(helixAtEcal.origin); 
-	if(debug)System.out.println(this.getClass().getName()+"::  reference to TrackState @ ecal = "+
-			   +refAtEcal[0]+", "+refAtEcal[1]+","+ refAtEcal[2]);
-	TrackState ts_ecal_helix = new BaseTrackState(ecalLCSimParams,refAtEcal, ecalLCSimCov,  TrackState.AtCalorimeter, BAtEcal);
-	if(debug)System.out.println(this.getClass().getName()+":: Uncorrected track state:  curvature = "+ts_ecal_helix.getOmega()
-			   +"  bField = "+ts_ecal_helix.getBLocal()+"  momentum z = "+ts_ecal_helix.getMomentum()[0]);
-	System.out.println("Helix at ECal from kT.getHelixAtPlane and by hand conversions ");
-	System.out.println(ts_ecal_helix.toString());
-	*/
-	//newTrack.getTrackStates().add(ts_ecal_helix);
-	
-
 	// this is how createTrackState (above) goes from measurement to TrackState
 	// from the measurements.  It calls toHPShelix.
 	// the helix state here must already be propagated
@@ -719,15 +683,7 @@ public class KalmanInterface {
 
 	TrackState ts_ecal=helixAtEcal.toTrackState(alphaAtEcal, ecalPlane, TrackState.AtCalorimeter, saveTrackStateAtIntercept);
 	newTrack.getTrackStates().add(ts_ecal);
-	//if(debug)System.out.println("Helix at ECal from helix.toTrackState");
-	//	if(debug)System.out.println(ts_toTrackState.toString()); 
-	//	System.out.println("Helix at ECal from helix.toTrackState");
-	//	System.out.println(ts_toTrackState.toString()); 
-	
-        // Extrapolate to the ECAL and make a new trackState there.
-	//BaseTrackState ts_ecal = new BaseTrackState();
-        //ts_ecal = TrackUtils.getTrackExtrapAtEcalRK(newTrack, fM, runNumber);
-	
+
 	Vec targetFace=origin; 
 	Plane targetPlane = new Plane(targetFace, new Vec(0., 1., 0.));
 	HelixState helixAtTarget=kT.getHelixAtPlane(targetPlane,saveTrackStateAtIntercept);  // this propagates (via RK) the helix to the plane
@@ -739,16 +695,6 @@ public class KalmanInterface {
 	if(debug)System.out.println("Helix at Target from helix.toTrackState");
 	if(debug)System.out.println(ts_target.toString()); 
 	newTrack.getTrackStates().add(ts_target);
-        // Extrapolate to Target and make a new trackState there.
-	/*
-        BaseTrackState ts_target = new BaseTrackState();
-        if (target_pos != -999.9 && addTrackStateAtTarget){
-            ts_target = TrackUtils.getTrackExtrapAtTargetRK(newTrack, target_pos, beamPosition, fM, 0);
-            if (ts_target != null){
-                newTrack.getTrackStates().add(ts_target);
-            }
-        }
-	*/
         
         // other track properties
         newTrack.setChisq(kT.chi2);

--- a/tracking/src/main/java/org/hps/recon/tracking/kalman/MeasurementSite.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/kalman/MeasurementSite.java
@@ -76,7 +76,6 @@ class MeasurementSite {
         }
         return str;
     }
-
     MeasurementSite(int thisSite, SiModule data, KalmanParams kPar) {
         this.thisSite = thisSite;
         this.kPar = kPar;
@@ -718,11 +717,10 @@ class MeasurementSite {
     }
 
     public boolean isInSensor(Double[] rLocal){
-	double tol = kPar.edgeTolerance; // Tolerance on the check, in mm
-	//	double tol=0.0; 
-	if (rLocal[0] < m.xExtent[0] - tol || rLocal[0] > m.xExtent[1] + tol) return false;
-	if (rLocal[1] < m.yExtent[0] - tol || rLocal[1] > m.yExtent[1] + tol) return false;
-	return true;
+        double tol = kPar.edgeTolerance; // Tolerance on the check, in mm
+        if (rLocal[0] < m.xExtent[0] - tol || rLocal[0] > m.xExtent[1] + tol) return false;
+        if (rLocal[1] < m.yExtent[0] - tol || rLocal[1] > m.yExtent[1] + tol) return false;
+        return true;
     }
 
     // Comparator functions for sorting measurement sites by layer number

--- a/tracking/src/main/java/org/hps/recon/tracking/kalman/MeasurementSite.java
+++ b/tracking/src/main/java/org/hps/recon/tracking/kalman/MeasurementSite.java
@@ -717,6 +717,14 @@ class MeasurementSite {
         }
     }
 
+    public boolean isInSensor(Double[] rLocal){
+	double tol = kPar.edgeTolerance; // Tolerance on the check, in mm
+	//	double tol=0.0; 
+	if (rLocal[0] < m.xExtent[0] - tol || rLocal[0] > m.xExtent[1] + tol) return false;
+	if (rLocal[1] < m.yExtent[0] - tol || rLocal[1] > m.yExtent[1] + tol) return false;
+	return true;
+    }
+
     // Comparator functions for sorting measurement sites by layer number
     static Comparator<MeasurementSite> SiteComparatorUp = new Comparator<MeasurementSite>() {
         public int compare(MeasurementSite s1, MeasurementSite s2) {


### PR DESCRIPTION
Closes #1147 

Add hole on track--defined as the layer where the track is projected to go through the sensitive area of a sensor but no hit is included in the track.  

This is included in the Track object's _subdetId (see here [Track](https://github.com/JeffersonLab/hps-lcsim/blob/391d46492257c5ab155e22ecf74734efd7aaa27a/event-model/src/main/java/org/lcsim/event/base/BaseTrack.java#L386-L388)).  We already use this to account for the layer numbers with hits on track, setting _subdetId[layer]=1 for a  hit on track.  For a hole, I've set _subdetId[layer]=-1.  