### PR TITLE
Fix issue with the RfFitterDriver crashing if the RF pulse is absent.

### DIFF
--- a/evio/src/main/java/org/hps/evio/RfFitterDriver.java
+++ b/evio/src/main/java/org/hps/evio/RfFitterDriver.java
@@ -128,7 +128,7 @@ public class RfFitterDriver extends Driver {
         double pedVal[] = {-999, -999};
 
         // Look for bins containing the peaks (2-3 peaks)
-        for (int ii = 4; ii < adcSamples.length; ii++) {
+        for (int ii = 4; ii < adcSamples.length-1; ii++) {
             // After 2 peaks, stop looking for more
             if (iz == 2) {
                 break;

--- a/evio/src/main/java/org/hps/evio/RfFitterDriver.java
+++ b/evio/src/main/java/org/hps/evio/RfFitterDriver.java
@@ -143,8 +143,16 @@ public class RfFitterDriver extends Driver {
         }
 
         int jj = 0;
+        int ik = 1;
         // Choose peak closest to center of window (second peak, ik=1)
-        final int ik = 1;
+        if( iz >=2 ) {
+            ik = 1;
+        }else if( iz == 1){
+            ik = 0; // Only one peak found.
+        }else{
+            return 0;
+        }
+        
         pedVal[ik] = (adcSamples[peakBin[ik] - 6] + adcSamples[peakBin[ik] - 7] + adcSamples[peakBin[ik] - 8] + adcSamples[peakBin[ik] - 9]) / 4.0;
         fitThresh[ik] = (adcSamples[peakBin[ik]] + pedVal[ik]) / 3.0;
 

--- a/recon/src/main/java/org/hps/recon/skims/FEESkimmer.java
+++ b/recon/src/main/java/org/hps/recon/skims/FEESkimmer.java
@@ -17,7 +17,7 @@ public class FEESkimmer extends Skimmer {
     
     @Override
     public boolean passSelection(EventHeader event){
-	System.out.println(this.getClass().getName()+":: in pass selection"); 
+	// System.out.println(this.getClass().getName()+":: in pass selection");
 	boolean pass=true; 
 	
 	

--- a/recon/src/main/java/org/hps/recon/skims/ThreeBodySkimmer.java
+++ b/recon/src/main/java/org/hps/recon/skims/ThreeBodySkimmer.java
@@ -17,7 +17,7 @@ public class ThreeBodySkimmer extends Skimmer {
     
     @Override
     public boolean passSelection(EventHeader event){
-	System.out.println(this.getClass().getName()+":: in pass selection"); 
+	// System.out.println(this.getClass().getName()+":: in pass selection");
 	boolean pass=true; 
 	
 	


### PR DESCRIPTION
The code should not crash if the RF pulse is not detected. We have some early runs in 2021 where the RF pulse was not plugged in, so the data is garbage. We should still be able to analyze such data without needing to change the steering file.

The fix is simple, make a common sense guard against buffer over run (if you access i+1 do not loop to size()), and test if a peak was actually found before using the results.
